### PR TITLE
ftp: improve fragile check for first digit > 3

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -449,11 +449,14 @@ static CURLcode ftp_check_ctrl_on_data_wait(struct Curl_easy *data,
   bool response = FALSE;
 
   /* First check whether there is a cached response from server */
-  if(curlx_dyn_len(&pp->recvbuf) && (*curlx_dyn_ptr(&pp->recvbuf) > '3')) {
-    /* Data connection could not be established, let's return */
-    infof(data, "There is negative response in cache while serv connect");
-    (void)getftpresponse(data, &nread, &ftpcode);
-    return CURLE_FTP_ACCEPT_FAILED;
+  if(curlx_dyn_len(&pp->recvbuf)) {
+    const char *l = curlx_dyn_ptr(&pp->recvbuf);
+    if(!ISDIGIT(*l) || (*l > '3')) {
+      /* Data connection could not be established, let's return */
+      infof(data, "There is negative response in cache while serv connect");
+      (void)getftpresponse(data, &nread, &ftpcode);
+      return CURLE_FTP_ACCEPT_FAILED;
+    }
   }
 
   if(pp->overflow)


### PR DESCRIPTION
In a case where rubbish would be sent in the line something that isn't a digit could be first in line and treated as less than '3'. Prevent this risk by first doing a check that the byte is a digit.