### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -125,6 +125,7 @@ jobs:
       - name: 'check spelling'
         run: |
           source ~/venv/bin/activate
+          # setup the custom wordlist
           grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
           aspell --version
           pyspelling --version

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -100,8 +100,8 @@ jobs:
       - name: 'mdlinkcheck'
         run: ./scripts/mdlinkcheck
 
-  spellcheck:
-    name: 'spellcheck'
+  pyspelling:
+    name: 'pyspelling'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/configure.ac
+++ b/configure.ac
@@ -5033,8 +5033,8 @@ if test "x$want_ech" != "xno"; then
       ECH_ENABLED_WOLFSSL=1)
   fi
   if test "x$RUSTLS_ENABLED" = "x1"; then
-      ECH_SUPPORT="$ECH_SUPPORT rustls-ffi"
-      ECH_ENABLED_RUSTLS=1
+    ECH_SUPPORT="$ECH_SUPPORT rustls-ffi"
+    ECH_ENABLED_RUSTLS=1
   fi
 
   dnl now deal with whatever we found

--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ OPT_SCHANNEL=no
 AC_ARG_WITH(schannel,dnl
 AS_HELP_STRING([--with-schannel],[enable Windows native SSL/TLS]),
   OPT_SCHANNEL=$withval
-  TLSCHOICE="schannel")
+  TLSCHOICE="Schannel")
 
 OPT_AMISSL=no
 AC_ARG_WITH(amissl,dnl

--- a/docs/libcurl/libcurl.m4
+++ b/docs/libcurl/libcurl.m4
@@ -178,7 +178,7 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
           x=CURLOPT_ERRORBUFFER;
           x=CURLOPT_STDERR;
           x=CURLOPT_VERBOSE;
-          if (x) {;}
+          if(x) {;}
         ]])],libcurl_cv_lib_curl_usable=yes,libcurl_cv_lib_curl_usable=no)
 
         CPPFLAGS=$_libcurl_save_cppflags

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -134,7 +134,6 @@ int Curl_thread_join(curl_thread_t *hnd)
 
   Curl_thread_destroy(hnd);
 
-
   return ret;
 }
 

--- a/lib/curlx/version_win32.c
+++ b/lib/curlx/version_win32.c
@@ -139,7 +139,7 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
 #pragma clang diagnostic ignored "-Wcast-function-type-strict"
 #endif
     pRtlVerifyVersionInfo = CURLX_FUNCTION_CAST(RTLVERIFYVERSIONINFO_FN,
-      (GetProcAddress(GetModuleHandleA("ntdll"), "RtlVerifyVersionInfo")));
+      GetProcAddress(GetModuleHandleA("ntdll"), "RtlVerifyVersionInfo"));
 #if defined(__clang__) && __clang_major__ >= 16
 #pragma clang diagnostic pop
 #endif

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -1062,7 +1062,7 @@ UNITTEST void de_cleanup(struct dohentry *d)
  * @return is 1 for success, error otherwise
  *
  * The encoding here is defined in
- * https://tools.ietf.org/html/rfc1035#section-3.1
+ * https://datatracker.ietf.org/doc/html/rfc1035#section-3.1
  *
  * The input buffer pointer will be modified so it points to
  * just after the end of the DNS name encoding on output. (And

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -106,8 +106,8 @@ CURLcode Curl_win32_init(long flags)
 #endif
     IF_NAMETOINDEX_FN pIfNameToIndex =
       CURLX_FUNCTION_CAST(IF_NAMETOINDEX_FN,
-                          (GetProcAddress(s_hIpHlpApiDll,
-                                          CURL_TEXT("if_nametoindex"))));
+                          GetProcAddress(s_hIpHlpApiDll,
+                                         CURL_TEXT("if_nametoindex")));
 
     if(pIfNameToIndex)
       Curl_if_nametoindex = pIfNameToIndex;
@@ -202,7 +202,7 @@ static HMODULE curl_load_library(LPCTSTR filename)
      and above */
   pLoadLibraryEx =
     CURLX_FUNCTION_CAST(LOADLIBRARYEX_FN,
-                        (GetProcAddress(hKernel32, LOADLIBARYEX)));
+                        GetProcAddress(hKernel32, LOADLIBARYEX));
 
   /* Detect if there is already a path in the filename and load the library if
      there is. Note: Both back slashes and forward slashes have been supported

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -939,7 +939,6 @@ static bool bad_option(const char *data)
  * Look at the sub-option buffer, and try to be helpful to the other
  * side.
  */
-
 static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
 {
   struct curl_slist *v;
@@ -1023,13 +1022,11 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
   return CURLE_OK;
 }
 
-
 /*
  * sendsuboption()
  *
  * Send suboption information to the server side.
  */
-
 static void sendsuboption(struct Curl_easy *data,
                           struct TELNET *tn, int option)
 {
@@ -1083,7 +1080,6 @@ static void sendsuboption(struct Curl_easy *data,
     break;
   }
 }
-
 
 static
 CURLcode telrcv(struct Curl_easy *data,

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -108,15 +108,15 @@
  */
 typedef enum
 {
-   CURL_TS_DATA = 0,
-   CURL_TS_IAC,
-   CURL_TS_WILL,
-   CURL_TS_WONT,
-   CURL_TS_DO,
-   CURL_TS_DONT,
-   CURL_TS_CR,
-   CURL_TS_SB,   /* sub-option collection */
-   CURL_TS_SE   /* looking for sub-option end */
+  CURL_TS_DATA = 0,
+  CURL_TS_IAC,
+  CURL_TS_WILL,
+  CURL_TS_WONT,
+  CURL_TS_DO,
+  CURL_TS_DONT,
+  CURL_TS_CR,
+  CURL_TS_SB,   /* sub-option collection */
+  CURL_TS_SE    /* looking for sub-option end */
 } TelnetReceive;
 
 struct TELNET {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -125,7 +125,7 @@ static void ossl_provider_cleanup(struct Curl_easy *data);
  * X509_V_ERR_EC_KEY_EXPLICIT_PARAMS. */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
   !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL) && \
-  (!defined(OPENSSL_IS_AWSLC) || (defined(X509_V_ERR_EC_KEY_EXPLICIT_PARAMS)))
+  (!defined(OPENSSL_IS_AWSLC) || defined(X509_V_ERR_EC_KEY_EXPLICIT_PARAMS))
 #define HAVE_SSL_CTX_SET_DEFAULT_READ_BUFFER_LEN 1
 #endif
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2558,8 +2558,8 @@ static int schannel_init(void)
 #endif
   WINE_GET_VERSION_FN p_wine_get_version =
     CURLX_FUNCTION_CAST(WINE_GET_VERSION_FN,
-                        (GetProcAddress(GetModuleHandleA("ntdll"),
-                                        "wine_get_version")));
+                        GetProcAddress(GetModuleHandleA("ntdll"),
+                                       "wine_get_version"));
 #if defined(__clang__) && __clang_major__ >= 16
 #pragma clang diagnostic pop
 #endif

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1579,9 +1579,9 @@ CURLcode curl_ws_recv(CURL *d, void *buffer,
   *metap = &ws->recvframe;
   *nread = ws->recvframe.len;
   CURL_TRC_WS(data, "curl_ws_recv(len=%zu) -> %zu bytes (frame at %"
-               FMT_OFF_T ", %" FMT_OFF_T " left)",
-               buflen, *nread, ws->recvframe.offset,
-               ws->recvframe.bytesleft);
+              FMT_OFF_T ", %" FMT_OFF_T " left)",
+              buflen, *nread, ws->recvframe.offset,
+              ws->recvframe.bytesleft);
   /* all's well, try to send any pending control. we do not know
    * when the application will call `curl_ws_send()` again. */
   if(!data->set.ws_raw_mode && ws->pending.type) {

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -545,7 +545,7 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
       const unsigned char tmp = '\0';
       /* special case of a 0 length frame, need to write once */
       result = write_cb(&tmp, 0, dec->frame_age, dec->frame_flags,
-                          0, 0, write_ctx, &nwritten);
+                        0, 0, write_ctx, &nwritten);
       if(result)
         return result;
       dec->state = WS_DEC_INIT;
@@ -680,8 +680,8 @@ static CURLcode ws_cw_dec_next(const unsigned char *buf, size_t buflen,
                 payload_len, buflen);
 
     result = Curl_cwriter_write(data, ctx->next_writer,
-                              (ctx->cw_type | CLIENTWRITE_0LEN),
-                              (const char *)buf, buflen);
+                                (ctx->cw_type | CLIENTWRITE_0LEN),
+                                (const char *)buf, buflen);
     if(result)
       return result;
   }


### PR DESCRIPTION
- GHA/checkdocs: rename `spellcheck` job to `pyspelling` to say
  the exact tool used.
- GHA/checkdocs: restore a comment.
- autotools: use correct casing for `Schannel`.
- doh: update RFC URL.
- drop redundant parenthesis.
- fix indentation, whitespace.
