### PR TITLE
cfilters: check return code from Curl_pollset_set_out_only()

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -542,8 +542,9 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
       Curl_pollfds_reset(&cpfds);
       /* In general, we want to send after connect, wait on that. */
       if(sockfd != CURL_SOCKET_BAD)
-        Curl_pollset_set_out_only(data, &ps, sockfd);
-      result = Curl_conn_adjust_pollset(data, data->conn, &ps);
+        result = Curl_pollset_set_out_only(data, &ps, sockfd);
+      if(!result)
+        result = Curl_conn_adjust_pollset(data, data->conn, &ps);
       if(result)
         goto out;
       result = Curl_pollfds_add_ps(&cpfds, &ps);

--- a/lib/select.h
+++ b/lib/select.h
@@ -154,11 +154,12 @@ void Curl_pollset_move(struct easy_pollset *to, struct easy_pollset *from);
  */
 CURLcode Curl_pollset_change(struct Curl_easy *data,
                              struct easy_pollset *ps, curl_socket_t sock,
-                             int add_flags, int remove_flags);
+                             int add_flags,
+                             int remove_flags) WARN_UNUSED_RESULT;
 
 CURLcode Curl_pollset_set(struct Curl_easy *data,
                           struct easy_pollset *ps, curl_socket_t sock,
-                          bool do_in, bool do_out);
+                          bool do_in, bool do_out) WARN_UNUSED_RESULT;
 
 #define Curl_pollset_add_in(data, ps, sock) \
           Curl_pollset_change((data), (ps), (sock), CURL_POLL_IN, 0)


### PR DESCRIPTION
I added WARN_UNUSED_RESULT to two of the cfilter functions to make this mistake harder to slip in next time.

Pointed out by CodeSonar