### PR TITLE
asyn-ares: use the duped hostname pointer for all calls

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -793,7 +793,7 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
     /* The stack seems to be IPv6-enabled */
     /* areschannel is already setup in the Curl_open() function */
     CURL_TRC_DNS(data, "asyn-ares: fire off query for A");
-    ares_gethostbyname(ares->channel, hostname, PF_INET,
+    ares_gethostbyname(ares->channel, data->state.async.hostname, PF_INET,
                        async_ares_hostbyname_cb, data);
     CURL_TRC_DNS(data, "asyn-ares: fire off query for AAAA");
     ares->num_pending = 2;


### PR DESCRIPTION
In one c-ares call the passed in pointer was used and not the new duplicated one. This is probably fine but might as well use the new pointer as all the other calls do, which will survive longer.

Reported-by: Joshua Rogers