### PR TITLE
lib: add asserts that hostname has content

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -458,6 +458,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
 
   DEBUGASSERT(conn);
   DEBUGASSERT(!data->state.async.doh);
+  DEBUGASSERT(hostname && hostname[0]);
   if(data->state.async.doh)
     Curl_doh_cleanup(data);
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -858,6 +858,7 @@ CURLcode Curl_resolv(struct Curl_easy *data,
 
   /* We should intentionally error and not resolve .onion TLDs */
   hostname_len = strlen(hostname);
+  DEBUGASSERT(hostname_len);
   if(hostname_len >= 7 &&
      (curl_strequal(&hostname[hostname_len - 6], ".onion") ||
       curl_strequal(&hostname[hostname_len - 7], ".onion."))) {
@@ -982,7 +983,7 @@ CURLcode Curl_resolv_blocking(struct Curl_easy *data,
                               struct Curl_dns_entry **dnsentry)
 {
   CURLcode result;
-
+  DEBUGASSERT(hostname && *hostname);
   *dnsentry = NULL;
   result = Curl_resolv(data, hostname, port, ip_version, FALSE, dnsentry);
   switch(result) {
@@ -1060,6 +1061,7 @@ CURLcode Curl_resolv_timeout(struct Curl_easy *data,
 #endif /* USE_ALARM_TIMEOUT */
   CURLcode result;
 
+  DEBUGASSERT(hostname && *hostname);
   *entry = NULL;
 
   if(timeoutms < 0)

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -331,6 +331,7 @@ static CURLproxycode socks4_resolving(struct socks_state *sx,
   if(sx->start_resolving) {
     /* need to resolve hostname to add destination address */
     sx->start_resolving = FALSE;
+    DEBUGASSERT(sx->hostname && *sx->hostname);
 
     result = Curl_resolv(data, sx->hostname, sx->remote_port,
                          cf->conn->ip_version, TRUE, &dns);
@@ -858,6 +859,7 @@ static CURLproxycode socks5_resolving(struct socks_state *sx,
   if(sx->start_resolving) {
     /* need to resolve hostname to add destination address */
     sx->start_resolving = FALSE;
+    DEBUGASSERT(sx->hostname && *sx->hostname);
 
     result = Curl_resolv(data, sx->hostname, sx->remote_port,
                          cf->conn->ip_version, TRUE, &dns);


### PR DESCRIPTION
For all network related protocols there must be a non-blank hostname used. This change adds a few asserts in some places to make debug/tests catch mistakes if any such would slip in.