### PR TITLE
rustls: fix clang-tidy warning

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -410,7 +410,7 @@ read_file_into(const char *filename,
     return 0;
   }
 
-  while(!feof(f)) {
+  for(;;) {
     uint8_t buf[256];
     const size_t rr = fread(buf, 1, sizeof(buf), f);
     if(rr == 0 ||
@@ -418,6 +418,8 @@ read_file_into(const char *filename,
       fclose(f);
       return 0;
     }
+    if(rr < sizeof(buf))
+      break;
   }
 
   return fclose(f) == 0;


### PR DESCRIPTION
Seen with v21.1.1, non-debug-enabled build:
```
lib/vtls/rustls.c:415:23: error: File position of the stream might be 'indeterminate'
after a failed operation. Can cause undefined behavior [clang-analyzer-unix.Stream,-warnings-as-errors]
  415 |     const size_t rr = fread(buf, 1, sizeof(buf), f);
      |                       ^
```
Ref: https://github.com/curl/curl/actions/runs/17898248031/job/50887746633?pr=18660#step:11:174

Cherry-picked from #18660
