### PR TITLE
ngtcp2: fix early return

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1304,8 +1304,10 @@ static CURLcode cf_ngtcp2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   *pnread = 0;
 
   /* handshake verification failed in callback, do not recv anything */
-  if(ctx->tls_vrfy_result)
-    return ctx->tls_vrfy_result;
+  if(ctx->tls_vrfy_result) {
+    result = ctx->tls_vrfy_result;
+    goto out;
+  }
 
   pktx_init(&pktx, cf, data);
 


### PR DESCRIPTION
On a failed tls handshake, the receive function returned without restoring the current data.

Reported in Joshua's sarif data