### PR TITLE
openldap: remove const from supportedSASLMechanisms

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -462,10 +462,8 @@ static CURLcode oldap_perform_mechs(struct Curl_easy *data)
     Curl_conn_meta_get(data->conn, CURL_META_LDAP_CONN);
   int rc;
   char name[]="supportedSASLMechanisms";
-  char *supportedSASLMechanisms[2] = {
-    name,
-    NULL
-  };
+  char *supportedSASLMechanisms[2] = { NULL, NULL };
+  supportedSASLMechanisms[0] = name;
 
   if(!li)
     return CURLE_FAILED_INIT;


### PR DESCRIPTION
Casting away const for a parameter that the LDAP API expects as a non-const char ** is unsafe: if the LDAP implementation ever writes to, frees, or otherwise mutates the provided array, undefined behavior or crashes can occur.

Reported-by: Joshua Rogers