### PR TITLE
url: we can't change set.verbose as it was user-set and should be sticky

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -266,7 +266,6 @@ CURLcode Curl_close(struct Curl_easy **datap)
   Curl_resolv_unlink(data, &data->state.dns[0]); /* done with this */
   Curl_resolv_unlink(data, &data->state.dns[1]);
 
-  data->set.verbose = FALSE; /* no more calls to DEBUGFUNCTION */
   data->magic = 0; /* force a clear AFTER the possibly enforced removal from
                     * the multi handle and async dns shutdown. The multi
                     * handle might check the magic and so might any


### PR DESCRIPTION
... to be used for subsequent transfes using the same handle.

Follow-up to b30e3fb21d589e3b