### PR TITLE
cf-socket: use the right byte order for ports in bindlocal

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -790,10 +790,10 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
       infof(data, "Bind to local port %d failed, trying next", port - 1);
       /* We reuse/clobber the port variable here below */
       if(sock->sa_family == AF_INET)
-        si4->sin_port = ntohs(port);
+        si4->sin_port = htons(port);
 #ifdef USE_IPV6
       else
-        si6->sin6_port = ntohs(port);
+        si6->sin6_port = htons(port);
 #endif
     }
     else


### PR DESCRIPTION
Reported in Joshua's sarif data