### PR TITLE
tftp: propagate expired timer from tftp_state_timeout()

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1184,7 +1184,7 @@ static timediff_t tftp_state_timeout(struct tftp_conn *state,
   if(timeout_ms < 0) {
     state->error = TFTP_ERR_TIMEOUT;
     state->state = TFTP_STATE_FIN;
-    return 0;
+    return timeout_ms;
   }
   current = time(NULL);
   if(current > state->rx_time + state->retry_time) {


### PR DESCRIPTION
When Curl_timeleft() < 0 we used to return 0, masking the expiry and skipping the caller’s (timeout_ms < 0) path. Now we set FIN and return the negative value so tftp_multi_statemach() aborts with CURLE_OPERATION_TIMEDOUT as intended.