### PR TITLE
windows: show error codes in the same format across the codebase

### DIFF
--- a/lib/curlx/winapi.c
+++ b/lib/curlx/winapi.c
@@ -103,7 +103,7 @@ const char *curlx_winapi_strerror(DWORD err, char *buf, size_t buflen)
 #endif
     /* some GCC compilers cause false positive warnings if we allow this
        warning */
-    SNPRINTF(buf, buflen, "Unknown error %lu (0x%08lX)", err, err);
+    SNPRINTF(buf, buflen, "Unknown error %lu (0x%08lx)", err, err);
 #if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic pop
 #endif

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -656,7 +656,7 @@ const char *Curl_sspi_strerror(SECURITY_STATUS err, char *buf, size_t buflen)
 
   if(err == SEC_E_ILLEGAL_MESSAGE) {
     curl_msnprintf(buf, buflen,
-                   "SEC_E_ILLEGAL_MESSAGE (0x%08lX) - This error usually "
+                   "SEC_E_ILLEGAL_MESSAGE (0x%08lx) - This error usually "
                    "occurs when a fatal SSL/TLS alert is received (e.g. "
                    "handshake failed). More detail may be available in "
                    "the Windows System event log.", err);
@@ -664,9 +664,9 @@ const char *Curl_sspi_strerror(SECURITY_STATUS err, char *buf, size_t buflen)
   else {
     char msgbuf[256];
     if(curlx_get_winapi_error((DWORD)err, msgbuf, sizeof(msgbuf)))
-      curl_msnprintf(buf, buflen, "%s (0x%08lX) - %s", txt, err, msgbuf);
+      curl_msnprintf(buf, buflen, "%s (0x%08lx) - %s", txt, err, msgbuf);
     else
-      curl_msnprintf(buf, buflen, "%s (0x%08lX)", txt, err);
+      curl_msnprintf(buf, buflen, "%s (0x%08lx)", txt, err);
   }
 
 #else

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -313,7 +313,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                                   &type_3_desc,
                                                   &attrs, NULL);
   if(status != SEC_E_OK) {
-    infof(data, "NTLM handshake failure (type-3 message): Status=%lx",
+    infof(data, "NTLM handshake failure (type-3 message): Status=0x%08lx",
           status);
 
     if(status == SEC_E_INSUFFICIENT_MEMORY)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -659,7 +659,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                 cert_showfilename_error);
         else
           failf(data, "schannel: Failed to import cert file %s, "
-                "last error is 0x%lx",
+                "last error is 0x%08lx",
                 cert_showfilename_error, errorcode);
         return CURLE_SSL_CERTPROBLEM;
       }
@@ -678,7 +678,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
 
       if(!client_certs[0]) {
         failf(data, "schannel: Failed to get certificate from file %s"
-              ", last error is 0x%lx",
+              ", last error is 0x%08lx",
               cert_showfilename_error, GetLastError());
         CertCloseStore(cert_store, 0);
         return CURLE_SSL_CERTPROBLEM;
@@ -700,7 +700,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
         char *path_utf8 =
           curlx_convert_tchar_to_UTF8(cert_store_path);
         failf(data, "schannel: Failed to open cert store %lx %s, "
-              "last error is 0x%lx",
+              "last error is 0x%08lx",
               cert_store_name,
               (path_utf8 ? path_utf8 : "(unknown)"),
               GetLastError());

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -871,7 +871,7 @@ curl_socket_t win32_stdin_read_thread(void)
                         0, FALSE, DUPLICATE_SAME_ACCESS);
 
     if(!r) {
-      errorf("DuplicateHandle error: %08lx", GetLastError());
+      errorf("DuplicateHandle error: 0x%08lx", GetLastError());
       break;
     }
 
@@ -882,7 +882,7 @@ curl_socket_t win32_stdin_read_thread(void)
     stdin_thread = CreateThread(NULL, 0, win_stdin_thread_func,
                                 tdata, 0, NULL);
     if(!stdin_thread) {
-      errorf("CreateThread error: %08lx", GetLastError());
+      errorf("CreateThread error: 0x%08lx", GetLastError());
       break;
     }
 
@@ -908,7 +908,7 @@ curl_socket_t win32_stdin_read_thread(void)
 
     /* Set the stdin handle to read from the socket. */
     if(SetStdHandle(STD_INPUT_HANDLE, (HANDLE)socket_r) == 0) {
-      errorf("SetStdHandle error: %08lx", GetLastError());
+      errorf("SetStdHandle error: 0x%08lx", GetLastError());
       break;
     }
 

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -62,13 +62,13 @@ int getfiletime(const char *filename, curl_off_t *stamp)
       }
     }
     else {
-      warnf("Failed to get filetime: GetFileTime failed: GetLastError %lu",
+      warnf("Failed to get filetime: GetFileTime failed: GetLastError %08lx",
             GetLastError());
     }
     CloseHandle(hfile);
   }
   else if(GetLastError() != ERROR_FILE_NOT_FOUND) {
-    warnf("Failed to get filetime: CreateFile failed: GetLastError %lu",
+    warnf("Failed to get filetime: CreateFile failed: GetLastError %08lx",
           GetLastError());
   }
 #else
@@ -118,14 +118,14 @@ void setfiletime(curl_off_t filetime, const char *filename)
     ft.dwHighDateTime = (DWORD)(converted >> 32);
     if(!SetFileTime(hfile, NULL, &ft, &ft)) {
       warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
-            " on outfile: SetFileTime failed: GetLastError %lu",
+            " on outfile: SetFileTime failed: GetLastError %08lx",
             filetime, GetLastError());
     }
     CloseHandle(hfile);
   }
   else {
     warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
-          " on outfile: CreateFile failed: GetLastError %lu",
+          " on outfile: CreateFile failed: GetLastError %08lx",
           filetime, GetLastError());
   }
 

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -62,13 +62,13 @@ int getfiletime(const char *filename, curl_off_t *stamp)
       }
     }
     else {
-      warnf("Failed to get filetime: GetFileTime failed: GetLastError %08lx",
+      warnf("Failed to get filetime: GetFileTime failed: GetLastError 0x%08lx",
             GetLastError());
     }
     CloseHandle(hfile);
   }
   else if(GetLastError() != ERROR_FILE_NOT_FOUND) {
-    warnf("Failed to get filetime: CreateFile failed: GetLastError %08lx",
+    warnf("Failed to get filetime: CreateFile failed: GetLastError 0x%08lx",
           GetLastError());
   }
 #else
@@ -118,14 +118,14 @@ void setfiletime(curl_off_t filetime, const char *filename)
     ft.dwHighDateTime = (DWORD)(converted >> 32);
     if(!SetFileTime(hfile, NULL, &ft, &ft)) {
       warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
-            " on outfile: SetFileTime failed: GetLastError %08lx",
+            " on outfile: SetFileTime failed: GetLastError 0x%08lx",
             filetime, GetLastError());
     }
     CloseHandle(hfile);
   }
   else {
     warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
-          " on outfile: CreateFile failed: GetLastError %08lx",
+          " on outfile: CreateFile failed: GetLastError 0x%08lx",
           filetime, GetLastError());
   }
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -59,7 +59,8 @@ static CURLcode test_lib3026(const char *URL)
     results[i] = CURL_LAST; /* initialize with invalid value */
     th = CreateThread(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
     if(!th) {
-      curl_mfprintf(stderr, "%s:%d Couldn't create thread, errno %08lx\n",
+      curl_mfprintf(stderr, "%s:%d Couldn't create thread, "
+                    "GetLastError 0x%08lx\n",
                     __FILE__, __LINE__, GetLastError());
       tid_count = i;
       test_failure = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -59,7 +59,7 @@ static CURLcode test_lib3026(const char *URL)
     results[i] = CURL_LAST; /* initialize with invalid value */
     th = CreateThread(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
     if(!th) {
-      curl_mfprintf(stderr, "%s:%d Couldn't create thread, errno %lu\n",
+      curl_mfprintf(stderr, "%s:%d Couldn't create thread, errno %08lx\n",
                     __FILE__, __LINE__, GetLastError());
       tid_count = i;
       test_failure = TEST_ERR_MAJOR_BAD;


### PR DESCRIPTION
For `GetLastError()` and `SECURITY_STATUS`:
0x-prefixed, 8-digit, lowercase hex: 0x1234abcd
