### PR TITLE
checksrc: fix possible endless loops/errors in the banned function logic

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -907,10 +907,9 @@ sub scanfile {
             checkwarn("BANNEDFUNC",
                       $line, length($prefix), $file, $ol,
                       "use of $bad is banned");
-            my $replace = 'x' x (length($bad) + 1);
-            $prefix = quotemeta($prefix);
-            $suff = quotemeta($suff);
-            $l =~ s/$prefix$bad$suff/$prefix$replace/;
+            my $search = quotemeta($prefix . $bad . $suff);
+            my $replace = $prefix . 'x' x (length($bad) + 1);
+            $l =~ s/$search/$replace/;
             goto again;
         }
         $l = $bl; # restore to pre-bannedfunc content

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -909,6 +909,7 @@ sub scanfile {
                       "use of $bad is banned");
             my $replace = 'x' x (length($bad) + 1);
             $prefix =~ s/\*/\\*/;
+            $prefix =~ s/\+/\\+/;
             $prefix =~ s/\[/\\[/;
             $prefix =~ s/\]/\\]/;
             $prefix =~ s/\(/\\(/;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -908,13 +908,8 @@ sub scanfile {
                       $line, length($prefix), $file, $ol,
                       "use of $bad is banned");
             my $replace = 'x' x (length($bad) + 1);
-            $prefix =~ s/\*/\\*/;
-            $prefix =~ s/\+/\\+/;
-            $prefix =~ s/\[/\\[/;
-            $prefix =~ s/\]/\\]/;
-            $prefix =~ s/\(/\\(/;
-            $prefix =~ s/\)/\\)/;
-            $suff =~ s/\(/\\(/;
+            $prefix = quotemeta($prefix);
+            $suff = quotemeta($suff);
             $l =~ s/$prefix$bad$suff/$prefix$replace/;
             goto again;
         }


### PR DESCRIPTION
By quoting the search expression to be replaced. This avoid the issue
when the code leading up to a banned function contained regex characters
that the script did not explicitly handle, e.g. `+`.

Assisted-by: Daniel Stenberg

Ref: https://perldoc.perl.org/functions/quotemeta
Follow-up to dd37d6970cfd8b4cf47ebd469f03772813b92c23 #18775

---

Is there a way to search and replace plain strings in Perl, without regexes?
