### PR TITLE
cmake: two minor tidy-ups

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -29,12 +29,10 @@ set(_picky_nocheck "")  # not to pass to feature checks
 if(CURL_WERROR)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
-  else()
-    if(MSVC)
-      list(APPEND _picky_nocheck "-WX")
-    else()  # llvm/clang and gcc style options
-      list(APPEND _picky_nocheck "-Werror")
-    endif()
+  elseif(MSVC)
+    list(APPEND _picky_nocheck "-WX")
+  else()  # llvm/clang and gcc-style options
+    list(APPEND _picky_nocheck "-Werror")
   endif()
 
   if((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND


### PR DESCRIPTION
- flatten an if tree.
- fix a typo in comment.
