### PR TITLE
tftp: return error when sendto() fails

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -535,11 +535,12 @@ static CURLcode tftp_send_first(struct tftp_conn *state,
                       (SEND_TYPE_ARG3)sbytes, 0,
                       CURL_SENDTO_ARG5(&remote_addr->curl_sa_addr),
                       (curl_socklen_t)remote_addr->addrlen);
+    free(filename);
     if(senddata != (ssize_t)sbytes) {
       char buffer[STRERROR_LEN];
       failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
+      return CURLE_SEND_ERROR;
     }
-    free(filename);
     break;
 
   case TFTP_EVENT_OACK:


### PR DESCRIPTION
The code just called failf() and then continued without returning error.

Reported in Joshua's sarif data