### PR TITLE
checksrc: ban `_beginthreadex()`

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -74,6 +74,7 @@ my %banfunc = (
     "LoadLibraryEx" => 1,
     "LoadLibraryExA" => 1,
     "LoadLibraryExW" => 1,
+    "_beginthreadex" => 1,
     "_waccess" => 1,
     "_access" => 1,
     "access" => 1,


### PR DESCRIPTION
In favor of `CreateThread()`.

Follow-up to 1c49f2f26d0f200bb9de61f795f06a1bc56845e9 #18451
