### PR TITLE
tidy-up: `fcntl.h` includes

### DIFF
--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -41,9 +41,6 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -44,9 +44,6 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -41,9 +41,6 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif

--- a/lib/curlx/fopen.h
+++ b/lib/curlx/fopen.h
@@ -28,6 +28,10 @@
 
 #include "multibyte.h"
 
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>  /* for open() and attributes */
+#endif
+
 #if defined(_WIN32) && !defined(UNDER_CE)
 FILE *curlx_win32_fopen(const char *filename, const char *mode);
 int curlx_win32_stat(const char *path, struct_stat *buffer);
@@ -36,9 +40,6 @@ int curlx_win32_open(const char *filename, int oflag, ...);
 #define curlx_stat(fname, stp)       curlx_win32_stat(fname, stp)
 #define curlx_open                   curlx_win32_open
 #else
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>  /* for open() */
-#endif
 #define CURLX_FOPEN_LOW              fopen
 #define curlx_stat(fname, stp)       stat(fname, stp)
 #define curlx_open                   open

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -26,9 +26,6 @@
 
 #include <limits.h>
 
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -43,9 +43,6 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
 
 #include "../urldata.h"
 #include "../cfilters.h"

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -29,9 +29,6 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
 
 #include "../urldata.h"
 #include "../cfilters.h"


### PR DESCRIPTION
- drop from source files without obvious users.
- include in `curlx/fopen.h` also for Windows.

Follow-up to 9678ff5b1bfea1c847aee4f9edf023e8f01c9293 #18776

---

Tested OK with macOS/Windows example builds with the `fcntl.h` include deleted from `curl_setup_once.h`.
