### PR TITLE
openldap: limit max incoming size

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -666,8 +666,10 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
        /* Set the maximum allowed size of an incoming message, which to
           OpenLDAP means that it will malloc() memory up to this size. If not
           set, there is no limit and we instead risk a malloc() failure. */
-       ber_sockbuf_ctrl(sb, LBER_SB_OPT_SET_MAX_INCOMING, &max))
-      return CURLE_FAILED_INIT;
+       ber_sockbuf_ctrl(sb, LBER_SB_OPT_SET_MAX_INCOMING, &max)) {
+      result = CURLE_FAILED_INIT;
+      goto out;
+    }
   }
 
 #ifdef USE_SSL


### PR DESCRIPTION
Set the maximum allowed size of an incoming LDAP message, which to OpenLDAP means that it allows malloc() up to this size. If not set, there is no limit and we instead risk a malloc() failure.

The limit is arbitrarily set to 256K as I can't figure out what a reasonable value should be.

OpenLDAP docs: https://openldap.org/software/man.cgi?query=lber-sockbuf&apropos=0&sektion=0&manpath=OpenLDAP+2.6-Release&arch=default&format=html

Bug: https://issues.oss-fuzz.com/issues/432441303