### PR TITLE
feat: Add --write-out-format for structured JSON output

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -161,6 +161,7 @@ struct OperationConfig {
   char *krblevel;
   char *request_target;
   char *writeout;           /* %-styled format string to output */
+  char *writeout_format;    /* format for stdout output */
   struct curl_slist *quote;
   struct curl_slist *postquote;
   struct curl_slist *prequote;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -374,6 +374,7 @@ static const struct LongShort aliases[]= {
   {"wdebug",                     ARG_BOOL, ' ', C_WDEBUG},
 #endif
   {"write-out",                  ARG_STRG, 'w', C_WRITE_OUT},
+  {"write-out-format",           ARG_STRG, ' ', C_WRITEOUT_FORMAT},
   {"xattr",                      ARG_BOOL, ' ', C_XATTR},
 };
 
@@ -2755,6 +2756,15 @@ static ParameterError opt_string(struct OperationConfig *config,
     break;
   case C_WRITE_OUT: /* --write-out */
     err = parse_writeout(config, nextarg);
+    break;
+  case C_WRITEOUT_FORMAT: /* --write-out-format */
+    err = getstr(&config->writeout_format, nextarg, DENY_BLANK);
+    if(!err && config->writeout_format &&
+       strcmp(config->writeout_format, "json")) {
+      errorf("Format '%s' not supported. Currently, only 'json' is valid.",
+             nextarg);
+      err = PARAM_BAD_USE;
+    }
     break;
   case C_PREPROXY: /* --preproxy */
     err = getstr(&config->preproxy, nextarg, DENY_BLANK);

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -309,6 +309,7 @@ typedef enum {
   C_VLAN_PRIORITY,
   C_WDEBUG,
   C_WRITE_OUT,
+  C_WRITEOUT_FORMAT,
   C_XATTR
 } cmdline_t;
 

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -730,6 +730,13 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
   bool fclose_stream = FALSE;
   struct dynbuf name;
 
+  if(config->writeout_format && !strcmp(config->writeout_format, "json")) {
+    ourWriteOutStructuredJSON(stdout, variables,
+                              CURL_ARRAYSIZE(variables),
+                              per, per_result);
+    return;
+  }
+
   if(!writeinfo)
     return;
 

--- a/src/tool_writeout_json.h
+++ b/src/tool_writeout_json.h
@@ -32,6 +32,10 @@ int jsonquoted(const char *in, size_t len,
 void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
                      size_t nentries,
                      struct per_transfer *per, CURLcode per_result);
+void ourWriteOutStructuredJSON(FILE *stream,
+                               const struct writeoutvar variables[],
+                               size_t num_vars, struct per_transfer *per,
+                               CURLcode per_result);
 void headerJSON(FILE *stream, struct per_transfer *per);
 void jsonWriteString(FILE *stream, const char *in, bool lowercase);
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -281,6 +281,6 @@ test3100 test3101 test3102 test3103 test3104 test3105 \
 \
 test3200 test3201 test3202 test3203 test3204 test3205 test3207 test3208 \
 test3209 test3210 test3211 test3212 test3213 test3214 test3215 \
-test4000 test4001
+test4000 test4001 test2999
 
 EXTRA_DIST = $(TESTCASES) DISABLED

--- a/tests/data/test2999
+++ b/tests/data/test2999
@@ -1,0 +1,18 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+write-out
+json
+</keywords>
+</info>
+<name>Test --write-out-format json</name>
+<command>--write-out-format json --silent %URL</command>
+<protocol>http</protocol>
+<verify>
+<json>
+<file name="stdout"/>
+<jq>.response_code == 200 and .url_effective == "%URL/" and .size_download > 0</jq>
+</json>
+</verify>
+</testcase>


### PR DESCRIPTION
This commit introduces a new command-line option, `--write-out-format`, to support structured output from `--write-out`. The initial implementation supports `json` as a format.

When `--write-out-format json` is used, curl will output a JSON object containing all the available `--write-out` variables and their values. This is particularly useful for scripting and automation, as it provides a machine-readable output that is easy to parse.

A test case has been added in `tests/data/test2999` to cover this new functionality.