### PR TITLE
GHA/checksrc: also run on .md file changes

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -12,7 +12,6 @@ name: 'Source'
       - master
       - '*/ci'
     paths-ignore:
-      - '**/*.md'
       - '.circleci/**'
       - 'appveyor.*'
       - 'Dockerfile'
@@ -22,7 +21,6 @@ name: 'Source'
     branches:
       - master
     paths-ignore:
-      - '**/*.md'
       - '.circleci/**'
       - 'appveyor.*'
       - 'Dockerfile'


### PR DESCRIPTION
To avoid missing e.g. codespell issue when updating Markdown files only,
as in 82fd9edb0e0313f206b23f90a000164b52412072 #18927

Follow-up to 0b54ce6ffc395148f2c43ce4664ecd9678f822bd
