### PR TITLE
GHA/distcheck: disable `man-db/auto-update`

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -33,7 +33,9 @@ jobs:
           persist-credentials: false
 
       - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
+        run: |
+          sudo rm -f /var/lib/man-db/auto-update
+          sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'autoreconf'
         run: autoreconf -fi

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -233,7 +233,9 @@ jobs:
           persist-credentials: false
 
       - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
+        run: |
+          sudo rm -f /var/lib/man-db/auto-update
+          sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'generate release tarballs'
         run: ./scripts/dmaketgz 9.10.11


### PR DESCRIPTION
Make sure to not rebuild man pages after purging system curl, to make
the job faster and avoid timeouts:
```
Sun, 14 Sep 2025 10:16:28 GMT Removing curl (8.5.0-2ubuntu10.6) ...
Sun, 14 Sep 2025 10:16:28 GMT Processing triggers for man-db (2.12.0-4build2) ...
Sun, 14 Sep 2025 10:21:22 GMT (Reading database ... 218629 files and directories currently installed.)
```
Ref: https://github.com/curl/curl/actions/runs/17709785947/job/50326910814?pr=18535#step:3:19