### PR TITLE
telnet: send failure logged but not returned

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -983,6 +983,7 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
       if(bytes_written < 0) {
         err = SOCKERRNO;
         failf(data,"Sending data failed (%d)",err);
+        return CURLE_SEND_ERROR;
       }
       printsub(data, '>', &temp[2], len-2);
       break;


### PR DESCRIPTION
Return error correctly when sending fails.

Reported-by: Joshua Rogers