### PR TITLE
vquic: sending non-gso packets fix for EAGAIN

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -254,7 +254,7 @@ out:
   CURL_TRC_CF(data, cf, "vquic_%s(len=%zu, gso=%zu, calls=%zu)"
               " -> %d, sent=%zu",
               VQUIC_SEND_METHOD, pktlen, gsolen, calls, result, *psent);
-  return CURLE_OK;
+  return result;
 }
 
 static CURLcode vquic_send_packets(struct Curl_cfilter *cf,


### PR DESCRIPTION
The function returned OK on EAGAIN and not the correct code.

reported-by: Joshua Rogers