### PR TITLE
libssh: make atime and mtime cap the timestamp instead of wrap

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1864,6 +1864,9 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       sshc->actualcode = CURLE_QUOTE_ERROR;
       return SSH_NO_ERROR;
     }
+    if(date > UINT_MAX)
+      /* because the liubssh API can't deal with a larger value */
+      date = UINT_MAX;
     if(!strncmp(cmd, "atime", 5))
       sshc->quote_attrs->atime = (uint32_t)date;
     else /* mtime */


### PR DESCRIPTION
The libssh API uses a 32 bit type for datestamp, so instead of just force-typecast it, make sure it gets capped at UINT_MAX if the value is larger.

Reported-by: Joshua Rogers