### PR TITLE
mod_curltest: tidy-ups and small fixes

### DIFF
--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -629,6 +629,7 @@ static int curltest_put_handler(request_rec *r)
   apr_table_unset(r->headers_out, "Content-Length");
   /* Discourage content-encodings */
   apr_table_unset(r->headers_out, "Content-Encoding");
+  apr_table_setn(r->headers_out, "request-id", request_id);
   apr_table_setn(r->subprocess_env, "no-brotli", "1");
   apr_table_setn(r->subprocess_env, "no-gzip", "1");
 
@@ -813,6 +814,8 @@ static int curltest_sslinfo_handler(request_rec *r)
   apr_table_unset(r->headers_out, "Content-Length");
   /* Discourage content-encodings */
   apr_table_unset(r->headers_out, "Content-Encoding");
+  if(request_id)
+    apr_table_setn(r->headers_out, "request-id", request_id);
   apr_table_setn(r->subprocess_env, "no-brotli", "1");
   apr_table_setn(r->subprocess_env, "no-gzip", "1");
 


### PR DESCRIPTION
- honor request id (`id=<number>`) in `curltest/put` and
  `curltest/sslinfo` handlers.
- do not truncate `max_upload` input parameter.
- delete unused variables.
- formatting.

Inspired by Joshua's report on tests.