### PR TITLE
tftp: return error if it hits an illegal state

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -567,7 +567,7 @@ static CURLcode tftp_send_first(struct tftp_conn *state,
 
   default:
     failf(state->data, "tftp_send_first: internal error");
-    break;
+    return CURLE_TFTP_ILLEGAL;
   }
 
   return result;


### PR DESCRIPTION
Reported-by: Joshua Rogers