### PR TITLE
GHA/dependabot: group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       interval: 'monthly'
     cooldown:
       default-days: 7
+    groups:
+      actions-deps:
+        patterns:
+          - '*'
     commit-message:
       prefix: 'GHA:'
 
@@ -24,5 +28,9 @@ updates:
       semver-major-days: 15
       semver-minor-days: 7
       semver-patch-days: 3
+    groups:
+      actions-deps:
+        patterns:
+          - '*'
     commit-message:
       prefix: 'GHA:'


### PR DESCRIPTION
To avoid update spam and PR that can't be applied on top of each other.

Ref: #19217 #19218 #19219
