### PR TITLE
lib: introduce `CURL_ACCEPT()`

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -2116,7 +2116,7 @@ static CURLcode cf_tcp_accept_connect(struct Curl_cfilter *cf,
     s_accepted = accept4(ctx->sock, (struct sockaddr *) &add, &size,
                          SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
-    s_accepted = accept(ctx->sock, (struct sockaddr *) &add, &size);
+    s_accepted = CURL_ACCEPT(ctx->sock, (struct sockaddr *) &add, &size);
 #endif
   }
 

--- a/lib/curl_mem_undef.h
+++ b/lib/curl_mem_undef.h
@@ -29,12 +29,14 @@
 #undef calloc
 #undef realloc
 #undef free
-#undef send
-#undef recv
-
 #ifdef _WIN32
 #undef _tcsdup
 #endif
+
+#ifdef CURLDEBUG
+
+#undef send
+#undef recv
 
 #undef socket
 #undef accept
@@ -51,6 +53,8 @@
 #endif
 #undef fdopen
 #undef fclose
+
+#endif /* CURLDEBUG */
 
 #undef HEADER_CURL_MEMORY_H
 #undef HEADER_CURL_MEMDEBUG_H

--- a/lib/curl_mem_undef.h
+++ b/lib/curl_mem_undef.h
@@ -39,7 +39,6 @@
 #undef recv
 
 #undef socket
-#undef accept
 #ifdef HAVE_ACCEPT4
 #undef accept4
 #endif

--- a/lib/curl_mem_undef.h
+++ b/lib/curl_mem_undef.h
@@ -29,14 +29,12 @@
 #undef calloc
 #undef realloc
 #undef free
+#undef send
+#undef recv
+
 #ifdef _WIN32
 #undef _tcsdup
 #endif
-
-#ifdef CURLDEBUG
-
-#undef send
-#undef recv
 
 #undef socket
 #ifdef HAVE_ACCEPT4
@@ -52,8 +50,6 @@
 #endif
 #undef fdopen
 #undef fclose
-
-#endif /* CURLDEBUG */
 
 #undef HEADER_CURL_MEMORY_H
 #undef HEADER_CURL_MEMDEBUG_H

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1084,6 +1084,9 @@ CURL_EXTERN ALLOC_FUNC
 #define CURL_FREEADDRINFO(data) \
   curl_dbg_freeaddrinfo(data, __LINE__, __FILE__)
 
+#define CURL_ACCEPT(sock,addr,len) \
+  curl_dbg_accept(sock, addr, len, __LINE__, __FILE__)
+
 #else /* !CURLDEBUG */
 
 #define sclose(x) CURL_SCLOSE(x)
@@ -1091,6 +1094,8 @@ CURL_EXTERN ALLOC_FUNC
 
 #define CURL_GETADDRINFO getaddrinfo
 #define CURL_FREEADDRINFO freeaddrinfo
+
+#define CURL_ACCEPT accept
 
 #endif /* CURLDEBUG */
 

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -371,7 +371,7 @@ curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
   struct sockaddr *addr = (struct sockaddr *)saddr;
   curl_socklen_t *addrlen = (curl_socklen_t *)saddrlen;
 
-  curl_socket_t sockfd = (accept)(s, addr, addrlen);
+  curl_socket_t sockfd = accept(s, addr, addrlen);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d accept() = %" FMT_SOCKET_T "\n",

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -59,9 +59,6 @@
 #undef socket
 #define socket(domain,type,protocol) \
   curl_dbg_socket((int)domain, type, protocol, __LINE__, __FILE__)
-#undef accept /* for those with accept as a macro */
-#define accept(sock,addr,len) \
-  curl_dbg_accept(sock, addr, len, __LINE__, __FILE__)
 #ifdef HAVE_ACCEPT4
 #undef accept4 /* for those with accept4 as a macro */
 #define accept4(sock,addr,len,flags) \

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -201,7 +201,7 @@ int Curl_socketpair(int domain, int type, int protocol,
   pfd[0].events = POLLIN;
   pfd[0].revents = 0;
   (void)Curl_poll(pfd, 1, 1000); /* one second */
-  socks[1] = accept(listener, NULL, NULL);
+  socks[1] = CURL_ACCEPT(listener, NULL, NULL);
   if(socks[1] == CURL_SOCKET_BAD)
     goto error;
   else {

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -765,8 +765,8 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
   SOCKADDR_IN clientAddr;
   int clientAddrLen = sizeof(clientAddr);
 
-  curl_socket_t socket_w = accept(tdata->socket_l, (SOCKADDR*)&clientAddr,
-                                  &clientAddrLen);
+  curl_socket_t socket_w = CURL_ACCEPT(tdata->socket_l, (SOCKADDR*)&clientAddr,
+                                       &clientAddrLen);
 
   if(socket_w == CURL_SOCKET_BAD) {
     errorf("accept error: %08lx", GetLastError());


### PR DESCRIPTION
To avoid overriding the system symbol `accept`, which is a macro on some
systems (AIX), and thus can't be called via the `(function)` PP trick.

It's also problematic to reset such macro to its original value.

Follow-up to 3bb5e58c105d7be450b667858d1b8e7ae3ded555 #17827
Reported-by: Andrew Kirillov
Fixes #18500
Closes #18501

---

- [ ] do the same for `accept4()` (2 uses), `socketpair()` (2 uses), `socket()` (8 uses)?
- [ ] ban these functions via lib/src `.checksrc`. Also `getaddrinfo` and `freeaddrinfo`.

Also [SKIP for now]:
- curl_mem_undef.h: guard undefs with `CURLDEBUG`, for symbols that are
  redefined for `CURLDEBUG` only.
  This probably isn't a fix in itself, as shown in this particular case.
