### PR TITLE
examples/chkspeed: minor tweaks to example

### DIFF
--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -184,20 +184,22 @@ int main(int argc, char *argv[])
       /* check for bytes downloaded */
       res = curl_easy_getinfo(curl_handle, CURLINFO_SIZE_DOWNLOAD_T, &val);
       if((CURLE_OK == res) && (val > 0))
-        printf("Data downloaded: %lu bytes.\n", (unsigned long)val);
+        printf("Data downloaded: %" CURL_FORMAT_CURL_OFF_T " bytes.\n", val);
 
       /* check for total download time */
       res = curl_easy_getinfo(curl_handle, CURLINFO_TOTAL_TIME_T, &val);
       if((CURLE_OK == res) && (val > 0))
-        printf("Total download time: %lu.%06lu sec.\n",
-               (unsigned long)(val / 1000000),
-               (unsigned long)(val % 1000000));
+        printf("Total download time: %" CURL_FORMAT_CURL_OFF_T
+               ".%06" CURL_FORMAT_CURL_OFF_T " sec.\n",
+               val / 1000000,
+               val % 1000000);
 
       /* check for average download speed */
       res = curl_easy_getinfo(curl_handle, CURLINFO_SPEED_DOWNLOAD_T, &val);
       if((CURLE_OK == res) && (val > 0))
-        printf("Average download speed: %lu kbyte/sec.\n",
-               (unsigned long)(val / 1024));
+        printf("Average download speed: %"
+               CURL_FORMAT_CURL_OFF_T " kbyte/sec.\n",
+               val / 1024);
 
       if(prtall) {
         /* check for name resolution time */


### PR DESCRIPTION
ensure portable printing when outputting curl_off_t values