### PR TITLE
http: Unify the error handling pattern in lib/http.c:Curl_http()

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2936,8 +2936,10 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
     char *pq = NULL;
     if(data->state.up.query) {
       pq = curl_maprintf("%s?%s", data->state.up.path, data->state.up.query);
-      if(!pq)
-        return CURLE_OUT_OF_MEMORY;
+      if(!pq) {
+        result = CURLE_OUT_OF_MEMORY;
+        goto out;
+      }
     }
     result = Curl_http_output_auth(data, data->conn, method, httpreq,
                                    (pq ? pq : data->state.up.path), FALSE);


### PR DESCRIPTION
Except for one location, the error handling code in lib/http.c:Curl_http() has the same pattern (i.e., `goto out;`).
In such a situation, this PR aligns the oom failure path with the established pattern.
By doing so, it ensures all error paths follow identical cleanup procedures, reducing maintenance complexity and potential future leaks.