### PR TITLE
openssl: fix build for v1.0.2

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -296,7 +296,12 @@ do {                              \
 
 static int asn1_object_dump(const ASN1_OBJECT *a, char *buf, size_t len)
 {
-  int i = i2t_ASN1_OBJECT(buf, (int)len, a);
+  int i;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+  i = i2t_ASN1_OBJECT(buf, (int)len, a);
+#else
+  i = i2t_ASN1_OBJECT(buf, (int)len, CURL_UNCONST(a));
+#endif
   return (i >= (int)len);  /* buffer too small */
 }
 


### PR DESCRIPTION
```
lib/vtls/openssl.c: In function 'asn1_object_dump':
lib/vtls/openssl.c:299:42: error: passing argument 3 of 'i2t_ASN1_OBJECT' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  299 |   int i = i2t_ASN1_OBJECT(buf, (int)len, a);
      |                                          ^
In file included from /home/runner/djgpp/include/openssl/objects.h:965,
                 from /home/runner/djgpp/include/openssl/evp.h:94,
                 from /home/runner/djgpp/include/openssl/x509.h:73,
                 from /home/runner/djgpp/include/openssl/ssl.h:156,
                 from lib/curl_ntlm_core.c:71,
                 from bld/lib/CMakeFiles/libcurl_static.dir/Unity/unity_0_c.c:88:
/home/runner/djgpp/include/openssl/asn1.h:921:58: note: expected 'ASN1_OBJECT *' {aka 'struct asn1_object_st *'} but argument is of type 'const ASN1_OBJECT *' {aka 'const struct asn1_object_st *'}
  921 | int i2t_ASN1_OBJECT(char *buf, int buf_len, ASN1_OBJECT *a);
      |                                             ~~~~~~~~~~~~~^
```
Ref: https://github.com/curl/curl/actions/runs/18236773678/job/51931937131?pr=18039

Follow-up to bb46d42407cd0503a9c499b4646af594a4db4947 #18647