### PR TITLE
runtests: tag tests that require curl with verbose strings

### DIFF
--- a/tests/data/test1007
+++ b/tests/data/test1007
@@ -13,6 +13,9 @@ FAILURE
 <server>
 tftp
 </server>
+<features>
+verbose-strings
+</features>
 <name>
 TFTP send with invalid permission on server
 </name>

--- a/tests/data/test1287
+++ b/tests/data/test1287
@@ -62,6 +62,7 @@ HTTP over proxy-tunnel ignore TE and CL in CONNECT 2xx responses
 </command>
 <features>
 proxy
+verbose-strings
 </features>
 </client>
 

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -48,6 +48,9 @@ file contents should appear once for each file
 <server>
 http
 </server>
+<features>
+verbose-strings
+</features>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -13,6 +13,9 @@ verbose logs
 
 # Client-side
 <client>
+<features>
+verbose-strings
+</features>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -23,6 +23,9 @@ Content-Length: 0
 <server>
 http
 </server>
+<features>
+verbose-strings
+</features>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1559
+++ b/tests/data/test1559
@@ -14,6 +14,7 @@ verbose logs
 # require HTTP so that CURLOPT_POSTFIELDS works as assumed
 <features>
 http
+verbose-strings
 </features>
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test1652
+++ b/tests/data/test1652
@@ -9,6 +9,7 @@ infof
 <client>
 <features>
 unittest
+verbose-strings
 </features>
 <name>
 infof

--- a/tests/data/test2402
+++ b/tests/data/test2402
@@ -49,6 +49,7 @@ file contents should appear once for each file
 <features>
 http/2
 SSL
+verbose-strings
 </features>
 <server>
 http/2

--- a/tests/data/test2404
+++ b/tests/data/test2404
@@ -49,6 +49,7 @@ file contents should appear once for each file
 <features>
 http/2
 SSL
+verbose-strings
 </features>
 <server>
 http/2

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -48,6 +48,7 @@ file contents should appear once for each file
 <client>
 <features>
 http/3
+verbose-strings
 </features>
 <server>
 http/3


### PR DESCRIPTION
To skip them when curl has verbose strings disabled, instead of failing.

Cherry-picked from #18797
