### PR TITLE
socks: handle premature close

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -255,8 +255,14 @@ static CURLproxycode socks_recv(struct socks_state *sx,
             curl_easy_strerror(result));
       return CURLPX_RECV_CONNECT;
     }
-    else if(!nread) /* EOF */
+    else if(!nread) { /* EOF */
+      if(Curl_bufq_len(&sx->iobuf) < min_bytes) {
+        failf(data, "Failed to receive SOCKS response, "
+              "proxy closed connection");
+        return CURLPX_RECV_CONNECT;
+      }
       break;
+    }
   }
   *done = TRUE;
   return CURLPX_OK;


### PR DESCRIPTION
When expecting to receive a number of bytes during socks connect, treat an early connection close as error.

reported-by: Joshua Rogers