### PR TITLE
renovate: adjust commit message prefixes, try making CodeQL and AWS-LC updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-    ignore:
-    # ignore patch updates to reduce noise
-    - dependency-name: 'github/codeql-action'
-      update-type: 'version-update:semver-minor'
+      interval: 'monthly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+    # ignore patch updates to reduce noise
+    - dependency-name: 'github/codeql-action'
+      update-type: 'version-update:semver-minor'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'monthly'

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
         "pinDigest",
         "digest"
       ],
-      "commitMessagePrefix": "ci: ",
+      "commitMessagePrefix": "CI: ",
       "labels": [
         "CI"
       ]
@@ -30,7 +30,7 @@
       "matchManagers": [
         "custom.regex"
       ],
-      "commitMessagePrefix": "ci: ",
+      "commitMessagePrefix": "CI: ",
       "labels": [
         "CI"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,26 @@
         ".github/workflows/linux-old.yml"
       ],
       "enabled": false
+    },
+    {
+      "description": "Schedule CodeQL updates on the 10th of each month",
+      "matchPackageNames": [
+        "/codeql/i"
+      ],
+      "groupName": "CodeQL",
+      "schedule": [
+        "* * 10 * *"
+      ]
+    },
+    {
+      "description": "Schedule package updates on the 10th of each month",
+      "matchSourceUrls": [
+        "**/awslabs/**"
+      ],
+      "groupName": "monthly updates",
+      "schedule": [
+        "* * 10 * *"
+      ]
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
       "matchManagers": [
         "github-actions"
       ],
-      "commitMessagePrefix": "gha: ",
+      "commitMessagePrefix": "GHA: ",
       "labels": [
         "CI"
       ]


### PR DESCRIPTION
Also:
- enable pip bumps in Dependabot.
- reduce dependabot to check monthly (was: weekly)
  Dependabot acts as a backup for mend/renovate.

---

It'd be nice to reduce churn by bumping only to the latest patch
release of the previous major.minor release. Is that possible? Or
something similar to that effect?

`npx --package renovate -- renovate-config-validator` doesn't 
list new errors after these changes. I wonder how to test it more,
in advance.

I expect GHA updates to remain mildly annoying: Renovate bumps
them on the 10th, then Dependabot does it on the 1st.

https://docs.renovatebot.com/config-overview/
https://docs.renovatebot.com/config-validation/

TODO:
- [x] try making codeql action updates less frequent.
- [x] try making AWS-LC updates less frequent.
