### PR TITLE
perlcheck: add script, enable in CI, fix fallouts

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -82,6 +82,10 @@ jobs:
           source ~/venv/bin/activate
           scripts/cmakelint.sh
 
+      - name: 'perlcheck'
+        run: |
+          scripts/perlcheck.sh
+
       - name: 'pytype'
         run: |
           source ~/venv/bin/activate

--- a/scripts/perlcheck.sh
+++ b/scripts/perlcheck.sh
@@ -30,18 +30,18 @@
 
 set -eu
 
-# TODO: also find Perl files without extension
-
 cd "$(dirname "$0")"/..
 
 {
   if [ -n "${1:-}" ]; then
     for A in "$@"; do printf "%s\n" "$A"; done
   elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    git ls-files
+    {
+      git ls-files | grep -E '\.(pl|pm)$'
+      git grep -l -E '^#!/usr/bin/env perl'
+    } | sort -u
   else
     # strip off the leading ./ to make the grep regexes work properly
-    find . -type f | sed 's@^\./@@'
+    find . -type f \( -name '*.pl' -o -name '*.pm' \) | sed 's@^\./@@'
   fi
-} | grep -E '\.(pl|pm)$' \
-  | xargs -n 1 perl -c -Itests
+} | xargs -n 1 perl -c -Itests

--- a/scripts/perlcheck.sh
+++ b/scripts/perlcheck.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Dan Fandrich, <dan@coneharvesters.com>, Viktor Szakats, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# The xargs invocation is portable, but does not preserve spaces in file names.
+# If such a file is ever added, then this can be portably fixed by switching to
+# "xargs -I{}" and appending {} to the end of the xargs arguments (which will
+# call cmakelint once per file) or by using the GNU extension "xargs -d'\n'".
+
+set -eu
+
+# TODO: also find Perl files without extension
+
+cd "$(dirname "$0")"/..
+
+{
+  if [ -n "${1:-}" ]; then
+    for A in "$@"; do printf "%s\n" "$A"; done
+  elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git ls-files
+  else
+    # strip off the leading ./ to make the grep regexes work properly
+    find . -type f | sed 's@^\./@@'
+  fi
+} | grep -E '\.(pl|pm)$' \
+  | xargs -n 1 perl -c -Itests

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -80,11 +80,27 @@ use pathhelp qw(
     dirsepadd
     );
 use Cwd qw(getcwd);
-use testutil qw(
-    shell_quote
-    );
 use File::Spec;
 
+
+#######################################################################
+# Quote an argument for passing safely to a Bourne shell
+# This does the same thing as String::ShellQuote but doesn't need a package.
+# Clone of the similar function in testutil.pm
+sub _shell_quote {
+    my ($s)=@_;
+    if($^O eq 'MSWin32') {
+        $s = '"' . $s . '"';
+    }
+    else {
+        if($s !~ m/^[-+=.,_\/:a-zA-Z0-9]+$/) {
+            # string contains a "dangerous" character--quote it
+            $s =~ s/'/'"'"'/g;
+            $s = "'" . $s . "'";
+        }
+    }
+    return $s;
+}
 
 #######################################################################
 # global configuration variables
@@ -107,8 +123,8 @@ our $randseed = 0;    # random number seed
 # paths
 our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
-our $perlcmd=shell_quote($^X);
-our $perl="$perlcmd -I. " . shell_quote("-I$srcdir"); # invoke perl like this
+our $perlcmd = _shell_quote($^X);
+our $perl="$perlcmd -I. " . _shell_quote("-I$srcdir"); # invoke perl like this
 our $LOGDIR="log";  # root of the log directory; this will be different for
                     # each runner in multiprocess mode
 our $LIBDIR=dirsepadd("./libtest/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
@@ -125,7 +141,7 @@ our $VCURL=$CURL;  # what curl binary to use to verify the servers with
                    # VCURL is handy to set to the system one when the one you
                    # just built hangs or crashes and thus prevent verification
 # the path to the script that analyzes the memory debug output file
-our $memanalyze="$perl " . shell_quote("$srcdir/memanalyze.pl");
+our $memanalyze = "$perl " . _shell_quote("$srcdir/memanalyze.pl");
 our $valgrind;     # path to valgrind, or empty if disabled
 our $dev_null = File::Spec->devnull();   # null device path, eg: /dev/null
 

--- a/tests/test745.pl
+++ b/tests/test745.pl
@@ -45,7 +45,8 @@ sub gettypecheck {
 }
 
 sub getinclude {
-    open(my $f, "<", "$root/include/curl/curl.h")
+    my $f;
+    open($f, "<", "$root/include/curl/curl.h")
         || die "no curl.h";
     while(<$f>) {
         if($_ =~ /\((CURLOPT[^,]*), (CURLOPTTYPE_[^,]*)/) {
@@ -61,7 +62,7 @@ sub getinclude {
     $enum{"CURLOPT_CONV_TO_NETWORK_FUNCTION"}++;
     close($f);
 
-    open(my $f, "<", "$root/include/curl/multi.h")
+    open($f, "<", "$root/include/curl/multi.h")
         || die "no curl.h";
     while(<$f>) {
         if($_ =~ /\((CURLMOPT[^,]*), (CURLOPTTYPE_[^,]*)/) {

--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -584,8 +584,10 @@ if(-f "./libcurl.pc") {
     }
 }
 
+my $f;
+
 logit_spaced "display lib/$confheader";
-open(my $f, "<", "lib/$confheader") or die "lib/$confheader: $!";
+open($f, "<", "lib/$confheader") or die "lib/$confheader: $!";
 while(<$f>) {
     print if /^ *#/;
 }
@@ -660,7 +662,7 @@ if(($have_embedded_ares) &&
 
 my $mkcmd = "$make -i" . ($targetos && !$configurebuild ? " $targetos" : "");
 logit "$mkcmd";
-open(my $f, "-|", "$mkcmd 2>&1") or die;
+open($f, "-|", "$mkcmd 2>&1") or die;
 while(<$f>) {
     s/$pwd//g;
     print;

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -219,25 +219,6 @@ sub exerunner {
     return '';
 }
 
-#######################################################################
-# Quote an argument for passing safely to a Bourne shell
-# This does the same thing as String::ShellQuote but doesn't need a package.
-#
-sub shell_quote {
-    my ($s)=@_;
-    if($^O eq 'MSWin32') {
-        $s = '"' . $s . '"';
-    }
-    else {
-        if($s !~ m/^[-+=.,_\/:a-zA-Z0-9]+$/) {
-            # string contains a "dangerous" character--quote it
-            $s =~ s/'/'"'"'/g;
-            $s = "'" . $s . "'";
-        }
-    }
-    return $s;
-}
-
 sub get_sha256_base64 {
     my ($file_path) = @_;
     return encode_base64(sha256(do { local $/; open my $fh, '<:raw', $file_path or die $!; <$fh> }), "");
@@ -275,4 +256,24 @@ sub substrippemfile {
         $$thing =~ s/%%FILE%%/$file_content/;
     }
 }
+
+#######################################################################
+# Quote an argument for passing safely to a Bourne shell
+# This does the same thing as String::ShellQuote but doesn't need a package.
+#
+sub shell_quote {
+    my ($s)=@_;
+    if($^O eq 'MSWin32') {
+        $s = '"' . $s . '"';
+    }
+    else {
+        if($s !~ m/^[-+=.,_\/:a-zA-Z0-9]+$/) {
+            # string contains a "dangerous" character--quote it
+            $s =~ s/'/'"'"'/g;
+            $s = "'" . $s . "'";
+        }
+    }
+    return $s;
+}
+
 1;


### PR DESCRIPTION
---

- [ ] find a better way to avoid the circular dependency between `globalconfig.pm` and `testutil.pm`.
