### PR TITLE
asyn-ares: remove wrong comment about the callback argument

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -517,8 +517,6 @@ static void async_ares_hostbyname_cb(void *user_data,
   (void)timeouts; /* ignored */
 
   if(ARES_EDESTRUCTION == status)
-    /* when this ares handle is getting destroyed, the 'arg' pointer may not
-       be valid so only defer it when we know the 'status' says its fine! */
     return;
 
   if(ARES_SUCCESS == status) {


### PR DESCRIPTION
Both the c-ares documentation and the c-ares source code contradict the previous comment (and mentions/contains no such restriction).

Ref: #19001