### PR TITLE
Add "-mt" for pthread support on HP-UX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4340,11 +4340,9 @@ if test "$want_threaded_resolver" = "yes" && test "$USE_THREADS_WIN32" != "1"; t
       AC_CHECK_FUNC(pthread_create, [USE_THREADS_POSIX=1] )
       LIBS="$save_LIBS"
 
-      dnl on HP-UX, life is more complicated...
       case $host in
         *-hp-hpux*)
-          dnl it doesn't actually work without -lpthread
-          USE_THREADS_POSIX=""
+          CFLAGS="$CFLAGS -mt"
           ;;
         *)
           ;;


### PR DESCRIPTION
HP-UX requires this compiler and linker flag to pass proper macros and add required libraries.

Adding just `-lpthread` is not enough, macros are missing. `-mt` does everything according to the manpage:
```
      -mt            Sets various -D flags to enable multi-threading.  Also
                     sets -lpthread.  +Oopenmp automatically implies -mt.
                     For details see HP C/aC++ Online Programmer's Guide.
```

Output:
```
 configure: Configured to build curl/libcurl:

  Host setup:       ia64-hp-hpux11.31
  Install prefix:   /opt/ports
  Compiler:         /opt/aCC/bin/aCC -AC99
   CFLAGS:          +We901 -z +W 4227,4255 +O2 -mt
   CFLAGS extras:
   CPPFLAGS:        -I/opt/ports/include -I/opt/ports/include -I/opt/ports/include
   LDFLAGS:         -L/opt/ports/lib/hpux32 -L/opt/ports/lib
     curl-config:   -L/opt/ports/lib/hpux32 -L/opt/ports/lib
   LIBS:            -lssl -lcrypto -L/opt/ports/lib/hpux32 -Wl,+b,/opt/ports/lib/hpux32 -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err -lz

  curl version:     8.15.0
  SSL:              enabled (OpenSSL v3+)
  SSH:              no      (--with-{libssh,libssh2})
  zlib:             enabled
  brotli:           no      (--with-brotli)
  zstd:             no      (--with-zstd)
  GSS-API:          enabled (MIT Kerberos/Heimdal)
  GSASL:            no      (libgsasl not found)
  TLS-SRP:          no      (--enable-tls-srp)
  resolver:         POSIX threaded

# curl --version
curl 8.15.0 (ia64-hp-hpux11.31) libcurl/8.15.0 OpenSSL/3.0.15 zlib/1.3.1
Release-Date: 2025-07-16
Protocols: file http https smtp smtps ws wss
Features: AsynchDNS GSS-API HSTS HTTPS-proxy IPv6 Kerberos Largefile libz SPNEGO SSL threadsafe UnixSockets
```