### PR TITLE
Windows: Add long path support for CreateFile operations

### DIFF
--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -321,4 +321,39 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
   return result;
 }
 
+TCHAR *curlx_win32_fix_long_path(const char *path)
+{
+  TCHAR *result = NULL;
+  TCHAR *fixed = NULL;
+  const TCHAR *target;
+
+  if(!path)
+    return NULL;
+
+#ifdef _UNICODE
+  wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
+  if(!path_w)
+    return NULL;
+
+  if(fix_excessive_path(path_w, &fixed))
+    target = fixed;
+  else
+    target = path_w;
+
+  result = (_wcsdup)(target);
+  (free)(fixed);
+  curlx_unicodefree(path_w);
+#else
+  if(fix_excessive_path(path, &fixed))
+    target = fixed;
+  else
+    target = path;
+
+  result = (strdup)(target);
+  (free)(fixed);
+#endif
+
+  return result;
+}
+
 #endif /* _WIN32 && !UNDER_CE */

--- a/lib/curlx/fopen.h
+++ b/lib/curlx/fopen.h
@@ -38,6 +38,7 @@ int curlx_fseek(void *stream, curl_off_t offset, int whence);
 FILE *curlx_win32_fopen(const char *filename, const char *mode);
 int curlx_win32_stat(const char *path, struct_stat *buffer);
 int curlx_win32_open(const char *filename, int oflag, ...);
+TCHAR *curlx_win32_fix_long_path(const char *path);
 #define CURLX_FOPEN_LOW(fname, mode) curlx_win32_fopen(fname, mode)
 #define curlx_stat(fname, stp)       curlx_win32_stat(fname, stp)
 #define curlx_open                   curlx_win32_open

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -41,7 +41,7 @@ int getfiletime(const char *filename, curl_off_t *stamp)
    access to a 64-bit type we can bypass stat and get the times directly. */
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
   HANDLE hfile;
-  TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar(filename);
+  TCHAR *tchar_filename = curlx_win32_fix_long_path(filename);
 
   hfile = CreateFile(tchar_filename, FILE_READ_ATTRIBUTES,
                      (FILE_SHARE_READ | FILE_SHARE_WRITE |
@@ -94,7 +94,7 @@ void setfiletime(curl_off_t filetime, const char *filename)
    access to a 64-bit type we can bypass utime and set the times directly. */
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
   HANDLE hfile;
-  TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar(filename);
+  TCHAR *tchar_filename = curlx_win32_fix_long_path(filename);
 
   /* 910670515199 is the maximum Unix filetime that can be used as a Windows
      FILETIME without overflow: 30827-12-31T23:59:59. */


### PR DESCRIPTION
Fixes: https://github.com/curl/curl/issues/8361

This PR extends Windows long path support (paths > 260 characters) to file operations using CreateFile API, particularly for getting and setting file timestamps in the curl command-line tool.

Implement curlx_win32_fix_long_path() to normalize, handle excessive/\\?\ long Windows paths and return a heap-allocated TCHAR* (UTF-16 or multibyte as appropriate). Replace direct curlx_convert_UTF8_to_tchar() calls in tool_filetime with the new helper so filetime operations work with long paths.