### PR TITLE
imap: parse and use UIDVALIDITY as a number

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -2203,10 +2203,12 @@ static CURLcode imap_parse_url_path(struct Curl_easy *data,
       else {
         free(name);
         free(value);
-
         return CURLE_URL_MALFORMAT;
       }
     }
+    else
+      /* blank? */
+      free(value);
     free(name);
   }
 


### PR DESCRIPTION
Instead of a string. Saves a malloc, adds earlier format check.

RFC 3501 section 2.3.1.1 documents the value as a 32-bit value.