### PR TITLE
cf-socket: tweak a memcpy() to read better

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -333,12 +333,12 @@ static CURLcode sock_assign_addr(struct Curl_sockaddr_ex *dest,
   }
   dest->addrlen = (unsigned int)ai->ai_addrlen;
 
-  if(dest->addrlen > sizeof(struct Curl_sockaddr_storage)) {
+  if(dest->addrlen > sizeof(dest->curl_sa_addrbuf)) {
     DEBUGASSERT(0);
     return CURLE_TOO_LARGE;
   }
 
-  memcpy(&dest->curl_sa_addr, ai->ai_addr, dest->addrlen);
+  memcpy(&dest->curl_sa_addrbuf, ai->ai_addr, dest->addrlen);
   return CURLE_OK;
 }
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -333,10 +333,9 @@ static CURLcode sock_assign_addr(struct Curl_sockaddr_ex *dest,
   }
   dest->addrlen = (unsigned int)ai->ai_addrlen;
 
-  if(dest->addrlen > sizeof(dest->curl_sa_addrbuf)) {
-    DEBUGASSERT(0);
+  DEBUGASSERT(dest->addrlen <= sizeof(dest->curl_sa_addrbuf));
+  if(dest->addrlen > sizeof(dest->curl_sa_addrbuf))
     return CURLE_TOO_LARGE;
-  }
 
   memcpy(&dest->curl_sa_addrbuf, ai->ai_addr, dest->addrlen);
   return CURLE_OK;

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -48,11 +48,12 @@ struct Curl_sockaddr_ex {
   int protocol;
   unsigned int addrlen;
   union {
-    struct sockaddr addr;
-    struct Curl_sockaddr_storage buff;
-  } _sa_ex_u;
+    struct sockaddr sa;
+    struct Curl_sockaddr_storage buf;
+  } addr;
 };
-#define curl_sa_addr _sa_ex_u.addr
+#define curl_sa_addr addr.sa
+#define curl_sa_addrbuf addr.buf
 
 /*
  * Parse interface option, and return the interface name and the host part.


### PR DESCRIPTION
By checking the size of the actual buffer and using that as memcpy target instead of another union member, this helps readers and static code analyzers to determine that this is not a buffer overflow.

Ref: #18677