### PR TITLE
tool_cb_hdr: fix fwrite check in header callback

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -116,7 +116,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
   if(per->config->headerfile && heads->stream) {
     size_t rc = fwrite(ptr, size, nmemb, heads->stream);
-    if(rc != cb)
+    if(rc != nmemb)
       return rc;
     /* flush the stream to send off what we got earlier */
     if(fflush(heads->stream)) {


### PR DESCRIPTION
Compare fwrite result to nmemb (items), not cb (bytes).

In every case at the moment, `size == 1`, so this doesn't have any real functional change.