### PR TITLE
remove data_idle handling

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -965,13 +965,6 @@ CURLcode Curl_conn_ev_data_setup(struct Curl_easy *data)
                       CF_CTRL_DATA_SETUP, 0, NULL);
 }
 
-CURLcode Curl_conn_ev_data_idle(struct Curl_easy *data)
-{
-  return cf_cntrl_all(data->conn, data, FALSE,
-                      CF_CTRL_DATA_IDLE, 0, NULL);
-}
-
-
 CURLcode Curl_conn_flush(struct Curl_easy *data, int sockindex)
 {
   if(!CONN_SOCK_IDX_VALID(sockindex))

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -118,7 +118,7 @@ typedef CURLcode Curl_cft_conn_keep_alive(struct Curl_cfilter *cf,
  */
 /*      data event                          arg1       arg2     return */
 #define CF_CTRL_DATA_SETUP            4  /* 0          NULL     first fail */
-#define CF_CTRL_DATA_IDLE             5  /* 0          NULL     first fail */
+/* unused now                         5  */
 #define CF_CTRL_DATA_PAUSE            6  /* on/off     NULL     first fail */
 #define CF_CTRL_DATA_DONE             7  /* premature  NULL     ignored */
 #define CF_CTRL_DATA_DONE_SEND        8  /* 0          NULL     ignored */
@@ -538,12 +538,6 @@ CURLcode Curl_cf_send_bufq(struct Curl_cfilter *cf,
  * a transfer.
  */
 CURLcode Curl_conn_ev_data_setup(struct Curl_easy *data);
-
-/**
- * Notify connection filters that now would be a good time to
- * perform any idle, e.g. time related, actions.
- */
-CURLcode Curl_conn_ev_data_idle(struct Curl_easy *data);
 
 /**
  * Notify connection filters that the transfer represented by `data`

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2040,16 +2040,6 @@ static CURLcode cf_ngtcp2_cntrl(struct Curl_cfilter *cf,
     }
     break;
   }
-  case CF_CTRL_DATA_IDLE: {
-    struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
-    CURL_TRC_CF(data, cf, "data idle");
-    if(stream && !stream->closed) {
-      result = check_and_set_expiry(cf, data, NULL);
-      if(result)
-        CURL_TRC_CF(data, cf, "data idle, check_and_set_expiry -> %d", result);
-    }
-    break;
-  }
   case CF_CTRL_CONN_INFO_UPDATE:
     if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2207,14 +2207,6 @@ static CURLcode cf_osslq_cntrl(struct Curl_cfilter *cf,
     }
     break;
   }
-  case CF_CTRL_DATA_IDLE: {
-    struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
-    CURL_TRC_CF(data, cf, "data idle");
-    if(stream && !stream->closed) {
-      result = check_and_set_expiry(cf, data);
-    }
-    break;
-  }
   case CF_CTRL_CONN_INFO_UPDATE:
     if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1232,15 +1232,6 @@ static CURLcode cf_quiche_cntrl(struct Curl_cfilter *cf,
     }
     break;
   }
-  case CF_CTRL_DATA_IDLE: {
-    struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
-    if(stream && !stream->closed) {
-      result = cf_flush_egress(cf, data);
-      if(result)
-        CURL_TRC_CF(data, cf, "data idle, flush egress -> %d", result);
-    }
-    break;
-  }
   case CF_CTRL_CONN_INFO_UPDATE:
     if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;


### PR DESCRIPTION
The transfer loop used to check the socket and if no poll events were seen, triggered a "DATA_IDLE" event into the filters to let them schedule times/do things anyway.

Since we no longer check the socket, the filters have been called already and the DATA_IDLE event is unnecessary work. Remove it.