### PR TITLE
DEPRECATE.md: We remove the OpenSSL-QUIC backend in March 2026

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -58,12 +58,15 @@ We remove support for this OpenSSL version from curl in June 2026.
 ## OpenSSL-QUIC
 
 OpenSSL-QUIC is what we call the curl QUIC backend that uses the OpenSSL QUIC
-stack. It is much slower and uses much more memory than ngtcp2 with OpenSSL's
-QUIC API and is only experimental in curl. It gets little attention from
-OpenSSL and we have no expectation of the major flaws getting corrected.
+stack.
 
-curl users building with OpenSSL can still use QUIC through the means of
-ngtcp2.
+ - It is slower and uses more memory than the alternatives and is only
+   experimental in curl.
+ - It gets little attention from OpenSSL and we have no expectation of the
+   major flaws getting corrected anytime soon.
+ - No one has spoken up for keeping it
+ - curl users building with vanilla OpenSSL can still use QUIC through the
+   means of ngtcp2
 
 We remove the OpenSSL-QUIC backend in March 2026.
 

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -55,6 +55,18 @@ free version risk being vulnerable.
 
 We remove support for this OpenSSL version from curl in June 2026.
 
+## OpenSSL-QUIC
+
+OpenSSL-QUIC is what we call the curl QUIC backend that uses OpenSSL's own
+QUIC stack. It is much slower and uses much more memory than ngtcp2 with
+OpenSSL's QUIC API and is only experimental in curl. It gets little attention
+from OpenSSL and we have no expectation of the major flaws getting corrected.
+
+curl users building with OpenSSL can still use QUIC through the means of
+ngtcp2.
+
+We remove the OpenSSL-QUIC backend in March 2026.
+
 ## Past removals
 
  - axTLS (removed in 7.63.0)

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -57,10 +57,10 @@ We remove support for this OpenSSL version from curl in June 2026.
 
 ## OpenSSL-QUIC
 
-OpenSSL-QUIC is what we call the curl QUIC backend that uses OpenSSL's own
-QUIC stack. It is much slower and uses much more memory than ngtcp2 with
-OpenSSL's QUIC API and is only experimental in curl. It gets little attention
-from OpenSSL and we have no expectation of the major flaws getting corrected.
+OpenSSL-QUIC is what we call the curl QUIC backend that uses the OpenSSL QUIC
+stack. It is much slower and uses much more memory than ngtcp2 with OpenSSL's
+QUIC API and is only experimental in curl. It gets little attention from
+OpenSSL and we have no expectation of the major flaws getting corrected.
 
 curl users building with OpenSSL can still use QUIC through the means of
 ngtcp2.


### PR DESCRIPTION
URL: https://curl.se/mail/lib-2025-10/0000.html