### PR TITLE
tidy-up: avoid using the reserved macro namespace

### DIFF
--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -71,14 +71,14 @@ int my_gettimeofday(struct timeval *tp, void *tzp)
   (void)tzp;
   if(tp) {
     /* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
-    #define _WIN32_FT_OFFSET (116444736000000000)
+    #define WIN32_FT_OFFSET (116444736000000000)
     union {
       CURL_TYPEOF_CURL_OFF_T ns100; /* time since 1 Jan 1601 in 100ns units */
       FILETIME ft;
     } _now;
     GetSystemTimeAsFileTime(&_now.ft);
     tp->tv_usec = (long)((_now.ns100 / 10) % 1000000);
-    tp->tv_sec = (long)((_now.ns100 - _WIN32_FT_OFFSET) / 10000000);
+    tp->tv_sec = (long)((_now.ns100 - WIN32_FT_OFFSET) / 10000000);
   }
   return 0;
 }

--- a/docs/internals/CODE_STYLE.md
+++ b/docs/internals/CODE_STYLE.md
@@ -335,6 +335,7 @@ This is the full list of functions generally banned.
     _mbscat
     _mbsncat
     _tcscat
+    _tcsdup
     _tcsncat
     _waccess
     _wcscat

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -199,8 +199,9 @@ struct Library *SocketBase = NULL;
 
 #ifdef __libnix__
 void __request(const char *msg);
+#define CURL_AMIGA_REQUEST(msg)  __request(msg)
 #else
-# define __request(msg)       Printf((const unsigned char *)(msg "\n\a"), 0)
+#define CURL_AMIGA_REQUEST(msg)  Printf((const unsigned char *)(msg "\n\a"), 0)
 #endif
 
 void Curl_amiga_cleanup(void)
@@ -217,14 +218,14 @@ CURLcode Curl_amiga_init(void)
     SocketBase = OpenLibrary((const unsigned char *)"bsdsocket.library", 4);
 
   if(!SocketBase) {
-    __request("No TCP/IP Stack running!");
+    CURL_AMIGA_REQUEST("No TCP/IP Stack running!");
     return CURLE_FAILED_INIT;
   }
 
   if(SocketBaseTags(SBTM_SETVAL(SBTC_ERRNOPTR(sizeof(errno))), (ULONG) &errno,
                     SBTM_SETVAL(SBTC_LOGTAGPTR), (ULONG) "curl",
                     TAG_DONE)) {
-    __request("SocketBaseTags ERROR");
+    CURL_AMIGA_REQUEST("SocketBaseTags ERROR");
     return CURLE_FAILED_INIT;
   }
 

--- a/lib/curl_mem_undef.h
+++ b/lib/curl_mem_undef.h
@@ -30,7 +30,7 @@
 #undef realloc
 #undef free
 #ifdef _WIN32
-#undef _tcsdup
+#undef Curl_tcsdup
 #endif
 
 #ifdef CURLDEBUG

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -77,11 +77,11 @@
 #define free(ptr) Curl_cfree(ptr)
 
 #ifdef _WIN32
-#undef _tcsdup
+#undef Curl_tcsdup
 #ifdef UNICODE
-#define _tcsdup(ptr) Curl_wcsdup(ptr)
+#define Curl_tcsdup(ptr) Curl_wcsdup(ptr)
 #else
-#define _tcsdup(ptr) Curl_cstrdup(ptr)
+#define Curl_tcsdup(ptr) Curl_cstrdup(ptr)
 #endif
 #endif /* _WIN32 */
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -46,7 +46,7 @@
    fail. Fixed in 14.2.0_1. Disable the workaround if the fix is detected. */
 #if defined(__APPLE__) && !defined(__clang__) && defined(__GNUC__) && \
   defined(__has_attribute)
-#  if !defined(__has_feature)
+#  if !defined(__has_feature)  /* Keep this PP check separate from others */
 #    define availability curl_pp_attribute_disabled
 #  elif !__has_feature(attribute_availability)
 #    define availability curl_pp_attribute_disabled

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -138,7 +138,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   }
 
   /* Setup the identity's user and length */
-  dup_user.tchar_ptr = _tcsdup(user.tchar_ptr);
+  dup_user.tchar_ptr = Curl_tcsdup(user.tchar_ptr);
   if(!dup_user.tchar_ptr) {
     curlx_unicodefree(useranddomain.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;
@@ -165,7 +165,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   passwd.tchar_ptr = curlx_convert_UTF8_to_tchar(passwdp);
   if(!passwd.tchar_ptr)
     return CURLE_OUT_OF_MEMORY;
-  dup_passwd.tchar_ptr = _tcsdup(passwd.tchar_ptr);
+  dup_passwd.tchar_ptr = Curl_tcsdup(passwd.tchar_ptr);
   if(!dup_passwd.tchar_ptr) {
     curlx_unicodefree(passwd.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;

--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -45,20 +45,18 @@
 #define curl_simple_lock atomic_int
 #define CURL_SIMPLE_LOCK_INIT 0
 
-/* a clang-thing */
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif
-
 #ifndef __INTEL_COMPILER
 /* The Intel compiler tries to look like GCC *and* clang *and* lies in its
    __has_builtin() function, so override it. */
 
 /* if GCC on i386/x86_64 or if the built-in is present */
-#if ( (defined(__GNUC__) && !defined(__clang__)) &&     \
-      (defined(__i386__) || defined(__x86_64__))) ||    \
-  __has_builtin(__builtin_ia32_pause)
+#if (defined(__GNUC__) && !defined(__clang__)) &&     \
+    (defined(__i386__) || defined(__x86_64__))
 #define HAVE_BUILTIN_IA32_PAUSE
+#elif defined(__has_builtin)  /* Do not merge with other PP checks */
+#if __has_builtin(__builtin_ia32_pause)
+#define HAVE_BUILTIN_IA32_PAUSE
+#endif
 #endif
 
 #endif

--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -53,7 +53,7 @@
 #if (defined(__GNUC__) && !defined(__clang__)) &&     \
     (defined(__i386__) || defined(__x86_64__))
 #define HAVE_BUILTIN_IA32_PAUSE
-#elif defined(__has_builtin)  /* Do not merge with other PP checks */
+#elif defined(__has_builtin)  /* Keep this PP check separate from others */
 #if __has_builtin(__builtin_ia32_pause)
 #define HAVE_BUILTIN_IA32_PAUSE
 #endif

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -48,11 +48,11 @@
 #define recv(a,b,c,d) curl_dbg_recv(a,b,c,d, __LINE__, __FILE__)
 
 #ifdef _WIN32
-#undef _tcsdup
+#undef Curl_tcsdup
 #ifdef UNICODE
-#define _tcsdup(ptr) curl_dbg_wcsdup(ptr, __LINE__, __FILE__)
+#define Curl_tcsdup(ptr) curl_dbg_wcsdup(ptr, __LINE__, __FILE__)
 #else
-#define _tcsdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
+#define Curl_tcsdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
 #endif
 #endif /* _WIN32 */
 

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -149,12 +149,6 @@ static CURLcode weak_random(struct Curl_easy *data,
 }
 #endif
 
-#ifdef USE_SSL
-#define _random(x,y,z) Curl_ssl_random(x,y,z)
-#else
-#define _random(x,y,z) weak_random(x,y,z)
-#endif
-
 static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
                        bool env_override)
 {
@@ -185,7 +179,11 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
 #endif
 
   /* data may be NULL! */
-  return _random(data, (unsigned char *)rnd, sizeof(*rnd));
+#ifdef USE_SSL
+  return Curl_ssl_random(data, (unsigned char *)rnd, sizeof(*rnd));
+#else
+  return weak_random(data, (unsigned char *)rnd, sizeof(*rnd));
+#endif
 }
 
 /*

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -277,7 +277,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
           if(!domain.tchar_ptr)
             return CURLE_OUT_OF_MEMORY;
 
-          dup_domain.tchar_ptr = _tcsdup(domain.tchar_ptr);
+          dup_domain.tchar_ptr = Curl_tcsdup(domain.tchar_ptr);
           if(!dup_domain.tchar_ptr) {
             curlx_unicodefree(domain.tchar_ptr);
             return CURLE_OUT_OF_MEMORY;

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -100,7 +100,7 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
   free(utf8_spn);
   if(!tchar_spn)
     return NULL;
-  dupe_tchar_spn = _tcsdup(tchar_spn);
+  dupe_tchar_spn = Curl_tcsdup(tchar_spn);
   curlx_unicodefree(tchar_spn);
   return dupe_tchar_spn;
 }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -433,7 +433,7 @@ get_cert_location(TCHAR *path, DWORD *store_name, TCHAR **store_path,
     return CURLE_SSL_CERTPROBLEM;
 
   *sep = TEXT('\0');
-  *store_path = _tcsdup(store_path_start);
+  *store_path = Curl_tcsdup(store_path_start);
   *sep = TEXT('\\');
   if(!*store_path)
     return CURLE_OUT_OF_MEMORY;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -62,6 +62,7 @@ my %banfunc = (
     "_mbscat" => 1,
     "_mbsncat" => 1,
     "_tcscat" => 1,
+    "_tcsdup" => 1,
     "_tcsncat" => 1,
     "_wcscat" => 1,
     "_wcsncat" => 1,

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -46,9 +46,10 @@
 #  undef  PATH_MAX
 #  define PATH_MAX MAX_PATH
 #elif !defined(__DJGPP__) || (__DJGPP__ < 2)  /* DJGPP 2.0 has _use_lfn() */
-#  define _use_lfn(f) (0)  /* long filenames never available */
+#  define CURL_USE_LFN(f) 0  /* long filenames never available */
 #elif defined(__DJGPP__)
-#  include <fcntl.h>       /* _use_lfn(f) prototype */
+#  include <fcntl.h>         /* for _use_lfn(f) prototype */
+#  define CURL_USE_LFN(f) _use_lfn(f)
 #endif
 
 #ifdef MSDOS
@@ -314,7 +315,7 @@ static SANITIZEcode msdosify(char **const sanitized, const char *file_name,
     return SANITIZE_ERR_INVALID_PATH;
 
   /* Support for Windows 9X VFAT systems, when available. */
-  if(_use_lfn(file_name)) {
+  if(CURL_USE_LFN(file_name)) {
     illegal_aliens = illegal_chars_w95;
     len -= (illegal_chars_w95 - illegal_chars_dos);
   }

--- a/src/tool_findfile.c
+++ b/src/tool_findfile.c
@@ -24,9 +24,13 @@
 #include "tool_setup.h"
 
 #ifdef HAVE_PWD_H
+#ifdef __AMIGA__
 #undef __NO_NET_API /* required for AmigaOS to declare getpwuid() */
+#endif
 #include <pwd.h>
+#ifdef __AMIGA__
 #define __NO_NET_API
+#endif
 #endif
 
 #ifdef HAVE_FCNTL_H


### PR DESCRIPTION
To avoid hitting `-Wreserved-macro-identifier` where possible.

- amigaos: introduce local macro instead of reusing `__request()`.
- easy_lock: avoid redefining `__has_builtin()`.
  Follow-up to 33fd57b8fff8c0d873da2316a2a7f911caac2bae #9062
- rand: drop interim macro `_random()`.
- windows: rename local macro `_tcsdup()` to `Curl_tcsdup()`.
  To avoid using the reserved macro namespace and to avoid
  colliding with `_tcsdup()` as defined by Windows headers.
- checksrc: ban `_tcsdup()` in favor of `Curl_tcsdup()`.
- tool_doswin: avoid redefining `_use_lfn()` (MS-DOS).
- tool_findfile: limit `__NO_NET_API` hack to AmigaOS.
  Syncing this pattern with `lib/netrc.c`.
  Follow-up to 784a8ec2c1a3cc4bd676077a28a0d5f6ee7786a5 #16279
- examples/http2-upload: avoid reserved namespace for local macro.

More cases will be removed when dropping WinCE support via #17927.

Cases remain when defining external macros out of curl's control.

Ref: #18477
