### PR TITLE
cf-socket: fix buffer overrun in Curl_sock_assign_addr

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -341,7 +341,7 @@ static CURLcode sock_assign_addr(struct Curl_sockaddr_ex *dest,
     return CURLE_TOO_LARGE;
   }
 
-  memcpy(&dest->curl_sa_addr, ai->ai_addr, dest->addrlen);
+  memcpy(&dest->_sa_ex_u.buff, ai->ai_addr, dest->addrlen);
   return CURLE_OK;
 }
 


### PR DESCRIPTION
Fix a buffer overrun vulnerability where memcpy() could write beyond the bounds of the destination buffer when copying socket address data.

The issue occurs when dest->addrlen (up to 128 bytes for some address families) exceeds the size of dest->curl_sa_addr (struct sockaddr, 16 bytes). While the existing check validates against sizeof(struct Curl_sockaddr_storage), the memcpy targets the smaller sockaddr member of the union.

Fix by copying to the union itself, which provides adequate space via the Curl_sockaddr_storage member (256 bytes) for all address types.

Reported-by: OpenScanHub