### PR TITLE
GHA: set `concurrency:` where missing

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -27,6 +27,10 @@ name: 'Source'
       - 'plan9/**'
       - 'tests/data/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,8 @@ name: 'CodeQL'
     - cron: '0 0 * * 4'
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -30,6 +30,10 @@ name: 'configure-vs-cmake'
       - '.github/scripts/cmp-config.pl'
       - '.github/workflows/configure-vs-cmake.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -35,6 +35,10 @@ name: 'Fuzzer'
       - 'projects/**'
       - 'tests/data/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -30,8 +30,7 @@ name: 'Linux HTTP/3'
       - 'projects/**'
 
 concurrency:
-  # Hardcoded workflow filename as workflow name above is just Linux again
-  group: http3-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,6 +13,10 @@ name: 'Labeler'
 
 'on': [pull_request_target]  # zizmor: ignore[dangerous-triggers]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -43,6 +43,10 @@ name: 'Old Linux'
       - 'plan9/**'
       - 'projects/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:


### PR DESCRIPTION
To silence zizmor 1.16.0 warnings.

Also:
- http3-linux: replace hard-coded workflow name with variable.
  Follow-up to a8174176b5425c5692b55b78e40aef3a2331155f #13841
- codeql: set `cancel-in-progress: true`.
  zizmor apparently does not allow `false` in pedantic mode anymore:
  https://github.com/zizmorcore/zizmor/pull/1227
- codeql: sync concurrency setting with the rest of the jobs.
  (I'm not sure this is correct, or why it was previously special-cased.)

Expressions used (before and after this patch):
- `group: ${{ github.workflow }}-${{ github.event.sha }}-${{ github.event.target_url }}`
  for GHA/appveyor-status.
- `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}`
  for all the rest.

Ref: https://github.com/curl/curl/actions/runs/18776245057/job/53571438139?pr=19209

---

I admit to not grasp how concurrency group expression works and if there
is supposed to be a special case for codeql, or appveyor-status.
