### PR TITLE
cmake/FindGSS: fix `pkg-config` fallback logic for CMake <3.16

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -68,7 +68,7 @@ jobs:
           dpkg -i freexian-archive-keyring_2022.06.08_all.deb
           echo 'deb http://deb.freexian.com/extended-lts stretch-lts main contrib non-free' | tee /etc/apt/sources.list.d/extended-lts.list
           apt-get -o Dpkg::Use-Pty=0 update
-          apt-get -o Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends cmake make automake autoconf libtool gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libgnutls28-dev libc-ares-dev libkrb5-dev libldap2-dev librtmp-dev stunnel4 groff
+          apt-get -o Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends cmake make automake autoconf libtool gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libgnutls28-dev libc-ares-dev heimdal-dev libldap2-dev librtmp-dev stunnel4 groff
           # GitHub's actions/checkout needs newer glibc and libstdc++. The latter also depends on
           # gcc-8-base, but it doesn't actually seem used in our situation and isn't available in
           # the main repo, so force the install.


### PR DESCRIPTION
The documented `<prefix>_<moduleName>_VERSION` variables are empty in
all tested versions since 3.7.2 to 4.1.2. Stop using it as a fallback
for <3.16 versions, and replace with the undocumented, but working,
`FindPkgConfig` internal variable `_pkg_check_modules_pkg_name`. It
contains the module name which was found.

In practice it caused that with CMake <3.16 + `pkg-config`, curl always
detected the Heimdal flavor of GSS.

Also: Delete a fallback version detection method, which was already
marked with a question mark in comments, and used the same, always
empty, CMake variables.

Ref: https://cmake.org/cmake/help/v4.1/module/FindPkgConfig.html

Bug: https://github.com/curl/curl/pull/18932#issuecomment-3381807070
