### PR TITLE
examples: fix two issues found by CodeQL

### DIFF
--- a/docs/examples/ftpuploadresume.c
+++ b/docs/examples/ftpuploadresume.c
@@ -38,7 +38,7 @@ static size_t getcontentlengthfunc(void *ptr, size_t size, size_t nmemb,
   long len = 0;
 
   r = sscanf(ptr, "Content-Length: %ld\n", &len);
-  if(r)
+  if(r == 1)
     *((long *) stream) = len;
 
   return size * nmemb;

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -45,6 +45,9 @@
 #ifdef _WIN32
 #undef stat
 #define stat _stat
+#undef fstat
+#define fstat _fstat
+#define fileno _fileno
 #endif
 
 /* curl stuff */
@@ -223,16 +226,6 @@ static int setup(struct input *i, int num, const char *upload)
 
   curl_msnprintf(url, 256, "https://localhost:8443/upload-%d", num);
 
-  /* get the file size of the local file */
-  if(stat(upload, &file_info)) {
-    fprintf(stderr, "error: could not stat file %s: %s\n", upload,
-            strerror(errno));
-    fclose(out);
-    return 1;
-  }
-
-  uploadsize = file_info.st_size;
-
   i->in = fopen(upload, "rb");
   if(!i->in) {
     fprintf(stderr, "error: could not open file %s for reading: %s\n", upload,
@@ -240,6 +233,19 @@ static int setup(struct input *i, int num, const char *upload)
     fclose(out);
     return 1;
   }
+
+#ifdef UNDER_CE
+  stat(i->in, &file_info);
+#else
+  if(fstat(fileno(i->in), &file_info)) {
+    fprintf(stderr, "error: could not stat file %s: %s\n", upload,
+            strerror(errno));
+    fclose(out);
+    return 1;
+  }
+#endif
+
+  uploadsize = file_info.st_size;
 
   hnd = i->hnd = curl_easy_init();
 

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -235,15 +235,15 @@ static int setup(struct input *i, int num, const char *upload)
   }
 
 #ifdef UNDER_CE
-  stat(i->in, &file_info);
+  if(stat(upload, &file_info) != 0) {
 #else
-  if(fstat(fileno(i->in), &file_info)) {
+  if(fstat(fileno(i->in), &file_info) != 0) {
+#endif
     fprintf(stderr, "error: could not stat file %s: %s\n", upload,
             strerror(errno));
     fclose(out);
     return 1;
   }
-#endif
 
   uploadsize = file_info.st_size;
 


### PR DESCRIPTION
- http2-upload: use `fstat()` to query file length to fix TOCTOU.

- ftpuploadresume: fix checking `sscanf()` return value.

Follow-up to b4922b1295333dc6679eb1d588ddc2fb6b7fd5b7 #18564
