### PR TITLE
cookie: only count accepted cookies in Curl_cookie_add

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -750,7 +750,6 @@ parse_cookie_header(struct Curl_easy *data,
   if(!co->name)
     return CERR_BAD;
 
-  data->req.setcookies++;
   return CERR_OK;
 }
 
@@ -1139,6 +1138,9 @@ Curl_cookie_add(struct Curl_easy *data,
    */
   if(co->expires && (co->expires < ci->next_expiration))
     ci->next_expiration = co->expires;
+
+  if(httpheader)
+    data->req.setcookies++;
 
   return co;
 fail:


### PR DESCRIPTION
The counter used to stop accepting cookies after a certain amount has been received in a single response would previously also count some cookies that were not actually accepted as they were discarded after the counter was increased.

Starting now, the counter is increased only for cookies that were accepted.

Pointed out by ZeroPath