### PR TITLE
http2: cleanup pushed newhandle on fail

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1030,6 +1030,7 @@ static int push_promise(struct Curl_cfilter *cf,
       infof(data, "failed to set user_data for stream %u",
             newstream->id);
       DEBUGASSERT(0);
+      discard_newhandle(cf, newhandle);
       rv = CURL_PUSH_DENY;
       goto fail;
     }


### PR DESCRIPTION
When nghttp2_session_set_stream_user_data() fails, clean up the new handle.

reported-by: Joshua Rogers