### PR TITLE
quiche: fix verbose message when ip quadruple cannot be obtained.

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1433,9 +1433,11 @@ out:
   if(result && result != CURLE_AGAIN) {
     struct ip_quadruple ip;
 
-    Curl_cf_socket_peek(cf->next, data, NULL, NULL, &ip);
-    infof(data, "connect to %s port %u failed: %s",
-          ip.remote_ip, ip.remote_port, curl_easy_strerror(result));
+    if(!Curl_cf_socket_peek(cf->next, data, NULL, NULL, &ip))
+      infof(data, "connect to %s port %u failed: %s",
+            ip.remote_ip, ip.remote_port, curl_easy_strerror(result));
+    else
+      infof(data, "connect failed: %s", curl_easy_strerror(result));
   }
 #endif
   return result;


### PR DESCRIPTION
Reported in Joshua's sarif data