### PR TITLE
GHA/macos: add macos-26, llvm20, gcc15, drop macos-14, gcc14

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -573,7 +573,7 @@ jobs:
         # https://github.com/actions/runner-images/tree/main/images/macos
         # https://en.wikipedia.org/wiki/MacOS_version_history
         # TODO when dropping macos-13: replace '$(brew --prefix ...' with /opt/homebrew
-        image: [macos-13, macos-14, macos-15, macos-26]
+        image: [macos-13, macos-15, macos-26]
         # Can skip these to reduce jobs:
         #   15.1 has the same default macOS SDK as 15.2 and identical test results.
         #   14.1, 15.4 not revealing new fallouts.


### PR DESCRIPTION
Number of combo jobs down to 22 from 24.

Also:
- update the version matrix.
- update exclusion matrix.
- include verbose compiler configuration dump.
  It makes the Apple-included, default `-I/usr/local/include` visible.
  Ref: #18683
