### PR TITLE
hostip: fix infof() output for non-ipv6 builds using IPv6 address

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1352,9 +1352,9 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
           }
         }
 #ifndef USE_IPV6
-        if(memchr(target.str, ':', target.len)) {
+        if(memchr(curlx_str(&target), ':', curlx_strlen(&target))) {
           infof(data, "Ignoring resolve address '%.*s', missing IPv6 support.",
-                (int)target.len, target.str);
+                (int)curlx_strlen(&target), curlx_str(&target));
           if(curlx_str_single(&host, ','))
             goto err;
           continue;


### PR DESCRIPTION
Pointed out by ZeroPath