### PR TITLE
socks: properly maintain the status of 'done'

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1248,8 +1248,10 @@ static CURLcode socks_proxy_cf_connect(struct Curl_cfilter *cf,
 
   if(!sx) {
     cf->ctx = sx = calloc(1, sizeof(*sx));
-    if(!sx)
-      return CURLE_OUT_OF_MEMORY;
+    if(!sx) {
+      result = CURLE_OUT_OF_MEMORY;
+      goto out;
+    }
 
     /* for the secondary socket (FTP), use the "connect to host"
      * but ignore the "connect to port" (use the secondary port)


### PR DESCRIPTION
In socks_proxy_cf_connect(), `*done` will be True after a TCP connection while the SOCKS Proxy is not actually done.
This PR properly maintains the status of 'done' when calloc fails and the socks connection is not performed.