### PR TITLE
CURLOPT_MAXLIFETIME_CONN: make default 24 hours

### DIFF
--- a/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
+++ b/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
@@ -35,16 +35,18 @@ connection to have to be considered for reuse for this request.
 
 libcurl features a connection cache that holds previously used connections.
 When a new request is to be done, libcurl considers any connection that
-matches for reuse. The CURLOPT_MAXLIFETIME_CONN(3) limit prevents
-libcurl from trying too old connections for reuse. This can be used for
-client-side load balancing. If a connection is found in the cache that is
-older than this set *maxlifetime*, it is instead marked for closure.
+matches for reuse. The CURLOPT_MAXLIFETIME_CONN(3) limit prevents libcurl from
+trying too old connections for reuse. This can be used for client-side load
+balancing. If a connection is found in the cache that is older than this set
+*maxlifetime*, it is instead marked for closure.
 
-If set to 0, this behavior is disabled: all connections are eligible for reuse.
+If set to 0, this behavior is disabled: all connections are eligible for
+reuse.
 
 # DEFAULT
 
-0 seconds (i.e., disabled)
+24 hours (since 8.17.0). Before that, the default was 0 seconds (i.e.,
+disabled)
 
 # %PROTOCOLS%
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -488,7 +488,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
   set->upkeep_interval_ms = CURL_UPKEEP_INTERVAL_DEFAULT;
   set->maxconnects = DEFAULT_CONNCACHE_SIZE; /* for easy handles */
   set->conn_max_idle_ms = 118 * 1000;
-  set->conn_max_age_ms = 0;
+  set->conn_max_age_ms = 24 * 3600 * 1000;
   set->http09_allowed = FALSE;
   set->httpwant = CURL_HTTP_VERSION_NONE
     ;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1390,9 +1390,9 @@ struct UserDefined {
   void *progress_client; /* pointer to pass to the progress callback */
   void *ioctl_client;   /* pointer to pass to the ioctl callback */
   timediff_t conn_max_idle_ms; /* max idle time to allow a connection that
-                           is to be reused */
+                                  is to be reused */
   timediff_t conn_max_age_ms; /* max time since creation to allow a
-                            connection that is to be reused */
+                                 connection that is to be reused */
   curl_off_t filesize;  /* size of file to upload, -1 means unknown */
   long low_speed_limit; /* bytes/second */
   long low_speed_time;  /* number of seconds */


### PR DESCRIPTION
Set a default value to only reuse existing connections if less than 24 hours old. This makes the TLS certificate check get redone for the new connection. An application can still set it to zero.