### PR TITLE
hmac: free memory properly on errors

### DIFF
--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -74,7 +74,7 @@ Curl_HMAC_init(const struct HMAC_params *hashparams,
   /* If the key is too long, replace it by its hash digest. */
   if(keylen > hashparams->maxkeylen) {
     if(hashparams->hinit(ctxt->hashctxt1))
-      return NULL;
+      goto fail;
     hashparams->hupdate(ctxt->hashctxt1, key, keylen);
     hkey = (unsigned char *) ctxt->hashctxt2 + hashparams->ctxtsize;
     hashparams->hfinal(hkey, ctxt->hashctxt1);
@@ -85,7 +85,7 @@ Curl_HMAC_init(const struct HMAC_params *hashparams,
   /* Prime the two hash contexts with the modified key. */
   if(hashparams->hinit(ctxt->hashctxt1) ||
      hashparams->hinit(ctxt->hashctxt2))
-    return NULL;
+    goto fail;
 
   for(i = 0; i < keylen; i++) {
     b = (unsigned char)(*key ^ hmac_ipad);
@@ -101,6 +101,10 @@ Curl_HMAC_init(const struct HMAC_params *hashparams,
 
   /* Done, return pointer to HMAC context. */
   return ctxt;
+
+fail:
+  free(ctxt);
+  return NULL;
 }
 
 int Curl_HMAC_update(struct HMAC_context *ctxt,


### PR DESCRIPTION
If one of the hmac init calls fail, Curl_HMAC_init previously would return without first freeing the allocated HMAC_context.

Fixes #19176
Reported-by: WangDaLei on github