### PR TITLE
ftp: fix ftp_do_more returning with *completep unset

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3632,6 +3632,9 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
 
   if(!ftpc || !ftp)
     return CURLE_FAILED_INIT;
+
+  *completep = 0; /* default to stay in the state */
+
   /* if the second connection has been set up, try to connect it fully
    * to the remote host. This may not complete at this time, for several
    * reasons:
@@ -3650,7 +3653,6 @@ static CURLcode ftp_do_more(struct Curl_easy *data, int *completep)
         /* this is a EPSV connect failing, try PASV instead */
         return ftp_epsv_disable(data, ftpc, conn);
       }
-      *completep = (int)complete;
       return result;
     }
   }


### PR DESCRIPTION
Specifically, when ftpc->wait_data_conn was true and Curl_conn_connect(...) returned with serv_conned == false the code called ftp_check_ctrl_on_data_wait and returned without setting *completep.

Now set it to 0 at function start to avoid this happening again.

Reported in Joshua's sarif data