### PR TITLE
lib: remove personal names from comments

### DIFF
--- a/docs/THANKS
+++ b/docs/THANKS
@@ -3245,6 +3245,7 @@ Tommy Tam
 Tom Regner
 Tom Seddon
 Tom Sparrow
+Tom St Denis
 Tom van der Woerdt
 Tom Wright
 tomy2105 on github
@@ -3317,6 +3318,7 @@ VictorVG on github
 Victor Vieux
 Vijay Panghal
 Vikram Saxena
+Viktor Dukhovni
 Viktor Petersson
 Viktor Szakats
 Vilhelm Prytz

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -821,8 +821,8 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
    * In October 2003 we effectively nullified this function on Windows due to
    * problems with it using all CPU in multi-threaded cases.
    *
-   * In May 2004, we bring it back to offer more info back on connect failures.
-   * Gisle Vanem could reproduce the former problems with this function, but
+   * In May 2004, we brought it back to offer more info back on connect
+   * failures. We could reproduce the former problems with this function, but
    * could avoid them by adding this SleepEx() call below:
    *
    *    "I do not have Rational Quantify, but the hint from his post was

--- a/lib/curlx/inet_ntop.c
+++ b/lib/curlx/inet_ntop.c
@@ -16,9 +16,6 @@
  *
  * SPDX-License-Identifier: ISC
  */
-/*
- * Original code by Paul Vixie. "curlified" by Gisle Vanem.
- */
 
 #include "../curl_setup.h"
 

--- a/lib/if2ip.h
+++ b/lib/if2ip.h
@@ -73,8 +73,7 @@ struct ifreq {
  } ifr_ifru;
 };
 
-/* This define was added by Daniel to avoid an extra #ifdef INTERIX in the
-   C code. */
+/* This define exists to avoid an extra #ifdef INTERIX in the C code. */
 
 #define ifr_name ifr_ifrn.ifrn_name /* interface name */
 #define ifr_addr ifr_ifru.ifru_addr /* address */

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -247,18 +247,6 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
  * There is ABSOLUTELY NO WARRANTY, express or implied.
  *
  * (This is a heavily cut-down "BSD license".)
- *
- * This differs from Colin Plumb's older public domain implementation in that
- * no exactly 32-bit integer data type is required (any 32-bit or wider
- * unsigned integer data type will do), there is no compile-time endianness
- * configuration, and the function prototypes match OpenSSL's. No code from
- * Colin Plumb's implementation has been reused; this comment merely compares
- * the properties of the two independent implementations.
- *
- * The primary goals of this implementation are portability and ease of use.
- * It is meant to be fast, but not as fast as possible. Some known
- * optimizations are not included to reduce source code size and avoid
- * compile-time configuration.
  */
 
 /* Any 32-bit or wider unsigned integer data type will do */

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -282,18 +282,6 @@ static void my_md5_final(unsigned char *digest, void *in)
  * There is ABSOLUTELY NO WARRANTY, express or implied.
  *
  * (This is a heavily cut-down "BSD license".)
- *
- * This differs from Colin Plumb's older public domain implementation in that
- * no exactly 32-bit integer data type is required (any 32-bit or wider
- * unsigned integer data type will do), there is no compile-time endianness
- * configuration, and the function prototypes match OpenSSL's. No code from
- * Colin Plumb's implementation has been reused; this comment merely compares
- * the properties of the two independent implementations.
- *
- * The primary goals of this implementation are portability and ease of use.
- * It is meant to be fast, but not as fast as possible. Some known
- * optimizations are not included to reduce source code size and avoid
- * compile-time configuration.
  */
 
 /* Any 32-bit or wider unsigned integer data type will do */

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -231,8 +231,8 @@ static void my_sha256_final(unsigned char *digest, void *in)
 
 /* When no other crypto library is available we use this code segment */
 
-/* This is based on SHA256 implementation in LibTomCrypt that was released into
- * public domain by Tom St Denis. */
+/* This is based on the SHA256 implementation in LibTomCrypt that was released
+ * into public domain. */
 
 #define WPA_GET_BE32(a) ((((unsigned long)(a)[0]) << 24) | \
                          (((unsigned long)(a)[1]) << 16) | \

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1773,8 +1773,6 @@ static CURLcode client_cert(struct Curl_easy *data,
 
     x509 = SSL_get_certificate(ssl);
 
-    /* This version was provided by Evan Jordan and is supposed to not
-       leak memory as the previous version: */
     if(x509) {
       EVP_PKEY *pktmp = X509_get_pubkey(x509);
       EVP_PKEY_copy_parameters(pktmp, SSL_get_privatekey(ssl));
@@ -2931,10 +2929,9 @@ ossl_set_ssl_version_min_max(struct Curl_cfilter *cf, SSL_CTX *ctx,
   case CURL_SSLVERSION_MAX_NONE:  /* none selected */
   case CURL_SSLVERSION_MAX_DEFAULT:  /* max selected */
   default:
-    /* SSL_CTX_set_max_proto_version states that:
-       setting the maximum to 0 will enable
-       protocol versions up to the highest version
-       supported by the library */
+    /* SSL_CTX_set_max_proto_version states that: setting the maximum to 0
+       will enable protocol versions up to the highest version supported by
+       the library */
     ossl_ssl_version_max = 0;
     break;
   }
@@ -3291,9 +3288,9 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
       if(!x509)
         continue;
 
-      /* Try to import the certificate. This may fail for legitimate
-         reasons such as duplicate certificate, which is allowed by MS but
-         not OpenSSL. */
+      /* Try to import the certificate. This may fail for legitimate reasons
+         such as duplicate certificate, which is allowed by MS but not
+         OpenSSL. */
       if(X509_STORE_add_cert(store, x509) == 1) {
 #if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
         infof(data, "SSL: Imported cert");
@@ -4721,9 +4718,7 @@ static CURLcode ossl_pkp_pin_peer_pubkey(struct Curl_easy *data, X509* cert,
     return result;
 
   do {
-    /* Begin Gyrations to get the subjectPublicKeyInfo     */
-    /* Thanks to Viktor Dukhovni on the OpenSSL mailing list */
-
+    /* Get the subjectPublicKeyInfo */
     /* https://groups.google.com/group/mailing.openssl.users/browse_thread/thread/d61858dae102c6c7 */
     len1 = i2d_X509_PUBKEY(X509_get_X509_PUBKEY(cert), NULL);
     if(len1 < 1)


### PR DESCRIPTION
- it's just too random who got mentioned
- we can't mention all, so better consistently mention none
- make sure they all are mentioned in THANKS
- also remove some unnecessary comment ramblings