### PR TITLE
checksrc: fix to handle `)` predecing a banned function

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -908,6 +908,7 @@ sub scanfile {
             $prefix =~ s/\[/\\[/;
             $prefix =~ s/\]/\\]/;
             $prefix =~ s/\(/\\(/;
+            $prefix =~ s/\)/\\)/;
             $suff =~ s/\(/\\(/;
             $l =~ s/$prefix$bad$suff/$prefix$replace/;
             goto again;

--- a/tests/data/test1185
+++ b/tests/data/test1185
@@ -75,6 +75,7 @@ void startfunc(int a, int b) {
  if(a) b++;
 
  if(sprintf(buffer, "%s", moo)) {}
+ *buffer_len = (ssize_t)alsobad((char *)buffer, NULL, 16);
 
  // CPP comment ?
 
@@ -197,7 +198,10 @@ void startfunc(int a, int b) {
 ./%LOGDIR/code1185.c:59:5: warning: use of sprintf is banned (BANNEDFUNC)
   if(sprintf(buffer, "%s", moo)) {}
      ^
-./%LOGDIR/code1185.c:61:2: warning: // comment (CPPCOMMENTS)
+./%LOGDIR/code1185.c:60:25: warning: use of alsobad is banned (BANNEDFUNC)
+  *buffer_len = (ssize_t)alsobad((char *)buffer, NULL, 16);
+                         ^
+./%LOGDIR/code1185.c:62:2: warning: // comment (CPPCOMMENTS)
   // CPP comment ?
   ^
 ./%LOGDIR/code1185.c:1:1: error: Missing copyright statement (COPYRIGHT)
@@ -206,7 +210,7 @@ void startfunc(int a, int b) {
 ./%LOGDIR/code1185.c:1:1: error: Missing closing comment (OPENCOMMENT)
  
  ^
-checksrc: 0 errors and 40 warnings
+checksrc: 0 errors and 41 warnings
 </stdout>
 <errorcode>
 5


### PR DESCRIPTION
Fixing:
```
Unmatched ) in regex; marked by <-- HERE in m/  \*buffer_len = \(ssize_t) <-- HERE
  strtol\(/ at /home/runner/work/curl/curl/scripts/checksrc.pl line 916, <$R> line 380.
```
Ref: https://github.com/curl/curl/actions/runs/18209824275/job/51848079550#step:3:5

Also add a test case.

Follow-up to 684f4cdd3ef0cc41c547fce0e45d8a059a3058b3 #18779
Cherry-picked from #18823
