### PR TITLE
Makefile.example: fix option order

### DIFF
--- a/docs/examples/Makefile.example
+++ b/docs/examples/Makefile.example
@@ -47,4 +47,4 @@ LIBS := -lcurl $(LIBS)
 
 # Link the target with all objects and libraries
 $(TARGET) : $(SRC)
-	$(CC) -o $(TARGET) $(CFLAGS) $(LDFLAGS) $(LIBS) $<
+	$(CC) $< $(CFLAGS) $(LDFLAGS) $(LIBS) -o $(TARGET)


### PR DESCRIPTION
The `ld` linker is sensitive to this, and did not find libcurl symbol
with the order before this patch. Seen with mingw-w64 gcc.

Follow-up to f6ddc1fc1e25ff8ea866f90942719af898d0ef0c #18554
