### PR TITLE
GHA/curl-for-win: drop libssh

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -172,8 +172,8 @@ jobs:
             "${OCI_IMAGE_DEBIAN}" \
             sh -c ./_ci-linux-debian.sh
 
-  win-gcc-libssh-zlibold-x64:
-    name: 'Windows gcc libssh zlib-classic (x64)'
+  win-gcc-zlibold-x64:
+    name: 'Windows gcc zlib-classic (x64)'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -186,7 +186,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-win-x64-gcc-libssh1-zlibold'
+          export CW_CONFIG='-main-werror-unitybatch-win-x64-gcc-zlibold'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default


### PR DESCRIPTION
Switch back to default libssh2.

The distribution server has reliability issues (this time it works
locally though):
```
++ curl [...] --output pkg.bin https://www.libssh.org/files/0.11/libssh-0.11.3.tar.xz --output pkg.sig https://www.libssh.org/files/0.11/libssh-0.11.3.tar.xz.asc
curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2) [4x]
```
Ref: https://github.com/curl/curl/actions/runs/18651134321/job/53169147048#step:3:2391

There is also no official mirror that I know of.

Ref: af8e1aa4b06e9dc78a559b485348e5464bd5cff5 #18257