### PR TITLE
autotools: capitalize 'Rustls' in the log output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -272,8 +272,8 @@ AC_ARG_WITH(rustls,dnl
 AS_HELP_STRING([--with-rustls=PATH],[where to look for Rustls, PATH points to the installation root]),[
   OPT_RUSTLS=$withval
   if test X"$withval" != Xno; then
-    TLSCHOICE="${TLSCHOICE:+$TLSCHOICE, }rustls"
-    experimental="$experimental rustls"
+    TLSCHOICE="${TLSCHOICE:+$TLSCHOICE, }Rustls"
+    experimental="$experimental Rustls"
   fi
 ])
 

--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -132,7 +132,7 @@ if test "x$OPT_RUSTLS" != xno; then
       dnl don't need any.
       LIBS="$SSL_LIBS $LIBS"
       link_pkgconfig=1
-      ssl_msg="rustls"
+      ssl_msg="Rustls"
       AC_DEFINE(USE_RUSTLS, 1, [if Rustls is enabled])
       USE_RUSTLS="yes"
       RUSTLS_ENABLED=1
@@ -176,7 +176,7 @@ if test "x$OPT_RUSTLS" != xno; then
         AC_DEFINE(USE_RUSTLS, 1, [if Rustls is enabled])
         RUSTLS_ENABLED=1
         USE_RUSTLS="yes"
-        ssl_msg="rustls"
+        ssl_msg="Rustls"
         test rustls != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
         ],
         AC_MSG_ERROR([--with-rustls was specified but could not find compatible Rustls.]),


### PR DESCRIPTION
To match the rest of the codebase.

Follow-up to 548d8a842123c854ba92aac90a24c6191e2a8bd4
Cherry-picked from #18660
