### PR TITLE
cmake: minor Heimdal flavour detection fix

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -164,7 +164,7 @@ if(NOT _gss_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     if(_gss_configure_failed)
       set(GSS_FLAVOUR "Heimdal")  # most probably, should not really matter
     else()
-      if(_gss_vendor MATCHES "Heimdal|heimdal" OR _gss_version MATCHES "Heimdal|heimdal")
+      if(_gss_vendor MATCHES "Heimdal|heimdal")
         set(GSS_FLAVOUR "Heimdal")
       else()
         set(GSS_FLAVOUR "MIT")


### PR DESCRIPTION
Do not detect Heimdal if a single `H` character appears in the vendor
string, require the full name: `Heimdal`.

Cherry-picked from #18932
