### PR TITLE
Makefile.example: bump default example from FTP to HTTPS

### DIFF
--- a/docs/examples/Makefile.example
+++ b/docs/examples/Makefile.example
@@ -22,7 +22,7 @@
 #
 ###########################################################################
 
-SRC ?= ftpget.c
+SRC ?= https.c
 
 # What to call the final executable
 TARGET ?= example


### PR DESCRIPTION
To have a chance to work out of the box, securely. (assuming a TLS
backend with CA certs setup.)
