### PR TITLE
curl_ngtcp2: fix `-Wunreachable-code` with H3 !verbose !unity clang

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -526,6 +526,7 @@ static int cf_ngtcp2_handshake_completed(ngtcp2_conn *tconn, void *user_data)
 
   ctx->tls_vrfy_result = Curl_vquic_tls_verify_peer(&ctx->tls, cf,
                                                     data, &ctx->peer);
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   if(Curl_trc_is_verbose(data)) {
     const ngtcp2_transport_params *rp;
     rp = ngtcp2_conn_get_remote_transport_params(ctx->qconn);
@@ -537,6 +538,7 @@ static int cf_ngtcp2_handshake_completed(ngtcp2_conn *tconn, void *user_data)
                (curl_uint64_t)rp->max_udp_payload_size,
                (curl_uint64_t)rp->initial_max_data);
   }
+#endif
 
   /* In case of earlydata, where we simulate being connected, update
    * the handshake time when we really did connect */


### PR DESCRIPTION
Not tested in default CI.

macOS / CM clang OpenSSL gsasl rtmp AppleIDN SecTrust +examples,
macOS / CM llvm@18 OpenSSL gsasl rtmp AppleIDN SecTrust +examples:
```
lib/vquic/curl_ngtcp2.c:530:5: error: code will never be executed [-Werror,-Wunreachable-code]
  530 |     const ngtcp2_transport_params *rp;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
Ref: https://github.com/curl/curl/actions/runs/18787154442/job/53608230871?pr=19225#step:11:183

Confirmed fixed via #19225
