### PR TITLE
telnet: only reply after SEND+negotiation; add null checks

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -947,10 +947,19 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
   size_t len;
   int err;
   struct connectdata *conn = data->conn;
+  int opt;
+  int qual;
 
   printsub(data, '<', (unsigned char *)tn->subbuffer, CURL_SB_LEN(tn) + 2);
-  switch(CURL_SB_GET(tn)) {
+  opt = CURL_SB_GET(tn);
+  qual = (CURL_SB_LEN(tn) > 0) ? CURL_SB_GET(tn) : -1;
+
+  switch(opt) {
     case CURL_TELOPT_TTYPE:
+      if(qual != CURL_TELQUAL_SEND || tn->us[CURL_TELOPT_TTYPE] != CURL_YES)
+        return CURLE_OK;
+      if(!tn->subopt_ttype)
+        return CURLE_OK;
       if(bad_option(tn->subopt_ttype))
         return CURLE_BAD_FUNCTION_ARGUMENT;
       if(strlen(tn->subopt_ttype) > 1000) {
@@ -970,6 +979,10 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
       printsub(data, '>', &temp[2], len-2);
       break;
     case CURL_TELOPT_XDISPLOC:
+      if(qual != CURL_TELQUAL_SEND || tn->us[CURL_TELOPT_XDISPLOC] != CURL_YES)
+        return CURLE_OK;
+      if(!tn->subopt_xdisploc)
+        return CURLE_OK;
       if(bad_option(tn->subopt_xdisploc))
         return CURLE_BAD_FUNCTION_ARGUMENT;
       if(strlen(tn->subopt_xdisploc) > 1000) {
@@ -987,6 +1000,8 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
       printsub(data, '>', &temp[2], len-2);
       break;
     case CURL_TELOPT_NEW_ENVIRON:
+      if(qual != CURL_TELQUAL_SEND || tn->us[CURL_TELOPT_NEW_ENVIRON] != CURL_YES)
+        return CURLE_OK;
       len = msnprintf((char *)temp, sizeof(temp), "%c%c%c%c",
                       CURL_IAC, CURL_SB, CURL_TELOPT_NEW_ENVIRON,
                       CURL_TELQUAL_IS);


### PR DESCRIPTION
We now reply to TTYPE, XDISPLOC, and NEW_ENVIRON only when the peer sent SEND and the option is negotiated (us[opt] == CURL_YES), so a hostile server can’t elicit data just by sending SB … without proper WILL/DO+SEND.

If TTYPE/XDISPLOC aren’t configured, we skip replying and guard them before bad_option(), so we don’t risk a NULL dereference when the server asks for values that don’t exist.

NEW_ENVIRON still sends only entries the caller explicitly provided; we don’t touch the process environment. This keeps the existing opt-in behavior.

RFC note: This moves us closer to RFC 1091/1096/1572, but it’s not fully compliant yet: we don’t parse/filter a NEW-ENVIRON SEND selection list, and we don’t enforce the 40-char TTYPE limit.