### PR TITLE
GHA/windows: drop `git config core.autocrlf input` steps

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -495,8 +495,6 @@ jobs:
           rm -r -f pack.bin
           ls -l
 
-      - run: git config --global core.autocrlf input
-
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false


### PR DESCRIPTION
CI works without it now. For an inexplicable reason, this single `git`
command took 9 seconds per job, making this patch save more than
2 minutes per workflow run. It was also the only step using PowerShell.
