### PR TITLE
sasl: clear canceled mechanism instead of toggling it

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -812,7 +812,9 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
 
   case SASL_CANCEL:
     /* Remove the offending mechanism from the supported list */
-    sasl->authmechs ^= sasl->authused;
+    sasl->authmechs &= (unsigned short)~sasl->authused;
+    sasl->authused = SASL_AUTH_NONE;
+    sasl->curmech = NULL;
 
     /* Start an alternative SASL authentication */
     return Curl_sasl_start(sasl, data, sasl->force_ir, progress);


### PR DESCRIPTION
Use &= ~authused in SASL_CANCEL (was ^=) to actually remove the offending mechanism and avoid re-enabling a disabled mech on retry.