### PR TITLE
socks_sspi: Fix some memory cleanup calls

### DIFF
--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -452,7 +452,6 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
       goto error;
     }
     Curl_safefree(etbuf);
-    etbuf_size = 0;
   }
 
   result = Curl_blockread_all(cf, data, (char *)socksreq, 4, &actualread);


### PR DESCRIPTION
- Ensure memory allocated by malloc() is freed by free().

Prior to this change SSPI's FreeContextBuffer() was sometimes used to free malloc'd memory. I can only assume the reason we have no crash reports about this is because the underlying heap free is probably the same for both.

Reported-by: Joshua Rogers

Fixes #18587
Closes #xxxx