### PR TITLE
curl_easy_setopt.md: add missing CURLOPT_POSTFIELDS

### DIFF
--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -686,6 +686,10 @@ Port number to connect to. See CURLOPT_PORT(3)
 
 Make an HTTP POST. See CURLOPT_POST(3)
 
+## CURLOPT_POSTFIELDS
+
+Send a POST with this data - does not copy it. See CURLOPT_POSTFIELDS(3)
+
 ## CURLOPT_POSTFIELDSIZE
 
 The POST data is this big. See CURLOPT_POSTFIELDSIZE(3)

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -90,7 +90,7 @@ sub scanmdpage {
         }
     }
     foreach my $m (@words) {
-        my @g = grep(/$m/, @m);
+        my @g = grep(/$m\b/, @m);
         if(!$g[0]) {
             print STDERR "Missing mention of $m in $file\n";
             $errors++;


### PR DESCRIPTION
It was mistakenly removed in 8dab7465a594b1fb4b (shipped in 8.9.0)

Also fix test 1139 which should have detected this but didn't due to a bad regex check.

Reported-by: Jonathan Cardoso
Fixes #19151