### PR TITLE
tool_getparam/set_rate: skip the multiplication on overflow

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1012,8 +1012,9 @@ static ParameterError set_rate(const char *nextarg)
       errorf("too large --rate unit");
       err = PARAM_NUMBER_TOO_LARGE;
     }
-    /* this typecast is okay based on the check above */
-    numerator *= (long)numunits;
+    else
+      /* this typecast is okay based on the check above */
+      numerator *= (long)numunits;
   }
 
   if(err)


### PR DESCRIPTION
The code detected the problem but didn't avoid the calculation correctly.

Fixes #18624
Reported-by: BobodevMm on github