### PR TITLE
socks: avoid UAF risk in error path

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -765,13 +765,12 @@ static CURLproxycode socks5_check_auth_resp(struct socks_state *sx,
 
   /* ignore the first (VER) byte */
   auth_status = resp[1];
-  Curl_bufq_skip(&sx->iobuf, 2);
-
   if(auth_status) {
     failf(data, "User was rejected by the SOCKS5 server (%d %d).",
           resp[0], resp[1]);
     return CURLPX_USER_REJECTED;
   }
+  Curl_bufq_skip(&sx->iobuf, 2);
   return CURLPX_OK;
 }
 


### PR DESCRIPTION
The code obtained a pointer resp via Curl_bufq_peek(), but called Curl_bufq_skip() before it would access them in the failf() call.

The Curl_bufq_skip() call can trigger prune_head which may free or recycle the chunk that resp points into.

Pointed out by ZeroPath