### PR TITLE
INTERNALS: drop Winsock 2.2 from the dependency list

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -38,7 +38,6 @@ versions of libs and build tools.
  - MIT Kerberos 1.2.4
  - Heimdal      ?
  - nghttp2      1.15.0
- - Winsock      2.2 (on Windows 95+ and Windows CE .NET 4.1+)
 
 ## Build tools
 


### PR DESCRIPTION
It's implied by the minimum requirement of Windows XP.
Also Windows CE is soon to be deleted via #17927.
