### PR TITLE
tests/server: replace banned functions with `curlx_str_hex`

### DIFF
--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -371,13 +371,20 @@ static void lograw(unsigned char *buffer, ssize_t len)
 static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
                             ssize_t *buffer_len)
 {
+  curl_off_t value;
+  const char *endp;
+
   if(!read_stdin(buffer, 5))
     return FALSE;
 
   buffer[5] = '\0';
 
-  /* !checksrc! disable BANNEDFUNC 1 */
-  *buffer_len = (ssize_t)strtol((char *)buffer, NULL, 16);
+  endp = (char *)buffer;
+  if(curlx_str_hex(&endp, &value, 0xfffff)) {
+    logmsg("Failed to decode buffer size");
+    return FALSE;
+  }
+  *buffer_len = (ssize_t)value;
   if(*buffer_len > maxlen) {
     logmsg("Buffer size (%zd bytes) too small for data size error "
            "(%zd bytes)", maxlen, *buffer_len);


### PR DESCRIPTION
Replace an `strtol()` and `strtoul()` call, both used in hex mode, with
`curlx_str_hex()`.

Follow-up to 45438c8d6f8e70385d66c029568524e9e803c539 #18823