### PR TITLE
examples/sessioninfo: do not disable security

### DIFF
--- a/docs/examples/sessioninfo.c
+++ b/docs/examples/sessioninfo.c
@@ -96,25 +96,22 @@ static size_t wrfu(void *ptr, size_t size, size_t nmemb, void *stream)
 
 int main(void)
 {
+  CURLcode res = CURLE_OK;
+
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
   curl = curl_easy_init();
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
-
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, wrfu);
-
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
-
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 0L);
 
-    (void)curl_easy_perform(curl);
+    res = curl_easy_perform(curl);
 
     curl_easy_cleanup(curl);
   }
 
   curl_global_cleanup();
 
-  return 0;
+  return (int)res;
 }


### PR DESCRIPTION
Also make it return the curl result code.

Follow-up to df70a68984308952dcacf33d11593cb22ad80464 #18909
