### PR TITLE
GHA: document permissions as required by zizmor 1.13.0

### DIFF
--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.sender.login == 'appveyor[bot]' }}
     permissions:
-      statuses: write
+      statuses: write  # To update build statuses
     steps:
       - name: 'Create individual AppVeyor build statuses'
         if: ${{ github.event.sha && github.event.target_url }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
     name: 'GHA and Python'
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      security-events: write  # To create/update security events
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -64,7 +64,7 @@ jobs:
     name: 'C'
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      security-events: write  # To create/update security events
     steps:
       - name: 'install prereqs'
         timeout-minutes: 5

--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -23,9 +23,8 @@ jobs:
     name: 'Add hacktoberfest-accepted label'
     runs-on: ubuntu-latest
     permissions:
-      # requires issues AND pull-requests write permissions to edit labels on PRs!
-      issues: write
-      pull-requests: write
+      issues: write          # To edit labels on PRs
+      pull-requests: write   # To edit labels on PRs
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -19,8 +19,8 @@ jobs:
     name: 'Labeler'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read        # To comply with https://github.com/actions/labeler documentation
+      pull-requests: write  # To edit labels on PRs
 
     steps:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6


### PR DESCRIPTION
Ref: https://github.com/zizmorcore/zizmor/pull/1131
Ref: https://docs.zizmor.sh/audits/#undocumented-permissions

Bug: https://github.com/curl/curl/pull/18539#issuecomment-3288151910