### PR TITLE
quic: fix min TLS version handling

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2865,11 +2865,12 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
 static CURLcode
-ossl_set_ssl_version_min_max(struct Curl_cfilter *cf, SSL_CTX *ctx)
+ossl_set_ssl_version_min_max(struct Curl_cfilter *cf, SSL_CTX *ctx,
+                             unsigned int ssl_version_min)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   /* first, TLS min version... */
-  long curl_ssl_version_min = conn_config->version;
+  long curl_ssl_version_min = (long)ssl_version_min;
   long curl_ssl_version_max;
 
   /* convert curl min SSL version option to OpenSSL constant */
@@ -4110,7 +4111,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
     ctx_options |= SSL_OP_NO_SSLv3;
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0 */
-    result = ossl_set_ssl_version_min_max(cf, octx->ssl_ctx);
+    result = ossl_set_ssl_version_min_max(cf, octx->ssl_ctx, ssl_version_min);
 #else
     result = ossl_set_ssl_version_min_max_legacy(&ctx_options, cf, data);
 #endif


### PR DESCRIPTION
When switching to TSLv1.2 as default in 9d8998c99408e1adf8eba629fad9f87b3235bdfa, this led to an explicit setting of 1.2 on QUIC connections when using quictls, overriding the already set min version of 1.3.

This leads to a ClientHello with TLS 1.2+1.3 offered on a QUIC connect which is rejected by the Caddy server. Using ngtcp2 with OpenSSL 3.5+, GnuTLS, AWS-LC is not affected.

refs #18518