### PR TITLE
openldap: improve check for receiving blank data

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1171,8 +1171,8 @@ static CURLcode oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
 
         if(!binary) {
           /* check for leading or trailing whitespace */
-          if(ISBLANK(bvals[i].bv_val[0]) ||
-             (bvals[i].bv_len &&
+          if(bvals[i].bv_len &&
+             (ISBLANK(bvals[i].bv_val[0]) ||
               ISBLANK(bvals[i].bv_val[bvals[i].bv_len - 1])))
             binval = TRUE;
           else {


### PR DESCRIPTION
It can't access the first byte either unless it has length.

Followup to 232d5a2ed9c091c88e3b724a1e7d6