### PR TITLE
tests: stop overriding system printf symbols

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -48,7 +48,10 @@ path = [
   "lib/vssh/.checksrc",
   "lib/vtls/.checksrc",
   "src/.checksrc",
+  "tests/libtest/.checksrc",
   "tests/server/.checksrc",
+  "tests/tunit/.checksrc",
+  "tests/unit/.checksrc",
 ]
 SPDX-FileCopyrightText = "Daniel Stenberg, <daniel@haxx.se>, et al."
 SPDX-License-Identifier = "curl"

--- a/tests/libtest/.checksrc
+++ b/tests/libtest/.checksrc
@@ -1,0 +1,8 @@
+banfunc aprintf
+banfunc fprintf
+banfunc msnprintf
+banfunc mvsnprintf
+banfunc printf
+banfunc vaprintf
+banfunc vfprintf
+banfunc vprintf

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -41,7 +41,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 # Get BUNDLE, FIRST_C, FIRST_H, UTILS_C, UTILS_H, CURLX_C, TESTS_C variables
 include Makefile.inc
 
-EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C) \
+EXTRA_DIST = CMakeLists.txt .checksrc $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C) \
   test307.pl test610.pl test613.pl test1013.pl test1022.pl mk-lib1521.pl
 
 CFLAGS += @CURL_CFLAG_EXTRAS@

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -52,8 +52,6 @@ extern int unitfail; /* for unittests */
 #include <sys/select.h>
 #endif
 
-#include "curl_printf.h"
-
 /* GCC <4.6 does not support '#pragma GCC diagnostic push' and
    does not support 'pragma GCC diagnostic' inside functions. */
 #if (defined(__GNUC__) && \

--- a/tests/libtest/lib1549.c
+++ b/tests/libtest/lib1549.c
@@ -58,14 +58,14 @@ static CURLcode test_lib1549(const char *URL)
       /* a linked list of cookies in cookie file format */
       struct curl_slist *each = cookies;
       while(each) {
-        printf("%s\n", each->data);
+        curl_mprintf("%s\n", each->data);
         each = each->next;
         num++;
       }
       /* we must free these cookies when we are done */
       curl_slist_free_all(cookies);
     }
-    fprintf(stderr, "%d cookies\n", num);
+    curl_mfprintf(stderr, "%d cookies\n", num);
   }
 test_cleanup:
 

--- a/tests/tunit/.checksrc
+++ b/tests/tunit/.checksrc
@@ -1,0 +1,8 @@
+banfunc aprintf
+banfunc fprintf
+banfunc msnprintf
+banfunc mvsnprintf
+banfunc printf
+banfunc vaprintf
+banfunc vfprintf
+banfunc vprintf

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -43,7 +43,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 # Get BUNDLE, FIRST_C, TESTS_C variables
 include Makefile.inc
 
-EXTRA_DIST = CMakeLists.txt README.md $(TESTS_C)
+EXTRA_DIST = CMakeLists.txt .checksrc README.md $(TESTS_C)
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 

--- a/tests/tunit/tool1394.c
+++ b/tests/tunit/tool1394.c
@@ -73,42 +73,42 @@ static CURLcode test_tool1394(const char *arg)
     if(p[1]) {
       if(certname) {
         if(strcmp(p[1], certname)) {
-          printf("expected certname '%s' but got '%s' "
-                 "for -E param '%s'\n", p[1], certname, p[0]);
+          curl_mprintf("expected certname '%s' but got '%s' "
+                       "for -E param '%s'\n", p[1], certname, p[0]);
           fail("assertion failure");
         }
       }
       else {
-        printf("expected certname '%s' but got NULL "
-               "for -E param '%s'\n", p[1], p[0]);
+        curl_mprintf("expected certname '%s' but got NULL "
+                     "for -E param '%s'\n", p[1], p[0]);
         fail("assertion failure");
       }
     }
     else {
       if(certname) {
-        printf("expected certname NULL but got '%s' "
-               "for -E param '%s'\n", certname, p[0]);
+        curl_mprintf("expected certname NULL but got '%s' "
+                     "for -E param '%s'\n", certname, p[0]);
         fail("assertion failure");
       }
     }
     if(p[2]) {
       if(passphrase) {
         if(strcmp(p[2], passphrase)) {
-          printf("expected passphrase '%s' but got '%s'"
-                 "for -E param '%s'\n", p[2], passphrase, p[0]);
+          curl_mprintf("expected passphrase '%s' but got '%s'"
+                       "for -E param '%s'\n", p[2], passphrase, p[0]);
           fail("assertion failure");
         }
       }
       else {
-        printf("expected passphrase '%s' but got NULL "
-               "for -E param '%s'\n", p[2], p[0]);
+        curl_mprintf("expected passphrase '%s' but got NULL "
+                     "for -E param '%s'\n", p[2], p[0]);
         fail("assertion failure");
       }
     }
     else {
       if(passphrase) {
-        printf("expected passphrase NULL but got '%s' "
-               "for -E param '%s'\n", passphrase, p[0]);
+        curl_mprintf("expected passphrase NULL but got '%s' "
+                     "for -E param '%s'\n", passphrase, p[0]);
         fail("assertion failure");
       }
     }

--- a/tests/tunit/tool1604.c
+++ b/tests/tunit/tool1604.c
@@ -35,9 +35,9 @@ static char *getflagstr(int flags)
   if(buf) {
     curl_msnprintf(buf, 256, "%s,%s",
                    ((flags & SANITIZE_ALLOW_PATH) ?
-                   "SANITIZE_ALLOW_PATH" : ""),
+                    "SANITIZE_ALLOW_PATH" : ""),
                    ((flags & SANITIZE_ALLOW_RESERVED) ?
-                   "SANITIZE_ALLOW_RESERVED" : ""));
+                    "SANITIZE_ALLOW_RESERVED" : ""));
   }
   return buf;
 }

--- a/tests/tunit/tool1604.c
+++ b/tests/tunit/tool1604.c
@@ -33,11 +33,11 @@ static char *getflagstr(int flags)
 {
   char *buf = malloc(256);
   if(buf) {
-    msnprintf(buf, 256, "%s,%s",
-              ((flags & SANITIZE_ALLOW_PATH) ?
-               "SANITIZE_ALLOW_PATH" : ""),
-              ((flags & SANITIZE_ALLOW_RESERVED) ?
-               "SANITIZE_ALLOW_RESERVED" : ""));
+    curl_msnprintf(buf, 256, "%s,%s",
+                   ((flags & SANITIZE_ALLOW_PATH) ?
+                   "SANITIZE_ALLOW_PATH" : ""),
+                   ((flags & SANITIZE_ALLOW_RESERVED) ?
+                   "SANITIZE_ALLOW_RESERVED" : ""));
   }
   return buf;
 }
@@ -46,13 +46,12 @@ static char *getcurlcodestr(int cc)
 {
   char *buf = malloc(256);
   if(buf) {
-    msnprintf(buf, 256, "%s (%d)",
-              (cc == SANITIZE_ERR_OK ? "SANITIZE_ERR_OK" :
-               cc == SANITIZE_ERR_BAD_ARGUMENT ? "SANITIZE_ERR_BAD_ARGUMENT" :
-               cc == SANITIZE_ERR_INVALID_PATH ? "SANITIZE_ERR_INVALID_PATH" :
-               cc == SANITIZE_ERR_OUT_OF_MEMORY ? "SANITIZE_ERR_OUT_OF_MEMORY":
-               "unexpected error code - add name"),
-              cc);
+    curl_msnprintf(buf, 256, "%s (%d)",
+             (cc == SANITIZE_ERR_OK ? "SANITIZE_ERR_OK" :
+              cc == SANITIZE_ERR_BAD_ARGUMENT ? "SANITIZE_ERR_BAD_ARGUMENT" :
+              cc == SANITIZE_ERR_INVALID_PATH ? "SANITIZE_ERR_INVALID_PATH" :
+              cc == SANITIZE_ERR_OUT_OF_MEMORY ? "SANITIZE_ERR_OUT_OF_MEMORY" :
+              "unexpected error code - add name"), cc);
   }
   return buf;
 }
@@ -225,21 +224,21 @@ static CURLcode test_tool1604(const char *arg)
     abort_unless(expected_ccstr, "out of memory");
 
     unitfail++;
-    fprintf(stderr, "\n"
-            "%s:%d sanitize_file_name failed.\n"
-            "input: %s\n"
-            "flags: %s\n"
-            "output: %s\n"
-            "result: %s\n"
-            "expected output: %s\n"
-            "expected result: %s\n",
-            __FILE__, __LINE__,
-            data[i].input,
-            flagstr,
-            (output ? output : "(null)"),
-            received_ccstr,
-            (data[i].expected_output ? data[i].expected_output : "(null)"),
-            expected_ccstr);
+    curl_mfprintf(stderr, "\n"
+                  "%s:%d sanitize_file_name failed.\n"
+                  "input: %s\n"
+                  "flags: %s\n"
+                  "output: %s\n"
+                  "result: %s\n"
+                  "expected output: %s\n"
+                  "expected result: %s\n",
+                  __FILE__, __LINE__,
+                  data[i].input,
+                  flagstr,
+                  output ? output : "(null)",
+                  received_ccstr,
+                  data[i].expected_output ? data[i].expected_output : "(null)",
+                  expected_ccstr);
 
     free(output);
     free(flagstr);
@@ -248,7 +247,7 @@ static CURLcode test_tool1604(const char *arg)
   }
   /* END sanitize_file_name */
 #else
-  fprintf(stderr, "Skipped test not for this platform\n");
+  curl_mfprintf(stderr, "Skipped test not for this platform\n");
 #endif /* _WIN32 || MSDOS */
 
   UNITTEST_END_SIMPLE

--- a/tests/tunit/tool1621.c
+++ b/tests/tunit/tool1621.c
@@ -74,8 +74,9 @@ static CURLcode test_tool1621(const char *arg)
     const char *url = tests[i].input;
     char *stripped = stripcredentials(url);
     const char *strippedstr = stripped ? stripped : "(null)";
-    printf("Test %u got input \"%s\", output: \"%s\", expected: \"%s\"\n",
-           i, tests[i].input, strippedstr, tests[i].output);
+    curl_mprintf("Test %u got input \"%s\", output: \"%s\", "
+                 "expected: \"%s\"\n",
+                 i, tests[i].input, strippedstr, tests[i].output);
 
     fail_if(strcmp(tests[i].output, strippedstr), tests[i].output);
     curl_free(stripped);

--- a/tests/unit/.checksrc
+++ b/tests/unit/.checksrc
@@ -1,0 +1,8 @@
+banfunc aprintf
+banfunc fprintf
+banfunc msnprintf
+banfunc mvsnprintf
+banfunc printf
+banfunc vaprintf
+banfunc vfprintf
+banfunc vprintf

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -42,7 +42,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 # Get BUNDLE, FIRST_C, TESTS_C variables
 include Makefile.inc
 
-EXTRA_DIST = CMakeLists.txt README.md $(TESTS_C)
+EXTRA_DIST = CMakeLists.txt .checksrc README.md $(TESTS_C)
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 

--- a/tests/unit/unit1302.c
+++ b/tests/unit/unit1302.c
@@ -38,7 +38,7 @@ static CURLcode test_unit1302(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
   CURLcode rc;
-  size_t i;
+  unsigned int i;
 
   /* common base64 encoding */
   struct etest encode[] = {
@@ -137,7 +137,7 @@ static CURLcode test_unit1302(const char *arg)
     abort_unless(rc == CURLE_OK, "return code should be CURLE_OK");
     abort_unless(olen == e->olen, "wrong output size");
     if(memcmp(out, e->output, e->olen)) {
-      curl_mfprintf(stderr, "Test %zu encoded badly\n", i);
+      curl_mfprintf(stderr, "Test %u encoded badly\n", i);
       unitfail++;
     }
     Curl_safefree(out);
@@ -145,16 +145,16 @@ static CURLcode test_unit1302(const char *arg)
     /* then verify decode */
     rc = curlx_base64_decode(e->output, &decoded, &dlen);
     if(rc != CURLE_OK) {
-      curl_mfprintf(stderr, "Test %zu URL decode returned %d\n", i, (int)rc);
+      curl_mfprintf(stderr, "Test %u URL decode returned %d\n", i, (int)rc);
       unitfail++;
     }
     if(dlen != e->ilen) {
-      curl_mfprintf(stderr, "Test %zu URL decode output length %zu "
+      curl_mfprintf(stderr, "Test %u URL decode output length %zu "
                     "instead of %zu\n", i, dlen, e->ilen);
       unitfail++;
     }
     if(memcmp(decoded, e->input, dlen)) {
-      curl_mfprintf(stderr, "Test %zu URL decoded badly. Got '%s', "
+      curl_mfprintf(stderr, "Test %u URL decoded badly. Got '%s', "
                     "expected '%s'\n", i, decoded, e->input);
       unitfail++;
     }
@@ -169,11 +169,11 @@ static CURLcode test_unit1302(const char *arg)
     rc = curlx_base64url_encode(e->input, e->ilen, &out, &olen);
     abort_unless(rc == CURLE_OK, "return code should be CURLE_OK");
     if(olen != e->olen) {
-      curl_mfprintf(stderr, "Test %zu URL encoded output length %zu "
+      curl_mfprintf(stderr, "Test %u URL encoded output length %zu "
                     "instead of %zu\n", i, olen, e->olen);
     }
     if(out && memcmp(out, e->output, e->olen)) {
-      curl_mfprintf(stderr, "Test %zu URL encoded badly. Got '%s', "
+      curl_mfprintf(stderr, "Test %u URL encoded badly. Got '%s', "
                     "expected '%s'\n", i, out, e->output);
       unitfail++;
     }
@@ -188,7 +188,7 @@ static CURLcode test_unit1302(const char *arg)
     /* then verify decode with illegal inputs */
     rc = curlx_base64_decode(e->output, &decoded, &dlen);
     if(rc != CURLE_BAD_CONTENT_ENCODING) {
-      curl_mfprintf(stderr, "Test %zu URL bad decoded badly. "
+      curl_mfprintf(stderr, "Test %u URL bad decoded badly. "
                     "Returned '%d', expected '%d'\n",
                     i, (int)rc, CURLE_BAD_CONTENT_ENCODING);
       unitfail++;

--- a/tests/unit/unit1302.c
+++ b/tests/unit/unit1302.c
@@ -38,7 +38,7 @@ static CURLcode test_unit1302(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
   CURLcode rc;
-  unsigned int i;
+  size_t i;
 
   /* common base64 encoding */
   struct etest encode[] = {
@@ -137,7 +137,7 @@ static CURLcode test_unit1302(const char *arg)
     abort_unless(rc == CURLE_OK, "return code should be CURLE_OK");
     abort_unless(olen == e->olen, "wrong output size");
     if(memcmp(out, e->output, e->olen)) {
-      fprintf(stderr, "Test %u encoded badly\n", i);
+      curl_mfprintf(stderr, "Test %zu encoded badly\n", i);
       unitfail++;
     }
     Curl_safefree(out);
@@ -145,17 +145,17 @@ static CURLcode test_unit1302(const char *arg)
     /* then verify decode */
     rc = curlx_base64_decode(e->output, &decoded, &dlen);
     if(rc != CURLE_OK) {
-      fprintf(stderr, "Test %u URL decode returned %d\n", i, (int)rc);
+      curl_mfprintf(stderr, "Test %zu URL decode returned %d\n", i, (int)rc);
       unitfail++;
     }
     if(dlen != e->ilen) {
-      fprintf(stderr, "Test %u URL decode output length %d instead of %d\n",
-              i, (int)dlen, (int)e->ilen);
+      curl_mfprintf(stderr, "Test %zu URL decode output length %zu "
+                    "instead of %zu\n", i, dlen, e->ilen);
       unitfail++;
     }
     if(memcmp(decoded, e->input, dlen)) {
-      fprintf(stderr, "Test %u URL decoded badly. Got '%s', expected '%s'\n",
-              i, decoded, e->input);
+      curl_mfprintf(stderr, "Test %zu URL decoded badly. Got '%s', "
+                    "expected '%s'\n", i, decoded, e->input);
       unitfail++;
     }
 
@@ -169,12 +169,12 @@ static CURLcode test_unit1302(const char *arg)
     rc = curlx_base64url_encode(e->input, e->ilen, &out, &olen);
     abort_unless(rc == CURLE_OK, "return code should be CURLE_OK");
     if(olen != e->olen) {
-      fprintf(stderr, "Test %u URL encoded output length %d instead of %d\n",
-              i, (int)olen, (int)e->olen);
+      curl_mfprintf(stderr, "Test %zu URL encoded output length %zu "
+                    "instead of %zu\n", i, olen, e->olen);
     }
     if(out && memcmp(out, e->output, e->olen)) {
-      fprintf(stderr, "Test %u URL encoded badly. Got '%s', expected '%s'\n",
-              i, out, e->output);
+      curl_mfprintf(stderr, "Test %zu URL encoded badly. Got '%s', "
+                    "expected '%s'\n", i, out, e->output);
       unitfail++;
     }
     Curl_safefree(out);
@@ -188,9 +188,9 @@ static CURLcode test_unit1302(const char *arg)
     /* then verify decode with illegal inputs */
     rc = curlx_base64_decode(e->output, &decoded, &dlen);
     if(rc != CURLE_BAD_CONTENT_ENCODING) {
-      fprintf(stderr, "Test %u URL bad decoded badly. "
-              "Returned '%d', expected '%d'\n",
-              i, (int)rc, CURLE_BAD_CONTENT_ENCODING);
+      curl_mfprintf(stderr, "Test %zu URL bad decoded badly. "
+                    "Returned '%d', expected '%d'\n",
+                    i, (int)rc, CURLE_BAD_CONTENT_ENCODING);
       unitfail++;
     }
   }

--- a/tests/unit/unit1307.c
+++ b/tests/unit/unit1307.c
@@ -264,7 +264,7 @@ static CURLcode test_unit1307(const char *arg)
                                   "a",                      NOMATCH|LINUX_FAIL}
   };
 
-  int i;
+  size_t i;
 
   enum system {
     SYSTEM_CUSTOM,
@@ -280,14 +280,14 @@ static CURLcode test_unit1307(const char *arg)
 #else
   machine = SYSTEM_LINUX;
 #endif
-  printf("Tested with system fnmatch(), %s-style\n",
-         machine == SYSTEM_LINUX ? "linux" : "mac");
+  curl_mprintf("Tested with system fnmatch(), %s-style\n",
+               machine == SYSTEM_LINUX ? "linux" : "mac");
 #else
-  printf("Tested with custom fnmatch()\n");
+  curl_mprintf("Tested with custom fnmatch()\n");
   machine = SYSTEM_CUSTOM;
 #endif
 
-  for(i = 0; i < (int)CURL_ARRAYSIZE(tests); i++) {
+  for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
     int result = tests[i].result;
     int rc = Curl_fnmatch(NULL, tests[i].pattern, tests[i].string);
     if(result & (LINUX_DIFFER|MAC_DIFFER)) {
@@ -298,10 +298,10 @@ static CURLcode test_unit1307(const char *arg)
       result &= 0x03; /* filter off all high bits */
     }
     if(rc != result) {
-      printf("Curl_fnmatch(\"%s\", \"%s\") should return %s (returns %s)"
-             " [%d]\n",
-             tests[i].pattern, tests[i].string, ret2name(result),
-             ret2name(rc), i);
+      curl_printf("Curl_fnmatch(\"%s\", \"%s\") should return %s (returns %s)"
+                  " [%zu]\n",
+                  tests[i].pattern, tests[i].string, ret2name(result),
+                  ret2name(rc), i);
       fail("pattern mismatch");
     }
   }

--- a/tests/unit/unit1307.c
+++ b/tests/unit/unit1307.c
@@ -298,10 +298,10 @@ static CURLcode test_unit1307(const char *arg)
       result &= 0x03; /* filter off all high bits */
     }
     if(rc != result) {
-      curl_printf("Curl_fnmatch(\"%s\", \"%s\") should return %s (returns %s)"
-                  " [%zu]\n",
-                  tests[i].pattern, tests[i].string, ret2name(result),
-                  ret2name(rc), i);
+      curl_mprintf("Curl_fnmatch(\"%s\", \"%s\") should return %s (returns %s)"
+                   " [%zu]\n",
+                   tests[i].pattern, tests[i].string, ret2name(result),
+                   ret2name(rc), i);
       fail("pattern mismatch");
     }
   }

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -36,10 +36,10 @@ static void splayprint(struct Curl_tree *t, int d, char output)
   splayprint(t->larger, d + 1, output);
   for(i = 0; i < d; i++)
     if(output)
-      printf("  ");
+      curl_mprintf("  ");
 
   if(output) {
-    printf("%ld.%ld[%d]", (long)t->key.tv_sec, (long)t->key.tv_usec, i);
+    curl_mprintf("%ld.%ld[%d]", (long)t->key.tv_sec, (long)t->key.tv_usec, i);
   }
 
   for(count = 0, node = t->samen; node != t; node = node->samen, count++)
@@ -47,9 +47,9 @@ static void splayprint(struct Curl_tree *t, int d, char output)
 
   if(output) {
     if(count)
-      printf(" [%d more]\n", count);
+      curl_mprintf(" [%d more]\n", count);
     else
-      printf("\n");
+      curl_mprintf("\n");
   }
 
   splayprint(t->smaller, d + 1, output);
@@ -86,14 +86,14 @@ static CURLcode test_unit1309(const char *arg)
 
   for(i = 0; i < NUM_NODES; i++) {
     int rem = (i + 7)%NUM_NODES;
-    printf("Tree look:\n");
+    curl_mprintf("Tree look:\n");
     splayprint(root, 0, 1);
     curl_mprintf("remove pointer %d, payload %zu\n", rem,
                  *(size_t *)Curl_splayget(&nodes[rem]));
     rc = Curl_splayremove(root, &nodes[rem], &root);
     if(rc) {
       /* failed! */
-      printf("remove %d failed!\n", rem);
+      curl_mprintf("remove %d failed!\n", rem);
       fail("remove");
     }
   }
@@ -117,7 +117,7 @@ static CURLcode test_unit1309(const char *arg)
 
   removed = NULL;
   for(i = 0; i <= 1100; i += 100) {
-    printf("Removing nodes not larger than %d\n", i);
+    curl_mprintf("Removing nodes not larger than %d\n", i);
     tv_now.tv_usec = i;
     root = Curl_splaygetbest(tv_now, root, &removed);
     while(removed) {

--- a/tests/unit/unit1323.c
+++ b/tests/unit/unit1323.c
@@ -45,13 +45,13 @@ static CURLcode test_unit1323(const char *arg)
   for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
     timediff_t result = curlx_timediff(tests[i].first, tests[i].second);
     if(result != tests[i].result) {
-      printf("%ld.%06u to %ld.%06u got %d, but expected %ld\n",
-             (long)tests[i].first.tv_sec,
-             tests[i].first.tv_usec,
-             (long)tests[i].second.tv_sec,
-             tests[i].second.tv_usec,
-             (int)result,
-             (long)tests[i].result);
+      curl_mprintf("%ld.%06u to %ld.%06u got %d, but expected %ld\n",
+                   (long)tests[i].first.tv_sec,
+                   tests[i].first.tv_usec,
+                   (long)tests[i].second.tv_sec,
+                   tests[i].second.tv_usec,
+                   (int)result,
+                   (long)tests[i].result);
       fail("unexpected result!");
     }
   }

--- a/tests/unit/unit1396.c
+++ b/tests/unit/unit1396.c
@@ -95,7 +95,7 @@ static CURLcode test_unit1396(const char *arg)
     fail_unless(!memcmp(out, list1[i].out, list1[i].outlen),
                 "bad output data returned");
 
-    printf("curl_easy_unescape test %d DONE\n", i);
+    curl_mprintf("curl_easy_unescape test %d DONE\n", i);
 
     curl_free(out);
   }
@@ -110,7 +110,7 @@ static CURLcode test_unit1396(const char *arg)
     fail_unless(!memcmp(out, list2[i].out, list2[i].outlen),
                 "bad output data returned");
 
-    printf("curl_easy_escape test %d DONE (%s)\n", i, out);
+    curl_mprintf("curl_easy_escape test %d DONE (%s)\n", i, out);
 
     curl_free(out);
   }

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -102,14 +102,14 @@ static CURLcode test_unit1607(const char *arg)
     },
   };
 
-  int i;
+  size_t i;
   struct Curl_multi *multi = NULL;
   struct Curl_easy *easy = NULL;
   struct curl_slist *list = NULL;
 
-  for(i = 0; i < (int)CURL_ARRAYSIZE(tests); ++i) {
-    int j;
-    int addressnum = CURL_ARRAYSIZE(tests[i].address);
+  for(i = 0; i < CURL_ARRAYSIZE(tests); ++i) {
+    size_t j;
+    size_t addressnum = CURL_ARRAYSIZE(tests[i].address);
     struct Curl_addrinfo *addr;
     struct Curl_dns_entry *dns;
     void *entry_id;
@@ -152,7 +152,7 @@ static CURLcode test_unit1607(const char *arg)
 
       if(addr && !Curl_addr2string(addr->ai_addr, addr->ai_addrlen,
                                    ipaddress, &port)) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. "
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. "
                       "getaddressinfo failed.\n",
                       __FILE__, __LINE__, i);
         problem = true;
@@ -160,24 +160,24 @@ static CURLcode test_unit1607(const char *arg)
       }
 
       if(addr && !tests[i].address[j]) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved addr "
-                      "is %s but tests[%d].address[%d] is NULL.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
+                      "is %s but tests[%zu].address[%zu] is NULL.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j);
         problem = true;
         break;
       }
 
       if(!addr && tests[i].address[j]) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved addr "
-                      "is NULL but tests[%d].address[%d] is %s.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
+                      "is NULL but tests[%zu].address[%zu] is %s.\n",
                       __FILE__, __LINE__, i, i, j, tests[i].address[j]);
         problem = true;
         break;
       }
 
       if(!curl_strequal(ipaddress, tests[i].address[j])) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved addr "
-                      "%s is not equal to tests[%d].address[%d] %s.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
+                      "%s is not equal to tests[%zu].address[%zu] %s.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j,
                       tests[i].address[j]);
         problem = true;
@@ -185,9 +185,9 @@ static CURLcode test_unit1607(const char *arg)
       }
 
       if(port != tests[i].port) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved port "
-                      "for tests[%d].address[%d] is %d "
-                      "but tests[%d].port is %d.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved port "
+                      "for tests[%zu].address[%zu] is %d "
+                      "but tests[%zu].port is %d.\n",
                       __FILE__, __LINE__, i, i, j, port, i, tests[i].port);
         problem = true;
         break;
@@ -195,16 +195,16 @@ static CURLcode test_unit1607(const char *arg)
 
       if(dns->timestamp.tv_sec && tests[i].permanent) {
         curl_mfprintf(stderr,
-                      "%s:%d tests[%d] failed. the timestamp is not zero "
-                      "but tests[%d].permanent is TRUE\n",
+                      "%s:%d tests[%zu] failed. the timestamp is not zero "
+                      "but tests[%zu].permanent is TRUE\n",
                       __FILE__, __LINE__, i, i);
         problem = true;
         break;
       }
 
       if(dns->timestamp.tv_sec == 0 && !tests[i].permanent) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the timestamp is zero "
-                      "but tests[%d].permanent is FALSE\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the timestamp is zero "
+                      "but tests[%zu].permanent is FALSE\n",
                       __FILE__, __LINE__, i, i);
         problem = true;
         break;

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -94,7 +94,7 @@ static CURLcode test_unit1609(const char *arg)
     },
   };
 
-  int i;
+  size_t i;
   struct Curl_multi *multi = NULL;
   struct Curl_easy *easy = NULL;
   struct curl_slist *list = NULL;
@@ -103,9 +103,9 @@ static CURLcode test_unit1609(const char *arg)
      and also clean cache after the loop. In contrast,for example,
      test 1607 sets up and cleans cache on each iteration. */
 
-  for(i = 0; i < (int)CURL_ARRAYSIZE(tests); ++i) {
-    int j;
-    int addressnum = CURL_ARRAYSIZE(tests[i].address);
+  for(i = 0; i < CURL_ARRAYSIZE(tests); ++i) {
+    size_t j;
+    size_t addressnum = CURL_ARRAYSIZE(tests[i].address);
     struct Curl_addrinfo *addr;
     struct Curl_dns_entry *dns;
     void *entry_id;
@@ -152,31 +152,31 @@ static CURLcode test_unit1609(const char *arg)
       if(addr && !Curl_addr2string(addr->ai_addr, addr->ai_addrlen,
                                    ipaddress, &port)) {
         curl_mfprintf(stderr,
-                      "%s:%d tests[%d] failed. Curl_addr2string failed.\n",
+                      "%s:%d tests[%zu] failed. Curl_addr2string failed.\n",
                       __FILE__, __LINE__, i);
         problem = true;
         break;
       }
 
       if(addr && !tests[i].address[j]) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved addr "
-                      "is %s but tests[%d].address[%d] is NULL.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
+                      "is %s but tests[%zu].address[%zu] is NULL.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j);
         problem = true;
         break;
       }
 
       if(!addr && tests[i].address[j]) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved addr "
-                      "is NULL but tests[%d].address[%d] is %s.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
+                      "is NULL but tests[%zu].address[%zu] is %s.\n",
                       __FILE__, __LINE__, i, i, j, tests[i].address[j]);
         problem = true;
         break;
       }
 
       if(!curl_strequal(ipaddress, tests[i].address[j])) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved addr "
-                      "%s is not equal to tests[%d].address[%d] %s.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
+                      "%s is not equal to tests[%zu].address[%zu] %s.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j,
                       tests[i].address[j]);
         problem = true;
@@ -184,9 +184,9 @@ static CURLcode test_unit1609(const char *arg)
       }
 
       if(port != tests[i].port) {
-        curl_mfprintf(stderr, "%s:%d tests[%d] failed. the retrieved port "
-                      "for tests[%d].address[%d] is %d "
-                      "but tests[%d].port is %d.\n",
+        curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved port "
+                      "for tests[%zu].address[%zu] is %d "
+                      "but tests[%zu].port is %d.\n",
                       __FILE__, __LINE__, i, i, j, port, i, tests[i].port);
         problem = true;
         break;

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -152,7 +152,7 @@ static CURLcode test_unit1652(const char *arg)
   memset(input, '\0', sizeof(input));
   memset(input, 'A', sizeof(input) - 1);
   Curl_infof(easy, "%s", input);
-  curl_fprintf(stderr, "output len %zu: %s", strlen(output), output);
+  curl_mfprintf(stderr, "output len %zu: %s", strlen(output), output);
   fail_unless(strlen(output) == 2047, "Truncation of infof input 3");
   fail_unless(output[sizeof(output) - 1] == '\0',
               "Truncation of infof input 3");

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -124,7 +124,7 @@ static CURLcode test_unit1652(const char *arg)
   memset(input, '\0', sizeof(input));
   memset(input, 'A', 2045);
   Curl_infof(easy, "%s", input);
-  fprintf(stderr, "output len %d: %s", (int)strlen(output), output);
+  curl_mfprintf(stderr, "output len %zu: %s", strlen(output), output);
   /* output is input + \n */
   fail_unless(strlen(output) == 2046, "No truncation of infof input");
   fail_unless(verify(output, input) == 0, "No truncation of infof input");
@@ -134,7 +134,7 @@ static CURLcode test_unit1652(const char *arg)
   /* Just over the limit without newline for truncation via '...' */
   memset(input + 2045, 'A', 4);
   Curl_infof(easy, "%s", input);
-  fprintf(stderr, "output len %d: %s", (int)strlen(output), output);
+  curl_mfprintf(stderr, "output len %zu: %s", strlen(output), output);
   fail_unless(strlen(output) == 2047, "Truncation of infof input 1");
   fail_unless(output[sizeof(output) - 1] == '\0',
               "Truncation of infof input 1");
@@ -143,7 +143,7 @@ static CURLcode test_unit1652(const char *arg)
   memset(input + 2045, 'A', 4);
   memset(input + 2045 + 4, '\n', 1);
   Curl_infof(easy, "%s", input);
-  fprintf(stderr, "output len %d: %s", (int)strlen(output), output);
+  curl_mfprintf(stderr, "output len %zu: %s", strlen(output), output);
   fail_unless(strlen(output) == 2047, "Truncation of infof input 2");
   fail_unless(output[sizeof(output) - 1] == '\0',
               "Truncation of infof input 2");
@@ -152,7 +152,7 @@ static CURLcode test_unit1652(const char *arg)
   memset(input, '\0', sizeof(input));
   memset(input, 'A', sizeof(input) - 1);
   Curl_infof(easy, "%s", input);
-  fprintf(stderr, "output len %d: %s", (int)strlen(output), output);
+  curl_fprintf(stderr, "output len %zu: %s", strlen(output), output);
   fail_unless(strlen(output) == 2047, "Truncation of infof input 3");
   fail_unless(output[sizeof(output) - 1] == '\0',
               "Truncation of infof input 3");

--- a/tests/unit/unit1655.c
+++ b/tests/unit/unit1655.c
@@ -67,7 +67,7 @@ static CURLcode test_unit1655(const char *arg)
       "this.is.an.otherwise-valid.hostname."
       "with-a-label-of-greater-length-than-the-sixty-three-characters-"
       "specified.in.the.RFCs.";
-    int i;
+    size_t i;
 
     struct test {
       const char *name;
@@ -89,7 +89,7 @@ static CURLcode test_unit1655(const char *arg)
       { max, DOH_OK }                      /* expect buffer overwrite */
     };
 
-    for(i = 0; i < (int)(CURL_ARRAYSIZE(playlist)); i++) {
+    for(i = 0; i < CURL_ARRAYSIZE(playlist); i++) {
       const char *name = playlist[i].name;
       size_t olen = 100000;
       struct demo victim;

--- a/tests/unit/unit1658.c
+++ b/tests/unit/unit1658.c
@@ -509,12 +509,12 @@ static CURLcode test_unit1658(const char *arg)
   /* so that we get the log output: */
   curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
   if(easy) {
-    unsigned int i;
+    size_t i;
 
     for(i = 0; i < CURL_ARRAYSIZE(t); i++) {
       struct Curl_https_rrinfo *hrr;
 
-      printf("test %i: %s\n", i, t[i].name);
+      curl_mprintf("test %zu: %s\n", i, t[i].name);
 
       result = doh_resp_decode_httpsrr(easy, t[i].dns, t[i].len, &hrr);
 
@@ -523,7 +523,7 @@ static CURLcode test_unit1658(const char *arg)
 
       /* is the output the expected? */
       if(strcmp(rrbuffer, t[i].expect)) {
-        curl_mfprintf(stderr, "Test %s (%i) failed\n"
+        curl_mfprintf(stderr, "Test %s (%zu) failed\n"
                       "Expected: %s\n"
                       "Received: %s\n", t[i].name, i, t[i].expect, rrbuffer);
         unitfail++;

--- a/tests/unit/unit1658.c
+++ b/tests/unit/unit1658.c
@@ -509,12 +509,12 @@ static CURLcode test_unit1658(const char *arg)
   /* so that we get the log output: */
   curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
   if(easy) {
-    size_t i;
+    unsigned int i;
 
     for(i = 0; i < CURL_ARRAYSIZE(t); i++) {
       struct Curl_https_rrinfo *hrr;
 
-      curl_mprintf("test %zu: %s\n", i, t[i].name);
+      curl_mprintf("test %u: %s\n", i, t[i].name);
 
       result = doh_resp_decode_httpsrr(easy, t[i].dns, t[i].len, &hrr);
 
@@ -523,7 +523,7 @@ static CURLcode test_unit1658(const char *arg)
 
       /* is the output the expected? */
       if(strcmp(rrbuffer, t[i].expect)) {
-        curl_mfprintf(stderr, "Test %s (%zu) failed\n"
+        curl_mfprintf(stderr, "Test %s (%u) failed\n"
                       "Expected: %s\n"
                       "Received: %s\n", t[i].name, i, t[i].expect, rrbuffer);
         unitfail++;

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -38,7 +38,7 @@ static CURLcode test_unit1660(const char *arg)
 static void showsts(struct stsentry *e, const char *chost)
 {
   if(!e)
-    printf("'%s' is not HSTS\n", chost);
+    curl_mprintf("'%s' is not HSTS\n", chost);
   else {
     curl_mprintf("%s [%s]: %" CURL_FORMAT_CURL_OFF_T "%s\n",
                  chost, e->host, e->expires,
@@ -141,7 +141,7 @@ static CURLcode test_unit1660(const char *arg)
         continue;
       }
       else if(result) {
-        printf("Input %u: error %d\n", i, (int) result);
+        curl_mprintf("Input %u: error %d\n", i, (int) result);
         continue;
       }
     }

--- a/tests/unit/unit1664.c
+++ b/tests/unit/unit1664.c
@@ -57,26 +57,26 @@ static CURLcode test_unit1664(const char *arg)
   };
 
   int i;
-  printf("curlx_str_word\n");
+  curl_mprintf("curlx_str_word\n");
   for(i = 0; wordparse[i]; i++) {
     struct Curl_str out;
     const char *line = wordparse[i];
     const char *orgline = line;
     int rc = curlx_str_word(&line, &out, 7);
-    printf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
-           i, orgline, rc, (int)out.len, out.str, (int)out.len,
-           (int)(line - orgline));
+    curl_mprintf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
+                 i, orgline, rc, (int)out.len, out.str, (int)out.len,
+                 (int)(line - orgline));
   }
 
-  printf("curlx_str_until\n");
+  curl_mprintf("curlx_str_until\n");
   for(i = 0; wordparse[i]; i++) {
     struct Curl_str out;
     const char *line = wordparse[i];
     const char *orgline = line;
     int rc = curlx_str_until(&line, &out, 7, 'd');
-    printf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
-           i, orgline, rc, (int)out.len, out.str, (int)out.len,
-           (int)(line - orgline));
+    curl_mprintf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
+                 i, orgline, rc, (int)out.len, out.str, (int)out.len,
+                 (int)(line - orgline));
   }
 
   {
@@ -96,15 +96,15 @@ static CURLcode test_unit1664(const char *arg)
       NULL
     };
 
-    printf("curlx_str_quotedword\n");
+    curl_mprintf("curlx_str_quotedword\n");
     for(i = 0; qwords[i]; i++) {
       struct Curl_str out;
       const char *line = qwords[i];
       const char *orgline = line;
       int rc = curlx_str_quotedword(&line, &out, 7);
-      printf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
-             i, orgline, rc, (int)out.len, out.str, (int)out.len,
-             (int)(line - orgline));
+      curl_mprintf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
+                   i, orgline, rc, (int)out.len, out.str, (int)out.len,
+                   (int)(line - orgline));
     }
   }
 
@@ -119,13 +119,13 @@ static CURLcode test_unit1664(const char *arg)
       "",
       NULL
     };
-    printf("curlx_str_single\n");
+    curl_mprintf("curlx_str_single\n");
     for(i = 0; single[i]; i++) {
       const char *line = single[i];
       const char *orgline = line;
       int rc = curlx_str_single(&line, 'a');
-      printf("%u: (\"%s\") %d, line %d\n",
-             i, orgline, rc, (int)(line - orgline));
+      curl_mprintf("%u: (\"%s\") %d, line %d\n",
+                   i, orgline, rc, (int)(line - orgline));
     }
   }
   {
@@ -141,13 +141,13 @@ static CURLcode test_unit1664(const char *arg)
       "",
       NULL
     };
-    printf("curlx_str_singlespace\n");
+    curl_mprintf("curlx_str_singlespace\n");
     for(i = 0; single[i]; i++) {
       const char *line = single[i];
       const char *orgline = line;
       int rc = curlx_str_singlespace(&line);
-      printf("%u: (\"%s\") %d, line %d\n",
-             i, orgline, rc, (int)(line - orgline));
+      curl_mprintf("%u: (\"%s\") %d, line %d\n",
+                   i, orgline, rc, (int)(line - orgline));
     }
   }
 
@@ -162,13 +162,13 @@ static CURLcode test_unit1664(const char *arg)
       "",
       NULL
     };
-    printf("curlx_str_single\n");
+    curl_mprintf("curlx_str_single\n");
     for(i = 0; single[i]; i++) {
       const char *line = single[i];
       const char *orgline = line;
       int rc = curlx_str_single(&line, 'a');
-      printf("%u: (\"%s\") %d, line %d\n",
-             i, orgline, rc, (int)(line - orgline));
+      curl_mprintf("%u: (\"%s\") %d, line %d\n",
+                   i, orgline, rc, (int)(line - orgline));
     }
   }
   {
@@ -187,14 +187,14 @@ static CURLcode test_unit1664(const char *arg)
       "",
       NULL
     };
-    printf("curlx_str_number\n");
+    curl_mprintf("curlx_str_number\n");
     for(i = 0; nums[i]; i++) {
       curl_off_t num;
       const char *line = nums[i];
       const char *orgline = line;
       int rc = curlx_str_number(&line, &num, 1235);
-      printf("%u: (\"%s\") %d, [%u] line %d\n",
-             i, orgline, rc, (int)num, (int)(line - orgline));
+      curl_mprintf("%u: (\"%s\") %d, [%u] line %d\n",
+                   i, orgline, rc, (int)num, (int)(line - orgline));
     }
   }
 
@@ -219,7 +219,7 @@ static CURLcode test_unit1664(const char *arg)
       { "12", 10},
       {NULL, 0}
     };
-    printf("curlx_str_number varying max\n");
+    curl_mprintf("curlx_str_number varying max\n");
     for(i = 0; nums[i].str; i++) {
       curl_off_t num;
       const char *line = nums[i].str;
@@ -259,7 +259,7 @@ static CURLcode test_unit1664(const char *arg)
       { "12", 16},
       {NULL, 0}
     };
-    printf("curlx_str_hex varying max\n");
+    curl_mprintf("curlx_str_hex varying max\n");
     for(i = 0; nums[i].str; i++) {
       curl_off_t num;
       const char *line = nums[i].str;
@@ -294,7 +294,7 @@ static CURLcode test_unit1664(const char *arg)
       { "8", 10},
       {NULL, 0}
     };
-    printf("curlx_str_octal varying max\n");
+    curl_mprintf("curlx_str_octal varying max\n");
     for(i = 0; nums[i].str; i++) {
       curl_off_t num;
       const char *line = nums[i].str;
@@ -330,7 +330,7 @@ static CURLcode test_unit1664(const char *arg)
       "999999999999999999",
       NULL
     };
-    printf("curlx_str_number / max\n");
+    curl_mprintf("curlx_str_number / max\n");
     for(i = 0; nums[i]; i++) {
       curl_off_t num;
       const char *line = nums[i];
@@ -356,7 +356,7 @@ static CURLcode test_unit1664(const char *arg)
       "",
       NULL
     };
-    printf("curlx_str_newline\n");
+    curl_mprintf("curlx_str_newline\n");
     for(i = 0; newl[i]; i++) {
       const char *line = newl[i];
       const char *orgline = line;
@@ -382,7 +382,7 @@ static CURLcode test_unit1664(const char *arg)
       "",
       NULL
     };
-    printf("curlx_str_hex\n");
+    curl_mprintf("curlx_str_hex\n");
     for(i = 0; nums[i]; i++) {
       curl_off_t num;
       const char *line = nums[i];
@@ -409,7 +409,7 @@ static CURLcode test_unit1664(const char *arg)
       "",
       NULL
     };
-    printf("curlx_str_octal\n");
+    curl_mprintf("curlx_str_octal\n");
     for(i = 0; nums[i]; i++) {
       curl_off_t num;
       const char *line = nums[i];
@@ -433,7 +433,7 @@ static CURLcode test_unit1664(const char *arg)
       "666666666666666666666",
       NULL
     };
-    printf("curlx_str_octal / max\n");
+    curl_mprintf("curlx_str_octal / max\n");
     for(i = 0; nums[i]; i++) {
       curl_off_t num;
       const char *line = nums[i];
@@ -469,7 +469,7 @@ static CURLcode test_unit1664(const char *arg)
       "ABCDEF",
       NULL
     };
-    printf("curlx_str_hex / max\n");
+    curl_mprintf("curlx_str_hex / max\n");
     for(i = 0; nums[i]; i++) {
       curl_off_t num;
       const char *line = nums[i];

--- a/tests/unit/unit2604.c
+++ b/tests/unit/unit2604.c
@@ -83,21 +83,21 @@ static CURLcode test_unit2604(const char *arg)
     char *path;
     const char *cp = i == 0 ? cp0 : list[i].cp;
     CURLcode result = Curl_get_pathname(&cp, &path, list[i].home);
-    printf("%u - Curl_get_pathname(\"%s\", ... \"%s\") == %u\n", i,
-           list[i].cp, list[i].home, list[i].result);
+    curl_mprintf("%u - Curl_get_pathname(\"%s\", ... \"%s\") == %u\n", i,
+                 list[i].cp, list[i].home, list[i].result);
     if(result != list[i].result) {
-      printf("... returned %d\n", result);
+      curl_mprintf("... returned %d\n", result);
       unitfail++;
     }
     if(!result) {
       if(cp && strcmp(cp, list[i].next)) {
-        printf("... cp points to '%s', not '%s' as expected \n",
-               cp, list[i].next);
+        curl_mprintf("... cp points to '%s', not '%s' as expected \n",
+                     cp, list[i].next);
         unitfail++;
       }
       if(path && strcmp(path, list[i].expect)) {
-        printf("... gave '%s', not '%s' as expected \n",
-               path, list[i].expect);
+        curl_mprintf("... gave '%s', not '%s' as expected \n",
+                     path, list[i].expect);
         unitfail++;
       }
       curl_free(path);

--- a/tests/unit/unit3214.c
+++ b/tests/unit/unit3214.c
@@ -28,14 +28,15 @@
 static void checksize(const char *name, size_t size, size_t allowed)
 {
   if(size > allowed) {
-    fprintf(stderr, "BAD: struct %s is %d bytes, allowed to be %d",
-            name, (int)size, (int)allowed);
-    fprintf(stderr, ": %d bytes too big\n", (int)(size - allowed));
+    curl_mfprintf(stderr, "BAD: struct %s is %zu bytes, "
+                  "allowed to be %zu: %zu bytes too big\n",
+                  name, size, allowed, size - allowed);
     unitfail++;
   }
   else {
-    printf("FINE: struct %s is %d bytes, allowed %d (margin: %d bytes)\n",
-           name, (int)size, (int)allowed, (int)(allowed - size));
+    curl_mprintf("FINE: struct %s is %zu bytes, "
+                 "allowed %zu (margin: %zu bytes)\n",
+                 name, size, allowed, allowed - size);
   }
 }
 


### PR DESCRIPTION
To make the source code match the functions called at runtime.
And to avoid the preprocessor trick that may introduces build issues.

Before this patch, libtests, tunits and units were calling a mixture
of curl and system printf calls, then transformed them all to curl
printf calls by including `curl_printf.h`.

Changes made:
- tests: stop including `curl_printf.h`.
- libtest: switch a couple of outlier system printf calls to curl
  printf.
- unit: use more curl printf to avoid casts and show whole values.
- unit: switch remaining calls to curl printf explicitly.
- tunit: switch to call curl printf explicitly.
- libtest, tunit, unit: ban system printf.
- unit1307, unit1607, unit1609, unit1652, unit1655, unit3214: bump
  types/masks to avoid casts.

After this patch:
- libtests, tunits, units: use exclusively curl printf.
  (as before, but explicitly, without relying on redefinitions.)
- servers: is unchanged (it can only use system printf).

---

- [x] libtests, tunits, units: enforce via checksrc?
- [x] units: switch to curl printf completely, for consistency?
