### PR TITLE
hostip: remove unnecessary leftover INT_MAX check in Curl_dnscache_prune

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -279,13 +279,9 @@ void Curl_dnscache_prune(struct Curl_easy *data)
     /* Remove outdated and unused entries from the hostcache */
     timediff_t oldest_ms = dnscache_prune(&dnscache->entries, timeout_ms, now);
 
-    if(Curl_hash_count(&dnscache->entries) > MAX_DNS_CACHE_SIZE) {
-      if(oldest_ms < INT_MAX)
-        /* prune the ones over half this age */
-        timeout_ms = (int)oldest_ms / 2;
-      else
-        timeout_ms = INT_MAX/2;
-    }
+    if(Curl_hash_count(&dnscache->entries) > MAX_DNS_CACHE_SIZE)
+      /* prune the ones over half this age */
+      timeout_ms = oldest_ms / 2;
     else
       break;
 


### PR DESCRIPTION
The math already uses timediff_t so no need for the extra logic

Ref: #18678