### PR TITLE
urldata: FILE is not a list-only protocol

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -116,7 +116,7 @@ typedef unsigned int curl_prot_t;
 #define PROTO_FAMILY_SSH  (CURLPROTO_SCP|CURLPROTO_SFTP)
 
 #if !defined(CURL_DISABLE_FTP) || defined(USE_SSH) ||   \
-  !defined(CURL_DISABLE_POP3) || !defined(CURL_DISABLE_FILE)
+  !defined(CURL_DISABLE_POP3)
 /* these protocols support CURLOPT_DIRLISTONLY */
 #define CURL_LIST_ONLY_PROTOCOL 1
 #endif


### PR DESCRIPTION
The struct field thus does not depend on the presence of it