### PR TITLE
curl_mem_undef.h: limit `#undef` to `CURLDEBUG` for non-allocaction overrides

### DIFF
--- a/lib/curl_mem_undef.h
+++ b/lib/curl_mem_undef.h
@@ -29,12 +29,14 @@
 #undef calloc
 #undef realloc
 #undef free
-#undef send
-#undef recv
-
 #ifdef _WIN32
 #undef _tcsdup
 #endif
+
+#ifdef CURLDEBUG
+
+#undef send
+#undef recv
 
 #undef socket
 #ifdef HAVE_ACCEPT4
@@ -50,6 +52,8 @@
 #endif
 #undef fdopen
 #undef fclose
+
+#endif /* CURLDEBUG */
 
 #undef HEADER_CURL_MEMORY_H
 #undef HEADER_CURL_MEMDEBUG_H


### PR DESCRIPTION
To fix build on 32-bit AIX, where `fopen` is a system macro.

Ref: #18502
Ref: https://github.com/curl/curl/pull/18502/commits/793a375ce3002454599ffe2d7b561b6340103306

Follow-up to 3bb5e58c105d7be450b667858d1b8e7ae3ded555 #17827
Reported-by: Andrew Kirillov
Fixes #18510
