### PR TITLE
vtls_scache: fix race condition

### DIFF
--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -902,7 +902,6 @@ CURLcode Curl_ssl_scache_take(struct Curl_cfilter *cf,
       peer->age = scache->age; /* set this as used in this age */
     }
   }
-  Curl_ssl_scache_unlock(data);
   if(s) {
     *ps = s;
     CURL_TRC_SSLS(data, "took session for %s [proto=0x%x, "
@@ -914,6 +913,7 @@ CURLcode Curl_ssl_scache_take(struct Curl_cfilter *cf,
   else {
     CURL_TRC_SSLS(data, "no cached session for %s", ssl_peer_key);
   }
+  Curl_ssl_scache_unlock(data);
   return result;
 }
 


### PR DESCRIPTION
- Lock before counting the cache sessions.

Prior to this change when taking a session a trace command counted the sessions but not under lock, which caused a race condition.

Reported by: Viktor Szakats

Fixes https://github.com/curl/curl/issues/18806
Closes #xxxx