### PR TITLE
GHA/codeql: tidy up config names

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  codeql:
+  gha_python:
     name: 'GHA and Python'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,23 +61,19 @@ jobs:
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3
 
   c:
-    name: 'C (${{ matrix.build.name }})'
-    runs-on: ${{ matrix.build.image }}
+    name: 'C'
+    runs-on: ${{ matrix.image }}
     permissions:
       security-events: write  # To create/update security events
     strategy:
       fail-fast: false
       matrix:
-        build:
-          - name: 'Linux'
-            image: ubuntu-latest
-          - name: 'Windows'
-            image: windows-2022
+        image: [ubuntu-latest, windows-2022]
     env:
-      MATRIX_IMAGE: '${{ matrix.build.image }}'
+      MATRIX_IMAGE: '${{ matrix.image }}'
     steps:
       - name: 'install prereqs'
-        if: ${{ contains(matrix.build.image, 'ubuntu') }}
+        if: ${{ contains(matrix.image, 'ubuntu') }}
         timeout-minutes: 5
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,18 +62,18 @@ jobs:
 
   c:
     name: 'C'
-    runs-on: ${{ matrix.image }}
+    runs-on: ${{ matrix.platform == 'Linux' && 'ubuntu-latest' || 'windows-2022' }}
     permissions:
       security-events: write  # To create/update security events
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-latest, windows-2022]
+        platform: [Linux, Windows]
     env:
-      MATRIX_IMAGE: '${{ matrix.image }}'
+      MATRIX_PLATFORM: '${{ matrix.platform }}'
     steps:
       - name: 'install prereqs'
-        if: ${{ contains(matrix.image, 'ubuntu') }}
+        if: ${{ matrix.platform == 'Linux' }}
         timeout-minutes: 5
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
@@ -95,7 +95,7 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          if [[ "${MATRIX_IMAGE}" = *'windows'* ]]; then
+          if [ "${MATRIX_PLATFORM}" = 'Windows' ]; then
             cmake -B . -DBUILD_SHARED_LIBS=OFF \
               -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
               -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBPSL=OFF -DUSE_WIN32_IDN=ON


### PR DESCRIPTION
Before this patch there was a single C config detected, named `build:`.

---

What's picked up is only seen after merging to master. Maybe there is
way to set the config names manually, but I couldn't find it.

https://github.com/github/codeql-action/blob/main/init/action.yml