### PR TITLE
Curl_resolv: fix comment. 'entry' argument is not optional

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -819,9 +819,9 @@ static CURLcode store_negative_resolve(struct Curl_easy *data,
 
 /*
  * Curl_resolv() is the main name resolve function within libcurl. It resolves
- * a name and returns a pointer to the entry in the 'entry' argument (if one
- * is provided). This function might return immediately if we are using asynch
- * resolves. See the return codes.
+ * a name and returns a pointer to the entry in the 'entry' argument. This
+ * function might return immediately if we are using asynch resolves. See the
+ * return codes.
  *
  * The cache entry we return will get its 'inuse' counter increased when this
  * function is used. You MUST call Curl_resolv_unlink() later (when you are


### PR DESCRIPTION
Reported-by: Joshua Rogers