### PR TITLE
tidy-up: miscellaneous (cont.)

### DIFF
--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -10,7 +10,7 @@ extend-ignore-identifiers-re = [
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
   "^[0-9a-zA-Z+]{64,}$",  # possibly base64
-  "^(Januar|eyeballers|HELO_smtp|kno22|MkTypLibCompatible|optin|passin|perfec|SMTP_HELO|v_alue)$",
+  "^(Januar|eyeballers|HELO_smtp|kno22|MkTypLibCompatible|optin|passin|perfec|SMTP_HELO)$",
   "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
   "^Tru64$",
   "secur32",

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -9,7 +9,7 @@ extend-ignore-identifiers-re = [
   "^(ECT0|ECT1|HELO|htpt|PASE)$",
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
-  "^(Januar|eyeballers|HELO_smtp|optin|passin|perfec|SMTP_HELO)$",
+  "^(eyeballers|HELO_smtp|optin|passin|perfec|SMTP_HELO)$",
   "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
   "^Tru64$",
   "secur32",

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -10,7 +10,7 @@ extend-ignore-identifiers-re = [
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
   "^[0-9a-zA-Z+]{64,}$",  # possibly base64
-  "^(Januar|eyeballers|HELO_smtp|kno22|MkTypLibCompatible|optin|passin|perfec|__SecURE|SMTP_HELO|v_alue)$",
+  "^(Januar|eyeballers|HELO_smtp|kno22|MkTypLibCompatible|optin|passin|perfec|SMTP_HELO|v_alue)$",
   "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
   "^Tru64$",
   "secur32",

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -10,8 +10,7 @@ extend-ignore-identifiers-re = [
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
   "^(eyeballers|HELO_smtp|optin|passin|perfec|SMTP_HELO)$",
-  "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
-  "^Tru64$",
+  "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|Tru64|_stati64)$",
   "secur32",
   "proxys",  # this should be limited to tests/http/*. Short for secure proxy.
 ]

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -9,7 +9,7 @@ extend-ignore-identifiers-re = [
   "^(ECT0|ECT1|HELO|htpt|PASE)$",
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
-  "^(Januar|eyeballers|HELO_smtp|kno22|MkTypLibCompatible|optin|passin|perfec|SMTP_HELO)$",
+  "^(Januar|eyeballers|HELO_smtp|kno22|optin|passin|perfec|SMTP_HELO)$",
   "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
   "^Tru64$",
   "secur32",

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -9,7 +9,6 @@ extend-ignore-identifiers-re = [
   "^(ECT0|ECT1|HELO|htpt|PASE)$",
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
-  "^[0-9a-zA-Z+]{64,}$",  # possibly base64
   "^(Januar|eyeballers|HELO_smtp|kno22|MkTypLibCompatible|optin|passin|perfec|SMTP_HELO)$",
   "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
   "^Tru64$",

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -26,8 +26,8 @@ extend-exclude = [
   ".github/scripts/spellcheck.words",
   "docs/THANKS",
   "packages/*",
-  "scripts/wcurl",
   "projects/Windows/tmpl/curl.vcxproj",
   "projects/Windows/tmpl/libcurl.vcxproj",
+  "scripts/wcurl",
   "tests/data/test*",
 ]

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -9,7 +9,7 @@ extend-ignore-identifiers-re = [
   "^(ECT0|ECT1|HELO|htpt|PASE)$",
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
-  "^(Januar|eyeballers|HELO_smtp|kno22|optin|passin|perfec|SMTP_HELO)$",
+  "^(Januar|eyeballers|HELO_smtp|optin|passin|perfec|SMTP_HELO)$",
   "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
   "^Tru64$",
   "secur32",

--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -13,8 +13,7 @@ extend-ignore-identifiers-re = [
   "^(clen|req_clen|smtp_perform_helo|smtp_state_helo_resp|_stati64)$",
   "^Tru64$",
   "secur32",
-  # this should be limited to tests/http/*. Short for secure proxy.
-  "proxys",
+  "proxys",  # this should be limited to tests/http/*. Short for secure proxy.
 ]
 
 extend-ignore-re = [

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,6 +10,7 @@
 # https://github.com/actions/labeler
 
 name: 'Labeler'
+
 'on': [pull_request_target]  # zizmor: ignore[dangerous-triggers]
 
 permissions: {}

--- a/configure.ac
+++ b/configure.ac
@@ -281,7 +281,7 @@ OPT_APPLE_SECTRUST=$curl_cv_apple
 AC_ARG_WITH(apple-sectrust,dnl
 AS_HELP_STRING([--with-apple-sectrust],[enable Apple OS native certificate verification]),[
   OPT_APPLE_SECTRUST=$withval
- ])
+])
 
 AC_PATH_PROG(PERL, perl,, $PATH:/usr/local/bin/perl:/usr/bin/:/usr/local/bin)
 AC_SUBST(PERL)

--- a/docs/examples/multi-event.c
+++ b/docs/examples/multi-event.c
@@ -69,7 +69,7 @@ static void add_download(const char *url, int num)
   FILE *file;
   CURL *handle;
 
-  snprintf(filename, 50, "%d.download", num);
+  snprintf(filename, sizeof(filename), "%d.download", num);
 
   file = fopen(filename, "wb");
   if(!file) {

--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -85,7 +85,7 @@ static void add_download(const char *url, int num, CURLM *multi)
   FILE *file;
   CURL *handle;
 
-  snprintf(filename, 50, "%d.download", num);
+  snprintf(filename, sizeof(filename), "%d.download", num);
 
   file = fopen(filename, "wb");
   if(!file) {

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -222,8 +222,8 @@ CURLcode Curl_amiga_init(void)
     return CURLE_FAILED_INIT;
   }
 
-  if(SocketBaseTags(SBTM_SETVAL(SBTC_ERRNOPTR(sizeof(errno))), (ULONG) &errno,
-                    SBTM_SETVAL(SBTC_LOGTAGPTR), (ULONG) "curl",
+  if(SocketBaseTags(SBTM_SETVAL(SBTC_ERRNOPTR(sizeof(errno))), (ULONG)&errno,
+                    SBTM_SETVAL(SBTC_LOGTAGPTR), (ULONG)"curl",
                     TAG_DONE)) {
     CURL_AMIGA_REQUEST("SocketBaseTags ERROR");
     return CURLE_FAILED_INIT;

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -412,9 +412,9 @@ evaluate:
     if(!more_possible)
       more_possible = cf_ai_iter_has_more(&bs->ipv6_iter);
 #endif
-    do_more =  more_possible &&
-               (curlx_timediff(now, bs->last_attempt_started) >=
-               bs->attempt_delay_ms);
+    do_more = more_possible &&
+              (curlx_timediff(now, bs->last_attempt_started) >=
+              bs->attempt_delay_ms);
     if(do_more)
       CURL_TRC_CF(data, cf, "happy eyeballs timeout expired, "
                   "start next attempt");

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -312,6 +312,7 @@ void Curl_trc_timer(struct Curl_easy *data, int tid, const char *fmt, ...)
     va_end(ap);
   }
 }
+
 void Curl_trc_easy_timers(struct Curl_easy *data)
 {
   if(CURL_TRC_TIMER_is_verbose(data)) {

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -558,7 +558,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
    * Go ahead and use the Range stuff supplied for HTTP
    */
   if(data->state.use_range &&
-     (rtspreq  & (RTSPREQ_PLAY | RTSPREQ_PAUSE | RTSPREQ_RECORD))) {
+     (rtspreq & (RTSPREQ_PLAY | RTSPREQ_PAUSE | RTSPREQ_RECORD))) {
 
     /* Check to see if there is a range set in the custom headers */
     if(!Curl_checkheaders(data, STRCONST("Range")) && data->state.range) {

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -364,7 +364,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
   }
 
   /* Store the challenge for use later */
-  digest->input_token = (BYTE *) Curl_memdup(chlg, chlglen + 1);
+  digest->input_token = (BYTE *)Curl_memdup(chlg, chlglen + 1);
   if(!digest->input_token)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -175,7 +175,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                                   ntlm->context, &type_1_desc,
                                                   &attrs, NULL);
   if(status == SEC_I_COMPLETE_NEEDED ||
-    status == SEC_I_COMPLETE_AND_CONTINUE)
+     status == SEC_I_COMPLETE_AND_CONTINUE)
     Curl_pSecFn->CompleteAuthToken(ntlm->context, &type_1_desc);
   else if(status == SEC_E_INSUFFICIENT_MEMORY)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -143,8 +143,8 @@ struct cf_ngtcp2_ctx {
   uint64_t max_bidi_streams;         /* max bidi streams we can open */
   size_t earlydata_max;              /* max amount of early data supported by
                                         server on session reuse */
-  size_t earlydata_skip;            /* sending bytes to skip when earlydata
-                                     * is accepted by peer */
+  size_t earlydata_skip;             /* sending bytes to skip when earlydata
+                                        is accepted by peer */
   CURLcode tls_vrfy_result;          /* result of TLS peer verification */
   int qlogfd;
   BIT(initialized);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -306,7 +306,7 @@ mbed_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,
                           bool prefer_rfc)
 {
   if(id == MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8)
-    curl_msnprintf(buf, buf_size, "%s", "TLS_ECJPAKE_WITH_AES_128_CCM_8");
+    curl_msnprintf(buf, buf_size, "TLS_ECJPAKE_WITH_AES_128_CCM_8");
   else
     return Curl_cipher_suite_get_str(id, buf, buf_size, prefer_rfc);
   return 0;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -306,7 +306,7 @@ mbed_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,
                           bool prefer_rfc)
 {
   if(id == MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8)
-    curl_msnprintf(buf, buf_size, "TLS_ECJPAKE_WITH_AES_128_CCM_8");
+    curl_msnprintf(buf, buf_size, "%s", "TLS_ECJPAKE_WITH_AES_128_CCM_8");
   else
     return Curl_cipher_suite_get_str(id, buf, buf_size, prefer_rfc);
   return 0;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3358,9 +3358,9 @@ static CURLcode ossl_windows_load_anchors(struct Curl_cfilter *cf,
 #endif /* USE_WIN32_CRYPTO */
 
 static CURLcode ossl_load_trust_anchors(struct Curl_cfilter *cf,
-                                         struct Curl_easy *data,
-                                         struct ossl_ctx *octx,
-                                         X509_STORE *store)
+                                        struct Curl_easy *data,
+                                        struct ossl_ctx *octx,
+                                        X509_STORE *store)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -34,9 +34,9 @@
 # the official API, but we reuse the code here to avoid duplication.
 CURLX_CFILES = \
   ../lib/curlx/base64.c \
-  ../lib/curlx/multibyte.c \
   ../lib/curlx/dynbuf.c \
   ../lib/curlx/fopen.c \
+  ../lib/curlx/multibyte.c \
   ../lib/curlx/nonblock.c \
   ../lib/curlx/strerr.c \
   ../lib/curlx/strparse.c \
@@ -48,11 +48,11 @@ CURLX_CFILES = \
   ../lib/curlx/winapi.c
 
 CURLX_HFILES = \
-  ../lib/curlx/binmode.h \
-  ../lib/curlx/multibyte.h \
   ../lib/curl_setup.h \
+  ../lib/curlx/binmode.h \
   ../lib/curlx/dynbuf.h \
   ../lib/curlx/fopen.h \
+  ../lib/curlx/multibyte.h \
   ../lib/curlx/nonblock.h \
   ../lib/curlx/strerr.h \
   ../lib/curlx/strparse.h \

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -999,7 +999,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
     /* open file for output, forcing VMS output format into stream
        mode which is needed for stat() call above to always work. */
     FILE *file = curlx_fopen(outfile, "ab",
-                           "ctx=stm", "rfm=stmlf", "rat=cr", "mrs=0");
+                             "ctx=stm", "rfm=stmlf", "rat=cr", "mrs=0");
 #else
     /* open file for output: */
     FILE *file = curlx_fopen(per->outfile, "ab");

--- a/tests/libtest/lib517.c
+++ b/tests/libtest/lib517.c
@@ -80,7 +80,7 @@ static CURLcode test_lib517(const char *URL)
     {"Sat, 15-Apr-17\"21:01:22\"GMT", 1492290082 },
     {"Partyday, 18- April-07 22:50:12", -1 },
     {"Partyday, 18 - Apri-07 22:50:12", -1 },
-    {"Wednes, 1-Januar-2003 00:00:00 GMT", -1 },
+    {"Wednes, 1-Januar-2003 00:00:00 GMT", -1 },/* spellchecker:disable-line */
     {"Sat, 15-Apr-17 21:01:22", 1492290082 },
     {"Sat, 15-Apr-17 21:01:22 GMT-2", 1492290082 },
     {"Sat, 15-Apr-17 21:01:22 GMT BLAH", 1492290082 },

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -461,13 +461,13 @@ static DWORD WINAPI select_ws_wait_thread(void *lpParameter)
         size.QuadPart = 0;
         size.LowPart = GetFileSize(handle, &length);
         if((size.LowPart != INVALID_FILE_SIZE) ||
-            (GetLastError() == NO_ERROR)) {
+           (GetLastError() == NO_ERROR)) {
           size.HighPart = (LONG)length;
           /* get the current position within the file */
           pos.QuadPart = 0;
           pos.LowPart = SetFilePointer(handle, 0, &pos.HighPart, FILE_CURRENT);
           if((pos.LowPart != INVALID_SET_FILE_POINTER) ||
-              (GetLastError() == NO_ERROR)) {
+             (GetLastError() == NO_ERROR)) {
             /* compare position with size, abort if not equal */
             if(size.QuadPart == pos.QuadPart) {
               /* sleep and continue waiting */


### PR DESCRIPTION
- examples: replace magic numbers with `sizeof()`.
- typos: drop rules no longer needed after excluding tests/data.
- typos: move an exception inline.
- alpha-sort lists.
- fix indentation, whitespace.

---

w/o sp https://github.com/curl/curl/pull/18898/files?w=1
