### PR TITLE
GHA: use `pyspelling` directly

### DIFF
--- a/.github/scripts/requirements-docs.txt
+++ b/.github/scripts/requirements-docs.txt
@@ -1,0 +1,5 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+pyspelling==2.11

--- a/.github/scripts/spellcheck.yaml
+++ b/.github/scripts/spellcheck.yaml
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 #
+# Docs: https://facelessuser.github.io/pyspelling/configuration/
 # Docs: https://github.com/UnicornGlobal/spellcheck-github-actions
 matrix:
   - name: Markdown

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -128,7 +128,7 @@ jobs:
           grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
           pyspelling --version
           aspell --version
-          pyspelling --verbose --jobs 5 --config .github/scripts/spellcheck.yaml
+          pyspelling --verbose --jobs 8 --config .github/scripts/spellcheck.yaml
 
   badwords-synopsis:
     name: 'badwords, synopsis'

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -128,7 +128,7 @@ jobs:
           grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
           pyspelling --version
           aspell --version
-          pyspelling --verbose --jobs 8 --config .github/scripts/spellcheck.yaml
+          pyspelling --verbose --jobs 5 --config .github/scripts/spellcheck.yaml
 
   badwords-synopsis:
     name: 'badwords, synopsis'

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -126,8 +126,8 @@ jobs:
         run: |
           source ~/venv/bin/activate
           grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
-          pyspelling --version
           aspell --version
+          pyspelling --version
           pyspelling --verbose --jobs 5 --config .github/scripts/spellcheck.yaml
 
   badwords-synopsis:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -128,7 +128,7 @@ jobs:
           grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
           pyspelling --version
           aspell --version
-          pyspelling --verbose --config .github/scripts/spellcheck.yaml
+          pyspelling --verbose --jobs 5 --config .github/scripts/spellcheck.yaml
 
   badwords-synopsis:
     name: 'badwords, synopsis'

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -113,13 +113,20 @@ jobs:
           # shellcheck disable=SC2046
           .github/scripts/cleancmd.pl $(find docs -name '*.md')
 
-      - name: 'setup the custom wordlist'
-        run: grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
+      - name: 'install'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo rm -f /var/lib/man-db/auto-update
+          sudo apt-get -o Dpkg::Use-Pty=0 install aspell aspell-en
+          python3 -m venv ~/venv
+          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r .github/scripts/requirements-docs.txt
 
-      - name: 'check Spelling'
-        uses: rojopolis/spellcheck-github-actions@739a1e3ceb79a98a5d4a9bf76f351137f9d78892 # v0
-        with:
-          config_path: .github/scripts/spellcheck.yaml
+      - name: 'check spelling'
+        run: |
+          source ~/venv/bin/activate
+          grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
+          pyspelling -c .github/scripts/spellcheck.yaml
 
   badwords-synopsis:
     name: 'badwords, synopsis'

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -126,7 +126,9 @@ jobs:
         run: |
           source ~/venv/bin/activate
           grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
-          pyspelling -c .github/scripts/spellcheck.yaml
+          pyspelling --version
+          aspell --version
+          pyspelling --verbose --config .github/scripts/spellcheck.yaml
 
   badwords-synopsis:
     name: 'badwords, synopsis'


### PR DESCRIPTION
To avoid depending on Docker Hub, an Docker image and a GitHub Action.
Also to simplify running this check on a local machine.

Pending question if Dependabot and Mend/Renovate will automatically pick
up `requirements-docs.txt`.

Also:
- enable parallel spellchecking. (also to win back the time lost with
  installing components directly from Debian and pip.)
- pin `pyspelling`.
- link to official `pyspelling` docs.

---

- [x] merge two unrelated changes separately. → edbf610c6a55ee9776f85352f9ad182cd52559b0, 5b8c80684b5b39c4d4fde2a7c4f2e3247c391fac