### PR TITLE
GHA/codeql: enable more build options, build servers and tunits

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,7 +81,7 @@ jobs:
           sudo rm -f /var/lib/man-db/auto-update
           sudo apt-get -o Dpkg::Use-Pty=0 install libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev \
             libnghttp2-dev libldap-dev heimdal-dev librtmp-dev libgnutls28-dev libwolfssl-dev
-          /home/linuxbrew/.linuxbrew/bin/brew install gsasl mbedtls libnghttp3 libngtcp2 rustls-ffi
+          /home/linuxbrew/.linuxbrew/bin/brew install gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:


### PR DESCRIPTION
- add HTTP/3 build with OpenSSL 3.5, nghttp3 and ngtcp2.
- enable GSASL, Heimdal, rtmp, SSLS-export.
- make one build MultiSSL with GnuTLS, mbedTLS, Rustls, wolfSSL.
- build servers (also on Windows), and tunits.
- use Linuxbrew to install build dependencies missing from Ubuntu.

Coverage is now 466 C files. (was: 446)

---

It's a first in curl CI that Linuxbrew packages are used in builds.
It allows building with packages missing from Ubuntu 24.04:
gsasl (upcoming in 24.10), mbedtls 3, also latest wolfSSL (though
not compatible with coexist), openssl, nghttp3, ngtcp2 (openssl), and
rustls-ffi.

clang 18 is slower (but able to build units) 1m44s: https://github.com/curl/curl/actions/runs/17744622476/job/50426706985?pr=18557
gcc 1m14s: https://github.com/curl/curl/actions/runs/17745349876/job/50429178627?pr=18557

- [x] add coverage for H3.
