### PR TITLE
pop3: function could get the ->transfer field wrong

### DIFF
--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1377,17 +1377,16 @@ static CURLcode pop3_perform(struct Curl_easy *data, bool *connected,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->req.no_body) {
-    /* Requested no body means no transfer */
-    pop3->transfer = PPTRANSFER_INFO;
-  }
-
-  *dophase_done = FALSE; /* not done yet */
-
-  /* Start the first command in the DO phase */
+  /* Start the first command in the DO phase, may alter data->req.no_body */
   result = pop3_perform_command(data);
   if(result)
     return result;
+
+  if(data->req.no_body)
+    /* Requested no body means no transfer */
+    pop3->transfer = PPTRANSFER_INFO;
+
+  *dophase_done = FALSE; /* not done yet */
 
   /* Run the state-machine */
   result = pop3_multi_statemach(data, dophase_done);


### PR DESCRIPTION
In pop3_perform(), pop3->transfer was derived from the old data->req.no_body. Then, pop3_perform_command() re-computed data->req.no_body.

Now we instead call pop3_perform_command() first.

Reported-by: Joshua Rogers