### PR TITLE
test766: verify CURLOPT_SOCKOPTFUNCTION error on accept

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
@@ -64,12 +64,14 @@ CURLOPT_SOCKOPTDATA(3) function.
 Return *CURL_SOCKOPT_OK* from the callback on success. Return
 *CURL_SOCKOPT_ERROR* from the callback function to signal an unrecoverable
 error to the library and it closes the socket and returns
-*CURLE_COULDNT_CONNECT*. Alternatively, the callback function can return
-*CURL_SOCKOPT_ALREADY_CONNECTED*, to tell libcurl that the socket is
-already connected and then libcurl does no attempt to connect. This allows an
-application to pass in an already connected socket with
-CURLOPT_OPENSOCKETFUNCTION(3) and then have this function make libcurl
-not attempt to connect (again).
+*CURLE_COULDNT_CONNECT* for *CURLSOCKTYPE_IPCXN* and
+*CURLE_ABORTED_BY_CALLBACK* for *CURLSOCKTYPE_ACCEPT*.
+
+The callback function may return *CURL_SOCKOPT_ALREADY_CONNECTED* for
+*CURLSOCKTYPE_IPCXN*, to tell libcurl that the socket is already connected and
+then libcurl does no attempt to connect. This allows an application to pass in
+an already connected socket with CURLOPT_OPENSOCKETFUNCTION(3) and then have
+this function make libcurl not attempt to connect (again).
 
 # DEFAULT
 

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -99,7 +99,6 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
     return CURLE_OPERATION_TIMEDOUT; /* already too little time */
   }
 
-  DEBUGF(infof(data, "pp_statematch, timeout=%" FMT_TIMEDIFF_T, timeout_ms));
   if(block) {
     interval_ms = 1000;  /* use 1 second timeout intervals */
     if(timeout_ms < interval_ms)
@@ -117,9 +116,6 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
     /* We are receiving and there is data ready in the SSL library */
     rc = 1;
   else {
-    DEBUGF(infof(data, "pp_statematch, select, timeout=%" FMT_TIMEDIFF_T
-           ", sendleft=%zu",
-           timeout_ms, pp->sendleft));
     rc = Curl_socket_check(pp->sendleft ? CURL_SOCKET_BAD : sock, /* reading */
                            CURL_SOCKET_BAD,
                            pp->sendleft ? sock : CURL_SOCKET_BAD, /* writing */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -109,7 +109,7 @@ test727 test728 test729 test730 test731 test732 test733 test734 test735 \
 test736 test737 test738 test739 test740 test741 test742 test743 test744 \
 test745 test746 test747 test748 test749 test750 test751 test752 test753 \
 test754 test755 test756 test757 test758 test759 test760 test761 test762 \
-test763 test764 test765 \
+test763 test764 test765 test766 \
 \
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
 test789 test790 test791 test792 test793 test794         test796 test797 \

--- a/tests/data/test766
+++ b/tests/data/test766
@@ -34,7 +34,6 @@ ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER
 <verify>
 # Strip off parts of the PORT and EPRT commands that might differ
 <strippart>
-s/^PORT (.*)/PORT/
 s/^EPRT \|1\|(.*)/EPRT \|1\|/
 </strippart>
 <protocol>

--- a/tests/data/test766
+++ b/tests/data/test766
@@ -39,7 +39,7 @@ s/^EPRT \|1\|(.*)/EPRT \|1\|/
 # The TYPE command might get sent so we ignore that
 <strip>
 ^TYPE
-</strip
+</strip>
 
 <protocol>
 USER anonymous

--- a/tests/data/test766
+++ b/tests/data/test766
@@ -35,7 +35,7 @@ ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER
 # Strip off parts of the EPRT command that might differ
 # The TYPE command might get sent so we ignore that
 <strippart>
-s/^TYPE (.*)//
+s/^TYPE (.*)$//
 s/^EPRT \|1\|(.*)/EPRT \|1\|/
 </strippart>
 <protocol>

--- a/tests/data/test766
+++ b/tests/data/test766
@@ -33,11 +33,14 @@ ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 # Strip off parts of the EPRT command that might differ
-# The TYPE command might get sent so we ignore that
 <strippart>
-s/^TYPE (.*)$//
 s/^EPRT \|1\|(.*)/EPRT \|1\|/
 </strippart>
+# The TYPE command might get sent so we ignore that
+<strip>
+^TYPE
+</strip
+
 <protocol>
 USER anonymous
 PASS ftp@example.com

--- a/tests/data/test766
+++ b/tests/data/test766
@@ -32,8 +32,10 @@ ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER
 
 # Verify data after the test has been "shot"
 <verify>
-# Strip off parts of the PORT and EPRT commands that might differ
+# Strip off parts of the EPRT command that might differ
+# The TYPE command might get sent so we ignore that
 <strippart>
+s/^TYPE (.*)//
 s/^EPRT \|1\|(.*)/EPRT \|1\|/
 </strippart>
 <protocol>

--- a/tests/data/test766
+++ b/tests/data/test766
@@ -1,0 +1,54 @@
+<testcase>
+<info>
+<keywords>
+FTP
+PORT
+CURLOPT_SOCKOPTFUNCTION
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+<tool>
+lib%TESTNUMBER
+</tool>
+<name>
+FTP PORT with sockopt callback refusing the accept
+</name>
+<command>
+ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# Strip off parts of the PORT and EPRT commands that might differ
+<strippart>
+s/^PORT (.*)/PORT/
+s/^EPRT \|1\|(.*)/EPRT \|1\|/
+</strippart>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+CWD path
+EPRT |1|
+</protocol>
+
+# 42 == CURLE_ABORTED_BY_CALLBACK
+<errorcode>
+42
+</errorcode>
+
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -76,6 +76,7 @@ TESTS_C = \
   lib694.c lib695.c \
   lib751.c          lib753.c                                     lib758.c \
   lib757.c \
+  lib766.c \
   lib1156.c \
   lib1301.c                                                   lib1308.c \
   lib1485.c \

--- a/tests/libtest/lib766.c
+++ b/tests/libtest/lib766.c
@@ -48,9 +48,6 @@ static CURLcode test_lib766(const char *URL)
   start_test_timing();
 
   res_global_init(CURL_GLOBAL_ALL);
-  if(res) {
-    return res;
-  }
 
   easy_init(easy);
   easy_setopt(easy, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib766.c
+++ b/tests/libtest/lib766.c
@@ -1,0 +1,127 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "first.h"
+
+#include "memdebug.h"
+
+static int sockopt_766(void *clientp,
+                       curl_socket_t curlfd,
+                       curlsocktype purpose)
+{
+  (void)clientp;
+  (void)curlfd;
+  if(purpose == CURLSOCKTYPE_ACCEPT) {
+    curl_mfprintf(stderr,
+                  "Return error from CURLOPT_SOCKOPTFUNCTION callback\n");
+    return 1; /* force error */
+  }
+  return 0;
+}
+
+static CURLcode test_lib766(const char *URL)
+{
+  CURL *easy = NULL;
+  CURLM *multi = NULL;
+  CURLcode res = CURLE_OK;
+  int running;
+  int msgs_left;
+  CURLMsg *msg;
+
+  start_test_timing();
+
+  res_global_init(CURL_GLOBAL_ALL);
+  if(res) {
+    return res;
+  }
+
+  easy_init(easy);
+  easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+  easy_setopt(easy, CURLOPT_URL, URL);
+  easy_setopt(easy, CURLOPT_FTPPORT, "-");
+  easy_setopt(easy, CURLOPT_SOCKOPTFUNCTION, sockopt_766);
+
+  multi_init(multi);
+
+  multi_add_handle(multi, easy);
+
+  for(;;) {
+    struct timeval interval;
+    fd_set fdread;
+    fd_set fdwrite;
+    fd_set fdexcep;
+    long timeout = -99;
+    int maxfd = -99;
+
+    multi_perform(multi, &running);
+
+    abort_on_test_timeout();
+
+    if(!running)
+      break; /* done */
+
+    FD_ZERO(&fdread);
+    FD_ZERO(&fdwrite);
+    FD_ZERO(&fdexcep);
+
+    multi_fdset(multi, &fdread, &fdwrite, &fdexcep, &maxfd);
+
+    /* At this point, maxfd is guaranteed to be greater or equal than -1. */
+
+    multi_timeout(multi, &timeout);
+
+    /* At this point, timeout is guaranteed to be greater or equal than -1. */
+
+    if(timeout != -1L) {
+      int itimeout;
+#if LONG_MAX > INT_MAX
+      itimeout = (timeout > (long)INT_MAX) ? INT_MAX : (int)timeout;
+#else
+      itimeout = (int)timeout;
+#endif
+      interval.tv_sec = itimeout/1000;
+      interval.tv_usec = (itimeout%1000)*1000;
+    }
+    else {
+      interval.tv_sec = 0;
+      interval.tv_usec = 100000L; /* 100 ms */
+    }
+
+    select_test(maxfd + 1, &fdread, &fdwrite, &fdexcep, &interval);
+
+    abort_on_test_timeout();
+  }
+
+  msg = curl_multi_info_read(multi, &msgs_left);
+  if(msg)
+    res = msg->data.result;
+
+test_cleanup:
+
+  curl_multi_cleanup(multi);
+  curl_easy_cleanup(easy);
+  curl_global_cleanup();
+
+  return res;
+}


### PR DESCRIPTION
This test does active FTP with a socketopt callback that returns error for the CURLSOCKTYPE_ACCEPT "purpose" to make sure we test and exercise this error path - without leaks.