### PR TITLE
GHA: bump dependencies

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -6,4 +6,4 @@ cmakelang==0.6.13
 codespell==2.4.1
 pytype==2024.10.11
 reuse==6.1.2
-ruff==0.13.2
+ruff==0.14.0

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -5,5 +5,5 @@
 cmakelang==0.6.13
 codespell==2.4.1
 pytype==2024.10.11
-reuse==6.0.0
+reuse==6.1.2
 ruff==0.13.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,13 +48,13 @@ jobs:
           persist-credentials: false
 
       - name: 'initialize'
-        uses: github/codeql-action/init@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+        uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
         with:
           languages: actions, python
           queries: security-extended
 
       - name: 'perform analysis'
-        uses: github/codeql-action/analyze@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+        uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
 
   c:
     name: 'C'
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: 'initialize'
-        uses: github/codeql-action/init@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+        uses: github/codeql-action/init@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
         with:
           languages: cpp
           build-mode: manual
@@ -130,4 +130,4 @@ jobs:
           fi
 
       - name: 'perform analysis'
-        uses: github/codeql-action/analyze@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+        uses: github/codeql-action/analyze@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7

--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-cryptography==44.0.1
+cryptography==46.0.2
 filelock==3.19.1
 psutil==7.1.0
 pytest==8.4.2


### PR DESCRIPTION
cryptography from 44.0.1 to 46.0.2 in /tests/http
ruff from 0.13.2 to 0.14.0 in /.github/scripts
reuse from 6.0.0 to 6.1.2 in /.github/scripts
github/codeql-action from 3.30.5 to 4.30.7

Closes #18945
Closes #18943
Closes #18942
Closes #18941
