### PR TITLE
GHA: relax `impacket` version requirement

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: curl
 
-impacket == 0.12.0
+impacket>=0.11.0


### PR DESCRIPTION
impacket 0.11.0 requires pyOpenSSL >= 21, while 0.12.0 pins it to 24,
which happens to contain a vulnerable OpenSSL. (and also forced to use
an older than ideal cryptography version I'm guessing)

It means that downgrading impacket allows upgrading crypto components
to newer, fixed, versions.

https://github.com/fortra/impacket/blob/impacket_0_11_0/requirements.txt
https://github.com/fortra/impacket/blob/impacket_0_12_0/requirements.txt

Follow-up to 7d5f8be532c19ec73063aaa4f27057047bdae5ac #18708
