### PR TITLE
tool_filetime: replace cast with the fitting printf mask (Windows)

### DIFF
--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -62,13 +62,13 @@ int getfiletime(const char *filename, curl_off_t *stamp)
       }
     }
     else {
-      warnf("Failed to get filetime: GetFileTime failed: GetLastError %08lx",
+      warnf("Failed to get filetime: GetFileTime failed: GetLastError %lu",
             GetLastError());
     }
     CloseHandle(hfile);
   }
   else if(GetLastError() != ERROR_FILE_NOT_FOUND) {
-    warnf("Failed to get filetime: CreateFile failed: GetLastError %08lx",
+    warnf("Failed to get filetime: CreateFile failed: GetLastError %lu",
           GetLastError());
   }
 #else
@@ -115,14 +115,14 @@ void setfiletime(curl_off_t filetime, const char *filename)
     ft.dwHighDateTime = (DWORD)(converted >> 32);
     if(!SetFileTime(hfile, NULL, &ft, &ft)) {
       warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
-            " on outfile: SetFileTime failed: GetLastError %08lx",
+            " on outfile: SetFileTime failed: GetLastError %lu",
             filetime, GetLastError());
     }
     CloseHandle(hfile);
   }
   else {
     warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
-          " on outfile: CreateFile failed: GetLastError %08lx",
+          " on outfile: CreateFile failed: GetLastError %lu",
           filetime, GetLastError());
   }
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -59,7 +59,7 @@ static CURLcode test_lib3026(const char *URL)
     results[i] = CURL_LAST; /* initialize with invalid value */
     th = CreateThread(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
     if(!th) {
-      curl_mfprintf(stderr, "%s:%d Couldn't create thread, errno %08lx\n",
+      curl_mfprintf(stderr, "%s:%d Couldn't create thread, errno %lu\n",
                     __FILE__, __LINE__, GetLastError());
       tid_count = i;
       test_failure = TEST_ERR_MAJOR_BAD;


### PR DESCRIPTION
Follow-up to d25b0503795f1fbf557632ce870298f52f2a78c1 #2204
