### PR TITLE
ssl-sessions.md: mark option experimental

### DIFF
--- a/docs/cmdline-opts/ssl-sessions.md
+++ b/docs/cmdline-opts/ssl-sessions.md
@@ -8,6 +8,7 @@ Help: Load/save SSL session tickets from/to this file
 Added: 8.12.0
 Category: tls
 Multi: single
+Experimental: yes
 See-also:
   - tls-earlydata
 Example:

--- a/scripts/managen
+++ b/scripts/managen
@@ -728,7 +728,8 @@ sub single {
     }
 
     if($experimental) {
-        push @leading, "**WARNING**: this option is experimental. Do not use in production.\n\n";
+        my $pref = $manpage ? "" : "[1]";
+        push @leading, "$pref**WARNING**: this option is experimental. Do not use in production.\n\n";
     }
 
     my $pre = $manpage ? "\n": "[1]";


### PR DESCRIPTION
Also make managen output the experimental text with the correct prefix/margin for the ascii version.