### PR TITLE
openssl-quic: check results better

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1424,12 +1424,16 @@ static CURLcode cf_progress_ingress(struct Curl_cfilter *cf,
     if(!snew)
       break;
 
-    (void)cf_osslq_h3conn_add_stream(&ctx->h3, snew, cf, data);
+    result = cf_osslq_h3conn_add_stream(&ctx->h3, snew, cf, data);
+    if(result)
+      goto out;
   }
 
   if(!SSL_handle_events(ctx->tls.ossl.ssl)) {
     int detail = SSL_get_error(ctx->tls.ossl.ssl, 0);
     result = cf_osslq_ssl_err(cf, data, detail, CURLE_RECV_ERROR);
+    if(result)
+      goto out;
   }
 
   if(ctx->h3.conn) {

--- a/tests/http/testenv/caddy.py
+++ b/tests/http/testenv/caddy.py
@@ -117,7 +117,10 @@ class Caddy:
         self._mkpath(self._tmp_dir)
         if self._process:
             self._process.terminate()
-            self._process.wait(timeout=2)
+            try:
+                self._process.wait(timeout=1)
+            except Exception:
+                self._process.kill()
             self._process = None
             return not wait_dead or self.wait_dead(timeout=timedelta(seconds=5))
         return True


### PR DESCRIPTION
Fail on errors from SSL_handle_events().
Force quit Caddy test instance that is left hanging longer with openssl-quic tests for unknown reasons.

Reported in Joshua's sarif data