### PR TITLE
tidy-up: LibreSSL Git repository URLs and local CI builds

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -213,7 +213,7 @@ jobs:
         run: |
           cd ~
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
-            --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
+            "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           cmake -B . -G Ninja -DLIBRESSL_APPS=OFF -DLIBRESSL_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/home/runner/libressl/build
           cmake --build .

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -362,8 +362,9 @@ jobs:
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
-          ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
-          make install
+          cmake -B . -G Ninja -DLIBRESSL_APPS=OFF -DLIBRESSL_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/home/runner/libressl
+          cmake --build .
+          cmake --install .
 
       - name: 'cache wolfssl (all)'
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-all') }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -360,7 +360,7 @@ jobs:
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
-            --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
+            "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
           make install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,7 @@ env:
   MAKEFLAGS: -j 5
   CURL_CI: github
   CURL_CLANG_TIDYFLAGS: '-checks=-clang-analyzer-security.insecureAPI.bzero,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-optin.performance.Padding,-clang-analyzer-security.ArrayBound,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-valist.Uninitialized'
-  # renovate: datasource=github-tags depName=libressl-portable/portable versioning=semver registryUrl=https://github.com
+  # renovate: datasource=github-tags depName=libressl/portable versioning=semver registryUrl=https://github.com
   LIBRESSL_VERSION: 4.1.1
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   WOLFSSL_VERSION: 5.8.2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,7 +58,7 @@ jobs:
       LDFLAGS: ''
       MATRIX_BUILD: ${{ matrix.build.generate && 'cmake' || 'autotools' }}
       MATRIX_OPTIONS: ${{ matrix.build.options }}
-      # renovate: datasource=github-tags depName=libressl-portable/portable versioning=semver registryUrl=https://github.com
+      # renovate: datasource=github-tags depName=libressl/portable versioning=semver registryUrl=https://github.com
       LIBRESSL_VERSION: 4.1.1
     strategy:
       fail-fast: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -124,9 +124,7 @@ jobs:
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
-          # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'
           cmake -B . -G Ninja \
-            -DHAVE_ENDIAN_H=0 \
             -DCMAKE_INSTALL_PREFIX=/Users/runner/libressl \
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_SYSTEM_PROCESSOR=aarch64 \

--- a/plan9/README
+++ b/plan9/README
@@ -11,7 +11,7 @@ The zlib that is available on Plan 9 can be downloaded from:
 
 LibreSSL Portable can be downloaded from:
 
-  https://github.com/libressl-portable/portable/pull/510
+  https://github.com/libressl/portable/pull/510
 
 Instruction
 ===========


### PR DESCRIPTION
Also:
- point the source tarball to a working URL.
  The GitHub release page misses the official source tarball for 4.1.1.
- GHA/linux: switch LibreSSL build to cmake (syncing with http3-linux.)
- GHA/macos: drop no longer needed LibreSSL build workaround.
