### PR TITLE
ares: fix leak in tracing

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -747,8 +747,11 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
   ares->result = CURLE_OK;
 
 #if ARES_VERSION >= 0x011800  /* >= v1.24.0 */
-  CURL_TRC_DNS(data, "asyn-ares: servers=%s",
-               ares_get_servers_csv(ares->channel));
+  if(CURL_TRC_DNS_is_verbose(data)) {
+    const char *csv = ares_get_servers_csv(ares->channel);
+    CURL_TRC_DNS(data, "asyn-ares: servers=%s", csv);
+    ares_free_string(csv);
+  }
 #endif
 
 #ifdef HAVE_CARES_GETADDRINFO

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -748,7 +748,7 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
 
 #if ARES_VERSION >= 0x011800  /* >= v1.24.0 */
   if(CURL_TRC_DNS_is_verbose(data)) {
-    const char *csv = ares_get_servers_csv(ares->channel);
+    char *csv = ares_get_servers_csv(ares->channel);
     CURL_TRC_DNS(data, "asyn-ares: servers=%s", csv);
     ares_free_string(csv);
   }

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -123,6 +123,8 @@ void Curl_trc_ws(struct Curl_easy *data,
 
 #define CURL_TRC_M_is_verbose(data) \
   Curl_trc_ft_is_verbose(data, &Curl_trc_feat_multi)
+#define CURL_TRC_DNS_is_verbose(data) \
+  Curl_trc_ft_is_verbose(data, &Curl_trc_feat_dns)
 
 #if defined(CURL_HAVE_C99) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
 #define infof(data, ...) \
@@ -141,7 +143,7 @@ void Curl_trc_ws(struct Curl_easy *data,
   do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_read)) \
          Curl_trc_read(data, __VA_ARGS__); } while(0)
 #define CURL_TRC_DNS(data, ...) \
-  do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_dns)) \
+  do { if(CURL_TRC_DNS_is_verbose(data)) \
          Curl_trc_dns(data, __VA_ARGS__); } while(0)
 
 #ifndef CURL_DISABLE_FTP


### PR DESCRIPTION
When DNS tracing is enabled, a string allocated by ares was not freed.

reported-by: jmaggard10