### PR TITLE
http2: check push header correctly

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1590,7 +1590,8 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
   if(frame->hd.type == NGHTTP2_PUSH_PROMISE) {
     char *h;
 
-    if(!strcmp(HTTP_PSEUDO_AUTHORITY, (const char *)name)) {
+    if((namelen == (sizeof(HTTP_PSEUDO_AUTHORITY)-1)) &&
+       !strncmp(HTTP_PSEUDO_AUTHORITY, (const char *)name, namelen)) {
       /* pseudo headers are lower case */
       int rc = 0;
       char *check = curl_maprintf("%s:%d", cf->conn->host.name,


### PR DESCRIPTION
header names delivered by nghttp2 are not 0-terminated. Fix code to accomodate for that.

reported-by: Joshua Rogers