### PR TITLE
urldata: make redirect counter 16 bit

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -983,7 +983,6 @@ struct UrlState {
 
   int retrycount; /* number of retries on a new connection */
   int os_errno;  /* filled in with errno whenever an error occurs */
-  long followlocation; /* redirect counter */
   int requests; /* request counter: redirects + authentication retakes */
 #ifdef HAVE_SIGNAL
   /* storage for the previous bag^H^H^HSIGPIPE signal handler :-) */
@@ -1103,6 +1102,7 @@ struct UrlState {
 #ifndef CURL_DISABLE_HTTP
   struct http_negotiation http_neg;
 #endif
+  unsigned short followlocation; /* redirect counter */
   unsigned char httpreq; /* Curl_HttpReq; what kind of HTTP request (if any)
                             is this */
   unsigned int creds_from:2; /* where is the server credentials originating


### PR DESCRIPTION
Instead of long (up to 64-bit) as the maximum allowed value set since b059f7deaf3 is 0x7fff. Saves 2 or 6 bytes.