### PR TITLE
windows: use native error code types more

### DIFF
--- a/lib/curlx/strerr.c
+++ b/lib/curlx/strerr.c
@@ -298,7 +298,7 @@ const char *curlx_strerror(int err, char *buf, size_t buflen)
 #ifdef USE_WINSOCK
       !get_winsock_error(err, buf, buflen) &&
 #endif
-      !curlx_get_winapi_error(err, buf, buflen))
+      !curlx_get_winapi_error((DWORD)err, buf, buflen))
       SNPRINTF(buf, buflen, "Unknown error %d (%#x)", err, err);
   }
 #else /* !_WIN32 */

--- a/lib/curlx/winapi.c
+++ b/lib/curlx/winapi.c
@@ -48,7 +48,7 @@
  * codes (GetLastError) to error messages.
  * Returns NULL if no error message was found for error code.
  */
-const char *curlx_get_winapi_error(int err, char *buf, size_t buflen)
+const char *curlx_get_winapi_error(DWORD err, char *buf, size_t buflen)
 {
   char *p;
   wchar_t wbuf[256];
@@ -64,7 +64,7 @@ const char *curlx_get_winapi_error(int err, char *buf, size_t buflen)
      expect the local codepage (eg fprintf, failf, infof).
      FormatMessageW -> wcstombs is used for Windows CE compatibility. */
   if(FormatMessageW((FORMAT_MESSAGE_FROM_SYSTEM |
-                     FORMAT_MESSAGE_IGNORE_INSERTS), NULL, (DWORD)err,
+                     FORMAT_MESSAGE_IGNORE_INSERTS), NULL, err,
                     LANG_NEUTRAL, wbuf, CURL_ARRAYSIZE(wbuf), NULL)) {
     size_t written = wcstombs(buf, wbuf, buflen - 1);
     if(written != (size_t)-1)
@@ -96,7 +96,7 @@ const char *curlx_winapi_strerror(DWORD err, char *buf, size_t buflen)
   *buf = '\0';
 
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
-  if(!curlx_get_winapi_error((int)err, buf, buflen)) {
+  if(!curlx_get_winapi_error(err, buf, buflen)) {
 #if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic warning "-Wformat-truncation=1"

--- a/lib/curlx/winapi.h
+++ b/lib/curlx/winapi.h
@@ -26,7 +26,7 @@
 
 #ifdef _WIN32
 #define WINAPI_ERROR_LEN 100
-const char *curlx_get_winapi_error(int err, char *buf, size_t buflen);
+const char *curlx_get_winapi_error(DWORD err, char *buf, size_t buflen);
 const char *curlx_winapi_strerror(DWORD err, char *buf, size_t buflen);
 #endif
 

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -546,7 +546,7 @@ curl_url_strerror(CURLUcode error)
  * Curl_sspi_strerror:
  * Variant of curlx_strerror if the error code is definitely Windows SSPI.
  */
-const char *Curl_sspi_strerror(int err, char *buf, size_t buflen)
+const char *Curl_sspi_strerror(SECURITY_STATUS err, char *buf, size_t buflen)
 {
 #ifdef _WIN32
   DWORD old_win_err = GetLastError();
@@ -656,7 +656,7 @@ const char *Curl_sspi_strerror(int err, char *buf, size_t buflen)
 
   if(err == SEC_E_ILLEGAL_MESSAGE) {
     curl_msnprintf(buf, buflen,
-                   "SEC_E_ILLEGAL_MESSAGE (0x%08X) - This error usually "
+                   "SEC_E_ILLEGAL_MESSAGE (0x%08lX) - This error usually "
                    "occurs when a fatal SSL/TLS alert is received (e.g. "
                    "handshake failed). More detail may be available in "
                    "the Windows System event log.", err);
@@ -664,9 +664,9 @@ const char *Curl_sspi_strerror(int err, char *buf, size_t buflen)
   else {
     char msgbuf[256];
     if(curlx_get_winapi_error((DWORD)err, msgbuf, sizeof(msgbuf)))
-      curl_msnprintf(buf, buflen, "%s (0x%08X) - %s", txt, err, msgbuf);
+      curl_msnprintf(buf, buflen, "%s (0x%08lX) - %s", txt, err, msgbuf);
     else
-      curl_msnprintf(buf, buflen, "%s (0x%08X)", txt, err);
+      curl_msnprintf(buf, buflen, "%s (0x%08lX)", txt, err);
   }
 
 #else

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -663,7 +663,7 @@ const char *Curl_sspi_strerror(int err, char *buf, size_t buflen)
   }
   else {
     char msgbuf[256];
-    if(curlx_get_winapi_error(err, msgbuf, sizeof(msgbuf)))
+    if(curlx_get_winapi_error((DWORD)err, msgbuf, sizeof(msgbuf)))
       curl_msnprintf(buf, buflen, "%s (0x%08X) - %s", txt, err, msgbuf);
     else
       curl_msnprintf(buf, buflen, "%s (0x%08X)", txt, err);

--- a/lib/strerror.h
+++ b/lib/strerror.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 
 #ifdef USE_WINDOWS_SSPI
-const char *Curl_sspi_strerror(int err, char *buf, size_t buflen);
+const char *Curl_sspi_strerror(SECURITY_STATUS err, char *buf, size_t buflen);
 #endif
 
 #endif /* HEADER_CURL_STRERROR_H */

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -473,8 +473,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     if(status == SEC_E_OK)
       output_token_len = chlg_buf[4].cbBuffer;
     else { /* delete the context so a new one can be made */
-      infof(data, "digest_sspi: MakeSignature failed, error 0x%08lx",
-            (long)status);
+      infof(data, "digest_sspi: MakeSignature failed, error 0x%08lx", status);
       Curl_pSecFn->DeleteSecurityContext(digest->http_context);
       Curl_safefree(digest->http_context);
     }

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -127,7 +127,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
   if(!nego->output_token) {
     /* Query the security package for Negotiate */
-    nego->status = (DWORD)Curl_pSecFn->QuerySecurityPackageInfo(
+    nego->status = Curl_pSecFn->QuerySecurityPackageInfo(
                                 (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
                                 &SecurityPackage);
     if(nego->status != SEC_E_OK) {
@@ -167,8 +167,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       return CURLE_OUT_OF_MEMORY;
 
     /* Acquire our credentials handle */
-    nego->status = (DWORD)
-      Curl_pSecFn->AcquireCredentialsHandle(NULL,
+    nego->status = Curl_pSecFn->AcquireCredentialsHandle(NULL,
                                 (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
                                 SECPKG_CRED_OUTBOUND, NULL,
                                 nego->p_identity, NULL, NULL,
@@ -216,11 +215,10 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       SEC_CHANNEL_BINDINGS channelBindings;
       SecPkgContext_Bindings pkgBindings;
       pkgBindings.Bindings = &channelBindings;
-      nego->status = (DWORD)Curl_pSecFn->QueryContextAttributes(
+      nego->status = Curl_pSecFn->QueryContextAttributes(
           nego->sslContext,
           SECPKG_ATTR_ENDPOINT_BINDINGS,
-          &pkgBindings
-      );
+          &pkgBindings);
       if(nego->status == SEC_E_OK) {
         chlg_desc.cBuffers++;
         chlg_buf[1].BufferType = SECBUFFER_CHANNEL_BINDINGS;
@@ -241,14 +239,14 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
   /* Generate our challenge-response message */
   nego->status =
-    (DWORD)Curl_pSecFn->InitializeSecurityContext(nego->credentials,
-                                                  chlg ? nego->context : NULL,
-                                                  nego->spn,
-                                                  ISC_REQ_CONFIDENTIALITY,
-                                                  0, SECURITY_NATIVE_DREP,
-                                                  chlg ? &chlg_desc : NULL,
-                                                  0, nego->context,
-                                                  &resp_desc, &attrs, NULL);
+    Curl_pSecFn->InitializeSecurityContext(nego->credentials,
+                                           chlg ? nego->context : NULL,
+                                           nego->spn,
+                                           ISC_REQ_CONFIDENTIALITY,
+                                           0, SECURITY_NATIVE_DREP,
+                                           chlg ? &chlg_desc : NULL,
+                                           0, nego->context,
+                                           &resp_desc, &attrs, NULL);
 
   /* Free the decoded challenge as it is not required anymore */
   free(chlg);
@@ -256,9 +254,9 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   if(GSS_ERROR(nego->status)) {
     char buffer[STRERROR_LEN];
     failf(data, "InitializeSecurityContext failed: %s",
-          Curl_sspi_strerror((int)nego->status, buffer, sizeof(buffer)));
+          Curl_sspi_strerror(nego->status, buffer, sizeof(buffer)));
 
-    if(nego->status == (DWORD)SEC_E_INSUFFICIENT_MEMORY)
+    if(nego->status == SEC_E_INSUFFICIENT_MEMORY)
       return CURLE_OUT_OF_MEMORY;
 
     return CURLE_AUTH_ERROR;
@@ -266,14 +264,13 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
   if(nego->status == SEC_I_COMPLETE_NEEDED ||
      nego->status == SEC_I_COMPLETE_AND_CONTINUE) {
-    nego->status = (DWORD)Curl_pSecFn->CompleteAuthToken(nego->context,
-                                                         &resp_desc);
+    nego->status = Curl_pSecFn->CompleteAuthToken(nego->context, &resp_desc);
     if(GSS_ERROR(nego->status)) {
       char buffer[STRERROR_LEN];
       failf(data, "CompleteAuthToken failed: %s",
-            Curl_sspi_strerror((int)nego->status, buffer, sizeof(buffer)));
+            Curl_sspi_strerror(nego->status, buffer, sizeof(buffer)));
 
-      if(nego->status == (DWORD)SEC_E_INSUFFICIENT_MEMORY)
+      if(nego->status == SEC_E_INSUFFICIENT_MEMORY)
         return CURLE_OUT_OF_MEMORY;
 
       return CURLE_AUTH_ERROR;

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -317,7 +317,7 @@ struct negotiatedata {
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   CtxtHandle *sslContext;
 #endif
-  DWORD status;
+  SECURITY_STATUS status;
   CredHandle *credentials;
   CtxtHandle *context;
   SEC_WINNT_AUTH_IDENTITY identity;


### PR DESCRIPTION
- curlx_get_winapi_error: accept DWORD (was: int), move casts one level
  up the callstack.

- sspi: bump some types to `SECURITY_STATUS` (int -> LONG).

- digest_sspi: drop unnecessary cast.
