### PR TITLE
GHA/distcheck: bump timeout for the cmake integration

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -252,7 +252,7 @@ jobs:
   cmake-integration:
     name: 'CM integration ${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     defaults:
       run:
         shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}


### PR DESCRIPTION
It may take 1.5 minutes to find the C compiler on macos with old cmake.
The build is also slow due to no unity and Ninja support.

```
Wed, 24 Sep 2025 04:56:51 GMT -- Using CMake version 3.11.4
Wed, 24 Sep 2025 04:58:01 GMT -- The C compiler identification is AppleClang 17.0.0.17000013
Wed, 24 Sep 2025 04:58:02 GMT -- Check for working C compiler: /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
Wed, 24 Sep 2025 04:59:33 GMT -- Check for working C compiler: /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -- works
Wed, 24 Sep 2025 04:59:33 GMT -- Detecting C compiler ABI info
Wed, 24 Sep 2025 04:59:35 GMT -- Detecting C compiler ABI info - done
```
Ref: https://github.com/curl/curl/actions/runs/17966736478/job/51100678487?pr=18700#step:10:50
