### PR TITLE
urldata: make 'retrycount' a single byte

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -980,8 +980,6 @@ struct UrlState {
   char *first_host;
   int first_remote_port;
   curl_prot_t first_remote_protocol;
-
-  int retrycount; /* number of retries on a new connection */
   int os_errno;  /* filled in with errno whenever an error occurs */
   long followlocation; /* redirect counter */
   int requests; /* request counter: redirects + authentication retakes */
@@ -1103,6 +1101,8 @@ struct UrlState {
 #ifndef CURL_DISABLE_HTTP
   struct http_negotiation http_neg;
 #endif
+  unsigned char retrycount; /* number of retries on a new connection, up to
+                               CONN_MAX_RETRIES */
   unsigned char httpreq; /* Curl_HttpReq; what kind of HTTP request (if any)
                             is this */
   unsigned int creds_from:2; /* where is the server credentials originating


### PR DESCRIPTION
Since it only counts up to 5