### PR TITLE
openssl: set io_need always

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5368,6 +5368,7 @@ static CURLcode ossl_recv(struct Curl_cfilter *cf,
         connclose(conn, "TLS close_notify");
       break;
     case SSL_ERROR_WANT_READ:
+      connssl->io_need = CURL_SSL_IO_NEED_RECV;
       result = CURLE_AGAIN;
       goto out;
     case SSL_ERROR_WANT_WRITE:


### PR DESCRIPTION
When OpenSSL reports SSL_ERROR_WANT_READ, set the io_need explicitly. It should have already been set by the BIO, but be safe.

Reported in Joshua's sarif data