### PR TITLE
curl_path: properly free the dynbuf on errors

### DIFF
--- a/lib/vssh/curl_path.c
+++ b/lib/vssh/curl_path.c
@@ -167,8 +167,10 @@ CURLcode Curl_get_pathname(const char **cpp, char **path, const char *homedir)
     /* Read to end of filename - either to whitespace or terminator */
     rc = curlx_str_word(&cp, &word, MAX_PATHLENGTH);
     if(rc) {
-      if(rc == STRE_BIG)
+      if(rc == STRE_BIG) {
+        curlx_dyn_free(&out);
         return CURLE_TOO_LARGE;
+      }
       else if(!content)
         /* no path, no word, this is incorrect */
         goto fail;


### PR DESCRIPTION
In lib/vssh/curl_path.c:Curl_get_pathname(), there are several potential memory leaks on error paths.
This PR unifies their error handling to properly free the dynbuf.