### PR TITLE
transfer with tiny speed limit, fix busy loop

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -283,7 +283,7 @@ static CURLcode sendrecv_dl(struct Curl_easy *data,
        * a quarter of the quota, break out. We want to stutter a bit
        * to keep in the limit, but too small receives will just cost
        * cpu unnecessarily. */
-      if(total_received >= (data->set.max_recv_speed / 4))
+      if(total_received && (total_received >= (data->set.max_recv_speed / 4)))
         break;
       if(data->set.max_recv_speed < (curl_off_t)bytestoread)
         bytestoread = (size_t)data->set.max_recv_speed;


### PR DESCRIPTION
When a transfer has a speed limit less than 4, the receive loop early exits without receiving anything, causing a busy loop for that transfer.

Perform that check only after the first receive has been done.

Reported in Joshua's sarif data