### PR TITLE
mbedtls: fix building with <3.6.1

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -779,7 +779,8 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-#if MBEDTLS_VERSION_NUMBER < 0x04000000 && defined(MBEDTLS_SSL_SESSION_TICKETS)
+#if defined(MBEDTLS_SSL_SESSION_TICKETS) && \
+  MBEDTLS_VERSION_NUMBER >= 0x03060100 && MBEDTLS_VERSION_NUMBER < 0x04000000
   /* New in mbedTLS 3.6.1, need to enable, default is now disabled.
      4.0.0 enabled it by default for TLSv1.3. */
   mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets(&backend->config,


### PR DESCRIPTION
```
lib/vtls/mbedtls.c:786:3: error: call to undeclared function 'mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  786 |   mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets(&backend->config,
      |   ^
lib/vtls/mbedtls.c:787:5: error: use of undeclared identifier 'MBEDTLS_SSL_TLS1_3_SIGNAL_NEW_SESSION_TICKETS_ENABLED'; did you mean 'MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH'?
  787 |     MBEDTLS_SSL_TLS1_3_SIGNAL_NEW_SESSION_TICKETS_ENABLED);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH
dep/mbedtls-3.4.0/_pkg/include/mbedtls/ssl.h:700:5: note: 'MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH' declared here
  700 |     MBEDTLS_SSL_TLS1_3_NEW_SESSION_TICKET_FLUSH,
      |     ^
2 errors generated.
```

Regression from d63e40f8e6298efaabae57c714ef8df57c54474d #18271 (8.16.0)
