### PR TITLE
tool: honor --continue-at across retries by resetting resume offset

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -522,6 +522,17 @@ static CURLcode retrycheck(struct OperationConfig *config,
         outs->bytes = 0; /* clear for next round */
       }
     }
+    /* When retrying a transfer that was started with --continue-at, make sure
+       subsequent attempts continue from the same point as the initial try.
+       If the user asked for "-" (current size), outs->init was set to the
+       file size at the time of the first attempt. We ensure libcurl's resume
+       offset reflects that initialization point for the retry. */
+    if(config->use_resume) {
+      if(config->resume_from_current)
+        config->resume_from = outs->init;
+      (void)curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE,
+                             config->resume_from);
+    }
     *retryp = TRUE;
     per->num_retries++;
     *delayms = sleeptime;


### PR DESCRIPTION
Summary
When combining --retry with --continue-at (including -), the retry attempt could ignore the intended resume point for the existing partial file.

What this changes
- Preserves the initial resume offset (outs->init) as the authoritative resume point.
- On retry, after truncation/seek, resets config->resume_from appropriately and re-applies CURLOPT_RESUME_FROM_LARGE.
- Ensures retries continue from the same offset chosen for the first attempt.

Why
User expectation is that retries do not discard the resume settings. This aligns progress/file handling with the libcurl resume offset used for the next perform().

Testing
- Reproduced by starting a large download with -C - and interrupting; with --retry set, subsequent attempts now consistently continue from the original offset.
- Local build on macOS/Linux; no linter errors.

Notes
- Change is tool-only, isolated to src/tool_operate.c.