### PR TITLE
vquic: replace assert

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -186,8 +186,9 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
       return CURLE_SEND_ERROR;
     }
   }
-  else {
-    assert(pktlen == (size_t)sent);
+  else if(pktlen != (size_t)sent) {
+    failf(data, "sendmsg() sent only %zd/%zu bytes", sent, pktlen);
+    return CURLE_SEND_ERROR;
   }
 #else
   ssize_t sent;


### PR DESCRIPTION
Replace the hard assert in case not all data is send on UDP (which should never happen), with an error return.