### PR TITLE
libssh: return the proper error for readdir problems

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -613,6 +613,7 @@ static int myssh_in_SFTP_READDIR(struct Curl_easy *data,
 
       if(result) {
         myssh_to(data, sshc, SSH_STOP);
+        sshc->actualcode = result;
         return SSH_NO_ERROR;
       }
 


### PR DESCRIPTION
The code would return without setting sshc->actualcode or returning the CURLcode error.

Reported by ZeroPath