### PR TITLE
Curl_resolv: explicitly set *entry to NULL when the dns is negative

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -848,6 +848,8 @@ CURLcode Curl_resolv(struct Curl_easy *data,
   size_t hostname_len;
   bool keep_negative = TRUE; /* cache a negative result */
 
+  *entry = NULL;
+
 #ifndef CURL_DISABLE_DOH
   data->conn->bits.doh = FALSE; /* default is not */
 #else
@@ -943,7 +945,6 @@ out:
     if(!dns->addr) {
       infof(data, "Negative DNS entry");
       dns->refcount--;
-      *entry = NULL;
       return CURLE_COULDNT_RESOLVE_HOST;
     }
     *entry = dns;
@@ -970,7 +971,6 @@ out:
 error:
   if(dns)
     Curl_resolv_unlink(data, &dns);
-  *entry = NULL;
   Curl_async_shutdown(data);
   if(keep_negative)
     store_negative_resolve(data, hostname, port);


### PR DESCRIPTION
In the negative DNS cache path, Curl_resolv() returns `CURLE_COULDNT_RESOLVE_HOST` but does not explicitly set `*entry` to `NULL`.

This PR ensures `*entry` is explicitly set to `NULL` in negative cache cases to comply with Curl_resolv()'s return value description "CURLE_COULDNT_RESOLVE_HOST = error, *entry == NULL".