### PR TITLE
tool_cfgable: Bug fix for double free

### DIFF
--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -184,8 +184,6 @@ static void free_config_fields(struct OperationConfig *config)
   tool_safefree(config->ftp_account);
   tool_safefree(config->ftp_alternative_to_user);
   tool_safefree(config->aws_sigv4);
-  tool_safefree(config->proto_str);
-  tool_safefree(config->proto_redir_str);
   tool_safefree(config->ech);
   tool_safefree(config->ech_config);
   tool_safefree(config->ech_public);


### PR DESCRIPTION
### 🧠 Summary
Fixes a double free in `free_config_fields()` .

### 🔍 Details
Double free  bug in src/tool_cfgable.c.
At lines 104–105 and 187–188, config->proto_str and config->proto_redir_str are each freed twice.

### ✅ Related Issue
https://github.com/curl/curl/issues/19213


