### PR TITLE
ws: reset decoder on 10 byte length error

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -453,6 +453,7 @@ static CURLcode ws_dec_read_head(struct ws_decoder *dec,
     case 10:
       if(dec->head[2] > 127) {
         failf(data, "[WS] frame length longer than 63 bit not supported");
+        ws_dec_reset(dec);
         return CURLE_RECV_ERROR;
       }
       dec->payload_len = ((curl_off_t)dec->head[2] << 56) |
@@ -468,6 +469,7 @@ static CURLcode ws_dec_read_head(struct ws_decoder *dec,
       /* this should never happen */
       DEBUGASSERT(0);
       failf(data, "[WS] unexpected frame header length");
+      ws_dec_reset(dec);
       return CURLE_RECV_ERROR;
     }
 


### PR DESCRIPTION
ws_dec_read_head returned CURLE_RECV_ERROR when the 64 bit length MSB was set without resetting the decoder. That left head_len and cont_flags stale and could cause no progress or misparse on the next call. Call ws_dec_reset before returning. Also call it on the unreachable default case.

Discovered by ZeroPath.