### PR TITLE
test_16: adjust timing expectations

### DIFF
--- a/tests/http/test_16_info.py
+++ b/tests/http/test_16_info.py
@@ -160,9 +160,12 @@ class TestInfo:
         for key in ['time_appconnect', 'time_connect', 'time_namelookup']:
             assert s[key] < s['time_pretransfer'], f'time "{key}" larger than' \
                 f'"time_pretransfer": {s}'
-        # assert transfer start is after pretransfer
-        assert s['time_pretransfer'] <= s['time_starttransfer'], f'"time_pretransfer" '\
-            f'greater than "time_starttransfer", {s}'
+        # assert transfer total is after pretransfer.
+        # (in MOST situations, pretransfer is before starttransfer, BUT
+        # in protocols like HTTP we might get a server response already before
+        # we transition to multi state DID.)
+        assert s['time_pretransfer'] <= s['time_total'], f'"time_pretransfer" '\
+            f'greater than "time_total", {s}'
         # assert that transfer start is before total
         assert s['time_starttransfer'] <= s['time_total'], f'"time_starttransfer" '\
             f'greater than "time_total", {s}'


### PR DESCRIPTION
In MOST protocols and runs, the 'pretransfer' time is less than the 'starttransfer'. E.g. request being sent before response comes in.

However, when curl is starved of cpu a server response might start streaming in before the multi-state transitioned to DID (and recorded the 'pretransfer' time).

Do no longer check that 'pretransfer' is less or equal 'starttransfer'. Check that is is less or equal to the total time instead.