### PR TITLE
appveyor: bump to OpenSSL 3.5, adjust to dropped 1.1.1 on VS2019

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -35,6 +35,8 @@ esac
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
   openssl_root_win="C:/OpenSSL-v35${openssl_suffix}"
+elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
+  openssl_root_win="C:/OpenSSL-v30${openssl_suffix}"
 else
   openssl_root_win="C:/OpenSSL-v111${openssl_suffix}"
 fi

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -34,7 +34,7 @@ case "${TARGET:-}" in
 esac
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
-  openssl_root_win="C:/OpenSSL-v34${openssl_suffix}"
+  openssl_root_win="C:/OpenSSL-v35${openssl_suffix}"
 else
   openssl_root_win="C:/OpenSSL-v111${openssl_suffix}"
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ environment:
 
     # generated CMake-based Visual Studio builds
 
-    - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3.4, Shared, Build-tests'
+    - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3.5, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       PRJ_GEN: 'Visual Studio 17 2022'
       TARGET: '-A x64'
@@ -109,7 +109,7 @@ environment:
       OPENSSL: 'ON'
       SCHANNEL: 'ON'
       SHARED: 'ON'
-    - job_name: 'CMake, VS2022, Debug, x64, OpenSSL 3.4 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'
+    - job_name: 'CMake, VS2022, Debug, x64, OpenSSL 3.5 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       PRJ_GEN: 'Visual Studio 17 2022'
       TARGET: '-A x64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ environment:
       OPENSSL: 'ON'
       SHARED: 'ON'
       TFLAGS: 'skipall'
-    - job_name: 'CMake, VS2019, Debug, x64, OpenSSL 1.1.1 + Schannel, Shared, Build-tests'
+    - job_name: 'CMake, VS2019, Debug, x64, OpenSSL 3.0 + Schannel, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2019'
       PRJ_GEN: 'Visual Studio 16 2019'
       TARGET: '-A x64'


### PR DESCRIPTION
- bump OpenSSL 3.4 to 3.5 on VS2022 runners.

- bump OpenSSL 1.1.1 to 3.0 on VS2019 runners.
  1.1.1 is documented to be present, but missing.
  Fixes:
  ```
  + cmake -G 'Visual Studio 16 2019' -A x64 [...] -DOPENSSL_ROOT_DIR=C:/OpenSSL-v111-Win64 [...]
  CMake Error at C:/Program Files/CMake/share/cmake-4.1/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
    Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
    system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
    OPENSSL_INCLUDE_DIR)
  Call Stack (most recent call first):
    CMakeLists.txt:757 (find_package)
  ```
  Ref: https://ci.appveyor.com/project/curlorg/curl/builds/52740431/job/tq6h4xhqpa3vgq47?fullLog=true
  Ref: https://www.appveyor.com/docs/windows-images-software/
  Ref: https://github.com/appveyor/website/commit/9a739f7bce4a624b28ff382d58a9ebc507ab0f78
