### PR TITLE
hostip: fix Y2K38 safety issue in Curl_dnscache_prune

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -280,11 +280,11 @@ void Curl_dnscache_prune(struct Curl_easy *data)
     timediff_t oldest_ms = dnscache_prune(&dnscache->entries, timeout_ms, now);
 
     if(Curl_hash_count(&dnscache->entries) > MAX_DNS_CACHE_SIZE) {
-      if(oldest_ms < INT_MAX)
+      if(oldest_ms <= LLONG_MAX / 2)
         /* prune the ones over half this age */
-        timeout_ms = (int)oldest_ms / 2;
+        timeout_ms = oldest_ms / 2;
       else
-        timeout_ms = INT_MAX/2;
+        timeout_ms = LLONG_MAX / 2;
     }
     else
       break;


### PR DESCRIPTION
Fix a Y2K38 safety issue where timediff_t values are truncated when cast to int for DNS cache timeout calculations.

The issue occurs when oldest_ms exceeds INT_MAX (2147483647 milliseconds, approximately 24.8 days). While this may seem like a large value, it becomes problematic in long-running applications and will be increasingly common after January 19, 2038 when timestamp calculations frequently exceed 32-bit integer limits.

The truncation from timediff_t (64-bit) to int (32-bit) causes timeout values to overflow to negative numbers or lose precision, potentially breaking DNS cache pruning logic.

Change the comparison and assignment to work entirely with timediff_t values, eliminating the unsafe cast and using LLONG_MAX for bounds checking instead of INT_MAX.

Before: timeout_ms = (int)oldest_ms / 2;  /* loses precision */
After:  timeout_ms = oldest_ms / 2;       /* preserves full range */

Reported-by: OpenScanHub