### PR TITLE
base64: allow zero length argument to base64_encode

### DIFF
--- a/lib/curlx/base64.c
+++ b/lib/curlx/base64.c
@@ -182,7 +182,7 @@ static CURLcode base64_encode(const char *table64,
   *outlen = 0;
 
   if(!insize)
-    insize = strlen(inputbuff);
+    return CURLE_OK;
 
 #if SIZEOF_SIZE_T == 4
   if(insize > UINT_MAX/4)
@@ -239,8 +239,6 @@ static CURLcode base64_encode(const char *table64,
  * return a pointer in *outptr to a newly allocated memory area holding
  * encoded data. Size of encoded data is returned in variable pointed by
  * outlen.
- *
- * Input length of 0 indicates input buffer holds a null-terminated string.
  *
  * Returns CURLE_OK on success, otherwise specific error code. Function
  * output shall not be considered valid unless CURLE_OK is returned.

--- a/tests/unit/unit1302.c
+++ b/tests/unit/unit1302.c
@@ -172,7 +172,7 @@ static CURLcode test_unit1302(const char *arg)
       fprintf(stderr, "Test %u URL encoded output length %d instead of %d\n",
               i, (int)olen, (int)e->olen);
     }
-    if(memcmp(out, e->output, e->olen)) {
+    if(out && memcmp(out, e->output, e->olen)) {
       fprintf(stderr, "Test %u URL encoded badly. Got '%s', expected '%s'\n",
               i, out, e->output);
       unitfail++;


### PR DESCRIPTION
We used to treat 0 as "call strlen() to get the length" for curlx_base64_encode, but it turns out this is rather fragile as we easily do the mistake of passing in zero when the data is actually not there and then calling strlen() is wrong.

Force the caller to pass in the correct size. Encoding a zero length string now returns a zero length output and a NULL pointer.