### PR TITLE
GHA/dist: fix number of parallel jobs on macos runner

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -258,6 +258,7 @@ jobs:
         shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}
     env:
       CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
+      MAKEFLAGS: ${{ contains(matrix.image, 'macos') && '-j 4' || '-j 5' }}
       MATRIX_IMAGE: '${{ matrix.image }}'
       TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }} ${{ contains(matrix.image, 'windows') && '-DCMAKE_UNITY_BUILD_BATCH_SIZE=30' || '' }}
       OLD_CMAKE_VERSION: 3.11.4


### PR DESCRIPTION
It was using the global parallel value in cmake integration tests, while
on macos runners, this should be lower by one, as used in other macos
jobs. Performance impact is minimal.

Follow-up to fb70812437ad28b74dbdc1031e46c1d86bc9db3c #16126
