### PR TITLE
openldap: fix memory-leak in error path

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1216,7 +1216,6 @@ static CURLcode oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
         break;
     }
 
-    ber_free(ber, 0);
 
     if(!result)
       result = client_write(data, STRCONST("\n"), NULL, 0, NULL, 0);
@@ -1225,6 +1224,7 @@ static CURLcode oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
     break;
   }
 
+  ber_free(ber, 0);
   ldap_msgfree(msg);
   return result;
 }


### PR DESCRIPTION
The 'ber' pointer could escape a free if an early error occurred.

Reported-by: Joshua Rogers