### PR TITLE
tool: fix exponential retry delay

### DIFF
--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -52,7 +52,6 @@ struct OperationConfig *config_alloc(void)
   config->ftp_skip_ip = TRUE;
   config->file_clobber_mode = CLOBBER_DEFAULT;
   config->upload_flags = CURLULFLAG_SEEN;
-  config->retry_delay_ms = RETRY_SLEEP_DEFAULT;
   curlx_dyn_init(&config->postdata, MAX_FILE2MEMORY);
   return config;
 }

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -209,7 +209,8 @@ struct OperationConfig {
   long httpversion;
   unsigned long socks5_auth;/* auth bitmask for socks5 proxies */
   long req_retry;           /* number of retries */
-  long retry_delay_ms;      /* delay between retries (in milliseconds) */
+  long retry_delay_ms;      /* delay between retries (in milliseconds),
+                               0 means increase exponentially */
   long retry_maxtime_ms;    /* maximum time to keep retrying */
 
   unsigned long mime_options; /* Mime option flags. */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -437,7 +437,6 @@ static CURLcode retrycheck(struct OperationConfig *config,
       ": FTP error"
     };
 
-    sleeptime = per->retry_sleep;
     if(RETRY_HTTP == retry) {
       curl_easy_getinfo(curl, CURLINFO_RETRY_AFTER, &retry_after);
       if(retry_after) {
@@ -464,20 +463,25 @@ static CURLcode retrycheck(struct OperationConfig *config,
         }
       }
     }
+    if(!sleeptime && !config->retry_delay_ms) {
+      if(!per->retry_sleep)
+        per->retry_sleep = RETRY_SLEEP_DEFAULT;
+      else
+        per->retry_sleep *= 2;
+      if(per->retry_sleep > RETRY_SLEEP_MAX)
+        per->retry_sleep = RETRY_SLEEP_MAX;
+    }
+    if(!sleeptime)
+      sleeptime = per->retry_sleep;
     warnf("Problem %s. "
-          "Will retry in %ld second%s. "
+          "Will retry in %ld.%03ld second%s. "
           "%ld retr%s left.",
-          m[retry], sleeptime/1000L,
+          m[retry], sleeptime/1000L, sleeptime%1000L,
           (sleeptime/1000L == 1 ? "" : "s"),
           per->retry_remaining,
           (per->retry_remaining > 1 ? "ies" : "y"));
 
     per->retry_remaining--;
-    if(!config->retry_delay_ms) {
-      per->retry_sleep *= 2;
-      if(per->retry_sleep > RETRY_SLEEP_MAX)
-        per->retry_sleep = RETRY_SLEEP_MAX;
-    }
 
     if(outs->bytes && outs->filename && outs->stream) {
 #ifndef __MINGW32CE__


### PR DESCRIPTION
Also, show retry delay with decimals since it might be not be integer seconds.

Regression from 8.16.0

Reported-by: Andrew Olsen
Fixes #18591