### PR TITLE
socksd: remove --bindonly mention, there is no such option

### DIFF
--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -851,7 +851,6 @@ static int test_socksd(int argc, char *argv[])
            " --ipv4\n"
            " --ipv6\n"
            " --unix-socket [file]\n"
-           " --bindonly\n"
            " --port [port]\n");
       return 0;
     }


### PR DESCRIPTION
Reported-by: Joshua Rogers