### PR TITLE
test446, 1034, 1160: set US-ASCII encoding in XML header

### DIFF
--- a/tests/data/test1034
+++ b/tests/data/test1034
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="US-ASCII"?>
 <testcase>
 <info>
 <keywords>

--- a/tests/data/test1160
+++ b/tests/data/test1160
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="US-ASCII"?>
 <testcase>
 <info>
 <keywords>

--- a/tests/data/test446
+++ b/tests/data/test446
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="US-ASCII"?>
 <testcase>
 <info>
 <keywords>


### PR DESCRIPTION
To match the ASCII-7 requirement for curl test data files.

Follow-up to 9243ed59b387a90940fa4a16ebfd99ad7d6c2f63 #17329
Follow-up to 87ba80a6df1dfd7ceaaa52352c9f23afff0ed513
