### PR TITLE
os400sys: protect shared global buffers when TLS key creation failed

### DIFF
--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -161,7 +161,11 @@ get_buffer(struct buffer_t *buf, long size)
 static char *
 buffer_unthreaded(localkey_t key, long size)
 {
-  return get_buffer(locbufs + key, size);
+  char *r;
+  pthread_mutex_lock(&mutex);
+  r = get_buffer(locbufs + key, size);
+  pthread_mutex_unlock(&mutex);
+  return r;
 }
 
 


### PR DESCRIPTION
buffer_undef may set Curl_thread_buffer = buffer_unthreaded. This avoids concurrent realloc()/write races across threads.