### PR TITLE
tool_operate: Improve wording in retry message

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -480,7 +480,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
           (sleeptime%1000L ? "." : ""),
           (sleeptime%1000L ? 3 : 0),
           sleeptime%1000L,
-          (sleeptime/1000L == 1 ? "" : "s"),
+          (sleeptime == 1000L ? "" : "s"),
           per->retry_remaining,
           (per->retry_remaining > 1 ? "ies" : "y"));
 


### PR DESCRIPTION
- Use the plural 'seconds' for anything other than exactly 1 second.

Before: Will retry in 1.250 second.
After: Will retry in 1.250 seconds.

Follow-up to ca034e83.

Closes #xxxx