### PR TITLE
docs: drop `CI.md` from tarball

### DIFF
--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -19,6 +19,7 @@ gitonly=".git*
 ^SECURITY.md
 ^LICENSES/*
 ^docs/examples/adddocsref.pl
+^docs/tests/CI.md
 ^docs/THANKS-filter
 ^projects/Windows/*
 ^scripts/ciconfig.pl
@@ -28,8 +29,7 @@ gitonly=".git*
 ^scripts/delta
 ^scripts/installcheck.sh
 ^scripts/release-notes.pl
-^scripts/singleuse.pl
-^tests/CI.md"
+^scripts/singleuse.pl"
 
 tarfiles="$(mktemp)"
 gitfiles="$(mktemp)"

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -42,7 +42,6 @@ CLEANFILES = $(MK_CA_DOCS) $(man_MANS) $(TEST_DOCS)
 endif
 
 TESTDOCS =                                      \
- tests/CI.md                                    \
  tests/FILEFORMAT.md                            \
  tests/HTTP.md                                  \
  tests/TEST-SUITE.md


### PR DESCRIPTION
Follow-up to fa3f889752e6b5034966de61a372a60773a69ca8 #17463