### PR TITLE
cpool: make bundle->dest an array; fix UB

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -79,7 +79,7 @@
 struct cpool_bundle {
   struct Curl_llist conns; /* connections in the bundle */
   size_t dest_len; /* total length of destination, including NUL */
-  char *dest[1]; /* destination of bundle, allocated to keep dest_len bytes */
+  char dest[1]; /* destination of bundle, allocated to keep dest_len bytes */
 };
 
 
@@ -91,13 +91,13 @@ static void cpool_discard_conn(struct cpool *cpool,
 static struct cpool_bundle *cpool_bundle_create(const char *dest)
 {
   struct cpool_bundle *bundle;
-  size_t dest_len = strlen(dest);
+  size_t dest_len = strlen(dest) + 1;
 
-  bundle = calloc(1, sizeof(*bundle) + dest_len);
+  bundle = calloc(1, sizeof(*bundle) + dest_len - 1);
   if(!bundle)
     return NULL;
   Curl_llist_init(&bundle->conns, NULL);
-  bundle->dest_len = dest_len + 1;
+  bundle->dest_len = dest_len;
   memcpy(bundle->dest, dest, bundle->dest_len);
   return bundle;
 }

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -320,7 +320,7 @@ static struct connectdata *cpool_get_oldest_idle(struct cpool *cpool)
   struct connectdata *oldest_idle = NULL;
   struct cpool_bundle *bundle;
   struct curltime now;
-  timediff_t highscore =- 1;
+  timediff_t highscore = -1;
   timediff_t score;
 
   now = curlx_now();


### PR DESCRIPTION
Replace `char *dest[1]` with a proper `char dest[1]` array in cpool_bundle. This removes undefined behavior from memcpy (writing past the declared object) while keeping the same key semantics: dest_len is strlen+1 (includes NUL), and hash add/delete calls remain unchanged.

also fixes a tiny typo in this code.