### PR TITLE
examples: call `curl_global_cleanup()` where missing

### DIFF
--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -252,5 +252,7 @@ int main(int argc, char **argv)
   uv_run(uv.loop, UV_RUN_DEFAULT);
   curl_multi_cleanup(uv.multi);
 
+  curl_global_cleanup();
+
   return 0;
 }

--- a/docs/examples/persistent.c
+++ b/docs/examples/persistent.c
@@ -66,5 +66,7 @@ int main(void)
     curl_easy_cleanup(curl);
   }
 
+  curl_global_cleanup();
+
   return 0;
 }

--- a/docs/examples/postit2-formadd.c
+++ b/docs/examples/postit2-formadd.c
@@ -115,5 +115,8 @@ int main(int argc, char *argv[])
     /* free slist */
     curl_slist_free_all(headerlist);
   }
+
+  curl_global_cleanup();
+
   return 0;
 }

--- a/docs/examples/postit2.c
+++ b/docs/examples/postit2.c
@@ -100,5 +100,8 @@ int main(int argc, char *argv[])
     /* free slist */
     curl_slist_free_all(headerlist);
   }
+
+  curl_global_cleanup();
+
   return 0;
 }

--- a/docs/examples/sepheaders.c
+++ b/docs/examples/sepheaders.c
@@ -91,5 +91,7 @@ int main(void)
   /* cleanup curl stuff */
   curl_easy_cleanup(curl_handle);
 
+  curl_global_cleanup();
+
   return 0;
 }

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -214,5 +214,7 @@ int main(int argc, char **argv)
   gdk_threads_leave();
   printf("gdk_threads_leave\n");
 
+  curl_global_cleanup();
+
   return 0;
 }

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -360,6 +360,9 @@ int main(int argc, char *argv[])
     conf_init(conf);
     curl_easy_cleanup(curl);
   }
+
+  curl_global_cleanup();
+
   return RetValue;
 }
 #endif /* CURL_WINDOWS_UWP */

--- a/docs/examples/threaded-ssl.c
+++ b/docs/examples/threaded-ssl.c
@@ -97,5 +97,7 @@ int main(int argc, char **argv)
     fprintf(stderr, "Thread %d terminated\n", i);
   }
 
+  curl_global_cleanup();
+
   return 0;
 }


### PR DESCRIPTION
Reported-by: Joshua Rogers (for `sepheaders.c`)