### PR TITLE
rustls: make read_file_into not reject good files

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -404,8 +404,8 @@ read_file_into(const char *filename,
   for(;;) {
     uint8_t buf[256];
     const size_t rr = fread(buf, 1, sizeof(buf), f);
-    if(rr == 0 ||
-       CURLE_OK != curlx_dyn_addn(out, buf, rr)) {
+    if((!rr && !feof(f)) ||
+       curlx_dyn_addn(out, buf, rr)) {
       curlx_fclose(f);
       return 0;
     }


### PR DESCRIPTION
For files with sizes using an exact multiple of 256 bytes, the final successful read(s) filled the buffer(s) and the subsequent fread returned 0 for EOF, which caused read_file_into to fail.

Now, it needs to return 0 and not be EOF to be an error.

Pointed out by ZeroPath