### PR TITLE
examples: drop unused `curl/mprintf.h` includes

### DIFF
--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -32,7 +32,6 @@
 #include <time.h>
 
 #include <curl/curl.h>
-#include <curl/mprintf.h>
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -36,7 +36,6 @@
 
 /* curl stuff */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf

--- a/docs/examples/http2-serverpush.c
+++ b/docs/examples/http2-serverpush.c
@@ -31,7 +31,6 @@
 
 /* curl stuff */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -54,7 +54,6 @@
 
 /* curl stuff */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 /* This little trick makes sure that we do not enable pipelining for libcurls


### PR DESCRIPTION
Follow-up to 45438c8d6f8e70385d66c029568524e9e803c539 #18823