### PR TITLE
examples: replace casts with `curl_off_t` printf masks

### DIFF
--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -197,24 +197,26 @@ int main(int argc, char *argv[])
       /* check for average download speed */
       res = curl_easy_getinfo(curl_handle, CURLINFO_SPEED_DOWNLOAD_T, &val);
       if((CURLE_OK == res) && (val > 0))
-        printf("Average download speed: %"
-               CURL_FORMAT_CURL_OFF_T " kbyte/sec.\n",
+        printf("Average download speed: "
+               "%" CURL_FORMAT_CURL_OFF_T " kbyte/sec.\n",
                val / 1024);
 
       if(prtall) {
         /* check for name resolution time */
         res = curl_easy_getinfo(curl_handle, CURLINFO_NAMELOOKUP_TIME_T, &val);
         if((CURLE_OK == res) && (val > 0))
-          printf("Name lookup time: %lu.%06lu sec.\n",
-                 (unsigned long)(val / 1000000),
-                 (unsigned long)(val % 1000000));
+          printf("Name lookup time: %" CURL_FORMAT_CURL_OFF_T
+                 ".%06" CURL_FORMAT_CURL_OFF_T " sec.\n",
+                 val / 1000000,
+                 val % 1000000);
 
         /* check for connect time */
         res = curl_easy_getinfo(curl_handle, CURLINFO_CONNECT_TIME_T, &val);
         if((CURLE_OK == res) && (val > 0))
-          printf("Connect time: %lu.%06lu sec.\n",
-                 (unsigned long)(val / 1000000),
-                 (unsigned long)(val % 1000000));
+          printf("Connect time: %" CURL_FORMAT_CURL_OFF_T
+                 ".%06" CURL_FORMAT_CURL_OFF_T " sec.\n",
+                 val / 1000000,
+                 val % 1000000);
       }
     }
     else {

--- a/docs/examples/fileupload.c
+++ b/docs/examples/fileupload.c
@@ -98,10 +98,12 @@ int main(void)
       curl_easy_getinfo(curl, CURLINFO_SPEED_UPLOAD_T, &speed_upload);
       curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME_T, &total_time);
 
-      fprintf(stderr, "Speed: %lu bytes/sec during %lu.%06lu seconds\n",
-              (unsigned long)speed_upload,
-              (unsigned long)(total_time / 1000000),
-              (unsigned long)(total_time % 1000000));
+      fprintf(stderr, "Speed: %" CURL_FORMAT_CURL_OFF_T " bytes/sec during "
+              "%" CURL_FORMAT_CURL_OFF_T
+              ".%06" CURL_FORMAT_CURL_OFF_T " seconds\n",
+              speed_upload,
+              total_time / 1000000,
+              total_time % 1000000);
     }
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/examples/ftpupload.c
+++ b/docs/examples/ftpupload.c
@@ -106,7 +106,7 @@ int main(void)
   }
   fsize = file_info.st_size;
 
-  printf("Local file size: %lu bytes.\n", (unsigned long)fsize);
+  printf("Local file size: %" CURL_FORMAT_CURL_OFF_T " bytes.\n", fsize);
 
   /* In Windows, this inits the Winsock stuff */
   res = curl_global_init(CURL_GLOBAL_ALL);

--- a/docs/examples/progressfunc.c
+++ b/docs/examples/progressfunc.c
@@ -53,14 +53,19 @@ static int xferinfo(void *p,
      be used */
   if((curtime - myp->lastruntime) >= MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL) {
     myp->lastruntime = curtime;
-    fprintf(stderr, "TOTAL TIME: %lu.%06lu\r\n",
-            (unsigned long)(curtime / 1000000),
-            (unsigned long)(curtime % 1000000));
+    fprintf(stderr, "TOTAL TIME: %" CURL_FORMAT_CURL_OFF_T
+            ".%06" CURL_FORMAT_CURL_OFF_T "\r\n",
+            curtime / 1000000,
+            curtime % 1000000);
   }
 
-  fprintf(stderr, "UP: %lu of %lu  DOWN: %lu of %lu\r\n",
-          (unsigned long)ulnow, (unsigned long)ultotal,
-          (unsigned long)dlnow, (unsigned long)dltotal);
+  fprintf(stderr,
+          "UP: "
+          "%" CURL_FORMAT_CURL_OFF_T " of %" CURL_FORMAT_CURL_OFF_T "  "
+          "DOWN: "
+          "%" CURL_FORMAT_CURL_OFF_T " of %" CURL_FORMAT_CURL_OFF_T "\r\n",
+          ulnow, ultotal,
+          dlnow, dltotal);
 
   if(dlnow > STOP_DOWNLOAD_AFTER_THIS_MANY_BYTES)
     return 1;

--- a/docs/examples/sftpuploadresume.c
+++ b/docs/examples/sftpuploadresume.c
@@ -68,7 +68,7 @@ static curl_off_t sftpGetRemoteFileSize(const char *i_remoteFile)
                                &remoteFileSizeByte);
     if(result)
       return -1;
-    printf("filesize: %lu\n", (unsigned long)remoteFileSizeByte);
+    printf("filesize: %" CURL_FORMAT_CURL_OFF_T "\n", remoteFileSizeByte);
   }
   curl_easy_cleanup(curlHandlePtr);
 


### PR DESCRIPTION
Follow-up to e4ec666a3d742202c06e76a97934f97f2bc7588c #19112