### PR TITLE
ldap: tidy-up types, fix error code confusion

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -127,9 +127,17 @@ struct ldap_urldesc {
 #undef LDAPURLDesc
 #define LDAPURLDesc struct ldap_urldesc
 
-static int  ldap_url_parse_low(struct Curl_easy *data,
-                               const struct connectdata *conn,
-                               LDAPURLDesc **ludp);
+#ifdef USE_WIN32_LDAP
+#define FREE_ON_WINLDAP(x) curlx_unicodefree(x)
+#define curl_ldap_num_t ULONG
+#else
+#define FREE_ON_WINLDAP(x)
+#define curl_ldap_num_t int
+#endif
+
+static curl_ldap_num_t ldap_url_parse_low(struct Curl_easy *data,
+                                          const struct connectdata *conn,
+                                          LDAPURLDesc **ludp);
 static void ldap_free_urldesc_low(LDAPURLDesc *ludp);
 
 #undef ldap_free_urldesc
@@ -303,15 +311,6 @@ static ULONG ldap_win_bind(struct Curl_easy *data, LDAP *server,
   return rc;
 }
 #endif /* USE_WIN32_LDAP */
-
-#ifdef USE_WIN32_LDAP
-#define FREE_ON_WINLDAP(x) curlx_unicodefree(x)
-#define curl_ldap_num_t ULONG
-#else
-#define FREE_ON_WINLDAP(x)
-#define curl_ldap_num_t int
-#endif
-
 
 static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 {

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -316,7 +316,7 @@ static ULONG ldap_win_bind(struct Curl_easy *data, LDAP *server,
 static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 {
   CURLcode result = CURLE_OK;
-  curl_ldap_num_t rc = 0;
+  curl_ldap_num_t rc = LDAP_SUCCESS;
   LDAP *server = NULL;
   LDAPURLDesc *ludp = NULL;
   LDAPMessage *ldapmsg = NULL;
@@ -488,7 +488,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 #else
   rc = ldap_simple_bind_s(server, user, passwd);
 #endif
-  if(!ldap_ssl && rc) {
+  if(!ldap_ssl && rc != LDAP_SUCCESS) {
     ldap_proto = LDAP_VERSION2;
     ldap_set_option(server, LDAP_OPT_PROTOCOL_VERSION, &ldap_proto);
 #ifdef USE_WIN32_LDAP
@@ -497,7 +497,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     rc = ldap_simple_bind_s(server, user, passwd);
 #endif
   }
-  if(rc) {
+  if(rc != LDAP_SUCCESS) {
 #ifdef USE_WIN32_LDAP
     failf(data, "LDAP local: bind via ldap_win_bind %s",
           ldap_err2string(rc));
@@ -514,7 +514,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
                      (curl_ldap_num_t)ludp->lud_scope,
                      ludp->lud_filter, ludp->lud_attrs, 0, &ldapmsg);
 
-  if(rc && rc != LDAP_SIZELIMIT_EXCEEDED) {
+  if(rc != LDAP_SUCCESS && rc != LDAP_SIZELIMIT_EXCEEDED) {
     failf(data, "LDAP remote: %s", ldap_err2string(rc));
     result = CURLE_LDAP_SEARCH_FAILED;
     goto quit;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -393,7 +393,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     /* Win32 LDAP SDK does not support insecure mode without CA! */
     server = ldap_sslinit(host, (curl_ldap_num_t)ipquad.remote_port, 1);
     ldap_set_option(server, LDAP_OPT_SSL, LDAP_OPT_ON);
-#else
+#else /* !USE_WIN32_LDAP */
     int ldap_option;
     char *ldap_ca = conn->ssl_config.CAfile;
 #ifdef LDAP_OPT_X_TLS
@@ -455,7 +455,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     }
 #endif
 
-#else
+#else /* !LDAP_OPT_X_TLS */
     (void)ldap_option;
     (void)ldap_ca;
     /* we should probably never come up to here since configure
@@ -464,9 +464,9 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
           "of the OpenLDAP toolkit\n");
     result = CURLE_SSL_CERTPROBLEM;
     goto quit;
-#endif
-#endif
-#endif /* CURL_LDAP_USE_SSL */
+#endif /* LDAP_OPT_X_TLS */
+#endif /* USE_WIN32_LDAP */
+#endif /* HAVE_LDAP_SSL */
   }
   else if(data->set.use_ssl > CURLUSESSL_TRY) {
     failf(data, "LDAP local: explicit TLS not supported");
@@ -749,7 +749,7 @@ static void ldap_trace_low(const char *fmt, ...)
   vfprintf(stderr, fmt, args);
   va_end(args);
 }
-#endif
+#endif /* DEBUG_LDAP */
 
 #ifndef HAVE_LDAP_URL_PARSE
 

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -414,7 +414,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
       rc = ldap_set_option(NULL, LDAP_OPT_X_TLS_CACERTFILE, ldap_ca);
       if(rc != LDAP_SUCCESS) {
         failf(data, "LDAP local: ERROR setting PEM CA cert: %s",
-                ldap_err2string(rc));
+              ldap_err2string(rc));
         result = CURLE_SSL_CERTPROBLEM;
         goto quit;
       }
@@ -426,7 +426,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     rc = ldap_set_option(NULL, LDAP_OPT_X_TLS_REQUIRE_CERT, &ldap_option);
     if(rc != LDAP_SUCCESS) {
       failf(data, "LDAP local: ERROR setting cert verify mode: %s",
-              ldap_err2string(rc));
+            ldap_err2string(rc));
       result = CURLE_SSL_CERTPROBLEM;
       goto quit;
     }
@@ -441,26 +441,27 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     rc = ldap_set_option(server, LDAP_OPT_X_TLS, &ldap_option);
     if(rc != LDAP_SUCCESS) {
       failf(data, "LDAP local: ERROR setting SSL/TLS mode: %s",
-              ldap_err2string(rc));
+            ldap_err2string(rc));
       result = CURLE_SSL_CERTPROBLEM;
       goto quit;
     }
-/*
+#if 0
     rc = ldap_start_tls_s(server, NULL, NULL);
     if(rc != LDAP_SUCCESS) {
       failf(data, "LDAP local: ERROR starting SSL/TLS mode: %s",
-              ldap_err2string(rc));
+            ldap_err2string(rc));
       result = CURLE_SSL_CERTPROBLEM;
       goto quit;
     }
-*/
+#endif
+
 #else
     (void)ldap_option;
     (void)ldap_ca;
     /* we should probably never come up to here since configure
        should check in first place if we can support LDAP SSL/TLS */
     failf(data, "LDAP local: SSL/TLS not supported with this version "
-            "of the OpenLDAP toolkit\n");
+          "of the OpenLDAP toolkit\n");
     result = CURLE_SSL_CERTPROBLEM;
     goto quit;
 #endif

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -1050,10 +1050,10 @@ static void ldap_free_urldesc_low(LDAPURLDesc *ludp)
 
   free(ludp);
 }
-#endif  /* !HAVE_LDAP_URL_PARSE */
+#endif /* !HAVE_LDAP_URL_PARSE */
 
 #if defined(__GNUC__) && defined(__APPLE__)
 #pragma GCC diagnostic pop
 #endif
 
-#endif  /* !CURL_DISABLE_LDAP && !USE_OPENLDAP */
+#endif /* !CURL_DISABLE_LDAP && !USE_OPENLDAP */

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -500,7 +500,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
   if(rc) {
 #ifdef USE_WIN32_LDAP
     failf(data, "LDAP local: bind via ldap_win_bind %s",
-          ldap_err2string((ULONG)rc));
+          ldap_err2string(rc));
 #else
     failf(data, "LDAP local: bind via ldap_simple_bind_s %s",
           ldap_err2string(rc));
@@ -798,11 +798,11 @@ static size_t num_entries(const char *s)
  *
  * Defined in RFC4516 section 2.
  */
-static int ldap_url_parse2_low(struct Curl_easy *data,
-                               const struct connectdata *conn,
-                               LDAPURLDesc *ludp)
+static curl_ldap_num_t ldap_url_parse2_low(struct Curl_easy *data,
+                                           const struct connectdata *conn,
+                                           LDAPURLDesc *ludp)
 {
-  int rc = LDAP_SUCCESS;
+  curl_ldap_num_t rc = LDAP_SUCCESS;
   char *p;
   char *path;
   char *q = NULL;
@@ -1003,12 +1003,12 @@ quit:
   return rc;
 }
 
-static int ldap_url_parse_low(struct Curl_easy *data,
-                              const struct connectdata *conn,
-                              LDAPURLDesc **ludpp)
+static curl_ldap_num_t ldap_url_parse_low(struct Curl_easy *data,
+                                          const struct connectdata *conn,
+                                          LDAPURLDesc **ludpp)
 {
   LDAPURLDesc *ludp = calloc(1, sizeof(*ludp));
-  int rc;
+  curl_ldap_num_t rc;
 
   *ludpp = NULL;
   if(!ludp)

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -98,6 +98,14 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+#ifdef USE_WIN32_LDAP
+#define FREE_ON_WINLDAP(x) curlx_unicodefree(x)
+#define curl_ldap_num_t ULONG
+#else
+#define FREE_ON_WINLDAP(x)
+#define curl_ldap_num_t int
+#endif
+
 #ifndef HAVE_LDAP_URL_PARSE
 
 /* Use our own implementation. */
@@ -127,14 +135,6 @@ struct ldap_urldesc {
 #undef LDAPURLDesc
 #define LDAPURLDesc struct ldap_urldesc
 
-#ifdef USE_WIN32_LDAP
-#define FREE_ON_WINLDAP(x) curlx_unicodefree(x)
-#define curl_ldap_num_t ULONG
-#else
-#define FREE_ON_WINLDAP(x)
-#define curl_ldap_num_t int
-#endif
-
 static curl_ldap_num_t ldap_url_parse_low(struct Curl_easy *data,
                                           const struct connectdata *conn,
                                           LDAPURLDesc **ludp);
@@ -142,7 +142,8 @@ static void ldap_free_urldesc_low(LDAPURLDesc *ludp);
 
 #undef ldap_free_urldesc
 #define ldap_free_urldesc       ldap_free_urldesc_low
-#endif
+
+#endif /* !HAVE_LDAP_URL_PARSE */
 
 #ifdef DEBUG_LDAP
   #define LDAP_TRACE(x)   do { \


### PR DESCRIPTION
- fix `CURLcode` vs. LDAP result code confusion.
  Return `LDAP_NO_MEMORY` when `Curl_create_sspi_identity()` fails,
  since it can only return `CURLE_OUT_OF_MEMORY` as error.
- use `ULONG` for result code on Windows. Drop casts.
- use portable `curl_ldap_num_t`. Drop casts.
- replace magic number 0 with `LDAP_SUCCESS`.
- compare with `LDAP_SUCCESS` instead of assuming non-zero.
  (where necessary.)
- add/fix `#endif` comments.
- fix indentation.

---

w/o sp https://github.com/curl/curl/pull/18888/files?w=1