### PR TITLE
base64: make base64_encode() error on too long input

### DIFF
--- a/lib/curlx/base64.c
+++ b/lib/curlx/base64.c
@@ -184,10 +184,10 @@ static CURLcode base64_encode(const char *table64,
   if(!insize)
     return CURLE_OK;
 
-#if SIZEOF_SIZE_T == 4
-  if(insize > UINT_MAX/4)
-    return CURLE_OUT_OF_MEMORY;
-#endif
+  /* safety precaution */
+  DEBUGASSERT(insize <= CURL_MAX_BASE64_INPUT);
+  if(insize > CURL_MAX_BASE64_INPUT)
+    return CURLE_TOO_LARGE;
 
   base64data = output = malloc((insize + 2) / 3 * 4 + 1);
   if(!output)

--- a/lib/curlx/base64.h
+++ b/lib/curlx/base64.h
@@ -33,4 +33,8 @@ CURLcode curlx_base64_decode(const char *src,
 
 extern const char Curl_base64encdec[];
 
+/* maximum input length acceptable to base64 encode, here to catch and prevent
+   mistakes */
+#define CURL_MAX_BASE64_INPUT 16000000
+
 #endif /* HEADER_CURL_BASE64_H */


### PR DESCRIPTION
The maximum size is set to 16MB.

It should not possible to call this function with this large input, but this is a precaution to catch mistakes and replaces the earlier check on architectures with small size_t.