### PR TITLE
rustls: typecast variable for safer trace output

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -121,7 +121,7 @@ read_cb(void *userdata, uint8_t *buf, uintptr_t len, uintptr_t *out_n)
     connssl->peer_closed = TRUE;
   *out_n = (uintptr_t)nread;
   CURL_TRC_CF(io_ctx->data, io_ctx->cf, "cf->next recv(len=%zu) -> %d, %zu",
-              len, result, nread);
+              (size_t)len, result, nread);
   return ret;
 }
 


### PR DESCRIPTION
This is a variadic function call with a mismatched argument type; on platforms where uintptr_t and size_t differ, this invokes undefined behavior.

Reported in Joshua's sarif data