### PR TITLE
examples/log_failed_transfers: make it build for WinCE

### DIFF
--- a/docs/examples/log_failed_transfers.c
+++ b/docs/examples/log_failed_transfers.c
@@ -156,7 +156,7 @@ static int mem_addf(struct mem *mem, const char *format, ...)
       return x;
     }
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(UNDER_CE)
     /* Not all versions of Windows CRT vsnprintf are compliant with C99. Some
        return -1 if buffer too small. Try _vscprintf to get the needed size. */
     if(!i && x < 0) {


### PR DESCRIPTION
- include `windows.h` after `winsock2.h` via `curl/curl.h`.
- avoid `errno` for WinCE.
- avoid `_vscprintf` for WinCE.

Ref: 4535532ed36d2129b107ab357262072f82c2b34a #18843
Follow-up to 0780de2625bf8bb3bcb0f88bbbc401b2750ec1bb #18668
