### PR TITLE
tool_operate: retry on HTTP response code 522

### DIFF
--- a/docs/cmdline-opts/retry.md
+++ b/docs/cmdline-opts/retry.md
@@ -20,8 +20,8 @@ Example:
 If a transient error is returned when curl tries to perform a transfer, it
 retries this number of times before giving up. Setting the number to 0 makes
 curl do no retries (which is the default). Transient error means either: a
-timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503 or 504
-response code.
+timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503, 504, 522
+or 524 response code.
 
 When curl is about to retry a transfer, it first waits one second and then for
 all forthcoming retries it doubles the waiting time until it reaches 10

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -413,6 +413,8 @@ static CURLcode retrycheck(struct OperationConfig *config,
       case 502: /* Bad Gateway */
       case 503: /* Service Unavailable */
       case 504: /* Gateway Timeout */
+      case 522: /* Connection Timed Out (Cloudflare) */
+      case 524: /* Proxy Read Timeout (Cloudflare) */
         retry = RETRY_HTTP;
         /*
          * At this point, we have already written data to the output


### PR DESCRIPTION
- Treat HTTP response code 522 as a transient error since Cloudflare may use it instead of 504 to signal timeout.

522 error message from Cloudflare:

"The initial connection between Cloudflare's network and the origin web server timed out. As a result, the web page can not be displayed."

We will now retry on that code when --retry is used.

Fixes https://github.com/curl/curl/discussions/16143
Closes #xxxx
