### PR TITLE
ftp: remove misleading comments

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2414,7 +2414,6 @@ static CURLcode ftp_state_stor_resp(struct Curl_easy *data,
   if(ftpcode >= 400) {
     failf(data, "Failed FTP upload: %0d", ftpcode);
     ftp_state(data, ftpc, FTP_STOP);
-    /* oops, we never close the sockets! */
     return CURLE_UPLOAD_FAILED;
   }
 


### PR DESCRIPTION
They indicated that sockets would not be closed but they are.