### PR TITLE
easy: check for timeout in curl_easy_send/recv

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1319,7 +1319,6 @@ CURLcode Curl_senddata(struct Curl_easy *data, const void *buffer,
  */
 CURLcode curl_easy_send(CURL *d, const void *buffer, size_t buflen, size_t *n)
 {
-  CURLcode result;
   struct Curl_easy *data = d;
   timediff_t timeout_ms;
 


### PR DESCRIPTION
.. because otherwise connect-only transfers may not timeout.

Reported-by: Pavel P

Fixes https://github.com/curl/curl/issues/18991
Closes #xxxx