### PR TITLE
examples/usercertinmem: avoid stripping const

### DIFF
--- a/docs/examples/usercertinmem.c
+++ b/docs/examples/usercertinmem.c
@@ -97,7 +97,7 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *pointer)
   (void)pointer;
 
   /* get a BIO */
-  bio = BIO_new_mem_buf((char *)mypem, -1);
+  bio = BIO_new_mem_buf(mypem, -1);
 
   if(!bio) {
     printf("BIO_new_mem_buf failed\n");
@@ -118,7 +118,7 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *pointer)
   }
 
   /* create a bio for the RSA key */
-  kbio = BIO_new_mem_buf((char *)mykey, -1);
+  kbio = BIO_new_mem_buf(mykey, -1);
   if(!kbio) {
     printf("BIO_new_mem_buf failed\n");
   }


### PR DESCRIPTION
This API started accepting a const somewhere between OpenSSL 1.0.2b and
1.0.2t. It means this example, like the other similar one now works best
with those versions or newer:
```
docs/examples/usercertinmem.c:100:33: error: cast from 'const char *' to 'char *' drops const qualifier [-Werror,-Wcast-qual]
  100 |   bio = BIO_new_mem_buf((char *)mypem, -1);
      |                                 ^
docs/examples/usercertinmem.c:121:34: error: cast from 'const char *' to 'char *' drops const qualifier [-Werror,-Wcast-qual]
  121 |   kbio = BIO_new_mem_buf((char *)mykey, -1);
      |                                  ^
```
