### PR TITLE
mdlinkcheck: reject URLs containing quotes

### DIFF
--- a/scripts/mdlinkcheck
+++ b/scripts/mdlinkcheck
@@ -140,6 +140,10 @@ sub checkurl {
     print "check $url\n";
     my $curlcmd="curl -ILfsm10 --retry 2 --retry-delay 5 -A \"Mozilla/curl.se link-probe\"";
     $url =~ s/\+/%2B/g;
+    if($url =~ /[\"\'\n]/) {
+        print STDERR "Bad URL in markdown: %s\n", $url{$url};
+        return 1; # fail
+    }
     my @content = `$curlcmd \"$url\"`;
     if(!$content[0]) {
         print STDERR "FAIL\n";


### PR DESCRIPTION
Those would be illegal anyway and would make the script misbehave

Reported-by: Stanislav Fort