### PR TITLE
http: only accept ';' as a separator for custom headers

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -318,11 +318,9 @@ char *Curl_copy_header_value(const char *header)
   /* find the end of the header name */
   if(!curlx_str_until(&header, &out, MAX_HTTP_RESP_HEADER_SIZE, ':') &&
      !curlx_str_single(&header, ':')) {
-    if(!curlx_str_untilnl(&header, &out, MAX_HTTP_RESP_HEADER_SIZE)) {
-      curlx_str_trimblanks(&out);
-      return Curl_memdup0(curlx_str(&out), curlx_strlen(&out));
-    }
-    return strdup("");
+    curlx_str_untilnl(&header, &out, MAX_HTTP_RESP_HEADER_SIZE);
+    curlx_str_trimblanks(&out);
+    return Curl_memdup0(curlx_str(&out), curlx_strlen(&out));
   }
   /* bad input, should never happen */
   DEBUGASSERT(0);


### PR DESCRIPTION
When parsing incoming headers, they need to have a plain normal colon.

Previously out of convenience we used the same parser function for both cases which made it too liberal on incoming HTTP traffic.