### PR TITLE
openssl: remove dead code

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4898,7 +4898,7 @@ static void infof_certstack(struct Curl_easy *data, const SSL *ssl)
       curl_msnprintf(group_name_final, sizeof(group_name_final), "/%s",
                      group_name);
     }
-    type_name = current_pkey ? EVP_PKEY_get0_type_name(current_pkey) : NULL;
+    type_name = EVP_PKEY_get0_type_name(current_pkey);
 #else
     get_group_name = 0;
     type_name = NULL;


### PR DESCRIPTION
A condition in infof_certstack() would always equal true after a previous change.

Follow-up to e2a4de8a607d3c7f52918ef50ab6411c75

Pointed out by Coverity