### PR TITLE
netrc: when the cached file is discarded, unmark it as loaded

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -362,6 +362,7 @@ out:
   }
   else {
     curlx_dyn_free(filebuf);
+    store->loaded = FALSE;
     if(!specific_login)
       free(login);
     free(password);


### PR DESCRIPTION
Pointed out by ZeroPath