### PR TITLE
CI: make pip use `tests/requirements.txt` in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
       - run:
           command: |
             sudo apt-get update && sudo apt-get install -y libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev python3-pip libpsl-dev
-            sudo python3 -m pip install impacket
+            sudo python3 -m pip install --progress-bar off --prefer-binary -r tests/requirements.txt
 
   install-wolfssl:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
       - run:
           command: |
             sudo apt-get update && sudo apt-get install -y libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev python3-pip libpsl-dev
-            sudo python3 -m pip install --progress-bar off --prefer-binary -r tests/requirements.txt
+            sudo python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/requirements.txt
 
   install-wolfssl:
     steps:


### PR DESCRIPTION
Also sync `pip` options with those used in GHA.
