### PR TITLE
ngtcp2: overwrite rate-limits defaults

### DIFF
--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -108,7 +108,6 @@ class TestCaddy:
 
     # download 5MB files sequentially
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
-    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_08_04a_download_10mb_sequential(self, env: Env, caddy: Caddy, proto):
         if proto == 'h3' and not env.have_h3_curl():
@@ -121,7 +120,6 @@ class TestCaddy:
 
     # download 10MB files sequentially
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
-    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_08_04b_download_10mb_sequential(self, env: Env, caddy: Caddy, proto):
         if proto == 'h3' and not env.have_h3_curl():
@@ -135,7 +133,6 @@ class TestCaddy:
     # download 10MB files parallel
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     def test_08_05_download_1mb_parallel(self, env: Env, caddy: Caddy, proto):
         if proto == 'h3' and not env.have_h3_curl():
             pytest.skip("h3 not supported in curl")


### PR DESCRIPTION
In pytests test_08 with the Caddy server, the new rate-limiting in ngtcp2 did close the connection because it found "too many" stream data packet repeats.

It is unclear if this is some Caddy issue or if the ngtcp2 implementaton is wrong. Or if curl can do anything here.

Reported as https://github.com/ngtcp2/ngtcp2/issues/1850

This PR overwrites the ratelimit defaults in ngtcp2 with ten times increased values. This makes the errors disappear on macOS.

Enable test_08_04/05 in CI again to see if there are any issues to be found there. (We had those disabled before having parallel pytests.)