### PR TITLE
pop3: fix CAPA response termination detection

### DIFF
--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -323,8 +323,10 @@ static bool pop3_endofresp(struct Curl_easy *data, struct connectdata *conn,
 
   /* Are we processing CAPA command responses? */
   if(pop3c->state == POP3_CAPA) {
-    /* Do we have the terminating line? */
-    if(len >= 1 && line[0] == '.')
+    /* Do we have the terminating line? Per RFC 2449 this is a line
+       containing only a single dot */
+    if((len == 3 && line[0] == '.' && line[1] == '\r') ||
+       (len == 2 && line[0] == '.' && line[1] == '\n'))
       /* Treat the response as a success */
       *resp = '+';
     else


### PR DESCRIPTION
Fixes #19228

The current code checks if a line starts with `.` which doesn't match the RFC spec. Per RFC 2449, the CAPA response terminator is a line containing only a single dot (plus CRLF).

While capability names can't actually start with `.` according to the spec (it's excluded from the allowed character set), the code should still match what the RFC says.

Changed the check to look for an exact match - either length 3 with `.\r` or length 2 with `.\n` to handle both standard CRLF and LF-only servers.

Tested with all 37 existing POP3 tests: everything passes.