### PR TITLE
easy_getinfo: check magic, Curl_close safety

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -877,11 +877,15 @@ void curl_easy_cleanup(CURL *ptr)
  * information from a performed transfer and similar.
  */
 #undef curl_easy_getinfo
-CURLcode curl_easy_getinfo(CURL *data, CURLINFO info, ...)
+CURLcode curl_easy_getinfo(CURL *easy, CURLINFO info, ...)
 {
+  struct Curl_easy *data = easy;
   va_list arg;
   void *paramp;
   CURLcode result;
+
+  if(!GOOD_EASY_HANDLE(data))
+    return CURLE_BAD_FUNCTION_ARGUMENT;
 
   va_start(arg, info);
   paramp = va_arg(arg, void *);


### PR DESCRIPTION
Check the easy handles magic in calls to curl_easy_getinfo(). In Curl_close() clear the magic after DNS shutdown since we'd like to see tracing for this.
When clearing the magic, also clear the verbose flag so we no longer call DEBUGFUNCTION on such a handle.