### PR TITLE
pingpong: change repsonse timeout to one minute

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3364,14 +3364,8 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
      * data has been transferred. This happens when doing through NATs etc that
      * abandon old silent connections.
      */
-    timediff_t old_time = pp->response_time;
-
-    pp->response_time = 60*1000; /* give it only a minute for now */
     pp->response = curlx_now(); /* timeout relative now */
-
     result = getftpresponse(data, &nread, &ftpcode);
-
-    pp->response_time = old_time; /* set this back to previous value */
 
     if(!nread && (CURLE_OPERATION_TIMEDOUT == result)) {
       failf(data, "control connection looks dead");

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -50,8 +50,8 @@ timediff_t Curl_pp_state_timeout(struct Curl_easy *data,
                                  struct pingpong *pp, bool disconnecting)
 {
   timediff_t timeout_ms; /* in milliseconds */
-  timediff_t response_time = (data->set.server_response_timeout > 0) ?
-    data->set.server_response_timeout : pp->response_time;
+  timediff_t response_time = data->set.server_response_timeout ?
+    data->set.server_response_timeout : RESP_TIMEOUT;
   struct curltime now = curlx_now();
 
   /* if CURLOPT_SERVER_RESPONSE_TIMEOUT is set, use that to determine

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -53,8 +53,6 @@ struct pingpong {
   size_t sendsize; /* total size of the sendthis buffer */
   struct curltime response; /* set to Curl_now() when a command has been sent
                                off, used to time-out response reading */
-  timediff_t response_time; /* When no timeout is given, this is the amount of
-                               milliseconds we await for a server response. */
   struct dynbuf sendbuf;
   struct dynbuf recvbuf;
   size_t overflow; /* number of bytes left after a final response line */
@@ -75,7 +73,6 @@ struct pingpong {
 
 #define PINGPONG_SETUP(pp,s,e)                   \
   do {                                           \
-    (pp)->response_time = RESP_TIMEOUT;          \
     (pp)->statemachine = s;                      \
     (pp)->endofresp = e;                         \
   } while(0)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -127,7 +127,7 @@ typedef unsigned int curl_prot_t;
 #define MAX_IPADR_LEN sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255")
 
 /* Default FTP/IMAP etc response timeout in milliseconds */
-#define RESP_TIMEOUT (120*1000)
+#define RESP_TIMEOUT (60*1000)
 
 /* Max string input length is a precaution against abuse and to detect junk
    input easier and better. */


### PR DESCRIPTION
It was previously two minutes by default and sometimes one minute. Removes a struct field.