### PR TITLE
examples: return `curl_easy_perform()` results

### DIFF
--- a/docs/examples/multithread.c
+++ b/docs/examples/multithread.c
@@ -57,7 +57,7 @@ static void *pull_one_url(void *pindex)
 
   curl = curl_easy_init();
   curl_easy_setopt(curl, CURLOPT_URL, urls[i]);
-  curl_easy_perform(curl); /* ignores error */
+  (void)curl_easy_perform(curl); /* ignores error */
   curl_easy_cleanup(curl);
 
   return NULL;

--- a/docs/examples/sepheaders.c
+++ b/docs/examples/sepheaders.c
@@ -38,6 +38,7 @@ static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
 
 int main(void)
 {
+  CURLcode res;
   CURL *curl_handle;
   static const char *headerfilename = "head.out";
   FILE *headerfile;
@@ -80,7 +81,7 @@ int main(void)
   curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, bodyfile);
 
   /* get it! */
-  curl_easy_perform(curl_handle);
+  res = curl_easy_perform(curl_handle);
 
   /* close the header file */
   fclose(headerfile);
@@ -93,5 +94,5 @@ int main(void)
 
   curl_global_cleanup();
 
-  return 0;
+  return (int)res;
 }

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -80,7 +80,7 @@ static void run_one(gchar *http, int j)
     /* Write to the file */
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, outfile);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_file);
-    curl_easy_perform(curl);
+    (void)curl_easy_perform(curl);
 
     fclose(outfile);
     curl_easy_cleanup(curl);

--- a/docs/examples/threaded-ssl.c
+++ b/docs/examples/threaded-ssl.c
@@ -64,7 +64,7 @@ static void *pull_one_url(void *pindex)
      might be downloading stuff from an impostor */
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
-  curl_easy_perform(curl); /* ignores error */
+  (void)curl_easy_perform(curl); /* ignores error */
   curl_easy_cleanup(curl);
 
   return NULL;

--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -38,6 +38,8 @@ static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
 
 int main(int argc, char *argv[])
 {
+  CURLcode res = CURLE_OK;
+
   CURL *curl_handle;
   static const char *pagefilename = "page.out";
   FILE *pagefile;
@@ -72,7 +74,7 @@ int main(int argc, char *argv[])
     curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, pagefile);
 
     /* get it! */
-    curl_easy_perform(curl_handle);
+    res = curl_easy_perform(curl_handle);
 
     /* close the header file */
     fclose(pagefile);
@@ -83,5 +85,5 @@ int main(int argc, char *argv[])
 
   curl_global_cleanup();
 
-  return 0;
+  return (int)res;
 }


### PR DESCRIPTION
Where missing. Or explicitly `(void)` it where we ignore it on purpose.

Reported-by: Joshua Rogers (for `sepheaders.c`)
