### PR TITLE
wolfssl: no double get_error() detail

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1877,7 +1877,6 @@ static CURLcode wssl_shutdown(struct Curl_cfilter *cf,
   char error_buffer[256];
   int nread = -1, err;
   size_t i;
-  int detail;
 
   DEBUGASSERT(wctx);
   if(!wctx->ssl || cf->shutdown) {


### PR DESCRIPTION
Code was calling wolfSSL_get_error() on code that it had already retrieved with the same function. Remove that.

reported-by: Joshua Rogers