### PR TITLE
multi_ev: return proper error code on internal error

### DIFF
--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -517,7 +517,8 @@ static CURLMcode mev_assess(struct Curl_multi *multi,
     else
       last_ps = mev_add_new_xfer_pollset(data);
     if(!last_ps) {
-      res = CURLM_OUT_OF_MEMORY;
+      DEBUGASSERT(0);
+      res = CURLM_INTERNAL_ERROR;
       goto out;
     }
   }


### PR DESCRIPTION
When not finding the last pollset that needs to be there, return CURLM_INTERNAL_ERROR instead of OOM and add a debug assert as well.

reported-by: Joshua Rogers