### PR TITLE
libssh2: fix EAGAIN return in ssh_state_auth_agent

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1850,8 +1850,9 @@ static CURLcode ssh_state_auth_agent(struct Curl_easy *data,
       if(rc != LIBSSH2_ERROR_EAGAIN) {
         /* tried and failed? go to next identity */
         sshc->sshagent_prev_identity = sshc->sshagent_identity;
+        return CURLE_OK;
       }
-      return CURLE_OK;
+      return CURLE_AGAIN;
     }
   }
 


### PR DESCRIPTION
Reported-by: Joshua Rogers