### PR TITLE
GHA/linux: fix address sanitizer error output

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -242,12 +242,12 @@ jobs:
               --disable-debug --disable-unity
 
           - name: 'address-sanitizer'
-            install_packages: libssh2-1-dev clang libssl-dev libubsan1 libasan8 libtsan2
+            install_packages: clang libssl-dev libubsan1 libasan8 libtsan2
             install_steps: pytest randcurl
             CFLAGS: -fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g
-            LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer
-            LIBS: -ldl -lubsan
-            configure: CC=clang --with-openssl --enable-debug
+            LDFLAGS: -fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -ldl -lubsan
+            CC: clang
+            generate: -DENABLE_DEBUG=ON
 
           - name: 'thread-sanitizer'
             install_packages: clang libtsan2


### PR DESCRIPTION
Same issue as seen earlier in the tsan job. Fix it the same way, by
switching to cmake to avoid autotools' libtool confusing the analyzer.
Ref: 2a46df31fdb91851895bc46d81f0065e6cafc80b #18274

Configuration remains identical. I removed libssh2 from the installed
packages, because it was unused before, but cmake enabled it by default
and libssh2 has memory leaks:
Ref: https://github.com/curl/curl/actions/runs/17941312820/job/51018425159

Fixing:
```
/usr/bin/llvm-symbolizer-18: /home/runner/work/curl/curl/bld/lib/.libs/libcurl.so.4: no version information available (required by /usr/bin/llvm-symbolizer-18)
/usr/bin/llvm-symbolizer-18: symbol lookup error: /home/runner/work/curl/curl/bld/lib/.libs/libcurl.so.4: undefined symbol: __asan_option_detect_stack_use_after_return
==33900==WARNING: Can't read from symbolizer at fd 3
[..]
==33900==WARNING: Can't write to symbolizer at fd 6
==33900==WARNING: Failed to use and restart external symbolizer
```
Ref: https://github.com/curl/curl/actions/runs/17939949191/job/51013953675?pr=18693

Cherry-picked from #18693
