### PR TITLE
managen: strict protocol check

### DIFF
--- a/docs/cmdline-opts/doh-cert-status.md
+++ b/docs/cmdline-opts/doh-cert-status.md
@@ -5,6 +5,7 @@ Long: doh-cert-status
 Help: Verify DoH server cert status OCSP-staple
 Added: 7.76.0
 Category: dns tls
+Protocols: DNS
 Multi: boolean
 See-also:
   - doh-insecure

--- a/docs/cmdline-opts/doh-insecure.md
+++ b/docs/cmdline-opts/doh-insecure.md
@@ -5,6 +5,7 @@ Long: doh-insecure
 Help: Allow insecure DoH server connections
 Added: 7.76.0
 Category: dns tls
+Protocols: DNS
 Multi: boolean
 See-also:
   - doh-url

--- a/docs/cmdline-opts/doh-url.md
+++ b/docs/cmdline-opts/doh-url.md
@@ -6,6 +6,7 @@ Arg: <URL>
 Help: Resolve hostnames over DoH
 Added: 7.62.0
 Category: dns
+Protocols: DNS
 Multi: single
 See-also:
   - doh-insecure

--- a/docs/cmdline-opts/follow.md
+++ b/docs/cmdline-opts/follow.md
@@ -4,6 +4,7 @@ SPDX-License-Identifier: curl
 Long: follow
 Help: Follow redirects per spec
 Category: http
+Protocols: HTTP
 Added: 8.16.0
 Multi: boolean
 See-also:

--- a/docs/cmdline-opts/form-escape.md
+++ b/docs/cmdline-opts/form-escape.md
@@ -3,7 +3,7 @@ c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Long: form-escape
 Help: Escape form fields using backslash
-Protocols: HTTP imap smtp
+Protocols: HTTP IMAP SMTP
 Added: 7.81.0
 Category: http upload post
 Multi: single

--- a/docs/cmdline-opts/ip-tos.md
+++ b/docs/cmdline-opts/ip-tos.md
@@ -6,7 +6,6 @@ Arg: <string>
 Help: Set IP Type of Service or Traffic Class
 Added: 8.9.0
 Category: connection
-Protocols: All
 Multi: single
 See-also:
   - tcp-nodelay

--- a/docs/cmdline-opts/key.md
+++ b/docs/cmdline-opts/key.md
@@ -3,7 +3,7 @@ c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Long: key
 Arg: <key>
-Protocols: TLS SSH
+Protocols: TLS SCP SFTP
 Help: Private key filename
 Category: tls ssh
 Added: 7.9.3

--- a/docs/cmdline-opts/pass.md
+++ b/docs/cmdline-opts/pass.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: curl
 Long: pass
 Arg: <phrase>
 Help: Passphrase for the private key
-Protocols: SSH TLS
+Protocols: TLS SCP SFTP
 Category: ssh tls auth
 Added: 7.9.3
 Multi: single

--- a/docs/cmdline-opts/sasl-authzid.md
+++ b/docs/cmdline-opts/sasl-authzid.md
@@ -4,6 +4,7 @@ SPDX-License-Identifier: curl
 Long: sasl-authzid
 Arg: <identity>
 Help: Identity for SASL PLAIN authentication
+Protocols: LDAP IMAP POP3 SMTP
 Added: 7.66.0
 Category: auth
 Multi: single

--- a/docs/cmdline-opts/sasl-ir.md
+++ b/docs/cmdline-opts/sasl-ir.md
@@ -3,6 +3,7 @@ c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Long: sasl-ir
 Help: Initial response in SASL authentication
+Protocols: LDAP IMAP POP3 SMTP
 Added: 7.31.0
 Category: auth
 Multi: boolean

--- a/docs/cmdline-opts/socks5-gssapi-nec.md
+++ b/docs/cmdline-opts/socks5-gssapi-nec.md
@@ -5,6 +5,7 @@ Long: socks5-gssapi-nec
 Help: Compatibility with NEC SOCKS5 server
 Added: 7.19.4
 Category: proxy auth
+Protocols: GSS/kerberos
 Multi: boolean
 See-also:
   - socks5

--- a/docs/cmdline-opts/socks5-gssapi.md
+++ b/docs/cmdline-opts/socks5-gssapi.md
@@ -5,6 +5,7 @@ Long: socks5-gssapi
 Help: Enable GSS-API auth for SOCKS5 proxies
 Added: 7.55.0
 Category: proxy auth
+Protocols: GSS/kerberos
 Multi: boolean
 See-also:
   - socks5

--- a/docs/cmdline-opts/telnet-option.md
+++ b/docs/cmdline-opts/telnet-option.md
@@ -6,6 +6,7 @@ Short: t
 Arg: <opt=val>
 Help: Set telnet option
 Category: telnet
+Protocols: TELNET
 Added: 7.7
 Multi: append
 See-also:

--- a/docs/cmdline-opts/upload-flags.md
+++ b/docs/cmdline-opts/upload-flags.md
@@ -4,6 +4,7 @@ SPDX-License-Identifier: curl
 Long: upload-flags
 Arg: <flags>
 Help: IMAP upload behavior
+Protocols: IMAP
 Category: curl output
 Added: 8.13.0
 Multi: single

--- a/docs/cmdline-opts/url-query.md
+++ b/docs/cmdline-opts/url-query.md
@@ -4,7 +4,6 @@ SPDX-License-Identifier: curl
 Long: url-query
 Arg: <data>
 Help: Add a URL query part
-Protocols: all
 Added: 7.87.0
 Category: http post upload
 Multi: append

--- a/docs/cmdline-opts/vlan-priority.md
+++ b/docs/cmdline-opts/vlan-priority.md
@@ -6,7 +6,6 @@ Arg: <priority>
 Help: Set VLAN priority
 Added: 8.9.0
 Category: connection
-Protocols: All
 Multi: single
 See-also:
   - ip-tos

--- a/scripts/managen
+++ b/scripts/managen
@@ -241,8 +241,38 @@ sub overrides {
     }
 }
 
+my %protexists = (
+    'DNS' => 1,
+    'FILE' => 1,
+    'FTP' => 1,
+    'FTPS' => 1,
+    'GSS/kerberos' => 1,
+    'HTTP' => 1,
+    'HTTPS' => 1,
+    'IMAP' => 1,
+    'IPFS' => 1,
+    'LDAP' => 1,
+    'MQTT' => 1,
+    'POP3' => 1,
+    'SCP' => 1,
+    'SFTP' => 1,
+    'SMTP' => 1,
+    'SSL' => 2, # deprecated
+    'TELNET' => 1,
+    'TFTP' => 1,
+    'TLS' => 1,
+    );
+
 sub protocols {
-    my ($manpage, $standalone, $data)=@_;
+    my ($f, $line, $manpage, $standalone, $data)=@_;
+    my @e = split(/ +/, $data);
+    for my $pr (@e) {
+        if(!$protexists{$pr}) {
+
+            print STDERR "$f:$line:1:ERROR: unrecognized protocol: $pr\n";
+            exit 2;
+        }
+    }
     if($standalone) {
         return ".SH \"PROTOCOLS\"\n$data\n";
     }
@@ -716,7 +746,7 @@ sub single {
     }
     my @leading;
     if($protocols) {
-        push @leading, protocols($manpage, $standalone, $protocols);
+        push @leading, protocols($f, $line, $manpage, $standalone, $protocols);
     }
 
     if($standalone) {


### PR DESCRIPTION
- protocols MUST match one in the accept-list
- protocols are typically all uppercase
- drop All
- use SCP and SFTP instead of SSH
- add Protocols: to some options previously missing one