### PR TITLE
GHA/windows: stop installing Perl `Win32-Process*` modules

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,63 +39,6 @@ env:
   CURL_CI: github
 
 jobs:
-  build-cache:
-    name: 'Build caches'
-    runs-on: ${{ matrix.image }}
-    timeout-minutes: 15
-    defaults:
-      run:
-        shell: msys2 {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [windows-2022, windows-11-arm]
-    steps:
-      - name: 'install build prereqs'
-        if: ${{ steps.cache-perl-win32-pkgs.outputs.cache-hit != 'true' }}
-        uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
-        with:
-          msystem: msys
-          install: gcc make
-
-      - name: 'perl version'
-        run: perl --version | tee "$GITHUB_WORKSPACE"/perlversion
-
-      - name: 'cache perl packages'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: cache-perl-win32-pkgs
-        env:
-          cache-name: cache-perl-win32-pkgs
-        with:
-          path: C:\perl-win32-pkgs
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}-${{ hashFiles('perlversion') }}
-
-      - name: 'build perl packages'
-        if: ${{ steps.cache-perl-win32-pkgs.outputs.cache-hit != 'true' }}
-        run: |
-          cd /c
-          mkdir perl-win32-pkgs
-          cd perl-win32-pkgs
-          sed -i.bak 's/#define I_CRYPT//g' /usr/lib/perl5/core_perl/CORE/config.h
-
-          # https://metacpan.org/pod/Win32::Process
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
-            --location "https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-Process-0.17.tar.gz" | tar -xz
-          cd Win32-Process-0.17
-          perl Makefile.PL
-          sed -i.bak 's/-lcrypt//g' Makefile
-          make
-          cd ..
-
-          # https://metacpan.org/pod/Win32::Process::List
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
-            --location "https://cpan.metacpan.org/authors/id/R/RP/RPAGITSCH/Win32-Process-List-0.09.tar.gz" | tar -xz
-          cd Win32-Process-List-0.09
-          perl Makefile.PL
-          sed -i.bak 's/-lcrypt//g' Makefile
-          make
-          cd ..
-
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
     runs-on: windows-2022
@@ -242,8 +185,6 @@ jobs:
 
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
-    needs:
-      - build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: 15
     defaults:
@@ -431,37 +372,6 @@ jobs:
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
           perl --version | tee "$GITHUB_WORKSPACE"/perlversion
 
-      - name: 'cache perl packages'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && matrix.sys != 'msys' }}
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: cache-perl-win32-pkgs
-        env:
-          cache-name: cache-perl-win32-pkgs
-        with:
-          path: C:\perl-win32-pkgs
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}-${{ hashFiles('perlversion') }}
-
-      - name: 'install test prereqs perl'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 5
-        run: &perl-win32-pkgs-install |
-          perl --version
-          if [ -d /c/perl-win32-pkgs ]; then
-            pushd /c/perl-win32-pkgs
-            pushd Win32-Process-0.17
-            install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
-            install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
-            popd
-            pushd Win32-Process-List-0.09
-            install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
-            install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
-            install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
-            install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-            popd
-            popd
-          fi
-          perl -MWin32::Process -MWin32::Process::List -e 1 && echo '! Modules loading OK.' || echo '! Failed to load modules.'
-
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 10
@@ -503,8 +413,6 @@ jobs:
 
   mingw-w64-standalone-downloads:
     name: 'dl-mingw, CM ${{ matrix.ver }}-${{ matrix.env }} ${{ matrix.name }}'
-    needs:
-      - build-cache
     runs-on: windows-2022
     timeout-minutes: 15
     defaults:
@@ -661,21 +569,6 @@ jobs:
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/requirements.txt
           perl --version | tee "$GITHUB_WORKSPACE"/perlversion
 
-      - name: 'cache perl packages'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: cache-perl-win32-pkgs
-        env:
-          cache-name: cache-perl-win32-pkgs
-        with:
-          path: C:\perl-win32-pkgs
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}-${{ hashFiles('perlversion') }}
-
-      - name: 'install test prereqs perl'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 5
-        run: *perl-win32-pkgs-install
-
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 10
@@ -802,8 +695,6 @@ jobs:
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
-    needs:
-      - build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: 15
     defaults:
@@ -1054,21 +945,6 @@ jobs:
             python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/requirements.txt
           fi
           perl --version | tee "$GITHUB_WORKSPACE"/perlversion
-
-      - name: 'cache perl packages'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: cache-perl-win32-pkgs
-        env:
-          cache-name: cache-perl-win32-pkgs
-        with:
-          path: C:\perl-win32-pkgs
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}-${{ hashFiles('perlversion') }}
-
-      - name: 'install test prereqs perl'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 5
-        run: *perl-win32-pkgs-install
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}


### PR DESCRIPTION
It's complex and did not help stabilizing CI runs.

Hard to say, but I'm suspicious it's related to the CI errors
-1073741502, 0xC0000142, seen in the 'build examples' and
'disk space used' steps.

Ref: #18526
Reverts 52775a7fb4ba63d66d60067dea4a5293fb7c55a1 #18296
