### PR TITLE
docs/cmdline-opts: drop double quotes from GLOBBING and URL examples

### DIFF
--- a/docs/cmdline-opts/_GLOBBING.md
+++ b/docs/cmdline-opts/_GLOBBING.md
@@ -6,31 +6,31 @@ or ranges within brackets. We call this "globbing".
 
 Provide a list with three different names like this:
 
-    "http://site.{one,two,three}.com"
+    http://site.{one,two,three}.com
 
 Do sequences of alphanumeric series by using [] as in:
 
-    "ftp://ftp.example.com/file[1-100].txt"
+    ftp://ftp.example.com/file[1-100].txt
 
 With leading zeroes:
 
-    "ftp://ftp.example.com/file[001-100].txt"
+    ftp://ftp.example.com/file[001-100].txt
 
 With letters through the alphabet:
 
-    "ftp://ftp.example.com/file[a-z].txt"
+    ftp://ftp.example.com/file[a-z].txt
 
 Nested sequences are not supported, but you can use several ones next to each
 other:
 
-    "http://example.com/archive[1996-1999]/vol[1-4]/part{a,b,c}.html"
+    http://example.com/archive[1996-1999]/vol[1-4]/part{a,b,c}.html
 
 You can specify a step counter for the ranges to get every Nth number or
 letter:
 
-    "http://example.com/file[1-100:10].txt"
+    http://example.com/file[1-100:10].txt
 
-    "http://example.com/file[a-z:2].txt"
+    http://example.com/file[a-z:2].txt
 
 When using [] or {} sequences when invoked from a command line prompt, you
 probably have to put the full URL within double quotes to avoid the shell from

--- a/docs/cmdline-opts/_URL.md
+++ b/docs/cmdline-opts/_URL.md
@@ -22,7 +22,7 @@ separate curl runs.
 
 Provide an IPv6 zone id in the URL with an escaped percentage sign. Like in
 
-    "http://[fe80::3%25eth0]/"
+    http://[fe80::3%25eth0]/
 
 Everything provided on the command line that is not a command line option or
 its argument, curl assumes is a URL and treats it as such.


### PR DESCRIPTION
It looks easier on the eye without them