### PR TITLE
c-ares: when resolving failed, persist error

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -302,11 +302,13 @@ CURLcode Curl_async_is_resolved(struct Curl_easy *data,
 
   if(data->state.async.done) {
     *dns = data->state.async.dns;
-    return CURLE_OK;
+    return ares->result;
   }
 
-  if(Curl_ares_perform(ares->channel, 0) < 0)
-    return CURLE_UNRECOVERABLE_POLL;
+  if(Curl_ares_perform(ares->channel, 0) < 0) {
+    result = CURLE_UNRECOVERABLE_POLL;
+    goto out;
+  }
 
 #ifndef HAVE_CARES_GETADDRINFO
   /* Now that we have checked for any last minute results above, see if there
@@ -371,6 +373,9 @@ CURLcode Curl_async_is_resolved(struct Curl_easy *data,
                  result, *dns ? "" : "not ");
     async_ares_cleanup(data);
   }
+
+out:
+  ares->result = result;
   return result;
 }
 


### PR DESCRIPTION
Repeated calls to `Curl_async_is_resolved()` after a failure returned OK and not the error that was the result of the resolve fail.

reported-by: Joshua Rogers