### PR TITLE
form.md: drop reference to MANUAL

### DIFF
--- a/docs/cmdline-opts/form.md
+++ b/docs/cmdline-opts/form.md
@@ -141,5 +141,3 @@ base64 attached file:
 
     curl -F '=text message;encoder=quoted-printable' \
          -F '=@localfile;encoder=base64' ... smtp://example.com
-
-See further examples and details in the MANUAL.


### PR DESCRIPTION
Since it isn't linked and users might not understand what it refers to.

Ref: #18755