### PR TITLE
vquic/ngtcp2: init pktx before early exit in cf_ngtcp2_recv()

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1326,13 +1326,13 @@ static CURLcode cf_ngtcp2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   DEBUGASSERT(ctx->h3conn);
   *pnread = 0;
 
+  pktx_init(&pktx, cf, data);
+
   /* handshake verification failed in callback, do not recv anything */
   if(ctx->tls_vrfy_result) {
     result = ctx->tls_vrfy_result;
     goto out;
   }
-
-  pktx_init(&pktx, cf, data);
 
   if(!stream || ctx->shutdown_started) {
     result = CURLE_RECV_ERROR;


### PR DESCRIPTION
cf_ngtcp2_recv() could goto out on tls_vrfy_result before pktx_init(), then pass &pktx to helpers that dereference it.
Move pktx_init() above the check to avoid using an uninitialized pktx on the failure path.