### PR TITLE
windows: stop passing unused, optional argument for Win9x compatibility

### DIFF
--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -83,7 +83,6 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
   CtxtHandle sspi_context;
   PCtxtHandle context_handle = NULL;
   SecPkgCredentials_Names names;
-  TimeStamp expiry;
   char *service_name = NULL;
   unsigned short us_length;
   unsigned long qop;
@@ -146,7 +145,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
                                        (TCHAR *)CURL_UNCONST(TEXT("Kerberos")),
                                           SECPKG_CRED_OUTBOUND,
                                           NULL, NULL, NULL, NULL,
-                                          &cred_handle, &expiry);
+                                          &cred_handle, NULL);
 
   if(check_sspi_err(data, status, "AcquireCredentialsHandle")) {
     failf(data, "Failed to acquire credentials.");
@@ -178,8 +177,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
                                              &input_desc, 0,
                                              &sspi_context,
                                              &output_desc,
-                                             &sspi_ret_flags,
-                                             &expiry);
+                                             &sspi_ret_flags, NULL);
 
     curlx_unicodefree(sname);
 

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -112,7 +112,6 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   SecBufferDesc resp_desc;
   SECURITY_STATUS status;
   unsigned long attrs;
-  TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
   /* Ensure we have a valid challenge message */
   if(!Curl_bufref_len(chlg)) {
@@ -168,7 +167,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                                    (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
                                    SECPKG_CRED_OUTBOUND, NULL,
                                    p_identity, NULL, NULL,
-                                   &credentials, &expiry);
+                                   &credentials, NULL);
 
   if(status != SEC_E_OK) {
     Curl_sspi_free_identity(p_identity);
@@ -197,7 +196,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   status = Curl_pSecFn->InitializeSecurityContext(&credentials, NULL, spn,
                                                   0, 0, 0, &chlg_desc, 0,
                                                   &context, &resp_desc, &attrs,
-                                                  &expiry);
+                                                  NULL);
 
   if(status == SEC_I_COMPLETE_NEEDED ||
      status == SEC_I_COMPLETE_AND_CONTINUE)
@@ -488,7 +487,6 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     SecBuffer resp_buf;
     SecBufferDesc resp_desc;
     unsigned long attrs;
-    TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
     TCHAR *spn;
 
     /* free the copy of user/passwd used to make the previous identity */
@@ -542,7 +540,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                    (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
                                    SECPKG_CRED_OUTBOUND, NULL,
                                    p_identity, NULL, NULL,
-                                   &credentials, &expiry);
+                                   &credentials, NULL);
     if(status != SEC_E_OK) {
       Curl_sspi_free_identity(p_identity);
       free(output_token);
@@ -597,7 +595,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                                   ISC_REQ_USE_HTTP_STYLE, 0, 0,
                                                   &chlg_desc, 0,
                                                   digest->http_context,
-                                                  &resp_desc, &attrs, &expiry);
+                                                  &resp_desc, &attrs, NULL);
     curlx_unicodefree(spn);
 
     if(status == SEC_I_COMPLETE_NEEDED ||

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -107,7 +107,6 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
   SecBufferDesc resp_desc;
   SECURITY_STATUS status;
   unsigned long attrs;
-  TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
   if(!krb5->spn) {
     /* Generate our SPN */
@@ -162,7 +161,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
                                  (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_KERBEROS)),
                                  SECPKG_CRED_OUTBOUND, NULL,
                                  krb5->p_identity, NULL, NULL,
-                                 krb5->credentials, &expiry);
+                                 krb5->credentials, NULL);
     if(status != SEC_E_OK)
       return CURLE_LOGIN_DENIED;
 
@@ -204,8 +203,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
                                                0, SECURITY_NATIVE_DREP,
                                                chlg ? &chlg_desc : NULL, 0,
                                                &context,
-                                               &resp_desc, &attrs,
-                                               &expiry);
+                                               &resp_desc, &attrs, NULL);
 
   if(status == SEC_E_INSUFFICIENT_MEMORY)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -98,7 +98,6 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   SecBufferDesc type_1_desc;
   SECURITY_STATUS status;
   unsigned long attrs;
-  TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
   /* Clean up any former leftovers and initialise to defaults */
   Curl_auth_cleanup_ntlm(ntlm);
@@ -147,7 +146,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                      (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NTLM)),
                                      SECPKG_CRED_OUTBOUND, NULL,
                                      ntlm->p_identity, NULL, NULL,
-                                     ntlm->credentials, &expiry);
+                                     ntlm->credentials, NULL);
   if(status != SEC_E_OK)
     return CURLE_LOGIN_DENIED;
 
@@ -174,7 +173,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                                   0, 0, SECURITY_NETWORK_DREP,
                                                   NULL, 0,
                                                   ntlm->context, &type_1_desc,
-                                                  &attrs, &expiry);
+                                                  &attrs, NULL);
   if(status == SEC_I_COMPLETE_NEEDED ||
     status == SEC_I_COMPLETE_AND_CONTINUE)
     Curl_pSecFn->CompleteAuthToken(ntlm->context, &type_1_desc);
@@ -255,7 +254,6 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   SecBufferDesc type_3_desc;
   SECURITY_STATUS status;
   unsigned long attrs;
-  TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
 #ifdef CURL_DISABLE_VERBOSE_STRINGS
   (void)data;
@@ -314,7 +312,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                                   &type_2_desc,
                                                   0, ntlm->context,
                                                   &type_3_desc,
-                                                  &attrs, &expiry);
+                                                  &attrs, NULL);
   if(status != SEC_E_OK) {
     infof(data, "NTLM handshake failure (type-3 message): Status=%lx",
           status);

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -105,7 +105,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   SecBufferDesc chlg_desc;
   SecBufferDesc resp_desc;
   unsigned long attrs;
-  TimeStamp expiry; /* For Windows 9x compatibility of SSPI calls */
 
 #ifdef CURL_DISABLE_VERBOSE_STRINGS
   (void)data;
@@ -173,7 +172,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                 (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
                                 SECPKG_CRED_OUTBOUND, NULL,
                                 nego->p_identity, NULL, NULL,
-                                nego->credentials, &expiry);
+                                nego->credentials, NULL);
     if(nego->status != SEC_E_OK)
       return CURLE_AUTH_ERROR;
 
@@ -250,8 +249,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                                   0, SECURITY_NATIVE_DREP,
                                                   chlg ? &chlg_desc : NULL,
                                                   0, nego->context,
-                                                  &resp_desc, &attrs,
-                                                  &expiry);
+                                                  &resp_desc, &attrs, NULL);
 
   /* Free the decoded challenge as it is not required anymore */
   free(chlg);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -796,8 +796,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                                             (TCHAR *)CURL_UNCONST(UNISP_NAME),
                                             SECPKG_CRED_OUTBOUND, NULL,
                                             &credentials, NULL, NULL,
-                                            &backend->cred->cred_handle,
-                                            &backend->cred->time_stamp);
+                                            &backend->cred->cred_handle, NULL);
   }
   else {
     /* Pre-Windows 10 1809 or the user set a legacy algorithm list.
@@ -835,8 +834,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                                             (TCHAR *)CURL_UNCONST(UNISP_NAME),
                                             SECPKG_CRED_OUTBOUND, NULL,
                                             &schannel_cred, NULL, NULL,
-                                            &backend->cred->cred_handle,
-                                            &backend->cred->time_stamp);
+                                            &backend->cred->cred_handle, NULL);
   }
 
   if(client_certs[0])

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1048,7 +1048,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     backend->req_flags, 0, 0,
     (backend->use_alpn ? &inbuf_desc : NULL),
     0, &backend->ctxt->ctxt_handle,
-    &outbuf_desc, &backend->ret_flags, &backend->ctxt->time_stamp);
+    &outbuf_desc, &backend->ret_flags, NULL);
 
   if(sspi_status != SEC_I_CONTINUE_NEEDED) {
     char buffer[STRERROR_LEN];
@@ -1257,7 +1257,7 @@ schannel_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
       &backend->cred->cred_handle, &backend->ctxt->ctxt_handle,
       backend->cred->sni_hostname, backend->req_flags,
       0, 0, &inbuf_desc, 0, NULL,
-      &outbuf_desc, &backend->ret_flags, &backend->ctxt->time_stamp);
+      &outbuf_desc, &backend->ret_flags, NULL);
 
     /* free buffer for received handshake data */
     Curl_safefree(inbuf[0].pvBuffer);
@@ -2438,8 +2438,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
       0,
       &backend->ctxt->ctxt_handle,
       &outbuf_desc,
-      &backend->ret_flags,
-      &backend->ctxt->time_stamp);
+      &backend->ret_flags, NULL);
 
     if((sspi_status == SEC_E_OK) || (sspi_status == SEC_I_CONTEXT_EXPIRED)) {
       /* send close message which is in output buffer */

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -99,7 +99,6 @@ typedef struct _SCH_CREDENTIALS {
 
 struct Curl_schannel_cred {
   CredHandle cred_handle;
-  TimeStamp time_stamp;
   TCHAR *sni_hostname;
   HCERTSTORE client_cert_store;
   int refcount;
@@ -107,7 +106,6 @@ struct Curl_schannel_cred {
 
 struct Curl_schannel_ctxt {
   CtxtHandle ctxt_handle;
-  TimeStamp time_stamp;
 };
 
 struct schannel_ssl_backend_data {


### PR DESCRIPTION
Expiry timestamp in `AcquireCredentialsHandle()` (SSPI) and
`InitializeSecurityContext()` (Schannel) calls. The argument is optional
in both. The returned value was never used in curl. The reason for
passing it was Windows 95 compatibility, according to comments in
the SSPI code. curl no longer supports Windows 95.

Ref: https://learn.microsoft.com/windows/win32/api/sspi/nf-sspi-acquirecredentialshandlea
Ref: https://learn.microsoft.com/windows/win32/secauthn/initializesecuritycontext--schannel

Ref: 3fe531196771c8e81f917eebca4a06e062ab3a19
Ref: aaa42aa0d594b95c6c670a373ba30c507aa0a5ed