### PR TITLE
openldap: fix memory-leak on oldap_do's exit path

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -988,8 +988,10 @@ static CURLcode oldap_do(struct Curl_easy *data, bool *done)
     Sockbuf *sb;
     /* re-install the libcurl SSL handlers into the sockbuf. */
     if((ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb) != LDAP_OPT_SUCCESS) ||
-       ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data))
+       ber_sockbuf_add_io(sb, &ldapsb_tls, LBER_SBIOD_LEVEL_TRANSPORT, data)) {
+      ldap_free_urldesc(lud);
       return CURLE_FAILED_INIT;
+    }
   }
 #endif
 


### PR DESCRIPTION
On SSL sockbuf setup failure in `oldap_do`, the 'lud' data would not be freed and instead leak.

Reported-by: Joshua Rogers