### PR TITLE
GHA/windows: drop disk space steps

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -239,9 +239,6 @@ jobs:
             make -C bld V=1 examples
           fi
 
-      - name: 'disk space used'
-        run: du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
-
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
     needs:
@@ -500,9 +497,6 @@ jobs:
             make -C bld V=1 examples
           fi
 
-      - name: 'disk space used'
-        run: du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
-
   mingw-w64-standalone-downloads:
     name: 'dl-mingw, CM ${{ matrix.ver }}-${{ matrix.env }} ${{ matrix.name }}'
     needs:
@@ -700,9 +694,6 @@ jobs:
           PATH="/d/my-cache/${MATRIX_DIR}/bin:$PATH"
           cmake --build bld --target curl-examples-build
 
-      - name: 'disk space used'
-        run: du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
-
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
@@ -798,9 +789,6 @@ jobs:
           else
             make -C bld examples
           fi
-
-      - name: 'disk space used'
-        run: du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
@@ -1101,6 +1089,3 @@ jobs:
         timeout-minutes: 5
         if: ${{ contains(matrix.name, '+examples') }}
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target curl-examples-build
-
-      - name: 'disk space used'
-        run: du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld


### PR DESCRIPTION
For no apparent reason, this step sometimes fail with an unexplained
error and makes the job red.

Follow-up to be71475b1313ff017acc1efab16e0fea84cd32f5 #18150

---

- [ ] perhaps also from `appveyor.yml`, though it's stable there.

Also seen sometimes in example step.

```
[disk space used]
0s
Run du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
Error: Process completed with exit code -1073741502.
```
0xC0000142
Ref: https://github.com/curl/curl/actions/runs/17921296805/job/50956829448?pr=18688#step:18:12
Ref: https://github.com/curl/curl/actions/runs/17931997451/job/50990965040#step:18:1
Ref: https://github.com/curl/curl/actions/runs/18050216093/job/51370480812?pr=18752

It seems to be happening after running tests, where the build examples step is skipped.
Also unrelated to the `Win32-Process*` Perl modules:
https://github.com/curl/curl/pull/19083#issuecomment-3440185679