### PR TITLE
INSTALL-CMAKE.md: fix descriptions for LDAP dependency options

### DIFF
--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -405,9 +405,9 @@ Details via CMake
 - `CARES_LIBRARY`:                          Path to `cares` library.
 - `DL_LIBRARY`:                             Path to `dl` library. (for Rustls)
 - `GSS_ROOT_DIR`:                           Set this variable to the root installation of GSS. (also supported as environment)
+- `LDAP_INCLUDE_DIR`:                       The LDAP include directory.
 - `LDAP_LIBRARY`:                           Path to `ldap` library.
 - `LDAP_LBER_LIBRARY`:                      Path to `lber` library.
-- `LDAP_INCLUDE_DIR`:                       Path to LDAP include directory.
 - `LIBGSASL_INCLUDE_DIR`:                   The libgsasl include directory.
 - `LIBGSASL_LIBRARY`:                       Path to `libgsasl` library.
 - `LIBIDN2_INCLUDE_DIR`:                    The libidn2 include directory.


### PR DESCRIPTION
After introducing the local FindLDAP module, these options work the same
way as with other dependencies.

Follow-up to 49f2a23d509645d534cbb2e2ffbd6347fac6e59e #15273
