### PR TITLE
tool_operate: return error on strdup() failure

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2072,6 +2072,10 @@ static CURLcode cacertpaths(struct OperationConfig *config)
     if(cafile) {
       curlx_fclose(cafile);
       config->cacert = strdup(cacert);
+      if(!config->cacert) {
+        result = CURLE_OUT_OF_MEMORY;
+        goto fail;
+      }
     }
 #elif !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE) && \
   !defined(CURL_DISABLE_CA_SEARCH)


### PR DESCRIPTION
In src/tool_operate.c inside the Windows safe-search branch (#ifdef CURL_CA_SEARCH_SAFE), the code assigns config->cacert = strdup(cacert); at line 2076 without checking whether strdup returned NULL.

This would allow the code to continue with the wrong value set, causing possible confusion.

Pointed out by ZeroPath