### PR TITLE
tidy-up: MS links, allow long URLs in source

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -163,11 +163,11 @@ for further information on that format.
 Schannel does not support setting individual TLS 1.2 cipher suites directly.
 It only allows the enabling and disabling of encryption algorithms. These are
 in the form of `CALG_xxx`, see the [Schannel `ALG_ID`
-documentation](https://docs.microsoft.com/windows/desktop/SecCrypto/alg-id)
+documentation](https://learn.microsoft.com/windows/win32/seccrypto/alg-id)
 for a list of these algorithms. Also, (since curl 7.77.0)
 `SCH_USE_STRONG_CRYPTO` can be given to pass that flag to Schannel, lookup the
 [documentation for the Windows version in
-use](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel)
+use](https://learn.microsoft.com/windows/win32/secauthn/cipher-suites-in-schannel)
 to see how that affects the cipher suite selection. When not specifying the
 `--ciphers` and `--tls13-ciphers` options curl passes this flag by default.
 
@@ -264,7 +264,7 @@ Restrict to only TLS 1.2 with the `CAMELLIA-128-GCM` cipher.
 - [OpenSSL cipher suite names documentation](https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names)
 - [wolfSSL cipher support documentation](https://www.wolfssl.com/documentation/manuals/wolfssl/chapter04.html#cipher-support)
 - [mbedTLS cipher suites reference](https://mbed-tls.readthedocs.io/projects/api/en/development/api/file/ssl__ciphersuites_8h/)
-- [Schannel cipher suites documentation](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel)
+- [Schannel cipher suites documentation](https://learn.microsoft.com/windows/win32/secauthn/cipher-suites-in-schannel)
 - [IANA cipher suites list](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4)
 - [Wikipedia cipher suite article](https://en.wikipedia.org/wiki/Cipher_suite)
 - [GnuTLS Priority Strings](https://gnutls.org/manual/html_node/Priority-Strings.html)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -193,9 +193,9 @@ You can build curl with:
  KB140584 is a must for any Windows developer. Especially important is full
  understanding if you are not going to follow the advice given above.
 
- - [How To Use the C Runtime](https://support.microsoft.com/help/94248/how-to-use-the-c-run-time)
- - [Runtime Library Compiler Options](https://docs.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library)
- - [Potential Errors Passing CRT Objects Across DLL Boundaries](https://docs.microsoft.com/cpp/c-runtime-library/potential-errors-passing-crt-objects-across-dll-boundaries)
+ - [How To Use the C Runtime](https://learn.microsoft.com/troubleshoot/developer/visualstudio/cpp/libraries/use-c-run-time)
+ - [Runtime Library Compiler Options](https://learn.microsoft.com/cpp/build/reference/md-mt-ld-use-run-time-library)
+ - [Potential Errors Passing CRT Objects Across DLL Boundaries](https://learn.microsoft.com/cpp/c-runtime-library/potential-errors-passing-crt-objects-across-dll-boundaries)
 
 If your app is misbehaving in some strange way, or it is suffering from memory
 corruption, before asking for further help, please try first to rebuild every

--- a/docs/TODO
+++ b/docs/TODO
@@ -860,14 +860,14 @@
  The existing support for the -E/--cert and --key options could be
  extended by supplying a custom certificate and key in PEM format, see:
  - Getting a Certificate for Schannel
-   https://msdn.microsoft.com/en-us/library/windows/desktop/aa375447.aspx
+   https://learn.microsoft.com/windows/win32/secauthn/getting-a-certificate-for-schannel
 
 15.2 Extend support for the --ciphers option
 
  The existing support for the --ciphers option could be extended
  by mapping the OpenSSL/GnuTLS cipher suites to the Schannel APIs, see
  - Specifying Schannel Ciphers and Cipher Strengths
-   https://msdn.microsoft.com/en-us/library/windows/desktop/aa380161.aspx
+   https://learn.microsoft.com/windows/win32/secauthn/specifying-schannel-ciphers-and-cipher-strengths
 
 15.4 Add option to allow abrupt server closure
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -453,7 +453,7 @@ int Curl_socket_close(struct Curl_easy *data, struct connectdata *conn,
 /* When you run a program that uses the Windows Sockets API, you may
    experience slow performance when you copy data to a TCP server.
 
-   https://support.microsoft.com/kb/823764
+   https://learn.microsoft.com/troubleshoot/windows-server/networking/slow-performance-copy-data-tcp-server-sockets-api
 
    Work-around: Make the Socket Send Buffer Size Larger Than the Program Send
    Buffer Size

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -80,7 +80,7 @@ int Curl_socket_close(struct Curl_easy *data, struct connectdata *conn,
 /* When you run a program that uses the Windows Sockets API, you may
    experience slow performance when you copy data to a TCP server.
 
-   https://support.microsoft.com/kb/823764
+   https://learn.microsoft.com/troubleshoot/windows-server/networking/slow-performance-copy-data-tcp-server-sockets-api
 
    Work-around: Make the Socket Send Buffer Size Larger Than the Program Send
    Buffer Size

--- a/lib/curlx/multibyte.c
+++ b/lib/curlx/multibyte.c
@@ -170,7 +170,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
    * \\?\c:\longpath        --->    \\?\c:\longpath  (unchanged)
    * \\server\c$\longpath   --->    \\?\UNC\server\c$\longpath
    *
-   * https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+   * https://learn.microsoft.com/dotnet/standard/io/file-path-formats
    */
   if(!wcsncmp(fbuf, L"\\\\?\\", 4))
     ; /* do nothing */

--- a/lib/select.h
+++ b/lib/select.h
@@ -85,7 +85,7 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms);
 
 /*
    With Winsock the valid range is [0..INVALID_SOCKET-1] according to
-   https://docs.microsoft.com/en-us/windows/win32/winsock/socket-data-type-2
+   https://learn.microsoft.com/windows/win32/winsock/socket-data-type-2
 */
 #ifdef USE_WINSOCK
 #define VALID_SOCK(s) ((s) < INVALID_SOCKET)

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -277,8 +277,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   * we have to pass a second SecBuffer to the SecBufferDesc
   * otherwise IIS will not pass the authentication (401 response).
   * Minimum supported version is Windows 7.
-  * https://docs.microsoft.com/en-us/security-updates
-  * /SecurityAdvisories/2009/973811
+  * https://learn.microsoft.com/security-updates/SecurityAdvisories/2009/973811
   */
   if(ntlm->sslContext) {
     SEC_CHANNEL_BINDINGS channelBindings;

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -211,7 +211,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     * we have to pass a second SecBuffer to the SecBufferDesc
     * otherwise IIS will not pass the authentication (401 response).
     * Minimum supported version is Windows 7.
-    * !checksrc! disable LONGLINE
     * https://learn.microsoft.com/security-updates/SecurityAdvisories/2009/973811
     */
     if(nego->sslContext) {

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -211,8 +211,8 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     * we have to pass a second SecBuffer to the SecBufferDesc
     * otherwise IIS will not pass the authentication (401 response).
     * Minimum supported version is Windows 7.
-    * https://docs.microsoft.com/en-us/security-updates
-    * /SecurityAdvisories/2009/973811
+    * !checksrc! disable LONGLINE
+    * https://learn.microsoft.com/security-updates/SecurityAdvisories/2009/973811
     */
     if(nego->sslContext) {
       SEC_CHANNEL_BINDINGS channelBindings;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3448,8 +3448,7 @@ static CURLcode ossl_populate_x509_store(struct Curl_cfilter *cf,
        problems with server-sent legacy intermediates. Newer versions of
        OpenSSL do alternate chain checking by default but we do not know how to
        determine that in a reliable manner.
-       https://web.archive.org/web/20190422050538/
-       rt.openssl.org/Ticket/Display.html?id=3621
+       https://web.archive.org/web/20190422050538/rt.openssl.org/Ticket/Display.html?id=3621
     */
     X509_STORE_set_flags(store, X509_V_FLAG_TRUSTED_FIRST);
     if(!ssl_config->no_partialchain && !ssl_crlfile) {
@@ -4719,8 +4718,7 @@ static CURLcode ossl_pkp_pin_peer_pubkey(struct Curl_easy *data, X509* cert,
     /* Begin Gyrations to get the subjectPublicKeyInfo     */
     /* Thanks to Viktor Dukhovni on the OpenSSL mailing list */
 
-    /* https://groups.google.com/group/mailing.openssl.users/browse_thread
-       /thread/d61858dae102c6c7 */
+    /* https://groups.google.com/group/mailing.openssl.users/browse_thread/thread/d61858dae102c6c7 */
     len1 = i2d_X509_PUBKEY(X509_get_X509_PUBKEY(cert), NULL);
     if(len1 < 1)
       break; /* failed */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -139,7 +139,7 @@
 
 /* ALPN requires version 8.1 of the Windows SDK, which was
    shipped with Visual Studio 2013, aka _MSC_VER 1800:
-     https://technet.microsoft.com/en-us/library/hh831771%28v=ws.11%29.aspx
+     https://learn.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh831771
    Or mingw-w64 9.0 or upper.
 */
 #if (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR >= 9) || \
@@ -585,8 +585,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
 
     if(fInCert || blob) {
       /* Reading a .P12 or .pfx file, like the example at bottom of
-         https://social.msdn.microsoft.com/Forums/windowsdesktop/
-         en-US/3e7bc95f-b21a-4bcd-bd2c-7f996718cae5
+         https://learn.microsoft.com/archive/msdn-technet-forums/3e7bc95f-b21a-4bcd-bd2c-7f996718cae5
       */
       CRYPT_DATA_BLOB datablob;
       WCHAR* pszPassword;
@@ -1039,7 +1038,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
 
   /* Schannel InitializeSecurityContext:
-     https://msdn.microsoft.com/en-us/library/windows/desktop/aa375924.aspx
+     https://learn.microsoft.com/windows/win32/api/rrascfg/nn-rrascfg-ieapproviderconfig
 
      At the moment we do not pass inbuf unless we are using ALPN since we only
      use it for that, and WINE (for which we currently disable ALPN) is giving
@@ -1945,7 +1944,7 @@ schannel_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   /* copy data into output buffer */
   memcpy(outbuf[1].pvBuffer, buf, len);
 
-  /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa375390.aspx */
+  /* https://learn.microsoft.com/windows/win32/api/sspi/nf-sspi-encryptmessage */
   sspi_status = Curl_pSecFn->EncryptMessage(&backend->ctxt->ctxt_handle, 0,
                                             &outbuf_desc, 0);
 
@@ -2164,7 +2163,7 @@ schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     InitSecBuffer(&inbuf[3], SECBUFFER_EMPTY, NULL, 0);
     InitSecBufferDesc(&inbuf_desc, inbuf, 4);
 
-    /* https://msdn.microsoft.com/en-us/library/windows/desktop/aa375348.aspx
+    /* https://learn.microsoft.com/windows/win32/api/sspi/nf-sspi-decryptmessage
      */
     sspi_status = Curl_pSecFn->DecryptMessage(&backend->ctxt->ctxt_handle,
                                            &inbuf_desc, 0, NULL);
@@ -2373,7 +2372,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
                                   bool send_shutdown, bool *done)
 {
-  /* See https://msdn.microsoft.com/en-us/library/windows/desktop/aa380138.aspx
+  /* See https://learn.microsoft.com/windows/win32/secauthn/shutting-down-an-schannel-connection
    * Shutting Down an Schannel Connection
    */
   struct ssl_connect_data *connssl = cf->ctx;

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -552,7 +552,6 @@ CURLcode Curl_verify_host(struct Curl_cfilter *cf,
    * Right now we are only asking for the first preferred alternative name.
    * Instead we would need to do all via CERT_NAME_SEARCH_ALL_NAMES_FLAG
    * (If Windows CE supports that?) and run this section in a loop for each.
-   * !checksrc! disable LONGLINE
    * https://learn.microsoft.com/windows/win32/api/wincrypt/nf-wincrypt-certgetnamestringa
    * curl: (51) schannel: CertGetNameString() certificate hostname
    * (.google.com) did not match connection (google.com)

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -552,7 +552,8 @@ CURLcode Curl_verify_host(struct Curl_cfilter *cf,
    * Right now we are only asking for the first preferred alternative name.
    * Instead we would need to do all via CERT_NAME_SEARCH_ALL_NAMES_FLAG
    * (If Windows CE supports that?) and run this section in a loop for each.
-   * https://msdn.microsoft.com/en-us/library/windows/desktop/aa376086.aspx
+   * !checksrc! disable LONGLINE
+   * https://learn.microsoft.com/windows/win32/api/wincrypt/nf-wincrypt-certgetnamestringa
    * curl: (51) schannel: CertGetNameString() certificate hostname
    * (.google.com) did not match connection (google.com)
    */

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -515,7 +515,7 @@ sub scanfile {
         }
 
         # detect long lines
-        if(length($l) > $max_column) {
+        if(length($l) > $max_column && $l !~ / https:\/\//) {
             checkwarn("LONGLINE", $line, length($l), $file, $l,
                       "Longer than $max_column columns");
         }

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -83,7 +83,7 @@ f:\foo:bar => f:\foo:bar   (flag SANITIZE_ALLOW_PATH)
 
 This function was implemented according to the guidelines in 'Naming Files,
 Paths, and Namespaces' section 'Naming Conventions'.
-https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
+https://learn.microsoft.com/windows/win32/fileio/naming-a-file
 
 Flags
 -----
@@ -472,9 +472,8 @@ static SANITIZEcode rename_if_reserved_dos(char **const sanitized,
 
   /* Rename reserved device names that are known to be accessible without \\.\
      Examples: CON => _CON, CON.EXT => CON_EXT, CON:ADS => CON_ADS
-     https://web.archive.org/web/20160314141551/
-       support.microsoft.com/en-us/kb/74496
-     https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
+     https://web.archive.org/web/20160314141551/support.microsoft.com/en-us/kb/74496
+     https://learn.microsoft.com/windows/win32/fileio/naming-a-file
      */
   for(p = fname; p; p = (p == fname && fname != base ? base : NULL)) {
     size_t p_len;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -404,8 +404,8 @@ static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
  * other handle types supported by WaitForMultipleObjectsEx() as
  * well as disk files, anonymous and names pipes, and character input.
  *
- * https://msdn.microsoft.com/en-us/library/windows/desktop/ms687028.aspx
- * https://msdn.microsoft.com/en-us/library/windows/desktop/ms741572.aspx
+ * https://learn.microsoft.com/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjectsex
+ * https://learn.microsoft.com/windows/win32/api/winsock2/nf-winsock2-wsaenumnetworkevents
  */
 struct select_ws_wait_data {
   HANDLE handle; /* actual handle to wait for during select */

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -229,12 +229,9 @@ curl_off_t our_getpid(void)
   curl_off_t pid = (curl_off_t)t_getpid();
 #ifdef _WIN32
   /* store pid + MAX_PID to avoid conflict with Cygwin/msys PIDs, see also:
-   * - 2019-01-31: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;
-   *               h=b5e1003722cb14235c4f166be72c09acdffc62ea
-   * - 2019-02-02: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;
-   *               h=448cf5aa4b429d5a9cebf92a0da4ab4b5b6d23fe
-   * - 2024-12-19: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;
-   *               h=363357c023ce01e936bdaedf0f479292a8fa4e0f
+   * - 2019-01-31: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=b5e1003722cb14235c4f166be72c09acdffc62ea
+   * - 2019-02-02: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=448cf5aa4b429d5a9cebf92a0da4ab4b5b6d23fe
+   * - 2024-12-19: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=363357c023ce01e936bdaedf0f479292a8fa4e0f
    */
   pid += 4194304;
 #endif
@@ -422,7 +419,7 @@ static void exit_signal_handler(int signum)
  * They are included for ANSI compatibility. Therefore, you can set
  * signal handlers for these signals by using signal, and you can also
  * explicitly generate these signals by calling raise. Source:
- * https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/signal
+ * https://learn.microsoft.com/cpp/c-runtime-library/reference/signal
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {


### PR DESCRIPTION
- refresh MSDN documentation links.
  (also drop language designator where present.)
- checksrc: allow longer than 78 character lines if they
  contain a https URL. To make these links easier to use and parse.
- merge some links split into two lines.
