### PR TITLE
mbedtls: fix building with sha-256 missing from PSA

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -73,6 +73,7 @@
 #include "../multiif.h"
 #include "mbedtls_threadlock.h"
 #include "../strdup.h"
+#include "../curl_sha256.h"
 
 /* The last 2 #include files should be in this order */
 #include "../curl_memory.h"


### PR DESCRIPTION
Fixing:
```
lib/vtls/mbedtls.c:1505:10: error: call to undeclared function 'Curl_sha256it'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1505 |   return Curl_sha256it(sha256sum, input, inputlen);
      |          ^
1 error generated.
```

with mbedTLS configuration:
```
tf-psa-crypto/scripts/config.py unset PSA_WANT_ALG_SHA_256
tf-psa-crypto/scripts/config.py unset PSA_WANT_ALG_TLS12_ECJPAKE_TO_PMS
tf-psa-crypto/scripts/config.py unset MBEDTLS_LMS_C
```

Follow-up to 3a305831d1a9d10b2bfd4fa3939ed41275fee7f7 #19077

---

I wonder if such mbedTLS build is possible in practice... [YES]
