### PR TITLE
lib: fix build error and compiler warnings with verbose strings disabled

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -746,7 +746,8 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
   ares->ares_status = ARES_ENOTFOUND;
   ares->result = CURLE_OK;
 
-#if ARES_VERSION >= 0x011800  /* >= v1.24.0 */
+#if !defined(CURL_DISABLE_VERBOSE_STRINGS) && \
+  ARES_VERSION >= 0x011800  /* >= v1.24.0 */
   if(CURL_TRC_DNS_is_verbose(data)) {
     char *csv = ares_get_servers_csv(ares->channel);
     CURL_TRC_DNS(data, "asyn-ares: servers=%s", csv);

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -672,6 +672,11 @@ void Curl_trc_dns(struct Curl_easy *data, const char *fmt, ...)
   (void)data; (void)fmt;
 }
 
+void Curl_trc_timer(struct Curl_easy *data, int tid, const char *fmt, ...)
+{
+  (void)data; (void)tid; (void)fmt;
+}
+
 void Curl_trc_read(struct Curl_easy *data, const char *fmt, ...)
 {
   (void)data; (void)fmt;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1103,6 +1103,7 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
     Curl_multi_mark_dirty(data);
   }
 
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   if(CURL_TRC_M_is_verbose(data)) {
     size_t timeout_count = Curl_llist_count(&data->state.timeoutlist);
     switch(ps->n) {
@@ -1137,6 +1138,7 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
     }
     CURL_TRC_EASY_TIMERS(data);
   }
+#endif
 
   if(expect_sockets && !ps->n && data->multi &&
      !Curl_uint_bset_contains(&data->multi->dirty, data->mid) &&
@@ -3050,6 +3052,7 @@ static void multi_mark_expired_as_dirty(struct multi_run_ctx *mrc)
     data = Curl_splayget(t); /* assign this for next loop */
     if(!data)
       continue;
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
     if(CURL_TRC_TIMER_is_verbose(data)) {
       struct Curl_llist_node *e = Curl_llist_head(&data->state.timeoutlist);
       if(e) {
@@ -3057,6 +3060,7 @@ static void multi_mark_expired_as_dirty(struct multi_run_ctx *mrc)
         CURL_TRC_TIMER(data, n->eid, "has expired");
       }
     }
+#endif
     (void)add_next_timeout(mrc->now, multi, data);
     Curl_multi_mark_dirty(data);
   }
@@ -3329,7 +3333,9 @@ static CURLMcode multi_timeout(struct Curl_multi *multi,
                                long *timeout_ms)
 {
   static const struct curltime tv_zero = {0, 0};
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   struct Curl_easy *data = NULL;
+#endif
 
   if(multi->dead) {
     *timeout_ms = 0;
@@ -3357,15 +3363,19 @@ static CURLMcode multi_timeout(struct Curl_multi *multi,
        curlx_timediff_us(multi->timetree->key, now) > 0) {
       /* some time left before expiration */
       timediff_t diff = curlx_timediff_ceil(multi->timetree->key, now);
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
       data = Curl_splayget(multi->timetree);
+#endif
       /* this should be safe even on 32-bit archs, as we do not use that
          overly long timeouts */
       *timeout_ms = (long)diff;
     }
     else {
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
       if(multi->timetree) {
         data = Curl_splayget(multi->timetree);
       }
+#endif
       /* 0 means immediately */
       *timeout_ms = 0;
     }
@@ -3375,6 +3385,7 @@ static CURLMcode multi_timeout(struct Curl_multi *multi,
     *timeout_ms = -1;
   }
 
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   if(data && CURL_TRC_TIMER_is_verbose(data)) {
     struct Curl_llist_node *e =
       Curl_llist_head(&data->state.timeoutlist);
@@ -3384,6 +3395,7 @@ static CURLMcode multi_timeout(struct Curl_multi *multi,
                      *timeout_ms);
     }
   }
+#endif
 
   return CURLM_OK;
 }


### PR DESCRIPTION
- asyn-ares: fix compiler warning:
  ```
  lib/asyn-ares.c:751:17: error: code will never be executed [clang-diagnostic-unreachable-code,-warnings-as-errors]
    751 |     char *csv = ares_get_servers_csv(ares->channel);
        |                 ^~~~~~~~~~~~~~~~~~~~
  ```

- curl_trc: fix missing symbol:
  ```
  /usr/bin/ld: ../lib/.libs/libcurl.so: undefined reference to `Curl_trc_timer'
  collect2: error: ld returned 1 exit status
  ```
  Ref: https://app.circleci.com/pipelines/github/curl/curl/15446/workflows/67afa113-9c49-4249-9180-f6f01fc7dfdd/jobs/149177
  Ref: https://github.com/curl/curl/actions/runs/18174250400/job/51736249444#step:33:623
  Follow-up to b02238975768d0bcbf8c7ef00eaaee3ec379f4ff #18768

- multi: fix `-Wunreachable-code`:
  ```
  lib/multi.c:1107:28: error: code will never be executed [-Werror,-Wunreachable-code]
   1107 |     size_t timeout_count = Curl_llist_count(&data->state.timeoutlist);
        |                            ^~~~~~~~~~~~~~~~
  lib/multi.c:3054:35: error: code will never be executed [-Werror,-Wunreachable-code]
   3054 |       struct Curl_llist_node *e = Curl_llist_head(&data->state.timeoutlist);
        |                                   ^~~~~~~~~~~~~~~
  lib/multi.c:3380:7: error: code will never be executed [-Werror,-Wunreachable-code]
   3380 |       Curl_llist_head(&data->state.timeoutlist);
        |       ^~~~~~~~~~~~~~~
  ```

Cherry-picked from #18797
