### PR TITLE
GHA/curl-for-win: use `DOCKER_IMAGE_STABLE`

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -58,17 +58,17 @@ jobs:
           mv curl-for-win/* .
           export CW_CONFIG='-main-werror-unitybatch-linux-a64-x64-gcc'
           export CW_REVISION="${GITHUB_SHA}"
-          DOCKER_IMAGE='debian:bookworm-slim'
+          . ./_versions.sh
           export CW_CCSUFFIX='-15'
           export CW_GCCSUFFIX='-12'
           sudo podman image trust set --type reject default
           sudo podman image trust set --type accept docker.io/library
-          time podman pull "${DOCKER_IMAGE}"
+          time podman pull "${DOCKER_IMAGE_STABLE}"
           podman images --digests
           time podman run --volume "$(pwd):$(pwd)" --workdir "$(pwd)" \
             --env-file <(env | grep -a -E \
               '^(CW_|GITHUB_)') \
-            "${DOCKER_IMAGE}" \
+            "${DOCKER_IMAGE_STABLE}" \
             sh -c ./_ci-linux-debian.sh
 
   linux-musl-llvm:


### PR DESCRIPTION
Replacing the hard-wired stable image. After this patch, it
will automatically follow upstream updates.

Follow-up to https://github.com/curl/curl-for-win/commit/6870bc1b35baff03168af1d0506ec8610851a819
Follow-up to https://github.com/curl/curl-for-win/commit/5a25df253da4f68de52b14a2e612df5fc60b8aa6
