### PR TITLE
docs/libcurl: remove ancient version references

### DIFF
--- a/docs/libcurl/curl_easy_getinfo.md
+++ b/docs/libcurl/curl_easy_getinfo.md
@@ -45,7 +45,7 @@ The session's active socket. See CURLINFO_ACTIVESOCKET(3)
 ## CURLINFO_APPCONNECT_TIME
 
 The time it took from the start until the SSL connect/handshake with the
-remote host was completed as a double in number of seconds. (Added in 7.19.0)
+remote host was completed as a double in number of seconds.
 
 ## CURLINFO_APPCONNECT_TIME_T
 
@@ -222,7 +222,7 @@ User's private data pointer. See CURLINFO_PRIVATE(3)
 
 ## CURLINFO_PROTOCOL
 
-(**Deprecated**) The protocol used for the connection. (Added in 7.52.0) See
+(**Deprecated**) The protocol used for the connection. See
 CURLINFO_PROTOCOL(3)
 
 ## CURLINFO_PROXYAUTH_AVAIL
@@ -303,7 +303,7 @@ RTSP session ID. See CURLINFO_RTSP_SESSION_ID(3)
 
 ## CURLINFO_SCHEME
 
-The scheme used for the connection. (Added in 7.52.0) See CURLINFO_SCHEME(3)
+The scheme used for the connection. See CURLINFO_SCHEME(3)
 
 ## CURLINFO_SIZE_DOWNLOAD
 

--- a/docs/libcurl/curl_formadd.md
+++ b/docs/libcurl/curl_formadd.md
@@ -101,8 +101,6 @@ If you pass a 0 (zero) for this option, libcurl calls strlen() on the contents
 to figure out the size. If you really want to send a zero byte content then
 you must make sure strlen() on the data pointer returns zero.
 
-(Option added in 7.46.0)
-
 ## CURLFORM_CONTENTSLENGTH
 
 (This option is deprecated. Use *CURLFORM_CONTENTLEN* instead.)
@@ -171,13 +169,12 @@ long which gives the length of the buffer.
 
 ## CURLFORM_STREAM
 
-Tells libcurl to use the CURLOPT_READFUNCTION(3) callback to get
-data. The parameter you pass to *CURLFORM_STREAM* is the pointer passed on
-to the read callback's fourth argument. If you want the part to look like a
-file upload one, set the *CURLFORM_FILENAME* parameter as well. Note that
-when using *CURLFORM_STREAM*, *CURLFORM_CONTENTSLENGTH* must also be
-set with the total expected length of the part unless the formpost is sent
-chunked encoded. (Option added in libcurl 7.18.2)
+Tells libcurl to use the CURLOPT_READFUNCTION(3) callback to get data. The
+parameter you pass to *CURLFORM_STREAM* is the pointer passed on to the read
+callback's fourth argument. If you want the part to look like a file upload
+one, set the *CURLFORM_FILENAME* parameter as well. Note that when using
+*CURLFORM_STREAM*, *CURLFORM_CONTENTSLENGTH* must also be set with the total
+expected length of the part unless the formpost is sent chunked encoded.
 
 ## CURLFORM_ARRAY
 

--- a/docs/libcurl/curl_global_init.md
+++ b/docs/libcurl/curl_global_init.md
@@ -108,7 +108,7 @@ This bit has no point since 7.69.0 but its behavior is instead the default.
 
 Before 7.69.0: when this flag is set, curl acknowledges EINTR condition when
 connecting or when waiting for data. Otherwise, curl waits until full timeout
-elapses. (Added in 7.30.0)
+elapses.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/curl_version_info.md
+++ b/docs/libcurl/curl_version_info.md
@@ -165,13 +165,13 @@ HTTP Alt-Svc parsing and the associated options (Added in 7.64.1)
 
 libcurl was built with support for asynchronous name lookups, which allows
 more exact timeouts (even on Windows) and less blocking when using the multi
-interface. (added in 7.10.7)
+interface.
 
 ## `brotli`
 
 *features* mask bit: CURL_VERSION_BROTLI
 
-supports HTTP Brotli content encoding using libbrotlidec (Added in 7.57.0)
+supports HTTP Brotli content encoding using libbrotlidec
 
 ## `asyn-rr`
 
@@ -185,7 +185,7 @@ resolves, but uses the threaded resolver for "normal" resolves (Added in
 
 *features* mask bit: CURL_VERSION_DEBUG
 
-libcurl was built with debug capabilities (added in 7.10.6)
+libcurl was built with debug capabilities
 
 ## `ECH`
 
@@ -207,7 +207,6 @@ authentication methods. (added in 7.76.0)
 libcurl was built with support for GSS-API. This makes libcurl use provided
 functions for Kerberos and SPNEGO authentication. It also allows libcurl
 to use the current user credentials without the app having to pass them on.
-(Added in 7.38.0)
 
 ## `HSTS`
 
@@ -221,7 +220,6 @@ libcurl was built with support for HSTS (HTTP Strict Transport Security)
 *features* mask bit: CURL_VERSION_HTTP2
 
 libcurl was built with support for HTTP2.
-(Added in 7.33.0)
 
 ## `HTTP3`
 
@@ -234,7 +232,6 @@ HTTP/3 and QUIC support are built-in (Added in 7.66.0)
 *features* mask bit: CURL_VERSION_HTTPS_PROXY
 
 libcurl was built with support for HTTPS-proxy.
-(Added in 7.52.0)
 
 ## `HTTPSRR`
 
@@ -248,7 +245,7 @@ in 8.12.0)
 *features* mask bit: CURL_VERSION_IDN
 
 libcurl was built with support for IDNA, domain names with international
-letters. (Added in 7.12.0)
+letters.
 
 ## `IPv6`
 
@@ -261,19 +258,19 @@ supports IPv6
 *features* mask bit: CURL_VERSION_KERBEROS5
 
 supports Kerberos V5 authentication for FTP, IMAP, LDAP, POP3, SMTP and
-SOCKSv5 proxy. (Added in 7.40.0)
+SOCKSv5 proxy.
 
 ## `Largefile`
 
 *features* mask bit: CURL_VERSION_LARGEFILE
 
-libcurl was built with support for large files. (Added in 7.11.1)
+libcurl was built with support for large files.
 
 ## `libz`
 
 *features* mask bit: CURL_VERSION_LIBZ
 
-supports HTTP deflate using libz (Added in 7.10)
+supports HTTP deflate using libz
 
 ## `MultiSSL`
 
@@ -281,20 +278,19 @@ supports HTTP deflate using libz (Added in 7.10)
 
 libcurl was built with multiple SSL backends. For details, see
 curl_global_sslset(3).
-(Added in 7.56.0)
 
 ## `NTLM`
 
 *features* mask bit: CURL_VERSION_NTLM
 
-supports HTTP NTLM (added in 7.10.6)
+supports HTTP NTLM
 
 ## `NTLM_WB`
 
 *features* mask bit: CURL_VERSION_NTLM_WB
 
-libcurl was built with support for NTLM delegation to a winbind helper.
-(Added in 7.22.0) This feature was removed from curl in 8.8.0.
+libcurl was built with support for NTLM delegation to a winbind helper. This
+feature was removed from curl in 8.8.0.
 
 ## `PSL`
 
@@ -302,20 +298,19 @@ libcurl was built with support for NTLM delegation to a winbind helper.
 
 libcurl was built with support for Mozilla's Public Suffix List. This makes
 libcurl ignore cookies with a domain that is on the list.
-(Added in 7.47.0)
 
 ## `SPNEGO`
 
 *features* mask bit: CURL_VERSION_SPNEGO
 
 libcurl was built with support for SPNEGO authentication (Simple and Protected
-GSS-API Negotiation Mechanism, defined in RFC 2478.) (added in 7.10.8)
+GSS-API Negotiation Mechanism, defined in RFC 2478.)
 
 ## `SSL`
 
 *features* mask bit: CURL_VERSION_SSL
 
-supports SSL (HTTPS/FTPS) (Added in 7.10)
+supports SSL (HTTPS/FTPS)
 
 ## `SSLS-EXPORT`
 
@@ -331,7 +326,7 @@ libcurl was built with SSL session import/export support
 libcurl was built with support for SSPI. This is only available on Windows and
 makes libcurl use Windows-provided functions for Kerberos, NTLM, SPNEGO and
 Digest authentication. It also allows libcurl to use the current user
-credentials without the app having to pass them on. (Added in 7.13.2)
+credentials without the app having to pass them on.
 
 ## `threadsafe`
 
@@ -345,14 +340,14 @@ curl initialization. (Added in 7.84.0) See libcurl-thread(3)
 *features* mask bit: CURL_VERSION_TLSAUTH_SRP
 
 libcurl was built with support for TLS-SRP (in one or more of the built-in TLS
-backends). (Added in 7.21.4)
+backends).
 
 ## `TrackMemory`
 
 *features* mask bit: CURL_VERSION_CURLDEBUG
 
 libcurl was built with memory tracking debug capabilities. This is mainly of
-interest for libcurl hackers. (added in 7.19.6)
+interest for libcurl hackers.
 
 ## `Unicode`
 
@@ -366,7 +361,6 @@ characters work in filenames and options passed to libcurl. (Added in 7.72.0)
 *features* mask bit: CURL_VERSION_UNIX_SOCKETS
 
 libcurl was built with support for Unix domain sockets.
-(Added in 7.40.0)
 
 ## `zstd`
 
@@ -379,13 +373,13 @@ supports HTTP zstd content encoding using zstd library (Added in 7.72.0)
 *features* mask bit: CURL_VERSION_CONV
 
 libcurl was built with support for character conversions provided by
-callbacks. Always 0 since 7.82.0. (Added in 7.15.4, deprecated.)
+callbacks. Always 0 since 7.82.0. Deprecated.
 
 ## no name
 
 *features* mask bit: CURL_VERSION_GSSNEGOTIATE
 
-supports HTTP GSS-Negotiate (added in 7.10.6, deprecated in 7.38.0)
+supports HTTP GSS-Negotiate. Deprecated.
 
 ## no name
 

--- a/docs/libcurl/libcurl-errors.md
+++ b/docs/libcurl/libcurl-errors.md
@@ -349,7 +349,7 @@ Initiating the SSL Engine failed.
 
 ## CURLE_LOGIN_DENIED (67)
 
-The remote server denied curl to login (Added in 7.13.1)
+The remote server denied curl to login
 
 ## CURLE_TFTP_NOTFOUND (68)
 
@@ -403,22 +403,20 @@ Failed to shut down the SSL connection.
 
 Socket is not ready for send/recv. Wait until it is ready and try again. This
 return code is only returned from curl_easy_recv(3) and curl_easy_send(3)
-(Added in 7.18.2)
 
 ## CURLE_SSL_CRL_BADFILE (82)
 
-Failed to load CRL file (Added in 7.19.0)
+Failed to load CRL file
 
 ## CURLE_SSL_ISSUER_ERROR (83)
 
-Issuer check failed (Added in 7.19.0)
+Issuer check failed
 
 ## CURLE_FTP_PRET_FAILED (84)
 
 The FTP server does not understand the PRET command at all or does not support
 the given argument. Be careful when using CURLOPT_CUSTOMREQUEST(3), a
-custom LIST command is sent with the PRET command before PASV as well. (Added
-in 7.20.0)
+custom LIST command is sent with the PRET command before PASV as well.
 
 ## CURLE_RTSP_CSEQ_ERROR (85)
 
@@ -439,7 +437,7 @@ Chunk callback reported error.
 ## CURLE_NO_CONNECTION_AVAILABLE (89)
 
 (For internal use only, is never returned by libcurl) No connection available,
-the session is queued. (added in 7.30.0)
+the session is queued.
 
 ## CURLE_SSL_PINNEDPUBKEYNOTMATCH (90)
 
@@ -509,7 +507,6 @@ used.
 
 An alias for *CURLM_CALL_MULTI_PERFORM*. Never returned by modern libcurl
 versions.
-(Added in 7.15.5)
 
 ## CURLM_OK (0)
 
@@ -536,17 +533,15 @@ This can only be returned if libcurl bugs. Please report it to us.
 ## CURLM_BAD_SOCKET (5)
 
 The passed-in socket is not a valid one that libcurl already knows about.
-(Added in 7.15.4)
 
 ## CURLM_UNKNOWN_OPTION (6)
 
 curl_multi_setopt() with unsupported option
-(Added in 7.15.4)
 
 ## CURLM_ADDED_ALREADY (7)
 
 An easy handle already added to a multi handle was attempted to get added a
-second time. (Added in 7.32.1)
+second time.
 
 ## CURLM_RECURSIVE_API_CALL (8)
 
@@ -592,12 +587,11 @@ An invalid share object was passed to the function.
 ## CURLSHE_NOMEM (4)
 
 Not enough memory was available.
-(Added in 7.12.0)
 
 ## CURLSHE_NOT_BUILT_IN (5)
 
 The requested sharing could not be done because the library you use do not have
-that particular feature enabled. (Added in 7.23.0)
+that particular feature enabled.
 
 # CURLUcode
 

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
@@ -29,8 +29,8 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD,
 # DESCRIPTION
 
 Pass a pointer to a double to receive the content-length of the download. This
-is the value read from the Content-Length: field. Since 7.19.4, this returns
--1 if the size is not known.
+is the value read from the Content-Length: field. This returns -1 if the size
+is not known.
 
 CURLINFO_CONTENT_LENGTH_DOWNLOAD_T(3) is a newer replacement that returns a more
 sensible variable type.

--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
@@ -31,14 +31,11 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_TLS_SESSION,
 
 # DESCRIPTION
 
-**This option has been superseded** by CURLINFO_TLS_SSL_PTR(3) which
-was added in 7.48.0. The only reason you would use this option instead is if
-you could be using a version of libcurl earlier than 7.48.0.
+**This option has been superseded** by CURLINFO_TLS_SSL_PTR(3).
 
-This option is exactly the same as CURLINFO_TLS_SSL_PTR(3) except in the
-case of OpenSSL and wolfSSL. If the session *backend* is
-CURLSSLBACKEND_OPENSSL the session *internals* pointer varies depending
-on the option:
+This option is exactly the same as CURLINFO_TLS_SSL_PTR(3) except in the case
+of OpenSSL and wolfSSL. If the session *backend* is CURLSSLBACKEND_OPENSSL the
+session *internals* pointer varies depending on the option:
 
 ## OpenSSL:
 

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -51,27 +51,27 @@ Enforce HTTP 1.1 requests.
 ## CURL_HTTP_VERSION_2_0
 
 Attempt HTTP 2 requests. libcurl falls back to HTTP 1.1 if HTTP 2 cannot be
-negotiated with the server. (Added in 7.33.0)
+negotiated with the server.
 
 When libcurl uses HTTP/2 over HTTPS, it does not itself insist on TLS 1.2 or
 higher even though that is required by the specification. A user can add this
 version requirement with CURLOPT_SSLVERSION(3).
 
-The alias *CURL_HTTP_VERSION_2* was added in 7.43.0 to better reflect the
-actual protocol name.
+The alias *CURL_HTTP_VERSION_2* was added to better reflect the actual
+protocol name.
 
 ## CURL_HTTP_VERSION_2TLS
 
 Attempt HTTP 2 over TLS (HTTPS) only. libcurl falls back to HTTP 1.1 if HTTP 2
 cannot be negotiated with the HTTPS server. For clear text HTTP servers,
-libcurl uses 1.1. (Added in 7.47.0)
+libcurl uses 1.1.
 
 ## CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE
 
 Issue non-TLS HTTP requests using HTTP/2 without HTTP/1.1 Upgrade. It requires
 prior knowledge that the server supports HTTP/2 straight away. HTTPS requests
 still do HTTP/2 the standard way with negotiated protocol version in the TLS
-handshake. (Added in 7.49.0)
+handshake.
 
 Since 8.10.0 if this option is set for an HTTPS request then the application
 layer protocol version (ALPN) offered to the server is only HTTP/2. Prior to

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
@@ -43,8 +43,8 @@ not considered as failure.
 
 A specific error code (CURLE_SSL_ISSUER_ERROR) is defined with the option,
 which is returned if the setup of the SSL/TLS session has failed due to a
-mismatch with the issuer of peer certificate (CURLOPT_SSL_VERIFYPEER(3)
-has to be set too for the check to fail). (Added in 7.19.0)
+mismatch with the issuer of peer certificate (CURLOPT_SSL_VERIFYPEER(3) has to
+be set too for the check to fail).
 
 Using this option multiple times makes the last set string override the
 previous ones. Set it to NULL to disable its use again.

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.md
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.md
@@ -56,7 +56,6 @@ static curl_socket_t opensocket(void *clientp,
 static int sockopt_callback(void *clientp, curl_socket_t curlfd,
                             curlsocktype purpose)
 {
-  /* This return code was added in libcurl 7.21.5 */
   return CURL_SOCKOPT_ALREADY_CONNECTED;
 }
 

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.md
@@ -104,7 +104,6 @@ static curl_socket_t opensocket(void *clientp,
 static int sockopt_callback(void *clientp, curl_socket_t curlfd,
                             curlsocktype purpose)
 {
-  /* This return code was added in libcurl 7.21.5 */
   return CURL_SOCKOPT_ALREADY_CONNECTED;
 }
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -72,33 +72,22 @@ supported for wolfSSL.
 
 The flag defines the maximum supported TLS version as TLSv1.2, or the default
 value from the SSL library.
-(Added in 7.54.0)
 
 ## CURL_SSLVERSION_MAX_TLSv1_0
 
 The flag defines maximum supported TLS version as TLSv1.0.
-(Added in 7.54.0)
 
 ## CURL_SSLVERSION_MAX_TLSv1_1
 
 The flag defines maximum supported TLS version as TLSv1.1.
-(Added in 7.54.0)
 
 ## CURL_SSLVERSION_MAX_TLSv1_2
 
 The flag defines maximum supported TLS version as TLSv1.2.
-(Added in 7.54.0)
 
 ## CURL_SSLVERSION_MAX_TLSv1_3
 
 The flag defines maximum supported TLS version as TLSv1.3.
-(Added in 7.54.0)
-
-##
-
-In versions of curl prior to 7.54 the CURL_SSLVERSION_TLS options were
-documented to allow *only* the specified TLS version, but behavior was
-inconsistent depending on the TLS library.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -49,8 +49,7 @@ Transport and OpenSSL.
 Tells libcurl to disable certificate revocation checks for those SSL backends
 where such behavior is present. This option is only supported for Schannel
 (the native Windows SSL library), with an exception in the case of Windows'
-Untrusted Publishers block list which it seems cannot be bypassed. (Added in
-7.44.0)
+Untrusted Publishers block list which it seems cannot be bypassed.
 
 ## CURLSSLOPT_NO_PARTIALCHAIN
 

--- a/docs/libcurl/opts/CURLOPT_QUOTE.md
+++ b/docs/libcurl/opts/CURLOPT_QUOTE.md
@@ -120,7 +120,7 @@ operand, provided it is empty.
 ## statvfs file
 
 The statvfs command returns statistics on the file system in which specified
-file resides. (Added in 7.49.0)
+file resides.
 
 ## symlink source_file target_file
 

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
@@ -96,7 +96,6 @@ static curl_socket_t opensocket(void *clientp,
 static int sockopt_callback(void *clientp, curl_socket_t curlfd,
                             curlsocktype purpose)
 {
-  /* This return code was added in libcurl 7.21.5 */
   return CURL_SOCKOPT_ALREADY_CONNECTED;
 }
 

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -58,58 +58,48 @@ SSL v3 - refused
 
 ## CURL_SSLVERSION_TLSv1_0
 
-TLS v1.0 or later (Added in 7.34.0)
+TLS v1.0 or later
 
 ## CURL_SSLVERSION_TLSv1_1
 
-TLS v1.1 or later (Added in 7.34.0)
+TLS v1.1 or later
 
 ## CURL_SSLVERSION_TLSv1_2
 
-TLS v1.2 or later (Added in 7.34.0)
+TLS v1.2 or later
 
 ## CURL_SSLVERSION_TLSv1_3
 
-TLS v1.3 or later (Added in 7.52.0)
+TLS v1.3 or later
 
 ##
 
-The maximum TLS version can be set by using *one* of the
-CURL_SSLVERSION_MAX_ macros below. It is also possible to OR *one* of the
-CURL_SSLVERSION_ macros with *one* of the CURL_SSLVERSION_MAX_ macros.
+The maximum TLS version can be set by using *one* of the CURL_SSLVERSION_MAX_
+macros below. It is also possible to OR *one* of the CURL_SSLVERSION_ macros
+with *one* of the CURL_SSLVERSION_MAX_ macros.
 
 ## CURL_SSLVERSION_MAX_DEFAULT
 
 The flag defines the maximum supported TLS version by libcurl, or the default
 value from the SSL library is used. libcurl uses a sensible default maximum,
 which was TLS v1.2 up to before 7.61.0 and is TLS v1.3 since then - assuming
-the TLS library support it. (Added in 7.54.0)
+the TLS library support it.
 
 ## CURL_SSLVERSION_MAX_TLSv1_0
 
 The flag defines maximum supported TLS version as TLS v1.0.
-(Added in 7.54.0)
 
 ## CURL_SSLVERSION_MAX_TLSv1_1
 
 The flag defines maximum supported TLS version as TLS v1.1.
-(Added in 7.54.0)
 
 ## CURL_SSLVERSION_MAX_TLSv1_2
 
 The flag defines maximum supported TLS version as TLS v1.2.
-(Added in 7.54.0)
 
 ## CURL_SSLVERSION_MAX_TLSv1_3
 
 The flag defines maximum supported TLS version as TLS v1.3.
-(Added in 7.54.0)
-
-##
-
-In versions of curl prior to 7.54 the CURL_SSLVERSION_TLS options were
-documented to allow *only* the specified TLS version, but behavior was
-inconsistent depending on the TLS library.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -47,8 +47,7 @@ Transport and OpenSSL.
 Tells libcurl to disable certificate revocation checks for those SSL backends
 where such behavior is present. This option is only supported for Schannel
 (the native Windows SSL library), with an exception in the case of Windows'
-Untrusted Publishers block list which it seems cannot be bypassed. (Added in
-7.44.0)
+Untrusted Publishers block list which it seems cannot be bypassed.
 
 ## CURLSSLOPT_NO_PARTIALCHAIN
 

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
@@ -28,7 +28,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_TCP_KEEPINTVL, long interval);
 # DESCRIPTION
 
 Pass a long. Sets the interval, in seconds, to wait between sending keepalive
-probes. Not all operating systems support this option. (Added in 7.25.0)
+probes. Not all operating systems support this option.
 
 The maximum value this accepts is 2147483648. Any larger value is capped to
 this amount.

--- a/docs/libcurl/opts/CURLSHOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLSHOPT_SHARE.md
@@ -54,10 +54,9 @@ the same multi handle share the DNS cache by default without using this option.
 
 ## CURL_LOCK_DATA_SSL_SESSION
 
-SSL sessions are shared across the easy handles using this shared
-object. This reduces the time spent in the SSL handshake when reconnecting to
-the same server. This symbol was added in 7.10.3 but was not implemented until
-7.23.0.
+SSL sessions are shared across the easy handles using this shared object. This
+reduces the time spent in the SSL handshake when reconnecting to the same
+server.
 
 Note that when you use the multi interface, all easy handles added to the same
 multi handle share the SSL session cache by default without using this option.
@@ -73,9 +72,6 @@ Connections that are used for HTTP/2 or HTTP/3 multiplexing only get
 additional transfers added to them if the existing connection is held by the
 same multi or easy handle. libcurl does not support doing multiplexed streams
 in different threads using a shared connection.
-
-Support for **CURL_LOCK_DATA_CONNECT** was added in 7.57.0, but the symbol
-existed before this.
 
 Note that when you use the multi interface, all easy handles added to the same
 multi handle share the connection cache by default without using this option.


### PR DESCRIPTION
To make the texts easier on the eye.

- Remove most free text references to curl versions before 7.60.0 (May 2018)
- Leave those present in a HISTORY section

Most of them are already documented in symbols-in-versions anyway.