### PR TITLE
telnet: use pointer[0] for "unknown" option instead of pointer[i]

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -732,7 +732,7 @@ static void printsub(struct Curl_easy *data,
       }
     }
     else
-      infof(data, "%d (unknown)", pointer[i]);
+      infof(data, "%d (unknown)", pointer[0]);
 
     switch(pointer[0]) {
     case CURL_TELOPT_NAWS:


### PR DESCRIPTION
i is taken from pointer[length-2] (often the IAC byte) before we do length -= 2, so using pointer[i] indexes an arbitrary/stale byte unrelated to the option code. pointer[0] is the suboption’s option code per the telnet SB format, so printing pointer[0] yields correct, stable diagnostics.