### PR TITLE
alpn setting, check proto parameter

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1993,6 +1993,11 @@ CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
       result = CURLE_SSL_CONNECT_ERROR;
       goto out;
     }
+    else if(!proto) {
+      DEBUGASSERT(0); /* with length, we need a pointer */
+      result = CURLE_SSL_CONNECT_ERROR;
+      goto out;
+    }
     else if((strlen(connssl->negotiated.alpn) != proto_len) ||
             memcmp(connssl->negotiated.alpn, proto, proto_len)) {
       failf(data, "ALPN: asked for '%s' from previous session, but server "


### PR DESCRIPTION
When setting the negotiated alpn protocol, either then length must be 0 or a pointer must be passed.

Reported in Joshua's sarif data