### PR TITLE
BINDINGS: point a link to archive.org

### DIFF
--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -43,7 +43,7 @@ Clojure: [clj-curl](https://github.com/lsevero/clj-curl) by Lucas Severo
 
 [Euphoria](https://web.archive.org/web/20050204080544/rays-web.com/eulibcurl.htm) Written by Ray Smith
 
-[Falcon](http://www.falconpl.org/project_docs/curl/)
+[Falcon](https://web.archive.org/web/20240130001835/www.falconpl.org/project_docs/curl/)
 
 [Ferite](https://web.archive.org/web/20150102192018/ferite.org/) Written by Paul Querna
 


### PR DESCRIPTION
The original website is hosting different content now.