### PR TITLE
socks_gssapi: reject too long tokens

### DIFF
--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -195,7 +195,9 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     if(gss_token != GSS_C_NO_BUFFER)
       gss_release_buffer(&gss_status, &gss_recv_token);
     if(check_gss_err(data, gss_major_status,
-                     gss_minor_status, "gss_init_sec_context")) {
+                     gss_minor_status, "gss_init_sec_context") ||
+       /* the size needs to fit in a 16 bit field */
+       (gss_send_token.length > 0xffff)) {
       gss_release_name(&gss_status, &server);
       gss_release_buffer(&gss_status, &gss_recv_token);
       gss_release_buffer(&gss_status, &gss_send_token);


### PR DESCRIPTION
If GSS returns a token to use that is longer than 65535 bytes, it can't be transmitted since the length field is an unisgned 16 bit field and thus needs to trigger an error.

Reported in Joshua's sarif data