### PR TITLE
http: fix `-Wunused-variable` in !alt-svc !proxy !ws builds

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2777,8 +2777,8 @@ static CURLcode http_add_hd(struct Curl_easy *data,
                             Curl_HttpReq httpreq)
 {
   CURLcode result = CURLE_OK;
-#if !defined(CURL_DISABLE_PROXY) || \
-  !defined(CURL_DISABLE_ALTSVC) || \
+#if !defined(CURL_DISABLE_ALTSVC) || \
+  !defined(CURL_DISABLE_PROXY) || \
   !defined(CURL_DISABLE_WEBSOCKETS)
   struct connectdata *conn = data->conn;
 #endif


### PR DESCRIPTION
```
lib/http.c:2783:23: error: unused variable 'conn' [-Werror,-Wunused-variable]
 2783 |   struct connectdata *conn = data->conn;
      |                       ^~~~
1 error generated.
```
