### PR TITLE
GHA/linux: run on `.md` file changes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,6 @@ name: 'Linux'
       - master
       - '*/ci'
     paths-ignore:
-      - '**/*.md'
       - '.circleci/**'
       - 'appveyor.*'
       - 'Dockerfile'
@@ -22,7 +21,6 @@ name: 'Linux'
     branches:
       - master
     paths-ignore:
-      - '**/*.md'
       - '.circleci/**'
       - 'appveyor.*'
       - 'Dockerfile'


### PR DESCRIPTION
To execute runtests on Markdown files. E.g. test 1275.
