### PR TITLE
GHA/configure-vs-cmake: reduce windows cross-toolchain apt installs

### DIFF
--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -131,7 +131,7 @@ jobs:
       - name: 'install packages'
         run: |
           sudo rm -f /var/lib/man-db/auto-update
-          sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64
+          sudo apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
Download size: 277 MB -> 65 MB (installed: 1293 MB -> 401 MB)

Also as a workaround for Azure Ubuntu mirror slowdown issues:
https://github.com/curl/curl/actions/runs/18289326469/job/52072333582?pr=18866

Follow-up to 0455d8772a1af20ce63c46c5738582aa9b1b8441 #18509
