### PR TITLE
libssh: drop two unused assigments

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1339,14 +1339,12 @@ static int myssh_in_SFTP_DOWNLOAD_STAT(struct Curl_easy *data,
 
       if((to_t == STRE_NO_NUM) || (to >= size)) {
         to = size - 1;
-        to_t = STRE_OK;
       }
 
       if(from_t == STRE_NO_NUM) {
         /* from is relative to end of file */
         from = size - to;
         to = size - 1;
-        from_t = STRE_OK;
       }
       if(from > size) {
         failf(data, "Offset (%" FMT_OFF_T ") was beyond file size (%"


### PR DESCRIPTION
Reported in macOS clang-tidy v21.1.1 build, after enabling libssh in it:
```
lib/vssh/libssh.c
lib/vssh/libssh.c:1342:9: error: Value stored to 'to_t' is never read [clang-analyzer-deadcode.DeadStores,-warnings-as-errors]
 1342 |         to_t = STRE_OK;
      |         ^
lib/vssh/libssh.c:1342:9: note: Value stored to 'to_t' is never read
lib/vssh/libssh.c:1349:9: error: Value stored to 'from_t' is never read [clang-analyzer-deadcode.DeadStores,-warnings-as-errors]
 1349 |         from_t = STRE_OK;
      |         ^
lib/vssh/libssh.c:1349:9: note: Value stored to 'from_t' is never read
2 warnings generated.
```
Ref: https://github.com/curl/curl/actions/runs/17909917954/job/50918955923?pr=18660#step:11:182

Cherry-picked from #18660