### PR TITLE
tcp-nodelay.md: expand the documentation

### DIFF
--- a/docs/cmdline-opts/tcp-nodelay.md
+++ b/docs/cmdline-opts/tcp-nodelay.md
@@ -14,8 +14,18 @@ Example:
 
 # `--tcp-nodelay`
 
-Turn on the TCP_NODELAY option. See the *curl_easy_setopt(3)* man page for
-details about this option.
+Turn on the TCP_NODELAY option.
+
+This option disables the Nagle algorithm on TCP connections. The purpose of
+this algorithm is to minimize the number of small packets on the network
+(where "small packets" means TCP segments less than the Maximum Segment Size
+for the network).
+
+Maximizing the amount of data sent per TCP segment is good because it
+amortizes the overhead of the send. However, in some cases small segments may
+need to be sent without delay. This is less efficient than sending larger
+amounts of data at a time, and can contribute to congestion on the network if
+overdone.
 
 curl sets this option by default and you need to explicitly switch it off if
 you do not want it on (added in 7.50.2).


### PR DESCRIPTION
Instead of referring to another document.