### PR TITLE
libssh2: drop two redundant null-terminations

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1995,8 +1995,6 @@ static CURLcode ssh_state_sftp_realpath(struct Curl_easy *data,
     return CURLE_AGAIN;
 
   if(rc > 0) {
-    /* It seems that this string is not always null-terminated */
-    sshp->readdir_filename[rc] = '\0';
     free(sshc->homedir);
     sshc->homedir = strdup(sshp->readdir_filename);
     if(!sshc->homedir) {
@@ -2407,9 +2405,6 @@ static CURLcode ssh_state_sftp_readdir_link(struct Curl_easy *data,
 
   if(rc < 0)
     return CURLE_OUT_OF_MEMORY;
-
-  /* It seems that this string is not always null-terminated */
-  sshp->readdir_filename[rc] = '\0';
 
   /* append filename and extra output */
   result = curlx_dyn_addf(&sshp->readdir, " -> %s", sshp->readdir_filename);


### PR DESCRIPTION
The null-termination was first added in the initial SFTP commit in 2006:
a634f644005cbe2b3dea2b84328d605ec3474054

At that time this was a reasonable concern because libssh2 started
null-terminating this string just one year prior, in 2005:
https://github.com/libssh2/libssh2/commit/efc3841fd2c2c945e96492e9089e4d1810709d53

This fix was released in libssh2 v0.13 (2006-03-02).

curl requires libssh2 v1.2.8, making this workaround no longer necessary.

Follow-up to 9f18cb6544bbf47e2e2fad6564bc03098273c7bc #18598
