### PR TITLE
vtls: check final cfilter node in find_ssl_filter

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5667,10 +5667,8 @@ static CURLcode ossl_get_channel_binding(struct Curl_easy *data, int sockindex,
       break;
     }
 
-    if(cf->next)
-      cf = cf->next;
-
-  } while(cf->next);
+    cf = cf->next;
+  } while(cf);
 
   if(!octx) {
     failf(data, "Failed to find the SSL filter");


### PR DESCRIPTION
find_ssl_filter used while(cf && cf->next) and skipped the last node. If the SSL filter was last, channel binding lookup failed and we returned CURLE_BAD_FUNCTION_ARGUMENT. Switch to while(cf) so the tail is examined.

This bug was found with ZeroPath.