### PR TITLE
autotools: fix duplicate `UNIX` and `BSD` flags in `buildinfo.txt`

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1474,14 +1474,6 @@ AC_DEFUN([CURL_PREPARE_BUILDINFO], [
   if test "$curl_cv_winuwp" = 'yes'; then
     curl_pflags="${curl_pflags} UWP"
   fi
-  case $host in
-    *-*-*bsd*|*-*-aix*|*-*-hpux*|*-*-interix*|*-*-irix*|*-*-linux*|*-*-solaris*|*-*-sunos*|*-apple-*|*-*-cygwin*|*-*-msys*)
-      curl_pflags="${curl_pflags} UNIX";;
-  esac
-  case $host in
-    *-*-*bsd*)
-      curl_pflags="${curl_pflags} BSD";;
-  esac
   if test "$curl_cv_cygwin" = 'yes'; then
     curl_pflags="${curl_pflags} CYGWIN"
   fi


### PR DESCRIPTION
2a292c39846107228201674d686be5b3ed96674d #15975