### PR TITLE
GHA/dependabot: find more pip deps, tweak commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       interval: 'monthly'
 
   - package-ecosystem: 'pip'
-    directory: '/'
+    directories:
+      - '/tests'
+      - '/tests/http'
+      - '/.github/scripts'
     schedule:
       interval: 'monthly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    commit-message:
+      prefix: 'GHA:'
 
   - package-ecosystem: 'pip'
     directories:
@@ -16,3 +18,5 @@ updates:
       - '/.github/scripts'
     schedule:
       interval: 'monthly'
+    commit-message:
+      prefix: 'GHA:'


### PR DESCRIPTION
Before this patch the Dependabot updater was only picking up
`tests/requirements.txt`:
https://github.com/curl/curl/network/updates/26616523/jobs
Bug: https://github.com/curl/curl/pull/18761#issuecomment-3381147189
Follow-up to b04137c1c6ed164594279c7d04b5e051634453ea #18761

Also prefix commit messages with `GHA:`.
