### PR TITLE
openldap: fix limit max incoming size test logic

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -662,11 +662,11 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   {
     ber_len_t max = 256*1024;
     Sockbuf *sb;
-    if(ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, (void **)&sb) ||
+    if((ldap_get_option(li->ld, LDAP_OPT_SOCKBUF, &sb) != LDAP_OPT_SUCCESS) ||
        /* Set the maximum allowed size of an incoming message, which to
           OpenLDAP means that it will malloc() memory up to this size. If not
           set, there is no limit and we instead risk a malloc() failure. */
-       ber_sockbuf_ctrl(sb, LBER_SB_OPT_SET_MAX_INCOMING, &max)) {
+       !ber_sockbuf_ctrl(sb, LBER_SB_OPT_SET_MAX_INCOMING, &max)) {
       result = CURLE_FAILED_INIT;
       goto out;
     }


### PR DESCRIPTION
Use LDAP_OPT_SUCCESS for ldap_get_option, as done in the other
calls. ber_sockbuf_ctrl returns 1 on success so reverse the logic.

Regression of f91be14bfb.