### PR TITLE
ftp: simplify the 150/126 size scanner

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2498,10 +2498,10 @@ static CURLcode ftp_state_get_resp(struct Curl_easy *data,
        * Example D above makes this parsing a little tricky */
       size_t len = curlx_dyn_len(&ftpc->pp.recvbuf);
       if(len >= 7) { /* "1 bytes" is 7 characters */
-        char *buf = curlx_dyn_ptr(&ftpc->pp.recvbuf);
         size_t i;
         for(i = 0; i < len - 7; i++) {
           curl_off_t what;
+          char *buf = curlx_dyn_ptr(&ftpc->pp.recvbuf);
           const char *c = &buf[i];
           if(!curlx_str_number(&c, &what, CURL_OFF_T_MAX) &&
              !curlx_str_single(&c, ' ') &&


### PR DESCRIPTION
The file size is weirdly returned in a 150 or 126 response as "XXX bytes" mentioned somewhere in the response string. This is a rewrite of the size scanner to replace the strange strstr() + backwards search from before with a plain forward search until '[number] + " bytes"' is a match.