### PR TITLE
cf-h2-proxy: break loop on edge case

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -433,6 +433,11 @@ static int proxy_h2_process_pending_input(struct Curl_cfilter *cf,
       *err = CURLE_RECV_ERROR;
       return -1;
     }
+    else if(!rv) {
+      /* nghttp2 does not want to process more, but has no error. This
+       * probably cannot happen, but be safe. */
+      break;
+    }
     Curl_bufq_skip(&ctx->inbufq, (size_t)rv);
     if(Curl_bufq_is_empty(&ctx->inbufq)) {
       CURL_TRC_CF(data, cf, "[0] all data in connection buffer processed");


### PR DESCRIPTION
nghttp2 always consumes the memory, but be safe in case it ever decideds to not to.

Fixes J2
Reported in Joshua's sarif data