### PR TITLE
curl_setup.h: include `limits.h` before testing for `#ifndef SSIZE_MAX`

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -479,6 +479,8 @@
 #include <stdint.h>
 #endif
 
+#include <limits.h>
+
 #ifdef _WIN32
 #  ifdef HAVE_IO_H
 #  include <io.h>


### PR DESCRIPTION
Ref: 93f333c18fffc3c091b149f3e0ec2ca02b8dab40 #18426 #18406
Fixes #18493
