### PR TITLE
GHA/codeql: try disabling the TRAP cache

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           languages: cpp
           build-mode: manual
+          trap-caching: false
 
       - name: 'build'
         timeout-minutes: 10


### PR DESCRIPTION
The `cpp` CodeQL job is adding a cache entry for each run on the master
branch. One for Linux, another for Windows. Size: 68MB + 180MB = 248MB.
In one week we got 50+ such entries, almost filling the available cache
space.

Following the recommendation in an open issue thread, this patch tries
to disable this cache. Since it only affects master, the effect can only
be verified after merging.

The latest cache is picked up in PRs. The performance impact is also to
be seen after merge.

Bug: https://github.com/curl/curl/pull/18528#issuecomment-3288950880
Ref: https://github.com/github/codeql-action/pull/1172
Ref: https://github.com/github/codeql-action/issues/2030
Ref: https://github.com/github/codeql-action/issues/2885#issuecomment-2879069087

Follow-up to cc50f05370981e4933504e8aaec6b15880ff847f #18528
