### PR TITLE
managen: verify the options used in example lines

### DIFF
--- a/docs/cmdline-opts/knownhosts.md
+++ b/docs/cmdline-opts/knownhosts.md
@@ -14,7 +14,7 @@ See-also:
   - insecure
   - key
 Example:
-  - --knownhost filename --key here $URL
+  - --knownhosts filename --key here $URL
 ---
 
 # `--knownhosts`

--- a/scripts/managen
+++ b/scripts/managen
@@ -876,6 +876,29 @@ sub single {
     if($examples[0]) {
         my $s ="";
         $s="s" if($examples[1]);
+        foreach my $e (@examples) {
+            my $check = $e;
+            # verify the used options
+            for my $e (split(/ /, $check)) {
+                if($e =~ /^-([^- ])/) {
+                    my $opt = $1;
+                    if(!$optshort{$opt}) {
+                        print STDERR "$f:$line:1:ERROR: unknown option in ".
+                            "example: -$opt\n";
+                        return 2;
+                    }
+                }
+                elsif($e =~ /^--([^ =]*)/) {
+                    my $opt = $1;
+                    $opt =~ s/^expand-//g;
+                    if(!$helplong{$opt}) {
+                        print STDERR "$f:$line:1:ERROR: unknown option in ".
+                            "example: '--$opt'\n";
+                        return 2;
+                    }
+                }
+            }
+        }
         if($manpage) {
             print "\nExample$s:\n";
             print ".nf\n";

--- a/tests/data/test1705
+++ b/tests/data/test1705
@@ -52,7 +52,7 @@ See-also:
   - trace
   - trace-ascii
 Example:
-  - --verbose $URL
+  - --fakeitreal $URL
 ---
 
 # `--verbose`
@@ -231,7 +231,7 @@ Disable it again with \-\-no-fakeitreal.
 
 Example:
 .nf
-curl --verbose https://example.com
+curl --fakeitreal https://example.com
 .fi
 
 This option is mutually exclusive with \fI\-\-trace\fP and \fI\-\-trace\-ascii\fP.

--- a/tests/data/test1706
+++ b/tests/data/test1706
@@ -52,7 +52,7 @@ See-also:
   - trace
   - trace-ascii
 Example:
-  - --verbose $URL
+  - --fakeitreal $URL
 ---
 
 # `--verbose`
@@ -196,7 +196,7 @@ DESCRIPTION
 	    effect. Disable it again with --no-fakeitreal.
 
 	    Example:
-	     curl --verbose https://example.com
+	     curl --fakeitreal https://example.com
 
 	    This option is mutually  exclusive with --trace and  --trace-ascii.
 	    See also --include, --silent, --trace and --trace-ascii.


### PR DESCRIPTION
Also fix the --knownhosts typo

Reported-by: Daniel Terhorst-North
URL: https://mas.to/@tastapod/115327102344617386