### PR TITLE
strerror: drop workaround for SalfordC win32 header bug

### DIFF
--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -698,11 +698,9 @@ get_winsock_error(int err, char *buf, size_t len)
   case WSAEREMOTE:
     p = "Remote error";
     break;
-#ifdef WSAEDISCON  /* missing in SalfordC! */
   case WSAEDISCON:
     p = "Disconnected";
     break;
-#endif
     /* Extended Winsock errors */
   case WSASYSNOTREADY:
     p = "Winsock library is not ready";


### PR DESCRIPTION
Follow-up to ccf43ce91dd9a56f30a4029377126e4c83c7f08a #15957
