### PR TITLE
httpsrr: free old pointers when storing new

### DIFF
--- a/lib/httpsrr.c
+++ b/lib/httpsrr.c
@@ -98,6 +98,7 @@ CURLcode Curl_httpsrr_set(struct Curl_easy *data,
   case HTTPS_RR_CODE_IPV4: /* addr4 list */
     if(!vlen || (vlen & 3)) /* the size must be 4-byte aligned */
       return CURLE_BAD_FUNCTION_ARGUMENT;
+    free(hi->ipv4hints);
     hi->ipv4hints = Curl_memdup(val, vlen);
     if(!hi->ipv4hints)
       return CURLE_OUT_OF_MEMORY;
@@ -107,6 +108,7 @@ CURLcode Curl_httpsrr_set(struct Curl_easy *data,
   case HTTPS_RR_CODE_ECH:
     if(!vlen)
       return CURLE_BAD_FUNCTION_ARGUMENT;
+    free(hi->echconfiglist);
     hi->echconfiglist = Curl_memdup(val, vlen);
     if(!hi->echconfiglist)
       return CURLE_OUT_OF_MEMORY;
@@ -116,6 +118,7 @@ CURLcode Curl_httpsrr_set(struct Curl_easy *data,
   case HTTPS_RR_CODE_IPV6: /* addr6 list */
     if(!vlen || (vlen & 15)) /* the size must be 16-byte aligned */
       return CURLE_BAD_FUNCTION_ARGUMENT;
+    free(hi->ipv6hints);
     hi->ipv6hints = Curl_memdup(val, vlen);
     if(!hi->ipv6hints)
       return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
In case we get "funny" input and the same field is provided several times, free the old pointer before stored a new memdup.

Reported in Joshua's sarif data