### PR TITLE
vtls: Remove call to PKCS12_PBE_add()

### DIFF
--- a/lib/setup-vms.h
+++ b/lib/setup-vms.h
@@ -257,7 +257,6 @@ static struct passwd *vms_getpwuid(uid_t uid)
 #endif
 #define PEM_read_X509 PEM_READ_X509
 #define PEM_write_bio_X509 PEM_WRITE_BIO_X509
-#define PKCS12_PBE_add PKCS12_PBE_ADD
 #define PKCS12_free PKCS12_FREE
 #define PKCS12_parse PKCS12_PARSE
 #define RAND_add RAND_ADD

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1578,8 +1578,6 @@ static int pkcs12load(struct Curl_easy *data,
     return 0;
   }
 
-  PKCS12_PBE_add();
-
   if(!PKCS12_parse(p12, key_passwd, &pri, &x509, &ca)) {
     failf(data,
           "could not parse PKCS12 file, check password, " OSSL_PACKAGE


### PR DESCRIPTION
Curl is one of the last callers of PKCS12_PBE_add(). It has been a noop since OpenSSL 0.9.8k (2006) stubbed it out when moving the built-in PBE algorithms to a static table:
https://github.com/openssl/openssl/commit/b8f702a0affa2087758230967b55df504a176774