### PR TITLE
examples: fix two build issues surfaced with WinCE

### DIFF
--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -40,8 +40,6 @@
 #ifndef _MSC_VER
 #include <sys/time.h>
 #include <unistd.h>
-#elif (_MSC_VER < 1900)
-#define snprintf _snprintf
 #endif
 
 #ifdef _WIN32
@@ -50,6 +48,10 @@
 #undef fstat
 #define fstat _fstat
 #define fileno _fileno
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#define snprintf _snprintf
 #endif
 
 /* curl stuff */

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -94,6 +94,8 @@ int main(void) { printf("Platform not supported.\n"); return 1; }
 
 #include <curl/curl.h>
 
+#include <windows.h>
+
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf
 #endif

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -90,9 +90,9 @@ int main(void) { printf("Platform not supported.\n"); return 1; }
 int main(void) { printf("Platform not supported.\n"); return 1; }
 #else
 
-#include <curl/curl.h>
-
 #include <time.h>
+
+#include <curl/curl.h>
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -90,10 +90,9 @@ int main(void) { printf("Platform not supported.\n"); return 1; }
 int main(void) { printf("Platform not supported.\n"); return 1; }
 #else
 
-#include <windows.h>
-#include <time.h>
-
 #include <curl/curl.h>
+
+#include <time.h>
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf


### PR DESCRIPTION
Both may apply to rare non-WinCE Windows builds too.

- fix gcc 4.4.0 preprocessor error:
  ```
  docs/examples/http2-upload.c:43:8: error: "_MSC_VER" is not defined
  ```
  Ref: https://github.com/curl/curl/actions/runs/18238150607/job/51935502616

- fix wrong header order:
  Inlcude `windows.h` after `winsock2.h` via `curl/curl.h`.

Regressions from 45438c8d6f8e70385d66c029568524e9e803c539 #18823
