### PR TITLE
aws-lc: re-enable large read-ahead with v1.61.0 again

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -121,7 +121,7 @@
 static void ossl_provider_cleanup(struct Curl_easy *data);
 #endif
 
-/* AWS-LC fixed a bug with large buffers in v1.16.0 which also introduced
+/* AWS-LC fixed a bug with large buffers in v1.61.0 which also introduced
  * X509_V_ERR_EC_KEY_EXPLICIT_PARAMS. */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
   !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL) && \


### PR DESCRIPTION
AWS-LC fixed a bug with large read ahead buffers in v1.61.0. Check a define introduced in that version to enable the large read ahead again.

Fixed AWS-LC issue: https://github.com/aws/aws-lc/issues/2650