### PR TITLE
curl_threads: delete WinCE fallback branch

### DIFF
--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -107,16 +107,12 @@ curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
 {
   curl_thread_t t = CreateThread(NULL, 0, func, arg, 0, NULL);
   if(!t) {
-#ifndef UNDER_CE
     DWORD gle = GetLastError();
     /* !checksrc! disable ERRNOVAR 1 */
     int err = (gle == ERROR_ACCESS_DENIED ||
                gle == ERROR_NOT_ENOUGH_MEMORY) ?
                EACCES : EINVAL;
     CURL_SETERRNO(err);
-#else
-    CURL_SETERRNO(31); /* Windows ERROR_GEN_FAILURE */
-#endif
     return curl_thread_t_null;
   }
   return t;


### PR DESCRIPTION
Both WinCE and Windows use `CreateThread()` now, so the use of
`GetLastError()` works for both.

Follow-up to 03448f477a0cfa3868dfd15a7b9278dcecf944a2 #18998
Follow-up to 1c49f2f26d0f200bb9de61f795f06a1bc56845e9 #18451
Follow-up to af0216251b94e751baa47146ac9609db70793b8e #1589
