### PR TITLE
tool_getparam: always disable "lib-ids" for tracing

### DIFF
--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -201,7 +201,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
 
   switch(type) {
   case CURLINFO_TEXT:
-    fprintf(output, "%s%s== Info: %.*s", timebuf, idsbuf, (int)size, data);
+    fprintf(output, "%s%s* %.*s", timebuf, idsbuf, (int)size, data);
     FALLTHROUGH();
   default: /* in case a new one is introduced to shock us */
     return 0;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -736,7 +736,10 @@ static CURLcode set_trace_config(const char *token)
     if((len == 3) && curl_strnequal(name, "all", 3)) {
       global->traceids = toggle;
       global->tracetime = toggle;
-      result = curl_global_trace(token);
+      if(toggle)
+        result = curl_global_trace("all,-lib-ids");
+      else
+        result = curl_global_trace(token);
       if(result)
         goto out;
     }
@@ -747,8 +750,8 @@ static CURLcode set_trace_config(const char *token)
       global->tracetime = toggle;
     }
     else {
-      char buffer[32];
-      msnprintf(buffer, sizeof(buffer), "%c%.*s", toggle ? '+' : '-',
+      char buffer[64];
+      msnprintf(buffer, sizeof(buffer), "%c%.*s,-lib-ids", toggle ? '+' : '-',
                 (int)len, name);
       result = curl_global_trace(buffer);
       if(result)


### PR DESCRIPTION
Since the tool code itself adds the ids (controlled with "ids"), getting them (also) added by the library adds nothing good. Always disable the lib-ids even when "--trace-config all" is selected.

Also: change "== Info:" into just "* " to reduce output redundancy.

Ref: #18755
Reported-by: Alice Lee Poetics