### PR TITLE
checksrc: fix possible endless loop when detecting `BANNEDFUNC`

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -902,6 +902,8 @@ sub scanfile {
                       "use of $bad is banned");
             my $replace = 'x' x (length($bad) + 1);
             $prefix =~ s/\*/\\*/;
+            $prefix =~ s/\[/\\[/;
+            $prefix =~ s/\]/\\]/;
             $suff =~ s/\(/\\(/;
             $l =~ s/$prefix$bad$suff/$prefix$replace/;
             goto again;


### PR DESCRIPTION
If the source line had square brackets before the match, the stripping
of the banned function left the original line intact, and repeated the
check on it forever. E.g. with `open` banned function in `lib518.c`:
```
t518_testfd[0] = open(DEV_NULL, O_RDONLY);
```
