### PR TITLE
smtp: check EHLO responses case insensitively

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -989,19 +989,19 @@ static CURLcode smtp_state_ehlo_resp(struct Curl_easy *data,
     len -= 4;
 
     /* Does the server support the STARTTLS capability? */
-    if(len >= 8 && !memcmp(line, "STARTTLS", 8))
+    if(len >= 8 && curl_strnequal(line, "STARTTLS", 8))
       smtpc->tls_supported = TRUE;
 
     /* Does the server support the SIZE capability? */
-    else if(len >= 4 && !memcmp(line, "SIZE", 4))
+    else if(len >= 4 && curl_strnequal(line, "SIZE", 4))
       smtpc->size_supported = TRUE;
 
     /* Does the server support the UTF-8 capability? */
-    else if(len >= 8 && !memcmp(line, "SMTPUTF8", 8))
+    else if(len >= 8 && curl_strnequal(line, "SMTPUTF8", 8))
       smtpc->utf8_supported = TRUE;
 
     /* Does the server support authentication? */
-    else if(len >= 5 && !memcmp(line, "AUTH ", 5)) {
+    else if(len >= 5 && curl_strnequal(line, "AUTH ", 5)) {
       smtpc->auth_supported = TRUE;
 
       /* Advance past the AUTH keyword */

--- a/tests/data/test980
+++ b/tests/data/test980
@@ -10,7 +10,7 @@ STARTTLS
 # Server-side
 <reply>
 <servercmd>
-CAPA STARTTLS
+CAPA starttls
 AUTH PLAIN
 REPLY STARTTLS 454 currently unavailable\r\n235 Authenticated\r\n250 2.1.0 Sender ok\r\n250 2.1.5 Recipient ok\r\n354 Enter mail\r\n250 2.0.0 Accepted
 REPLY AUTH 535 5.7.8 Authentication credentials invalid


### PR DESCRIPTION
Adjust test 980 to announce starttls in lowercase.

Fixes #18588
Reported-by: Joshua Rogers