### PR TITLE
autotools: fix silly mistake in clang detection for `buildinfo.txt`

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1492,7 +1492,7 @@ AC_DEFUN([CURL_PREPARE_BUILDINFO], [
   if test "x$compiler_id" = 'xGNU_C'; then
     curl_pflags="${curl_pflags} GCC"
   fi
-  if "$compiler_id" = "APPLECLANG"; then
+  if test "$compiler_id" = "APPLECLANG"; then
     curl_pflags="${curl_pflags} APPLE-CLANG"
   elif test "$compiler_id" = "CLANG"; then
     curl_pflags="${curl_pflags} LLVM-CLANG"


### PR DESCRIPTION
Follow-up to 0513f9f8786e0cc4246e05d56bd264d0292d9c92 #18645