### PR TITLE
doswin: CloseHandle the thread on shutdown

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -809,9 +809,6 @@ ThreadCleanup:
 }
 
 /* The background thread that reads and buffers the true stdin. */
-static HANDLE stdin_thread = NULL;
-static curl_socket_t socket_r = CURL_SOCKET_BAD;
-
 curl_socket_t win32_stdin_read_thread(void)
 {
   int result;
@@ -819,6 +816,8 @@ curl_socket_t win32_stdin_read_thread(void)
   int rc = 0, socksize = 0;
   struct win_thread_data *tdata = NULL;
   SOCKADDR_IN selfaddr;
+  static HANDLE stdin_thread = NULL;
+  static curl_socket_t socket_r = CURL_SOCKET_BAD;
 
   if(socket_r != CURL_SOCKET_BAD) {
     assert(stdin_thread != NULL);
@@ -930,6 +929,7 @@ curl_socket_t win32_stdin_read_thread(void)
 
     if(stdin_thread) {
       TerminateThread(stdin_thread, 1);
+      CloseHandle(stdin_thread);
       stdin_thread = NULL;
     }
 


### PR DESCRIPTION
As this is in the tool shutdown the impact of it was nothing.

Also, move two global variables to local.

Follow-up to 9a2663322c330ff11275abafd612e9c

Reported-by: Joshua Rogers