### PR TITLE
servers: drop `open` override in signal handler (Windows)

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -378,7 +378,7 @@ static void exit_signal_handler(int signum)
 #else
 #define OPENMODE S_IRUSR | S_IWUSR
 #endif
-    int fd = open(serverlogfile, O_WRONLY|O_CREAT|O_APPEND, OPENMODE);
+    int fd = _open(serverlogfile, O_WRONLY|O_CREAT|O_APPEND, OPENMODE);
     if(fd != -1) {
       static const char msg[] = "exit_signal_handler: called\n";
       (void)!write(fd, msg, sizeof(msg) - 1);


### PR DESCRIPTION
Turns out the signal handler on Windows still wasn't signal safe after
the previous round of fix. There is an `open()` call made from there,
and `open` happens to be unconditionally overridden via `curl_setup.h`
on Windows, to a local implementation, which does memory allocations
and possibly other things that are not signal safe.

Ref: #18634
Follow-up e95f509c66abdd88ae02e3243cdc217f19c4a330 #16852
