### PR TITLE
GHA/linux: add HTTP/3 c-ares scan-build and asan jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -248,10 +248,10 @@ jobs:
             CC: clang
             configure-prefix: scan-build
             make-prefix: scan-build --status-bugs
-            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
+            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             configure: >-
-              --with-openssl=/home/linuxbrew/.linuxbrew/opt/openssl --with-ngtcp2
+              --with-openssl=/home/linuxbrew/.linuxbrew/opt/openssl --with-ngtcp2 --with-nghttp3=
               --with-libidn2 --enable-httpsrr --enable-ares
               --disable-debug --disable-unity
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -263,6 +263,16 @@ jobs:
             CC: clang
             generate: -DENABLE_DEBUG=ON -DCURL_USE_LIBSSH=ON
 
+          - name: 'address-sanitizer H3 c-ares'
+            install_packages: clang libubsan1 libasan8 libtsan2
+            install_steps: pytest awslc
+            install_steps_brew: libngtcp2 libnghttp3 c-ares
+            CFLAGS: -fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g
+            LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan -Wl,-rpath,/home/runner/awslc/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
+            PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
+            CC: clang
+            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/runner/awslc -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DUSE_ECH=ON -DENABLE_ARES=ON
+
           - name: 'thread-sanitizer'
             install_packages: clang libtsan2
             install_steps: pytest openssl-tsan

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -241,6 +241,20 @@ jobs:
               --enable-ech --with-gssapi --enable-ssls-export
               --disable-debug --disable-unity
 
+          - name: 'scan-build H3 c-ares'
+            install_packages: clang-tools clang libidn2-dev libnghttp2-dev
+            install_steps: skipall awslc
+            install_steps_brew: libngtcp2 libnghttp3 c-ares
+            CC: clang
+            configure-prefix: scan-build
+            make-prefix: scan-build --status-bugs
+            PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
+            LDFLAGS: -Wl,-rpath,/home/runner/awslc/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
+            configure: >-
+              --with-openssl=/home/runner/awslc --enable-ech
+              --with-libidn2 --enable-httpsrr --enable-ares
+              --disable-debug --disable-unity
+
           - name: 'address-sanitizer'
             install_packages: clang libssl-dev libssh-dev libidn2-dev libnghttp2-dev libubsan1 libasan8 libtsan2
             install_steps: pytest randcurl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -249,7 +249,6 @@ jobs:
             configure-prefix: scan-build
             make-prefix: scan-build --status-bugs
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
-            LDFLAGS: -Wl,-rpath,/home/runner/awslc/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
             configure: >-
               --with-openssl=/home/runner/awslc --enable-ech
               --with-libidn2 --enable-httpsrr --enable-ares
@@ -265,13 +264,13 @@ jobs:
 
           - name: 'address-sanitizer H3 c-ares'
             install_packages: clang libubsan1 libasan8 libtsan2
-            install_steps: pytest awslc
+            install_steps: pytest openssl
             install_steps_brew: libngtcp2 libnghttp3 c-ares
             CFLAGS: -fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g
-            LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan -Wl,-rpath,/home/runner/awslc/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
+            LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             CC: clang
-            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/runner/awslc -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DUSE_ECH=ON -DENABLE_ARES=ON
+            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DUSE_ECH=ON -DENABLE_ARES=ON
 
           - name: 'thread-sanitizer'
             install_packages: clang libtsan2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -265,13 +265,13 @@ jobs:
 
           - name: 'address-sanitizer H3 c-ares'
             install_packages: clang libubsan1 libasan8 libtsan2
-            install_steps: pytest openssl
-            install_steps_brew: libngtcp2 libnghttp3 c-ares
+            install_steps: pytest
+            install_steps_brew: openssl libngtcp2 libnghttp3 c-ares
             CFLAGS: -fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g
             LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             CC: clang
-            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON
+            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON
 
           - name: 'thread-sanitizer'
             install_packages: clang libtsan2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -243,15 +243,15 @@ jobs:
 
           - name: 'scan-build H3 c-ares'
             install_packages: clang-tools clang libidn2-dev libnghttp2-dev
-            install_steps: skipall awslc
-            install_steps_brew: libngtcp2 libnghttp3 c-ares
+            install_steps: skipall
+            install_steps_brew: openssl libngtcp2 libnghttp3 c-ares
             CC: clang
             configure-prefix: scan-build
             make-prefix: scan-build --status-bugs
             LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             configure: >-
-              --with-openssl=/home/runner/awslc --enable-ech
+              --with-openssl=/home/linuxbrew/.linuxbrew/opt/openssl --with-ngtcp2
               --with-libidn2 --enable-httpsrr --enable-ares
               --disable-debug --disable-unity
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -270,7 +270,7 @@ jobs:
             LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             CC: clang
-            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DUSE_ECH=ON -DENABLE_ARES=ON
+            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON
 
           - name: 'thread-sanitizer'
             install_packages: clang libtsan2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -248,6 +248,7 @@ jobs:
             CC: clang
             configure-prefix: scan-build
             make-prefix: scan-build --status-bugs
+            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             configure: >-
               --with-openssl=/home/runner/awslc --enable-ech
@@ -267,7 +268,7 @@ jobs:
             install_steps: pytest openssl
             install_steps_brew: libngtcp2 libnghttp3 c-ares
             CFLAGS: -fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g
-            LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan
+            LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             CC: clang
             generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl -DUSE_NGTCP2=ON -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -248,7 +248,7 @@ jobs:
             CC: clang
             configure-prefix: scan-build
             make-prefix: scan-build --status-bugs
-            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib
+            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             configure: >-
               --with-openssl=/home/linuxbrew/.linuxbrew/opt/openssl --with-ngtcp2 --with-nghttp3=

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -248,7 +248,7 @@ jobs:
             CC: clang
             configure-prefix: scan-build
             make-prefix: scan-build --status-bugs
-            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
+            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
             PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
             configure: >-
               --with-openssl=/home/linuxbrew/.linuxbrew/opt/openssl --with-ngtcp2 --with-nghttp3=


### PR DESCRIPTION
They use Linuxbrew instead of locally built components.

Linuxbrew limitations compared to the locally built components in
GHA/http3-linux:
- libngtcp2 currently supports OpenSSL only.
- wolfssl can't coexist with openssl.
- somewhat tricky configuration with autotools.

Upside is easy of use, always the latest versions (may be downside),
and availability of almost all packages.

---

- [ ] disable verbose strings to add to the variations.
  There were fallouts when testing this combo.
