### PR TITLE
GHA/http3-linux: cleanup cache entry name after prev

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -73,7 +73,7 @@ jobs:
           cache-name: cache-openssl-http3-no-deprecated
         with:
           path: ~/openssl/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_VERSION }}-no-deprecated
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_VERSION }}
 
       - name: 'cache libressl'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -484,7 +484,7 @@ jobs:
           cache-name: cache-openssl-http3-no-deprecated
         with:
           path: ~/openssl/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_VERSION }}-no-deprecated
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_VERSION }}
           fail-on-cache-miss: true
 
       - name: 'cache libressl'


### PR DESCRIPTION
To avoid duplicate `no-deprecated` in the cache entry name.

Follow-up to c96bf36557ea2302e4cb838ee1e4bb9827fecee7 #18833