### PR TITLE
krb5: fix `output_token` allocators in the GSS debug stub (Windows)

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -31,6 +31,8 @@
 
 #ifdef DEBUGBUILD
 #if defined(HAVE_GSSGNU) || !defined(_WIN32)
+/* To avoid memdebug macro replacement, wrap the name in parentheses to call
+   the original version. It is freed via the GSS API gss_release_buffer(). */
 #define Curl_gss_alloc (malloc)
 #define Curl_gss_free  (free)
 #define CURL_GSS_STUB


### PR DESCRIPTION
Before this patch system `malloc()`/`free()` were used to allocate
the buffer returned in the `output_token` object from the debug stub
of `gss_init_sec_context()` when enabled via `CURL_STUB_GSS_CREDS` in
debug-enabled libcurl builds. This object is later released via stock
`gss_release_buffer()`, which, in the Windows builds of MIT Kerberos,
doesn't use the system `free()`, but the Win32 `HeapFree()`.

Fix it by using the GSS alloc/free macros: `gssalloc_malloc()` and
`gssalloc_free()` from `gssapi_alloc.h`.

To make this work without MIT Kerberos feature detection, use a canary
macro to detect a version which installs `gssapi_alloc.h` for Windows.
For <1.15 (2016-11-30) releases, that do not install it, disable the GSS
debug stub in libcurl.

Strictly speaking, non-Windows builds would also need to use GSS
allocators, but, detecting support for `gssapi_alloc.h` is impossible
without build-level logic. Built-level logic is complex and overkill,
and MIT Kerberos, as of 1.22.1, uses standard malloc/free on
non-Windows platforms anyway. (except in GSS debug builds.)

Follow-up to 73840836a51c443e6b5d385014ce1c8f5be3e02b #17752

---

- [x] detect the necessary MIT Kerberos version and disable the `DEBUGBUILD`
  stub feature with <1.18.

I haven't actually tested this with a Windows build, which is also missing
from CI at the moment.