### PR TITLE
INTERNALS: specify minimum version for Heimdal: 7.1.0

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -36,7 +36,7 @@ versions of libs and build tools.
  - wolfSSL      3.4.6
  - OpenLDAP     2.0
  - MIT Kerberos 1.2.4
- - Heimdal      ?
+ - Heimdal      7.1.0
  - nghttp2      1.15.0
  - Winsock      2.2 (on Windows 95+ and Windows CE .NET 4.1+)
 


### PR DESCRIPTION
Released on 2016-Dec-19, it's the first "revamped" stable version, and
the earliest available as a source tarball at the official repository:
https://github.com/heimdal/heimdal/releases/tag/heimdal-7.1.0

It's also the first version hosted by Homebrew. It builds fine locally
with curl, and also builds in CI with old linux: 7.1.0+dfsg-13+deb9u4.

---

Older versions may work, but they were never CI tested, or explicitly
reported in issues. In my test env, the preceding stable release 1.5.3
(2012-12-09) fails with a syntax error when running `./configure`.
