### PR TITLE
rustls: limit snprintf proper in cr_keylog_log_cb()

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -518,7 +518,7 @@ cr_keylog_log_cb(struct rustls_str label,
   (void)client_random_len;
   DEBUGASSERT(client_random_len == CLIENT_RANDOM_SIZE);
   /* Turning a "rustls_str" into a null delimited "c" string */
-  curl_msnprintf(clabel, label.len + 1, "%.*s", (int)label.len, label.data);
+  curl_msnprintf(clabel, sizeof(clabel), "%.*s", (int)label.len, label.data);
   Curl_tls_keylog_write(clabel, client_random, secret, secret_len);
 }
 


### PR DESCRIPTION
It should limit the size to the size of the target array, not the incoming data.

Pointed out by ZeroPath