### PR TITLE
ws: clarify an error message

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -453,7 +453,7 @@ static CURLcode ws_dec_read_head(struct ws_decoder *dec,
       break;
     case 10:
       if(dec->head[2] > 127) {
-        failf(data, "[WS] frame length longer than 64 signed not supported");
+        failf(data, "[WS] frame length longer than 63 bit not supported");
         return CURLE_RECV_ERROR;
       }
       dec->payload_len = ((curl_off_t)dec->head[2] << 56) |


### PR DESCRIPTION
Instead of:

 "[WS] frame length longer than 64 signed not supported"

Use:

 "[WS] frame length longer than 63 bit not supported"