### PR TITLE
tftp: don't pin or check address if recvfrom returns error

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1106,7 +1106,7 @@ static CURLcode tftp_receive_packet(struct Curl_easy *data,
                                 0,
                                 (struct sockaddr *)&remote_addr,
                                 &fromlen);
-  if(fromlen) {
+  if((state->rbytes >= 0) && fromlen) {
     if(state->remote_pinned) {
       /* pinned, verify that it comes from the same address */
       if((state->remote_addrlen != fromlen) ||


### PR DESCRIPTION
Follow-up to c4f9977c66bbb05a837a7eb0300
Reported-by: Joshua Rogers