### PR TITLE
ssh2: use sockindex consistently

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3207,12 +3207,12 @@ static ssize_t ssh_tls_recv(libssh2_socket_t sock, void *buffer,
                             size_t length, int flags, void **abstract)
 {
   struct Curl_easy *data = (struct Curl_easy *)*abstract;
+  int sockindex = Curl_conn_sockindex(data, sock);
   size_t nread;
   CURLcode result;
   struct connectdata *conn = data->conn;
-  Curl_recv *backup = conn->recv[0];
+  Curl_recv *backup = conn->recv[sockindex];
   struct ssh_conn *sshc = Curl_conn_meta_get(conn, CURL_META_SSH_CONN);
-  int socknum = Curl_conn_sockindex(data, sock);
   (void)flags;
 
   if(!sshc)
@@ -3220,9 +3220,9 @@ static ssize_t ssh_tls_recv(libssh2_socket_t sock, void *buffer,
 
   /* swap in the TLS reader function for this call only, and then swap back
      the SSH one again */
-  conn->recv[0] = sshc->tls_recv;
-  result = Curl_conn_recv(data, socknum, buffer, length, &nread);
-  conn->recv[0] = backup;
+  conn->recv[sockindex] = sshc->tls_recv;
+  result = Curl_conn_recv(data, sockindex, buffer, length, &nread);
+  conn->recv[sockindex] = backup;
   if(result == CURLE_AGAIN)
     return -EAGAIN; /* magic return code for libssh2 */
   else if(result)
@@ -3235,12 +3235,12 @@ static ssize_t ssh_tls_send(libssh2_socket_t sock, const void *buffer,
                             size_t length, int flags, void **abstract)
 {
   struct Curl_easy *data = (struct Curl_easy *)*abstract;
+  int sockindex = Curl_conn_sockindex(data, sock);
   size_t nwrite;
   CURLcode result;
   struct connectdata *conn = data->conn;
-  Curl_send *backup = conn->send[0];
+  Curl_send *backup = conn->send[sockindex];
   struct ssh_conn *sshc = Curl_conn_meta_get(conn, CURL_META_SSH_CONN);
-  int socknum = Curl_conn_sockindex(data, sock);
   (void)flags;
 
   if(!sshc)
@@ -3248,9 +3248,9 @@ static ssize_t ssh_tls_send(libssh2_socket_t sock, const void *buffer,
 
   /* swap in the TLS writer function for this call only, and then swap back
      the SSH one again */
-  conn->send[0] = sshc->tls_send;
-  result = Curl_conn_send(data, socknum, buffer, length, FALSE, &nwrite);
-  conn->send[0] = backup;
+  conn->send[sockindex] = sshc->tls_send;
+  result = Curl_conn_send(data, sockindex, buffer, length, FALSE, &nwrite);
+  conn->send[sockindex] = backup;
   if(result == CURLE_AGAIN)
     return -EAGAIN; /* magic return code for libssh2 */
   else if(result)


### PR DESCRIPTION
Although the protocol should only run on index 0, there was a mix of looked up sockindex and using constant 0 in tls send/recv.

reported-by: Joshua Rogers