### PR TITLE
cmake: fix building docs when the base directory contains `.3`

### DIFF
--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -53,7 +53,7 @@ function(curl_add_manual_pages _listname)
 
     list(APPEND _rofffiles "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
     string(REPLACE ".3" ".md" _mdfile "${_file}")
-    if(_mdfile STREQUAL "libcurl-symbols.md")  # Special case for auto-generated file
+    if(_file STREQUAL "libcurl-symbols.3")  # Special case for auto-generated file
       set(_mdfile "${CMAKE_CURRENT_BINARY_DIR}/${_mdfile}")
     endif()
     list(APPEND _mdfiles "${_mdfile}")

--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -52,11 +52,9 @@ function(curl_add_manual_pages _listname)
     endif()
 
     list(APPEND _rofffiles "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
-    if(_file STREQUAL "libcurl-symbols.3")
-      # Special case, an auto-generated file.
-      string(REPLACE ".3" ".md" _mdfile "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
-    else()
-      string(REPLACE ".3" ".md" _mdfile "${_file}")
+    string(REPLACE ".3" ".md" _mdfile "${_file}")
+    if(_mdfile STREQUAL "libcurl-symbols.md")  # Special case for auto-generated file
+      set(_mdfile "${CMAKE_CURRENT_BINARY_DIR}/${_mdfile}")
     endif()
     list(APPEND _mdfiles "${_mdfile}")
   endforeach()


### PR DESCRIPTION
Fixing:
```
ninja: error: '<...>/basedir.md/_bld/docs/libcurl/libcurl-symbols.md',
  needed by 'docs/libcurl/curl_easy_cleanup.3', missing and no known rule to make it
```

Reported-by: Nir Azkiel
Fixes #18560
Follow-up to 898b012a9bf388590c4be7f526815b5ab74feca1 #1288
