### PR TITLE
libssh2: avoid risking using an uninitialized local struct field

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1428,7 +1428,7 @@ sftp_download_stat(struct Curl_easy *data,
     data->req.size = -1;
     data->req.maxdownload = -1;
     Curl_pgrsSetDownloadSize(data, -1);
-    attrs.filesize = 0; /* might be unitialized but will be read below */
+    attrs.filesize = 0; /* might be uninitialized but will be read below */
   }
   else {
     curl_off_t size = attrs.filesize;


### PR DESCRIPTION
Reported-by: Joshua Rogers