### PR TITLE
openssl: avoid overwriting 'result' after error

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5106,12 +5106,6 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   struct ossl_certs_ctx chain;
-  long ocsp_len = 0;
-#ifdef HAVE_BORINGSSL_LIKE
-  const uint8_t *ocsp_data = NULL;
-#else
-  unsigned char *ocsp_data = NULL;
-#endif
   CURLcode result;
 
   memset(&chain, 0, sizeof(chain));
@@ -5124,6 +5118,12 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
     result = CURLE_PEER_FAILED_VERIFICATION;
   }
   else {
+#ifdef HAVE_BORINGSSL_LIKE
+    const uint8_t *ocsp_data = NULL;
+#else
+    unsigned char *ocsp_data = NULL;
+#endif
+    long ocsp_len = 0;
     if(conn_config->verifystatus && !octx->reused_session)
       ocsp_len = (long)SSL_get_tlsext_status_ocsp_resp(octx->ssl, &ocsp_data);
 


### PR DESCRIPTION
Follow-up to eefd03c572996e5de4dec4fe295ad6f

Pointed out by ZeroPath