### PR TITLE
cmake/FindGSS: drop wrong header check for GNU GSS

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -154,9 +154,7 @@ if(NOT _gss_FOUND)  # Not found by pkg-config. Let us take more traditional appr
         set(GSS_FLAVOUR "MIT")
       endif()
     else()
-      # I am not convinced if this is the right way but this is what autotools do at the moment
-      find_path(_gss_INCLUDE_DIRS NAMES "gssapi.h" HINTS ${_gss_root_hints} PATH_SUFFIXES "include" "inc")
-      find_path(_gss_INCLUDE_DIRS NAMES "gss.h"    HINTS ${_gss_root_hints} PATH_SUFFIXES "include")
+      find_path(_gss_INCLUDE_DIRS NAMES "gss.h" HINTS ${_gss_root_hints} PATH_SUFFIXES "include")
 
       if(_gss_INCLUDE_DIRS)
         set(GSS_FLAVOUR "GNU")


### PR DESCRIPTION
GNU GSS offers `gss.h`; do not check for `gssapi.h`. `gssapi.h`
was originally published by Heimdal, and later MIT Kerberos also added it
for Heimdal compatibility.

---

- [x] add CI jobs testing GNU GSS with both autotools and cmake. → #19008
