### PR TITLE
curl.h: remove incorrect comment about CURLOPT_PINNEDPUBLICKEY

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1953,8 +1953,7 @@ typedef enum {
   /* Pass in a bitmask of "header options" */
   CURLOPT(CURLOPT_HEADEROPT, CURLOPTTYPE_VALUES, 229),
 
-  /* The public key in DER form used to validate the peer public key
-     this option is used only if SSL_VERIFYPEER is true */
+  /* The public key used to validate the peer public key */
   CURLOPT(CURLOPT_PINNEDPUBLICKEY, CURLOPTTYPE_STRINGPOINT, 230),
 
   /* Path to Unix domain socket */


### PR DESCRIPTION
Bug: https://curl.se/mail/lib-2025-10/0018.html
Reported-by: curl.stunt430