### PR TITLE
examples: consistent variable naming across examples

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -91,68 +91,68 @@ static size_t write_cb(char *data, size_t n, size_t l, void *userp)
   return n * l;
 }
 
-static void add_transfer(CURLM *cm, unsigned int i, int *left)
+static void add_transfer(CURLM *multi, unsigned int i, int *left)
 {
-  CURL *eh = curl_easy_init();
-  if(eh) {
-    curl_easy_setopt(eh, CURLOPT_WRITEFUNCTION, write_cb);
-    curl_easy_setopt(eh, CURLOPT_URL, urls[i]);
-    curl_easy_setopt(eh, CURLOPT_PRIVATE, urls[i]);
-    curl_multi_add_handle(cm, eh);
+  CURL *curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_URL, urls[i]);
+    curl_easy_setopt(curl, CURLOPT_PRIVATE, urls[i]);
+    curl_multi_add_handle(multi, curl);
   }
   (*left)++;
 }
 
 int main(void)
 {
-  CURLM *cm;
+  CURLM *multi;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
-  cm = curl_multi_init();
-  if(cm) {
+  multi = curl_multi_init();
+  if(multi) {
     CURLMsg *msg;
     unsigned int transfers = 0;
     int msgs_left = -1;
     int left = 0;
 
     /* Limit the amount of simultaneous connections curl should allow: */
-    curl_multi_setopt(cm, CURLMOPT_MAXCONNECTS, (long)MAX_PARALLEL);
+    curl_multi_setopt(multi, CURLMOPT_MAXCONNECTS, (long)MAX_PARALLEL);
 
     for(transfers = 0; transfers < MAX_PARALLEL && transfers < NUM_URLS;
         transfers++)
-      add_transfer(cm, transfers, &left);
+      add_transfer(multi, transfers, &left);
 
     do {
       int still_alive = 1;
-      curl_multi_perform(cm, &still_alive);
+      curl_multi_perform(multi, &still_alive);
 
       /* !checksrc! disable EQUALSNULL 1 */
-      while((msg = curl_multi_info_read(cm, &msgs_left)) != NULL) {
+      while((msg = curl_multi_info_read(multi, &msgs_left)) != NULL) {
         if(msg->msg == CURLMSG_DONE) {
           char *url;
-          CURL *e = msg->easy_handle;
-          curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIVATE, &url);
+          CURL *curl = msg->easy_handle;
+          curl_easy_getinfo(curl, CURLINFO_PRIVATE, &url);
           fprintf(stderr, "R: %d - %s <%s>\n",
                   msg->data.result, curl_easy_strerror(msg->data.result), url);
-          curl_multi_remove_handle(cm, e);
-          curl_easy_cleanup(e);
+          curl_multi_remove_handle(multi, curl);
+          curl_easy_cleanup(curl);
           left--;
         }
         else {
           fprintf(stderr, "E: CURLMsg (%d)\n", msg->msg);
         }
         if(transfers < NUM_URLS)
-          add_transfer(cm, transfers++, &left);
+          add_transfer(multi, transfers++, &left);
       }
       if(left)
-        curl_multi_wait(cm, NULL, 0, 1000, NULL);
+        curl_multi_wait(multi, NULL, 0, 1000, NULL);
 
     } while(left);
 
-    curl_multi_cleanup(cm);
+    curl_multi_cleanup(multi);
   }
   curl_global_cleanup();
 

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -69,7 +69,7 @@ static int my_seek(void *userp, curl_off_t offset, int origin)
 }
 
 /* read callback function, fread() look alike */
-static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t nread;
 
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
   curl = curl_easy_init();
   if(curl) {
     /* we want to use our own read function */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
 
     /* which file to upload */
     curl_easy_setopt(curl, CURLOPT_READDATA, (void *) fp);

--- a/docs/examples/cacertinmem.c
+++ b/docs/examples/cacertinmem.c
@@ -48,7 +48,7 @@ typedef size_t ossl_valsize_t;
 typedef int ossl_valsize_t;
 #endif
 
-static size_t writefunction(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   fwrite(ptr, size, nmemb, (FILE *)stream);
   return nmemb * size;
@@ -115,37 +115,37 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *pointer)
 
 int main(void)
 {
-  CURL *ch;
+  CURL *curl;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
-  ch = curl_easy_init();
-  if(ch) {
-    curl_easy_setopt(ch, CURLOPT_VERBOSE, 0L);
-    curl_easy_setopt(ch, CURLOPT_HEADER, 0L);
-    curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
-    curl_easy_setopt(ch, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, writefunction);
-    curl_easy_setopt(ch, CURLOPT_WRITEDATA, stdout);
-    curl_easy_setopt(ch, CURLOPT_HEADERFUNCTION, writefunction);
-    curl_easy_setopt(ch, CURLOPT_HEADERDATA, stderr);
-    curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
-    curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 0L);
+    curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, stderr);
+    curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
 
     /* Turn off the default CA locations, otherwise libcurl loads CA
      * certificates from the locations that were detected/specified at
      * build-time
      */
-    curl_easy_setopt(ch, CURLOPT_CAINFO, NULL);
-    curl_easy_setopt(ch, CURLOPT_CAPATH, NULL);
+    curl_easy_setopt(curl, CURLOPT_CAINFO, NULL);
+    curl_easy_setopt(curl, CURLOPT_CAPATH, NULL);
 
     /* first try: retrieve page without ca certificates -> should fail
      * unless libcurl was built --with-ca-fallback enabled at build-time
      */
-    res = curl_easy_perform(ch);
+    res = curl_easy_perform(curl);
     if(res == CURLE_OK)
       printf("*** transfer succeeded ***\n");
     else
@@ -155,24 +155,24 @@ int main(void)
      * performance of multiple transfers but it is necessary order to
      * demonstrate this example. recall that the ssl ctx callback is only
      * called _before_ an SSL connection is established, therefore it does not
-     * affect existing verified SSL connections already in the connection cache
-     * associated with this handle. normally you would set the ssl ctx function
-     * before making any transfers, and not use this option.
+     * affect existing verified SSL connections already in the connection
+     * cache associated with this handle. normally you would set the ssl ctx
+     * function before making any transfers, and not use this option.
      */
-    curl_easy_setopt(ch, CURLOPT_FRESH_CONNECT, 1L);
+    curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1L);
 
-    /* second try: retrieve page using cacerts' certificate -> succeeds to load
-     * the certificate by installing a function doing the necessary
+    /* second try: retrieve page using cacerts' certificate -> succeeds to
+     * load the certificate by installing a function doing the necessary
      * "modifications" to the SSL CONTEXT just before link init
      */
-    curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, sslctx_function);
-    res = curl_easy_perform(ch);
+    curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, sslctx_function);
+    res = curl_easy_perform(curl);
     if(res == CURLE_OK)
       printf("*** transfer succeeded ***\n");
     else
       printf("*** transfer failed ***\n");
 
-    curl_easy_cleanup(ch);
+    curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
   return (int)res;

--- a/docs/examples/certinfo.c
+++ b/docs/examples/certinfo.c
@@ -29,7 +29,7 @@
 
 #include <curl/curl.h>
 
-static size_t wrfu(void *ptr,  size_t  size,  size_t  nmemb,  void *stream)
+static size_t write_cb(void *ptr,  size_t  size,  size_t  nmemb,  void *stream)
 {
   (void)stream;
   (void)ptr;
@@ -49,7 +49,7 @@ int main(void)
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
 
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, wrfu);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);

--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -52,7 +52,7 @@
 
 #define CHKSPEED_VERSION "1.0"
 
-static size_t WriteCallback(void *ptr, size_t size, size_t nmemb, void *data)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
 {
   /* we are not interested in the downloaded bytes itself,
      so we only return the size we would have saved ... */
@@ -63,7 +63,7 @@ static size_t WriteCallback(void *ptr, size_t size, size_t nmemb, void *data)
 
 int main(int argc, char *argv[])
 {
-  CURL *curl_handle;
+  CURL *curl;
   CURLcode res;
   int prtall = 0, prtsep = 0, prttime = 0;
   const char *url = URL_1M;
@@ -161,33 +161,33 @@ int main(int argc, char *argv[])
     return (int)res;
 
   /* init the curl session */
-  curl_handle = curl_easy_init();
-  if(curl_handle) {
+  curl = curl_easy_init();
+  if(curl) {
 
     /* specify URL to get */
-    curl_easy_setopt(curl_handle, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_URL, url);
 
     /* send all data to this function  */
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     /* some servers do not like requests that are made without a user-agent
        field, so we provide one */
-    curl_easy_setopt(curl_handle, CURLOPT_USERAGENT,
+    curl_easy_setopt(curl, CURLOPT_USERAGENT,
                      "libcurl-speedchecker/" CHKSPEED_VERSION);
 
     /* get it! */
-    res = curl_easy_perform(curl_handle);
+    res = curl_easy_perform(curl);
 
     if(CURLE_OK == res) {
       curl_off_t val;
 
       /* check for bytes downloaded */
-      res = curl_easy_getinfo(curl_handle, CURLINFO_SIZE_DOWNLOAD_T, &val);
+      res = curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD_T, &val);
       if((CURLE_OK == res) && (val > 0))
         printf("Data downloaded: %" CURL_FORMAT_CURL_OFF_T " bytes.\n", val);
 
       /* check for total download time */
-      res = curl_easy_getinfo(curl_handle, CURLINFO_TOTAL_TIME_T, &val);
+      res = curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME_T, &val);
       if((CURLE_OK == res) && (val > 0))
         printf("Total download time: %" CURL_FORMAT_CURL_OFF_T
                ".%06" CURL_FORMAT_CURL_OFF_T " sec.\n",
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
                val % 1000000);
 
       /* check for average download speed */
-      res = curl_easy_getinfo(curl_handle, CURLINFO_SPEED_DOWNLOAD_T, &val);
+      res = curl_easy_getinfo(curl, CURLINFO_SPEED_DOWNLOAD_T, &val);
       if((CURLE_OK == res) && (val > 0))
         printf("Average download speed: "
                "%" CURL_FORMAT_CURL_OFF_T " kbyte/sec.\n",
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
 
       if(prtall) {
         /* check for name resolution time */
-        res = curl_easy_getinfo(curl_handle, CURLINFO_NAMELOOKUP_TIME_T, &val);
+        res = curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME_T, &val);
         if((CURLE_OK == res) && (val > 0))
           printf("Name lookup time: %" CURL_FORMAT_CURL_OFF_T
                  ".%06" CURL_FORMAT_CURL_OFF_T " sec.\n",
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
                  val % 1000000);
 
         /* check for connect time */
-        res = curl_easy_getinfo(curl_handle, CURLINFO_CONNECT_TIME_T, &val);
+        res = curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME_T, &val);
         if((CURLE_OK == res) && (val > 0))
           printf("Connect time: %" CURL_FORMAT_CURL_OFF_T
                  ".%06" CURL_FORMAT_CURL_OFF_T " sec.\n",
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
     }
 
     /* cleanup curl stuff */
-    curl_easy_cleanup(curl_handle);
+    curl_easy_cleanup(curl);
   }
 
   /* we are done with libcurl, so clean it up */

--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -60,7 +60,7 @@ struct memory {
   size_t size;
 };
 
-static size_t grow_buffer(void *contents, size_t sz, size_t nmemb, void *ctx)
+static size_t write_cb(void *contents, size_t sz, size_t nmemb, void *ctx)
 {
   size_t realsize = sz * nmemb;
   struct memory *mem = (struct memory*) ctx;
@@ -78,48 +78,48 @@ static size_t grow_buffer(void *contents, size_t sz, size_t nmemb, void *ctx)
 
 static CURL *make_handle(const char *url)
 {
-  CURL *handle = curl_easy_init();
+  CURL *curl = curl_easy_init();
   struct memory *mem;
 
   /* Important: use HTTP2 over HTTPS */
-  curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
-  curl_easy_setopt(handle, CURLOPT_URL, url);
+  curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
+  curl_easy_setopt(curl, CURLOPT_URL, url);
 
   /* buffer body */
   mem = malloc(sizeof(*mem));
   mem->size = 0;
   mem->buf = malloc(1);
-  curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, grow_buffer);
-  curl_easy_setopt(handle, CURLOPT_WRITEDATA, mem);
-  curl_easy_setopt(handle, CURLOPT_PRIVATE, mem);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, mem);
+  curl_easy_setopt(curl, CURLOPT_PRIVATE, mem);
 
   /* For completeness */
-  curl_easy_setopt(handle, CURLOPT_ACCEPT_ENCODING, "");
-  curl_easy_setopt(handle, CURLOPT_TIMEOUT, 5L);
-  curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   /* only allow redirects to HTTP and HTTPS URLs */
-  curl_easy_setopt(handle, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
-  curl_easy_setopt(handle, CURLOPT_AUTOREFERER, 1L);
-  curl_easy_setopt(handle, CURLOPT_MAXREDIRS, 10L);
+  curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+  curl_easy_setopt(curl, CURLOPT_AUTOREFERER, 1L);
+  curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 10L);
   /* each transfer needs to be done within 20 seconds! */
-  curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, 20000L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 20000L);
   /* connect fast or fail */
-  curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT_MS, 2000L);
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 2000L);
   /* skip files larger than a gigabyte */
-  curl_easy_setopt(handle, CURLOPT_MAXFILESIZE_LARGE,
+  curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE,
                    (curl_off_t)1024*1024*1024);
-  curl_easy_setopt(handle, CURLOPT_COOKIEFILE, "");
-  curl_easy_setopt(handle, CURLOPT_FILETIME, 1L);
-  curl_easy_setopt(handle, CURLOPT_USERAGENT, "mini crawler");
-  curl_easy_setopt(handle, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
-  curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 1L);
-  curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
-  curl_easy_setopt(handle, CURLOPT_EXPECT_100_TIMEOUT_MS, 0L);
-  return handle;
+  curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
+  curl_easy_setopt(curl, CURLOPT_FILETIME, 1L);
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, "mini crawler");
+  curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
+  curl_easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+  curl_easy_setopt(curl, CURLOPT_EXPECT_100_TIMEOUT_MS, 0L);
+  return curl;
 }
 
 /* HREF finder implemented in libxml2 but could be any HTML parser */
-static size_t follow_links(CURLM *multi_handle, struct memory *mem,
+static size_t follow_links(CURLM *multi, struct memory *mem,
                            const char *url)
 {
   int opts = HTML_PARSE_NOBLANKS | HTML_PARSE_NOERROR | \
@@ -160,7 +160,7 @@ static size_t follow_links(CURLM *multi_handle, struct memory *mem,
     if(!link || strlen(link) < 20)
       continue;
     if(!strncmp(link, "http://", 7) || !strncmp(link, "https://", 8)) {
-      curl_multi_add_handle(multi_handle, make_handle(link));
+      curl_multi_add_handle(multi, make_handle(link));
       if(count++ == max_link_per_page)
         break;
     }
@@ -177,7 +177,7 @@ static int is_html(char *ctype)
 
 int main(void)
 {
-  CURLM *multi_handle;
+  CURLM *multi;
   int msgs_left;
   int pending;
   int complete;
@@ -190,18 +190,18 @@ int main(void)
 
   signal(SIGINT, sighandler);
   LIBXML_TEST_VERSION
-  multi_handle = curl_multi_init();
-  if(multi_handle) {
-    curl_multi_setopt(multi_handle, CURLMOPT_MAX_TOTAL_CONNECTIONS, max_con);
-    curl_multi_setopt(multi_handle, CURLMOPT_MAX_HOST_CONNECTIONS, 6L);
+  multi = curl_multi_init();
+  if(multi) {
+    curl_multi_setopt(multi, CURLMOPT_MAX_TOTAL_CONNECTIONS, max_con);
+    curl_multi_setopt(multi, CURLMOPT_MAX_HOST_CONNECTIONS, 6L);
 
     /* enables http/2 if available */
 #ifdef CURLPIPE_MULTIPLEX
-    curl_multi_setopt(multi_handle, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
+    curl_multi_setopt(multi, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
 #endif
 
     /* sets html start page */
-    curl_multi_add_handle(multi_handle, make_handle(start_page));
+    curl_multi_add_handle(multi, make_handle(start_page));
 
     pending = 0;
     complete = 0;
@@ -210,29 +210,29 @@ int main(void)
       int numfds;
       CURLMsg *m;
 
-      curl_multi_wait(multi_handle, NULL, 0, 1000, &numfds);
-      curl_multi_perform(multi_handle, &still_running);
+      curl_multi_wait(multi, NULL, 0, 1000, &numfds);
+      curl_multi_perform(multi, &still_running);
 
       /* See how the transfers went */
       m = NULL;
-      while((m = curl_multi_info_read(multi_handle, &msgs_left))) {
+      while((m = curl_multi_info_read(multi, &msgs_left))) {
         if(m->msg == CURLMSG_DONE) {
-          CURL *handle = m->easy_handle;
+          CURL *curl = m->easy_handle;
           char *url;
           struct memory *mem;
-          curl_easy_getinfo(handle, CURLINFO_PRIVATE, &mem);
-          curl_easy_getinfo(handle, CURLINFO_EFFECTIVE_URL, &url);
+          curl_easy_getinfo(curl, CURLINFO_PRIVATE, &mem);
+          curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url);
           if(m->data.result == CURLE_OK) {
             long res_status;
-            curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &res_status);
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &res_status);
             if(res_status == 200) {
               char *ctype;
-              curl_easy_getinfo(handle, CURLINFO_CONTENT_TYPE, &ctype);
+              curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &ctype);
               printf("[%d] HTTP 200 (%s): %s\n", complete, ctype, url);
               if(is_html(ctype) && mem->size > 100) {
                 if(pending < max_requests &&
                    (complete + pending) < max_total) {
-                  pending += follow_links(multi_handle, mem, url);
+                  pending += follow_links(multi_curl, mem, url);
                   still_running = 1;
                 }
               }
@@ -244,8 +244,8 @@ int main(void)
           else {
             printf("[%d] Connection failure: %s\n", complete, url);
           }
-          curl_multi_remove_handle(multi_handle, handle);
-          curl_easy_cleanup(handle);
+          curl_multi_remove_handle(multi, curl);
+          curl_easy_cleanup(curl);
           free(mem->buf);
           free(mem);
           complete++;
@@ -253,7 +253,7 @@ int main(void)
         }
       }
     }
-    curl_multi_cleanup(multi_handle);
+    curl_multi_cleanup(multi);
   }
   curl_global_cleanup();
   return 0;

--- a/docs/examples/debug.c
+++ b/docs/examples/debug.c
@@ -81,12 +81,12 @@ static void dump(const char *text, FILE *stream, unsigned char *ptr,
   fflush(stream);
 }
 
-static int my_trace(CURL *handle, curl_infotype type,
+static int my_trace(CURL *curl, curl_infotype type,
                     char *data, size_t size, void *userp)
 {
   struct data *config = (struct data *)userp;
   const char *text;
-  (void)handle;
+  (void)curl;
 
   switch(type) {
   case CURLINFO_TEXT:

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -90,7 +90,7 @@ struct GlobalInfo {
 
 /* Information associated with a specific easy handle */
 struct ConnInfo {
-  CURL *easy;
+  CURL *curl;
   char *url;
   struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
@@ -99,7 +99,7 @@ struct ConnInfo {
 /* Information associated with a specific socket */
 struct SockInfo {
   curl_socket_t sockfd;
-  CURL *easy;
+  CURL *curl;
   int action;
   long timeout;
   struct GlobalInfo *global;
@@ -172,20 +172,18 @@ static void check_multi_info(struct GlobalInfo *g)
   CURLMsg *msg;
   int msgs_left;
   struct ConnInfo *conn;
-  CURL *easy;
-  CURLcode res;
 
   fprintf(MSG_OUT, "REMAINING: %d\n", g->still_running);
   while((msg = curl_multi_info_read(g->multi, &msgs_left))) {
     if(msg->msg == CURLMSG_DONE) {
-      easy = msg->easy_handle;
-      res = msg->data.result;
-      curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
-      curl_easy_getinfo(easy, CURLINFO_EFFECTIVE_URL, &eff_url);
+      CURL *curl = msg->easy_handle;
+      CURLcode res = msg->data.result;
+      curl_easy_getinfo(curl, CURLINFO_PRIVATE, &conn);
+      curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &eff_url);
       fprintf(MSG_OUT, "DONE: %s => (%d) %s\n", eff_url, res, conn->error);
-      curl_multi_remove_handle(g->multi, easy);
+      curl_multi_remove_handle(g->multi, curl);
       free(conn->url);
-      curl_easy_cleanup(easy);
+      curl_easy_cleanup(curl);
       free(conn);
     }
   }
@@ -270,7 +268,7 @@ static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
 
   f->sockfd = s;
   f->action = act;
-  f->easy = e;
+  f->curl = e;
 
   ev.events = kind;
   ev.data.fd = s;
@@ -280,13 +278,13 @@ static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
 }
 
 /* Initialize a new SockInfo structure */
-static void addsock(curl_socket_t s, CURL *easy, int action,
+static void addsock(curl_socket_t s, CURL *curl, int action,
                     struct GlobalInfo *g)
 {
   struct SockInfo *fdp = (struct SockInfo*)calloc(1, sizeof(struct SockInfo));
 
   fdp->global = g;
-  setsock(fdp, s, easy, action, g);
+  setsock(fdp, s, curl, action, g);
   curl_multi_assign(g->multi, s, fdp);
 }
 
@@ -347,28 +345,28 @@ static void new_conn(const char *url, struct GlobalInfo *g)
   conn = (struct ConnInfo*)calloc(1, sizeof(*conn));
   conn->error[0] = '\0';
 
-  conn->easy = curl_easy_init();
-  if(!conn->easy) {
+  conn->curl = curl_easy_init();
+  if(!conn->curl) {
     fprintf(MSG_OUT, "curl_easy_init() failed, exiting!\n");
     exit(2);
   }
   conn->global = g;
   conn->url = strdup(url);
-  curl_easy_setopt(conn->easy, CURLOPT_URL, conn->url);
-  curl_easy_setopt(conn->easy, CURLOPT_WRITEFUNCTION, write_cb);
-  curl_easy_setopt(conn->easy, CURLOPT_WRITEDATA, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_VERBOSE, 1L);
-  curl_easy_setopt(conn->easy, CURLOPT_ERRORBUFFER, conn->error);
-  curl_easy_setopt(conn->easy, CURLOPT_PRIVATE, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_NOPROGRESS, 0L);
-  curl_easy_setopt(conn->easy, CURLOPT_PROGRESSFUNCTION, prog_cb);
-  curl_easy_setopt(conn->easy, CURLOPT_PROGRESSDATA, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_FOLLOWLOCATION, 1L);
-  curl_easy_setopt(conn->easy, CURLOPT_LOW_SPEED_TIME, 3L);
-  curl_easy_setopt(conn->easy, CURLOPT_LOW_SPEED_LIMIT, 10L);
+  curl_easy_setopt(conn->curl, CURLOPT_URL, conn->url);
+  curl_easy_setopt(conn->curl, CURLOPT_WRITEFUNCTION, write_cb);
+  curl_easy_setopt(conn->curl, CURLOPT_WRITEDATA, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_VERBOSE, 1L);
+  curl_easy_setopt(conn->curl, CURLOPT_ERRORBUFFER, conn->error);
+  curl_easy_setopt(conn->curl, CURLOPT_PRIVATE, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_NOPROGRESS, 0L);
+  curl_easy_setopt(conn->curl, CURLOPT_PROGRESSFUNCTION, prog_cb);
+  curl_easy_setopt(conn->curl, CURLOPT_PROGRESSDATA, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(conn->curl, CURLOPT_LOW_SPEED_TIME, 3L);
+  curl_easy_setopt(conn->curl, CURLOPT_LOW_SPEED_LIMIT, 10L);
   fprintf(MSG_OUT,
-          "Adding easy %p to multi %p (%s)\n", conn->easy, g->multi, url);
-  rc = curl_multi_add_handle(g->multi, conn->easy);
+          "Adding easy %p to multi %p (%s)\n", conn->curl, g->multi, url);
+  rc = curl_multi_add_handle(g->multi, conn->curl);
   mcode_or_die("new_conn: curl_multi_add_handle", rc);
 
   /* note that the add_handle() sets a timeout to trigger soon so that the

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -60,7 +60,7 @@
 #define INADDR_NONE 0xffffffff
 #endif
 
-static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
   return written;
@@ -143,7 +143,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
 
     /* send all data to this function  */
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     /* call this function to get a socket */
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket);

--- a/docs/examples/ftp-delete.c
+++ b/docs/examples/ftp-delete.c
@@ -30,7 +30,7 @@
  * </DESC>
  */
 
-static size_t my_fwrite(void *buffer, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *buffer, size_t size, size_t nmemb, void *stream)
 {
   (void)buffer;
   (void)stream;
@@ -54,7 +54,7 @@ int main(void)
      */
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://ftp.example.com/");
     /* Define our callback to get called when there is data to be written */
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, my_fwrite);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     /* Switch on full protocol/debug output */
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/docs/examples/ftp-wildcard.c
+++ b/docs/examples/ftp-wildcard.c
@@ -78,7 +78,7 @@ static long file_is_downloaded(void *input)
   return CURL_CHUNK_END_FUNC_OK;
 }
 
-static size_t write_it(char *buff, size_t size, size_t nmemb,
+static size_t write_cb(char *buff, size_t size, size_t nmemb,
                        void *cb_data)
 {
   struct callback_data *data = cb_data;
@@ -94,7 +94,7 @@ static size_t write_it(char *buff, size_t size, size_t nmemb,
 int main(int argc, char **argv)
 {
   /* curl easy handle */
-  CURL *handle;
+  CURL *curl;
 
   /* help data */
   struct callback_data data = { 0 };
@@ -105,40 +105,40 @@ int main(int argc, char **argv)
     return (int)res;
 
   /* initialization of easy handle */
-  handle = curl_easy_init();
-  if(!handle) {
+  curl = curl_easy_init();
+  if(!curl) {
     curl_global_cleanup();
     return CURLE_OUT_OF_MEMORY;
   }
 
   /* turn on wildcard matching */
-  curl_easy_setopt(handle, CURLOPT_WILDCARDMATCH, 1L);
+  curl_easy_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
 
   /* callback is called before download of concrete file started */
-  curl_easy_setopt(handle, CURLOPT_CHUNK_BGN_FUNCTION, file_is_coming);
+  curl_easy_setopt(curl, CURLOPT_CHUNK_BGN_FUNCTION, file_is_coming);
 
   /* callback is called after data from the file have been transferred */
-  curl_easy_setopt(handle, CURLOPT_CHUNK_END_FUNCTION, file_is_downloaded);
+  curl_easy_setopt(curl, CURLOPT_CHUNK_END_FUNCTION, file_is_downloaded);
 
   /* this callback writes contents into files */
-  curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_it);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
   /* put transfer data into callbacks */
-  curl_easy_setopt(handle, CURLOPT_CHUNK_DATA, &data);
-  curl_easy_setopt(handle, CURLOPT_WRITEDATA, &data);
+  curl_easy_setopt(curl, CURLOPT_CHUNK_DATA, &data);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
 
-  /* curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L); */
+  /* curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L); */
 
   /* set a URL containing wildcard pattern (only in the last part) */
   if(argc == 2)
-    curl_easy_setopt(handle, CURLOPT_URL, argv[1]);
+    curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
   else
-    curl_easy_setopt(handle, CURLOPT_URL, "ftp://example.com/test/*");
+    curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/test/*");
 
   /* and start transfer! */
-  res = curl_easy_perform(handle);
+  res = curl_easy_perform(curl);
 
-  curl_easy_cleanup(handle);
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
   return (int)res;
 }

--- a/docs/examples/ftpget.c
+++ b/docs/examples/ftpget.c
@@ -35,7 +35,7 @@ struct FtpFile {
   FILE *stream;
 };
 
-static size_t my_fwrite(void *buffer, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *buffer, size_t size, size_t nmemb, void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
   if(!out->stream) {
@@ -69,7 +69,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL,
                      "ftp://ftp.example.com/curl/curl-7.9.2.tar.gz");
     /* Define our callback to get called when there is data to be written */
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, my_fwrite);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     /* Set a pointer to our struct to pass to the callback */
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ftpfile);
 

--- a/docs/examples/ftpsget.c
+++ b/docs/examples/ftpsget.c
@@ -36,7 +36,7 @@ struct FtpFile {
   FILE *stream;
 };
 
-static size_t my_fwrite(void *buffer, size_t size, size_t nmemb,
+static size_t write_cb(void *buffer, size_t size, size_t nmemb,
                         void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
@@ -73,7 +73,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL,
                      "ftp://user@server/home/user/file.txt");
     /* Define our callback to get called when there is data to be written */
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, my_fwrite);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     /* Set a pointer to our struct to pass to the callback */
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ftpfile);
 

--- a/docs/examples/ftpupload.c
+++ b/docs/examples/ftpupload.c
@@ -59,7 +59,7 @@
    you MUST also provide a read callback with CURLOPT_READFUNCTION. Failing to
    do so might give you a crash since a DLL may not use the variable's memory
    when passed in to it from an app like this. */
-static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   unsigned long nread;
   /* in real-world cases, this would probably get this data differently
@@ -123,7 +123,7 @@ int main(void)
     headerlist = curl_slist_append(headerlist, buf_2);
 
     /* we want to use our own read function */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
 
     /* enable uploading */
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);

--- a/docs/examples/ftpuploadfrommem.c
+++ b/docs/examples/ftpuploadfrommem.c
@@ -45,7 +45,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *upload = (struct WriteThis *)userp;
   size_t max = size*nmemb;
@@ -99,7 +99,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
     /* we want to use our own read function */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
 
     /* pointer to pass to our read function */
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload);

--- a/docs/examples/ftpuploadresume.c
+++ b/docs/examples/ftpuploadresume.c
@@ -45,7 +45,7 @@ static size_t getcontentlengthfunc(void *ptr, size_t size, size_t nmemb,
 }
 
 /* discard downloaded data */
-static size_t discardfunc(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   (void)ptr;
   (void)stream;
@@ -53,7 +53,7 @@ static size_t discardfunc(void *ptr, size_t size, size_t nmemb, void *stream)
 }
 
 /* read data to upload */
-static size_t readfunc(char *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   FILE *f = stream;
   size_t n;
@@ -67,12 +67,12 @@ static size_t readfunc(char *ptr, size_t size, size_t nmemb, void *stream)
 }
 
 
-static int upload(CURL *curlhandle, const char *remotepath,
+static int upload(CURL *curl, const char *remotepath,
                   const char *localpath, long timeout, long tries)
 {
   FILE *f;
   long uploaded_len = 0;
-  CURLcode r = CURLE_GOT_NOTHING;
+  CURLcode res = CURLE_GOT_NOTHING;
   int c;
 
   f = fopen(localpath, "rb");
@@ -83,32 +83,32 @@ static int upload(CURL *curlhandle, const char *remotepath,
     return 0;
   }
 
-  curl_easy_setopt(curlhandle, CURLOPT_UPLOAD, 1L);
+  curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
-  curl_easy_setopt(curlhandle, CURLOPT_URL, remotepath);
+  curl_easy_setopt(curl, CURLOPT_URL, remotepath);
 
   if(timeout)
-    curl_easy_setopt(curlhandle, CURLOPT_SERVER_RESPONSE_TIMEOUT, timeout);
+    curl_easy_setopt(curl, CURLOPT_SERVER_RESPONSE_TIMEOUT, timeout);
 
-  curl_easy_setopt(curlhandle, CURLOPT_HEADERFUNCTION, getcontentlengthfunc);
-  curl_easy_setopt(curlhandle, CURLOPT_HEADERDATA, &uploaded_len);
+  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, getcontentlengthfunc);
+  curl_easy_setopt(curl, CURLOPT_HEADERDATA, &uploaded_len);
 
-  curl_easy_setopt(curlhandle, CURLOPT_WRITEFUNCTION, discardfunc);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
-  curl_easy_setopt(curlhandle, CURLOPT_READFUNCTION, readfunc);
-  curl_easy_setopt(curlhandle, CURLOPT_READDATA, f);
+  curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
+  curl_easy_setopt(curl, CURLOPT_READDATA, f);
 
   /* enable active mode */
-  curl_easy_setopt(curlhandle, CURLOPT_FTPPORT, "-");
+  curl_easy_setopt(curl, CURLOPT_FTPPORT, "-");
 
   /* allow the server no more than 7 seconds to connect back */
-  curl_easy_setopt(curlhandle, CURLOPT_ACCEPTTIMEOUT_MS, 7000L);
+  curl_easy_setopt(curl, CURLOPT_ACCEPTTIMEOUT_MS, 7000L);
 
-  curl_easy_setopt(curlhandle, CURLOPT_FTP_CREATE_MISSING_DIRS, 1L);
+  curl_easy_setopt(curl, CURLOPT_FTP_CREATE_MISSING_DIRS, 1L);
 
-  curl_easy_setopt(curlhandle, CURLOPT_VERBOSE, 1L);
+  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  for(c = 0; (r != CURLE_OK) && (c < tries); c++) {
+  for(c = 0; (res != CURLE_OK) && (c < tries); c++) {
     /* are we resuming? */
     if(c) { /* yes */
       /* determine the length of the file already written */
@@ -116,55 +116,52 @@ static int upload(CURL *curlhandle, const char *remotepath,
       /*
        * With NOBODY and NOHEADER, libcurl issues a SIZE command, but the only
        * way to retrieve the result is to parse the returned Content-Length
-       * header. Thus, getcontentlengthfunc(). We need discardfunc() above
+       * header. Thus, getcontentlengthfunc(). We need write_cb() above
        * because HEADER dumps the headers to stdout without it.
        */
-      curl_easy_setopt(curlhandle, CURLOPT_NOBODY, 1L);
-      curl_easy_setopt(curlhandle, CURLOPT_HEADER, 1L);
+      curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+      curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
 
-      r = curl_easy_perform(curlhandle);
-      if(r != CURLE_OK)
+      res = curl_easy_perform(curl);
+      if(res != CURLE_OK)
         continue;
 
-      curl_easy_setopt(curlhandle, CURLOPT_NOBODY, 0L);
-      curl_easy_setopt(curlhandle, CURLOPT_HEADER, 0L);
+      curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
+      curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
 
       fseek(f, uploaded_len, SEEK_SET);
 
-      curl_easy_setopt(curlhandle, CURLOPT_APPEND, 1L);
+      curl_easy_setopt(curl, CURLOPT_APPEND, 1L);
     }
     else { /* no */
-      curl_easy_setopt(curlhandle, CURLOPT_APPEND, 0L);
+      curl_easy_setopt(curl, CURLOPT_APPEND, 0L);
     }
 
-    r = curl_easy_perform(curlhandle);
+    res = curl_easy_perform(curl);
   }
 
   fclose(f);
 
-  if(r == CURLE_OK)
+  if(res == CURLE_OK)
     return 1;
   else {
-    fprintf(stderr, "%s\n", curl_easy_strerror(r));
+    fprintf(stderr, "%s\n", curl_easy_strerror(res));
     return 0;
   }
 }
 
 int main(void)
 {
-  CURL *curlhandle = NULL;
+  CURL *curl = NULL;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
-  curlhandle = curl_easy_init();
-  if(curlhandle) {
-
-    upload(curlhandle, "ftp://user:pass@example.com/path/file", "C:\\file",
-           0, 3);
-
-    curl_easy_cleanup(curlhandle);
+  curl = curl_easy_init();
+  if(curl) {
+    upload(curl, "ftp://user:pass@example.com/path/file", "C:\\file", 0, 3);
+    curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
 

--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -38,7 +38,7 @@ struct MemoryStruct {
   size_t size;
 };
 
-static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb,
+static size_t write_cb(void *contents, size_t size, size_t nmemb,
                                   void *userp)
 {
   size_t realsize = size * nmemb;
@@ -61,7 +61,7 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb,
 
 int main(void)
 {
-  CURL *curl_handle;
+  CURL *curl;
   CURLcode res;
 
   struct MemoryStruct chunk;
@@ -74,24 +74,24 @@ int main(void)
   chunk.size = 0;    /* no data at this point */
 
   /* init the curl session */
-  curl_handle = curl_easy_init();
-  if(curl_handle) {
+  curl = curl_easy_init();
+  if(curl) {
 
     /* specify URL to get */
-    curl_easy_setopt(curl_handle, CURLOPT_URL, "https://www.example.com/");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
 
     /* send all data to this function  */
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     /* we pass our 'chunk' struct to the callback function */
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
 
     /* some servers do not like requests that are made without a user-agent
        field, so we provide one */
-    curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");
 
     /* get it! */
-    res = curl_easy_perform(curl_handle);
+    res = curl_easy_perform(curl);
 
     /* check for errors */
     if(res != CURLE_OK) {
@@ -110,7 +110,7 @@ int main(void)
     }
 
     /* cleanup curl stuff */
-    curl_easy_cleanup(curl_handle);
+    curl_easy_cleanup(curl);
   }
 
   free(chunk.memory);

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -78,7 +78,7 @@ struct GlobalInfo {
 
 /* Information associated with a specific easy handle */
 struct ConnInfo {
-  CURL *easy;
+  CURL *curl;
   char *url;
   struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
@@ -87,7 +87,7 @@ struct ConnInfo {
 /* Information associated with a specific socket */
 struct SockInfo {
   curl_socket_t sockfd;
-  CURL *easy;
+  CURL *curl;
   int action;
   long timeout;
   GIOChannel *ch;
@@ -124,16 +124,16 @@ static void check_multi_info(struct GlobalInfo *g)
   MSG_OUT("REMAINING: %d\n", g->still_running);
   while((msg = curl_multi_info_read(g->multi, &msgs_left))) {
     if(msg->msg == CURLMSG_DONE) {
-      CURL *easy = msg->easy_handle;
+      CURL *curl = msg->easy_handle;
       CURLcode res = msg->data.result;
       char *eff_url;
       struct ConnInfo *conn;
-      curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
-      curl_easy_getinfo(easy, CURLINFO_EFFECTIVE_URL, &eff_url);
+      curl_easy_getinfo(curl, CURLINFO_PRIVATE, &conn);
+      curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &eff_url);
       MSG_OUT("DONE: %s => (%d) %s\n", eff_url, res, conn->error);
-      curl_multi_remove_handle(g->multi, easy);
+      curl_multi_remove_handle(g->multi, curl);
       free(conn->url);
-      curl_easy_cleanup(easy);
+      curl_easy_cleanup(curl);
       free(conn);
     }
   }
@@ -223,7 +223,7 @@ static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
 
   f->sockfd = s;
   f->action = act;
-  f->easy = e;
+  f->curl = e;
   if(f->ev) {
     g_source_remove(f->ev);
   }
@@ -231,14 +231,14 @@ static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
 }
 
 /* Initialize a new SockInfo structure */
-static void addsock(curl_socket_t s, CURL *easy, int action,
+static void addsock(curl_socket_t s, CURL *curl, int action,
                     struct GlobalInfo *g)
 {
   struct SockInfo *fdp = g_malloc0(sizeof(struct SockInfo));
 
   fdp->global = g;
   fdp->ch = g_io_channel_unix_new(s);
-  setsock(fdp, s, easy, action, g);
+  setsock(fdp, s, curl, action, g);
   curl_multi_assign(g->multi, s, fdp);
 }
 
@@ -301,29 +301,29 @@ static void new_conn(const char *url, struct GlobalInfo *g)
 
   conn = g_malloc0(sizeof(*conn));
   conn->error[0] = '\0';
-  conn->easy = curl_easy_init();
-  if(!conn->easy) {
+  conn->curl = curl_easy_init();
+  if(!conn->curl) {
     MSG_OUT("curl_easy_init() failed, exiting!\n");
     exit(2);
   }
   conn->global = g;
   conn->url = g_strdup(url);
-  curl_easy_setopt(conn->easy, CURLOPT_URL, conn->url);
-  curl_easy_setopt(conn->easy, CURLOPT_WRITEFUNCTION, write_cb);
-  curl_easy_setopt(conn->easy, CURLOPT_WRITEDATA, &conn);
-  curl_easy_setopt(conn->easy, CURLOPT_VERBOSE, SHOW_VERBOSE);
-  curl_easy_setopt(conn->easy, CURLOPT_ERRORBUFFER, conn->error);
-  curl_easy_setopt(conn->easy, CURLOPT_PRIVATE, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_NOPROGRESS, SHOW_PROGRESS ? 0L : 1L);
-  curl_easy_setopt(conn->easy, CURLOPT_XFERINFOFUNCTION, xferinfo_cb);
-  curl_easy_setopt(conn->easy, CURLOPT_PROGRESSDATA, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_FOLLOWLOCATION, 1L);
-  curl_easy_setopt(conn->easy, CURLOPT_CONNECTTIMEOUT, 30L);
-  curl_easy_setopt(conn->easy, CURLOPT_LOW_SPEED_LIMIT, 1L);
-  curl_easy_setopt(conn->easy, CURLOPT_LOW_SPEED_TIME, 30L);
+  curl_easy_setopt(conn->curl, CURLOPT_URL, conn->url);
+  curl_easy_setopt(conn->curl, CURLOPT_WRITEFUNCTION, write_cb);
+  curl_easy_setopt(conn->curl, CURLOPT_WRITEDATA, &conn);
+  curl_easy_setopt(conn->curl, CURLOPT_VERBOSE, SHOW_VERBOSE);
+  curl_easy_setopt(conn->curl, CURLOPT_ERRORBUFFER, conn->error);
+  curl_easy_setopt(conn->curl, CURLOPT_PRIVATE, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_NOPROGRESS, SHOW_PROGRESS ? 0L : 1L);
+  curl_easy_setopt(conn->curl, CURLOPT_XFERINFOFUNCTION, xferinfo_cb);
+  curl_easy_setopt(conn->curl, CURLOPT_PROGRESSDATA, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(conn->curl, CURLOPT_CONNECTTIMEOUT, 30L);
+  curl_easy_setopt(conn->curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+  curl_easy_setopt(conn->curl, CURLOPT_LOW_SPEED_TIME, 30L);
 
-  MSG_OUT("Adding easy %p to multi %p (%s)\n", conn->easy, g->multi, url);
-  rc = curl_multi_add_handle(g->multi, conn->easy);
+  MSG_OUT("Adding easy %p to multi %p (%s)\n", conn->curl, g->multi, url);
+  rc = curl_multi_add_handle(g->multi, conn->curl);
   mcode_or_die("new_conn: curl_multi_add_handle", rc);
 
   /* note that add_handle() sets a timeout to trigger soon so that the

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -90,7 +90,7 @@ struct GlobalInfo {
 
 /* Information associated with a specific easy handle */
 struct ConnInfo {
-  CURL *easy;
+  CURL *curl;
   char *url;
   struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
@@ -99,7 +99,7 @@ struct ConnInfo {
 /* Information associated with a specific socket */
 struct SockInfo {
   curl_socket_t sockfd;
-  CURL *easy;
+  CURL *curl;
   int action;
   long timeout;
   struct event ev;
@@ -162,20 +162,18 @@ static void check_multi_info(struct GlobalInfo *g)
   CURLMsg *msg;
   int msgs_left;
   struct ConnInfo *conn;
-  CURL *easy;
-  CURLcode res;
 
   fprintf(MSG_OUT, "REMAINING: %d\n", g->still_running);
   while((msg = curl_multi_info_read(g->multi, &msgs_left))) {
     if(msg->msg == CURLMSG_DONE) {
-      easy = msg->easy_handle;
-      res = msg->data.result;
-      curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
-      curl_easy_getinfo(easy, CURLINFO_EFFECTIVE_URL, &eff_url);
+      CURL *curl = msg->easy_handle;
+      CURLcode res = msg->data.result;
+      curl_easy_getinfo(curl, CURLINFO_PRIVATE, &conn);
+      curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &eff_url);
       fprintf(MSG_OUT, "DONE: %s => (%d) %s\n", eff_url, res, conn->error);
-      curl_multi_remove_handle(g->multi, easy);
+      curl_multi_remove_handle(g->multi, curl);
       free(conn->url);
-      curl_easy_cleanup(easy);
+      curl_easy_cleanup(curl);
       free(conn);
     }
   }
@@ -240,7 +238,7 @@ static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
 
   f->sockfd = s;
   f->action = act;
-  f->easy = e;
+  f->curl = e;
   if(event_initialized(&f->ev)) {
     event_del(&f->ev);
   }
@@ -249,13 +247,13 @@ static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
 }
 
 /* Initialize a new SockInfo structure */
-static void addsock(curl_socket_t s, CURL *easy, int action,
+static void addsock(curl_socket_t s, CURL *curl, int action,
                     struct GlobalInfo *g)
 {
   struct SockInfo *fdp = calloc(1, sizeof(struct SockInfo));
 
   fdp->global = g;
-  setsock(fdp, s, easy, action, g);
+  setsock(fdp, s, curl, action, g);
   curl_multi_assign(g->multi, s, fdp);
 }
 
@@ -317,26 +315,26 @@ static void new_conn(const char *url, struct GlobalInfo *g)
   conn = calloc(1, sizeof(*conn));
   conn->error[0] = '\0';
 
-  conn->easy = curl_easy_init();
-  if(!conn->easy) {
+  conn->curl = curl_easy_init();
+  if(!conn->curl) {
     fprintf(MSG_OUT, "curl_easy_init() failed, exiting!\n");
     exit(2);
   }
   conn->global = g;
   conn->url = strdup(url);
-  curl_easy_setopt(conn->easy, CURLOPT_URL, conn->url);
-  curl_easy_setopt(conn->easy, CURLOPT_WRITEFUNCTION, write_cb);
-  curl_easy_setopt(conn->easy, CURLOPT_WRITEDATA, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_VERBOSE, 1L);
-  curl_easy_setopt(conn->easy, CURLOPT_ERRORBUFFER, conn->error);
-  curl_easy_setopt(conn->easy, CURLOPT_PRIVATE, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_NOPROGRESS, 0L);
-  curl_easy_setopt(conn->easy, CURLOPT_XFERINFOFUNCTION, xferinfo_cb);
-  curl_easy_setopt(conn->easy, CURLOPT_PROGRESSDATA, conn);
-  curl_easy_setopt(conn->easy, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(conn->curl, CURLOPT_URL, conn->url);
+  curl_easy_setopt(conn->curl, CURLOPT_WRITEFUNCTION, write_cb);
+  curl_easy_setopt(conn->curl, CURLOPT_WRITEDATA, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_VERBOSE, 1L);
+  curl_easy_setopt(conn->curl, CURLOPT_ERRORBUFFER, conn->error);
+  curl_easy_setopt(conn->curl, CURLOPT_PRIVATE, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_NOPROGRESS, 0L);
+  curl_easy_setopt(conn->curl, CURLOPT_XFERINFOFUNCTION, xferinfo_cb);
+  curl_easy_setopt(conn->curl, CURLOPT_PROGRESSDATA, conn);
+  curl_easy_setopt(conn->curl, CURLOPT_FOLLOWLOCATION, 1L);
   fprintf(MSG_OUT,
-          "Adding easy %p to multi %p (%s)\n", conn->easy, g->multi, url);
-  rc = curl_multi_add_handle(g->multi, conn->easy);
+          "Adding easy %p to multi %p (%s)\n", conn->curl, g->multi, url);
+  rc = curl_multi_add_handle(g->multi, conn->curl);
   mcode_or_die("new_conn: curl_multi_add_handle", rc);
 
   /* note that the add_handle() sets a time-out to trigger soon so that

--- a/docs/examples/hsts-preload.c
+++ b/docs/examples/hsts-preload.c
@@ -46,13 +46,13 @@ struct state {
 
 /* "read" is from the point of the library, it wants data from us. One domain
    entry per invoke. */
-static CURLSTScode hstsread(CURL *easy, struct curl_hstsentry *e,
+static CURLSTScode hstsread(CURL *curl, struct curl_hstsentry *e,
                             void *userp)
 {
   const char *host;
   const char *expire;
   struct state *s = (struct state *)userp;
-  (void)easy;
+  (void)curl;
   host = preload_hosts[s->index].name;
   expire = preload_hosts[s->index++].exp;
 
@@ -67,10 +67,10 @@ static CURLSTScode hstsread(CURL *easy, struct curl_hstsentry *e,
   return CURLSTS_OK;
 }
 
-static CURLSTScode hstswrite(CURL *easy, struct curl_hstsentry *e,
+static CURLSTScode hstswrite(CURL *curl, struct curl_hstsentry *e,
                              struct curl_index *i, void *userp)
 {
-  (void)easy;
+  (void)curl;
   (void)userp; /* we have no custom input */
   printf("[%u/%u] %s %s\n", (unsigned int)i->index, (unsigned int)i->total,
          e->name, e->expire);

--- a/docs/examples/htmltitle.cpp
+++ b/docs/examples/htmltitle.cpp
@@ -86,43 +86,43 @@ static size_t writer(char *data, size_t size, size_t nmemb,
 //  libcurl connection initialization
 //
 
-static bool init(CURL *&conn, const char *url)
+static bool init(CURL *&curl, const char *url)
 {
-  CURLcode code;
+  CURLcode res;
 
-  conn = curl_easy_init();
+  curl = curl_easy_init();
 
-  if(conn == NULL) {
-    fprintf(stderr, "Failed to create CURL connection\n");
+  if(!curl) {
+    fprintf(stderr, "Failed to create CURL handle\n");
     return false;
   }
 
-  code = curl_easy_setopt(conn, CURLOPT_ERRORBUFFER, errorBuffer);
-  if(code != CURLE_OK) {
-    fprintf(stderr, "Failed to set error buffer [%d]\n", code);
+  res = curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errorBuffer);
+  if(res != CURLE_OK) {
+    fprintf(stderr, "Failed to set error buffer [%d]\n", res);
     return false;
   }
 
-  code = curl_easy_setopt(conn, CURLOPT_URL, url);
-  if(code != CURLE_OK) {
+  res = curl_easy_setopt(curl, CURLOPT_URL, url);
+  if(res != CURLE_OK) {
     fprintf(stderr, "Failed to set URL [%s]\n", errorBuffer);
     return false;
   }
 
-  code = curl_easy_setopt(conn, CURLOPT_FOLLOWLOCATION, 1L);
-  if(code != CURLE_OK) {
+  res = curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  if(res != CURLE_OK) {
     fprintf(stderr, "Failed to set redirect option [%s]\n", errorBuffer);
     return false;
   }
 
-  code = curl_easy_setopt(conn, CURLOPT_WRITEFUNCTION, writer);
-  if(code != CURLE_OK) {
+  res = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writer);
+  if(res != CURLE_OK) {
     fprintf(stderr, "Failed to set writer [%s]\n", errorBuffer);
     return false;
   }
 
-  code = curl_easy_setopt(conn, CURLOPT_WRITEDATA, &buffer);
-  if(code != CURLE_OK) {
+  res = curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
+  if(res != CURLE_OK) {
     fprintf(stderr, "Failed to set write data [%s]\n", errorBuffer);
     return false;
   }
@@ -262,7 +262,7 @@ static void parseHtml(const std::string &html,
 
 int main(int argc, char *argv[])
 {
-  CURL *conn = NULL;
+  CURL *curl = NULL;
   CURLcode res;
   std::string title;
 
@@ -277,18 +277,18 @@ int main(int argc, char *argv[])
   if(res)
     return (int)res;
 
-  // Initialize CURL connection
+  // Initialize CURL handle
 
-  if(!init(conn, argv[1])) {
-    fprintf(stderr, "Connection initialization failed\n");
+  if(!init(curl, argv[1])) {
+    fprintf(stderr, "Handle initialization failed\n");
     curl_global_cleanup();
     return EXIT_FAILURE;
   }
 
   // Retrieve content for the URL
 
-  res = curl_easy_perform(conn);
-  curl_easy_cleanup(conn);
+  res = curl_easy_perform(curl);
+  curl_easy_cleanup(curl);
 
   if(res != CURLE_OK) {
     fprintf(stderr, "Failed to get '%s' [%s]\n", argv[1], errorBuffer);

--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -48,7 +48,7 @@
  * http://www.apacheweek.com/features/put
  */
 
-static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t retcode;
   unsigned long nread;
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
   curl = curl_easy_init();
   if(curl) {
     /* we want to use our own read function */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
 
     /* enable uploading (implies PUT over HTTP) */
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);

--- a/docs/examples/imap-append.c
+++ b/docs/examples/imap-append.c
@@ -59,7 +59,7 @@ struct upload_status {
   size_t bytes_read;
 };
 
-static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;
@@ -108,7 +108,7 @@ int main(void)
     /* In this case, we are using a callback function to specify the data. You
      * could just use the CURLOPT_READDATA option to specify a FILE pointer to
      * read from. */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, payload_source);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_ctx);
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 

--- a/docs/examples/imap-multi.c
+++ b/docs/examples/imap-multi.c
@@ -46,10 +46,10 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    CURLM *mcurl;
+    CURLM *multi;
 
-    mcurl = curl_multi_init();
-    if(mcurl) {
+    multi = curl_multi_init();
+    if(multi) {
       int still_running = 1;
 
       /* Set username and password */
@@ -61,22 +61,22 @@ int main(void)
                        "INBOX/;UID=1");
 
       /* Tell the multi stack about our easy handle */
-      curl_multi_add_handle(mcurl, curl);
+      curl_multi_add_handle(multi, curl);
 
       do {
-        CURLMcode mc = curl_multi_perform(mcurl, &still_running);
+        CURLMcode mc = curl_multi_perform(multi, &still_running);
 
         if(still_running)
           /* wait for activity, timeout or "nothing" */
-          mc = curl_multi_poll(mcurl, NULL, 0, 1000, NULL);
+          mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
 
         if(mc)
           break;
       } while(still_running);
 
       /* Always cleanup */
-      curl_multi_remove_handle(mcurl, curl);
-      curl_multi_cleanup(mcurl);
+      curl_multi_remove_handle(multi, curl);
+      curl_multi_cleanup(multi);
     }
     curl_easy_cleanup(curl);
   }

--- a/docs/examples/log_failed_transfers.c
+++ b/docs/examples/log_failed_transfers.c
@@ -172,14 +172,14 @@ static int mem_addf(struct mem *mem, const char *format, ...)
   return -1;
 }
 
-static int mydebug(CURL *handle, curl_infotype type,
+static int mydebug(CURL *curl, curl_infotype type,
                    char *data, size_t size, void *userdata)
 {
   struct transfer *t = (struct transfer *)userdata;
   static const char s_infotype[CURLINFO_END][3] = {
     "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
 
-  (void)handle;
+  (void)curl;
 
   switch(type) {
   case CURLINFO_TEXT:
@@ -198,7 +198,7 @@ static int mydebug(CURL *handle, curl_infotype type,
   return 0;
 }
 
-static size_t mywrite(char *ptr, size_t size, size_t nmemb, void *userdata)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
   struct transfer *t = (struct transfer *)userdata;
 
@@ -258,7 +258,7 @@ int main(void)
     curl_easy_setopt(t->curl, CURLOPT_DEBUGDATA, t);
 
     /* Enable writing the body to a file */
-    curl_easy_setopt(t->curl, CURLOPT_WRITEFUNCTION, mywrite);
+    curl_easy_setopt(t->curl, CURLOPT_WRITEFUNCTION, write_cb);
     curl_easy_setopt(t->curl, CURLOPT_WRITEDATA, t);
 
     /* Enable immediate error on HTTP status codes >= 400 in most cases,

--- a/docs/examples/multi-double.c
+++ b/docs/examples/multi-double.c
@@ -36,52 +36,51 @@
  */
 int main(void)
 {
-  CURL *http_handle;
-  CURL *http_handle2;
+  CURL *curl;
+  CURL *curl2;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
-  http_handle = curl_easy_init();
-  http_handle2 = curl_easy_init();
+  curl = curl_easy_init();
+  curl2 = curl_easy_init();
 
-  if(http_handle &&
-     http_handle2) {
+  if(curl && curl2) {
 
-    CURLM *multi_handle;
-
-    /* set options */
-    curl_easy_setopt(http_handle, CURLOPT_URL, "https://www.example.com/");
+    CURLM *multi;
 
     /* set options */
-    curl_easy_setopt(http_handle2, CURLOPT_URL, "http://localhost/");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
+
+    /* set options */
+    curl_easy_setopt(curl2, CURLOPT_URL, "http://localhost/");
 
     /* init a multi stack */
-    multi_handle = curl_multi_init();
-    if(multi_handle) {
+    multi = curl_multi_init();
+    if(multi) {
 
       int still_running = 1; /* keep number of running handles */
 
       /* add the individual transfers */
-      curl_multi_add_handle(multi_handle, http_handle);
-      curl_multi_add_handle(multi_handle, http_handle2);
+      curl_multi_add_handle(multi, curl);
+      curl_multi_add_handle(multi, curl2);
 
       while(still_running) {
         CURLMsg *msg;
         int queued;
 
-        CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
+        CURLMcode mc = curl_multi_perform(multi, &still_running);
 
         if(still_running)
           /* wait for activity, timeout or "nothing" */
-          mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
+          mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
 
         if(mc)
           break;
 
         do {
-          msg = curl_multi_info_read(multi_handle, &queued);
+          msg = curl_multi_info_read(multi, &queued);
           if(msg) {
             if(msg->msg == CURLMSG_DONE) {
               /* a transfer ended */
@@ -91,15 +90,15 @@ int main(void)
         } while(msg);
       }
 
-      curl_multi_remove_handle(multi_handle, http_handle);
-      curl_multi_remove_handle(multi_handle, http_handle2);
+      curl_multi_remove_handle(multi, curl);
+      curl_multi_remove_handle(multi, curl2);
 
-      curl_multi_cleanup(multi_handle);
+      curl_multi_cleanup(multi);
     }
   }
 
-  curl_easy_cleanup(http_handle);
-  curl_easy_cleanup(http_handle2);
+  curl_easy_cleanup(curl);
+  curl_easy_cleanup(curl2);
 
   curl_global_cleanup();
 

--- a/docs/examples/multi-formadd.c
+++ b/docs/examples/multi-formadd.c
@@ -79,10 +79,10 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    CURLM *multi_handle;
+    CURLM *multi;
 
-    multi_handle = curl_multi_init();
-    if(multi_handle) {
+    multi = curl_multi_init();
+    if(multi) {
 
       int still_running = 0;
 
@@ -96,21 +96,21 @@ int main(void)
         curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
       )
 
-      curl_multi_add_handle(multi_handle, curl);
+      curl_multi_add_handle(multi, curl);
 
       do {
-        CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
+        CURLMcode mc = curl_multi_perform(multi, &still_running);
 
         if(still_running)
           /* wait for activity, timeout or "nothing" */
-          mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
+          mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
 
         if(mc)
           break;
 
       } while(still_running);
 
-      curl_multi_cleanup(multi_handle);
+      curl_multi_cleanup(multi);
     }
 
     /* always cleanup */

--- a/docs/examples/multi-post.c
+++ b/docs/examples/multi-post.c
@@ -46,10 +46,10 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    CURLM *multi_handle;
+    CURLM *multi;
 
-    multi_handle = curl_multi_init();
-    if(multi_handle) {
+    multi = curl_multi_init();
+    if(multi) {
       int still_running = 0;
 
       /* Create the form */
@@ -82,20 +82,20 @@ int main(void)
       curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
       curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
 
-      curl_multi_add_handle(multi_handle, curl);
+      curl_multi_add_handle(multi, curl);
 
       do {
-        CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
+        CURLMcode mc = curl_multi_perform(multi, &still_running);
 
         if(still_running)
           /* wait for activity, timeout or "nothing" */
-          mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
+          mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
 
         if(mc)
           break;
       } while(still_running);
 
-      curl_multi_cleanup(multi_handle);
+      curl_multi_cleanup(multi);
     }
 
     /* always cleanup */

--- a/docs/examples/multi-single.c
+++ b/docs/examples/multi-single.c
@@ -37,34 +37,34 @@
  */
 int main(void)
 {
-  CURL *http_handle;
+  CURL *curl;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
-  http_handle = curl_easy_init();
-  if(http_handle) {
+  curl = curl_easy_init();
+  if(curl) {
 
-    CURLM *multi_handle;
+    CURLM *multi;
     int still_running = 1; /* keep number of running handles */
 
     /* set the options (I left out a few, you get the point anyway) */
-    curl_easy_setopt(http_handle, CURLOPT_URL, "https://www.example.com/");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
 
     /* init a multi stack */
-    multi_handle = curl_multi_init();
-    if(multi_handle) {
+    multi = curl_multi_init();
+    if(multi) {
 
       /* add the individual transfers */
-      curl_multi_add_handle(multi_handle, http_handle);
+      curl_multi_add_handle(multi, curl);
 
       do {
-        CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
+        CURLMcode mc = curl_multi_perform(multi, &still_running);
 
         if(!mc)
           /* wait for activity, timeout or "nothing" */
-          mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
+          mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
 
         if(mc) {
           fprintf(stderr, "curl_multi_poll() failed, code %d.\n", (int)mc);
@@ -73,12 +73,12 @@ int main(void)
 
       } while(still_running);
 
-      curl_multi_remove_handle(multi_handle, http_handle);
+      curl_multi_remove_handle(multi, curl);
 
-      curl_multi_cleanup(multi_handle);
+      curl_multi_cleanup(multi);
     }
 
-    curl_easy_cleanup(http_handle);
+    curl_easy_cleanup(curl);
   }
 
   curl_global_cleanup();

--- a/docs/examples/pop3-multi.c
+++ b/docs/examples/pop3-multi.c
@@ -47,10 +47,10 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    CURLM *mcurl;
+    CURLM *multi;
 
-    mcurl = curl_multi_init();
-    if(mcurl) {
+    multi = curl_multi_init();
+    if(multi) {
       int still_running = 1;
 
       /* Set username and password */
@@ -61,14 +61,14 @@ int main(void)
       curl_easy_setopt(curl, CURLOPT_URL, "pop3://pop.example.com/1");
 
       /* Tell the multi stack about our easy handle */
-      curl_multi_add_handle(mcurl, curl);
+      curl_multi_add_handle(multi, curl);
 
       do {
-        CURLMcode mc = curl_multi_perform(mcurl, &still_running);
+        CURLMcode mc = curl_multi_perform(multi, &still_running);
 
         if(still_running)
           /* wait for activity, timeout or "nothing" */
-          mc = curl_multi_poll(mcurl, NULL, 0, 1000, NULL);
+          mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
 
         if(mc)
           break;
@@ -76,8 +76,8 @@ int main(void)
       } while(still_running);
 
       /* Always cleanup */
-      curl_multi_remove_handle(mcurl, curl);
-      curl_multi_cleanup(mcurl);
+      curl_multi_remove_handle(multi, curl);
+      curl_multi_cleanup(multi);
     }
     curl_easy_cleanup(curl);
   }

--- a/docs/examples/post-callback.c
+++ b/docs/examples/post-callback.c
@@ -43,7 +43,7 @@ struct WriteThis {
   size_t sizeleft;
 };
 
-static size_t read_callback(char *dest, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *dest, size_t size, size_t nmemb, void *userp)
 {
   struct WriteThis *wt = (struct WriteThis *)userp;
   size_t buffer_size = size*nmemb;
@@ -92,7 +92,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
 
     /* we want to use our own read function */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
 
     /* pointer to pass to our read function */
     curl_easy_setopt(curl, CURLOPT_READDATA, &wt);

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -35,7 +35,7 @@ struct MemoryStruct {
   size_t size;
 };
 
-static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb,
+static size_t write_cb(void *contents, size_t size, size_t nmemb,
                                   void *userp)
 {
   size_t realsize = size * nmemb;
@@ -75,7 +75,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.org/");
 
     /* send all data to this function  */
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     /* we pass our 'chunk' struct to the callback function */
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);

--- a/docs/examples/sepheaders.c
+++ b/docs/examples/sepheaders.c
@@ -30,7 +30,7 @@
 
 #include <curl/curl.h>
 
-static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
   return written;
@@ -38,33 +38,33 @@ static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
 
 int main(void)
 {
-  CURL *curl_handle;
+  CURL *curl;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
   /* init the curl session */
-  curl_handle = curl_easy_init();
-  if(curl_handle) {
+  curl = curl_easy_init();
+  if(curl) {
     static const char *headerfilename = "head.out";
     FILE *headerfile;
     static const char *bodyfilename = "body.out";
     FILE *bodyfile;
 
     /* set URL to get */
-    curl_easy_setopt(curl_handle, CURLOPT_URL, "https://example.com");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* no progress meter please */
-    curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
 
     /* send all data to this function  */
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_data);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     /* open the header file */
     headerfile = fopen(headerfilename, "wb");
     if(!headerfile) {
-      curl_easy_cleanup(curl_handle);
+      curl_easy_cleanup(curl);
       curl_global_cleanup();
       return -1;
     }
@@ -72,20 +72,20 @@ int main(void)
     /* open the body file */
     bodyfile = fopen(bodyfilename, "wb");
     if(!bodyfile) {
-      curl_easy_cleanup(curl_handle);
+      curl_easy_cleanup(curl);
       fclose(headerfile);
       curl_global_cleanup();
       return -1;
     }
 
     /* we want the headers be written to this file handle */
-    curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, headerfile);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, headerfile);
 
     /* we want the body be written to this file handle instead of stdout */
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, bodyfile);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, bodyfile);
 
     /* get it! */
-    res = curl_easy_perform(curl_handle);
+    res = curl_easy_perform(curl);
 
     /* close the header file */
     fclose(headerfile);
@@ -94,7 +94,7 @@ int main(void)
     fclose(bodyfile);
 
     /* cleanup curl stuff */
-    curl_easy_cleanup(curl_handle);
+    curl_easy_cleanup(curl);
   }
 
   curl_global_cleanup();

--- a/docs/examples/sessioninfo.c
+++ b/docs/examples/sessioninfo.c
@@ -43,7 +43,7 @@
 
 static CURL *curl;
 
-static size_t wrfu(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   const struct curl_tlssessioninfo *info;
   CURLcode res;
@@ -103,7 +103,7 @@ int main(void)
   curl = curl_easy_init();
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, wrfu);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 0L);
 
     res = curl_easy_perform(curl);

--- a/docs/examples/sftpget.c
+++ b/docs/examples/sftpget.c
@@ -45,7 +45,7 @@ struct FtpFile {
   FILE *stream;
 };
 
-static size_t my_fwrite(void *buffer, size_t size, size_t nmemb,
+static size_t write_cb(void *buffer, size_t size, size_t nmemb,
                         void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
@@ -79,7 +79,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL,
                      "sftp://user@server/home/user/file.txt");
     /* Define our callback to get called when there is data to be written */
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, my_fwrite);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     /* Set a pointer to our struct to pass to the callback */
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ftpfile);
 

--- a/docs/examples/sftpuploadresume.c
+++ b/docs/examples/sftpuploadresume.c
@@ -31,7 +31,7 @@
 #include <curl/curl.h>
 
 /* read data to upload */
-static size_t readfunc(char *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   FILE *f = (FILE *)stream;
   size_t n;
@@ -50,36 +50,36 @@ static size_t readfunc(char *ptr, size_t size, size_t nmemb, void *stream)
 static curl_off_t sftpGetRemoteFileSize(const char *i_remoteFile)
 {
   curl_off_t remoteFileSizeByte = -1;
-  CURL *curlHandlePtr = curl_easy_init();
+  CURL *curl = curl_easy_init();
 
-  if(curlHandlePtr) {
+  if(curl) {
     CURLcode result;
 
-    curl_easy_setopt(curlHandlePtr, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-    curl_easy_setopt(curlHandlePtr, CURLOPT_URL, i_remoteFile);
-    curl_easy_setopt(curlHandlePtr, CURLOPT_NOPROGRESS, 1L);
-    curl_easy_setopt(curlHandlePtr, CURLOPT_NOBODY, 1L);
-    curl_easy_setopt(curlHandlePtr, CURLOPT_HEADER, 1L);
-    curl_easy_setopt(curlHandlePtr, CURLOPT_FILETIME, 1L);
+    curl_easy_setopt(curl, CURLOPT_URL, i_remoteFile);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+    curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
+    curl_easy_setopt(curl, CURLOPT_FILETIME, 1L);
 
-    result = curl_easy_perform(curlHandlePtr);
+    result = curl_easy_perform(curl);
     if(CURLE_OK == result) {
-      result = curl_easy_getinfo(curlHandlePtr,
+      result = curl_easy_getinfo(curl,
                                  CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                                  &remoteFileSizeByte);
       if(result)
         return -1;
       printf("filesize: %" CURL_FORMAT_CURL_OFF_T "\n", remoteFileSizeByte);
     }
-    curl_easy_cleanup(curlHandlePtr);
+    curl_easy_cleanup(curl);
   }
 
   return remoteFileSizeByte;
 }
 
 
-static int sftpResumeUpload(CURL *curlhandle, const char *remotepath,
+static int sftpResumeUpload(CURL *curl, const char *remotepath,
                             const char *localpath)
 {
   FILE *f = NULL;
@@ -99,18 +99,18 @@ static int sftpResumeUpload(CURL *curlhandle, const char *remotepath,
     return 0;
   }
 
-  curl_easy_setopt(curlhandle, CURLOPT_UPLOAD, 1L);
-  curl_easy_setopt(curlhandle, CURLOPT_URL, remotepath);
-  curl_easy_setopt(curlhandle, CURLOPT_READFUNCTION, readfunc);
-  curl_easy_setopt(curlhandle, CURLOPT_READDATA, f);
+  curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  curl_easy_setopt(curl, CURLOPT_URL, remotepath);
+  curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
+  curl_easy_setopt(curl, CURLOPT_READDATA, f);
 
 #if defined(_WIN32) && !defined(UNDER_CE)
   _fseeki64(f, remoteFileSizeByte, SEEK_SET);
 #else
   fseek(f, (long)remoteFileSizeByte, SEEK_SET);
 #endif
-  curl_easy_setopt(curlhandle, CURLOPT_APPEND, 1L);
-  result = curl_easy_perform(curlhandle);
+  curl_easy_setopt(curl, CURLOPT_APPEND, 1L);
+  result = curl_easy_perform(curl);
 
   fclose(f);
 
@@ -124,22 +124,22 @@ static int sftpResumeUpload(CURL *curlhandle, const char *remotepath,
 
 int main(void)
 {
-  CURL *curlhandle = NULL;
+  CURL *curl = NULL;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
-  curlhandle = curl_easy_init();
-  if(curlhandle) {
+  curl = curl_easy_init();
+  if(curl) {
     const char *remote = "sftp://user:pass@example.com/path/filename";
     const char *filename = "filename";
 
-    if(!sftpResumeUpload(curlhandle, remote, filename)) {
+    if(!sftpResumeUpload(curl, remote, filename)) {
       printf("resumed upload using curl %s failed\n", curl_version());
     }
 
-    curl_easy_cleanup(curlhandle);
+    curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
 

--- a/docs/examples/shared-connection-cache.c
+++ b/docs/examples/shared-connection-cache.c
@@ -28,19 +28,19 @@
 #include <stdio.h>
 #include <curl/curl.h>
 
-static void my_lock(CURL *handle, curl_lock_data data,
+static void my_lock(CURL *curl, curl_lock_data data,
                     curl_lock_access laccess, void *useptr)
 {
-  (void)handle;
+  (void)curl;
   (void)data;
   (void)laccess;
   (void)useptr;
   fprintf(stderr, "-> Mutex lock\n");
 }
 
-static void my_unlock(CURL *handle, curl_lock_data data, void *useptr)
+static void my_unlock(CURL *curl, curl_lock_data data, void *useptr)
 {
-  (void)handle;
+  (void)curl;
   (void)data;
   (void)useptr;
   fprintf(stderr, "<- Mutex unlock\n");

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -60,7 +60,7 @@ const char * const urls[]= {
   "90030"
 };
 
-size_t write_file(void *ptr, size_t size, size_t nmemb, FILE *stream)
+size_t write_cb(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
   return fwrite(ptr, size, nmemb, stream);
 }
@@ -80,7 +80,7 @@ static void run_one(gchar *http, int j)
 
       /* Write to the file */
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, outfile);
-      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_file);
+      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
       (void)curl_easy_perform(curl);
 
       fclose(outfile);

--- a/docs/examples/smtp-authzid.c
+++ b/docs/examples/smtp-authzid.c
@@ -67,7 +67,7 @@ struct upload_status {
   size_t bytes_read;
 };
 
-static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;
@@ -133,7 +133,7 @@ int main(void)
     /* We are using a callback function to specify the payload (the headers and
      * body of the message). You could just use the CURLOPT_READDATA option to
      * specify a FILE pointer to read from. */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, payload_source);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_ctx);
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 

--- a/docs/examples/smtp-mail.c
+++ b/docs/examples/smtp-mail.c
@@ -64,7 +64,7 @@ struct upload_status {
   size_t bytes_read;
 };
 
-static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;
@@ -121,7 +121,7 @@ int main(void)
     /* We are using a callback function to specify the payload (the headers and
      * body of the message). You could just use the CURLOPT_READDATA option to
      * specify a FILE pointer to read from. */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, payload_source);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_ctx);
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 

--- a/docs/examples/smtp-multi.c
+++ b/docs/examples/smtp-multi.c
@@ -57,7 +57,7 @@ struct upload_status {
   size_t bytes_read;
 };
 
-static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;
@@ -89,10 +89,10 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    CURLM *mcurl;
+    CURLM *multi;
 
-    mcurl = curl_multi_init();
-    if(mcurl) {
+    multi = curl_multi_init();
+    if(multi) {
       int still_running = 1;
       struct curl_slist *recipients = NULL;
       struct upload_status upload_ctx = { 0 };
@@ -119,19 +119,19 @@ int main(void)
       /* We are using a callback function to specify the payload (the headers
        * and body of the message). You could just use the CURLOPT_READDATA
        * option to specify a FILE pointer to read from. */
-      curl_easy_setopt(curl, CURLOPT_READFUNCTION, payload_source);
+      curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
       curl_easy_setopt(curl, CURLOPT_READDATA, &upload_ctx);
       curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
       /* Tell the multi stack about our easy handle */
-      curl_multi_add_handle(mcurl, curl);
+      curl_multi_add_handle(multi, curl);
 
       do {
-        CURLMcode mc = curl_multi_perform(mcurl, &still_running);
+        CURLMcode mc = curl_multi_perform(multi, &still_running);
 
         if(still_running)
           /* wait for activity, timeout or "nothing" */
-          mc = curl_multi_poll(mcurl, NULL, 0, 1000, NULL);
+          mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
 
         if(mc)
           break;
@@ -142,8 +142,8 @@ int main(void)
       curl_slist_free_all(recipients);
 
       /* Always cleanup */
-      curl_multi_remove_handle(mcurl, curl);
-      curl_multi_cleanup(mcurl);
+      curl_multi_remove_handle(multi, curl);
+      curl_multi_cleanup(multi);
     }
     curl_easy_cleanup(curl);
   }

--- a/docs/examples/smtp-ssl.c
+++ b/docs/examples/smtp-ssl.c
@@ -61,7 +61,7 @@ struct upload_status {
   size_t bytes_read;
 };
 
-static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;
@@ -143,7 +143,7 @@ int main(void)
     /* We are using a callback function to specify the payload (the headers and
      * body of the message). You could just use the CURLOPT_READDATA option to
      * specify a FILE pointer to read from. */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, payload_source);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_ctx);
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 

--- a/docs/examples/smtp-tls.c
+++ b/docs/examples/smtp-tls.c
@@ -61,7 +61,7 @@ struct upload_status {
   size_t bytes_read;
 };
 
-static size_t payload_source(char *ptr, size_t size, size_t nmemb, void *userp)
+static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct upload_status *upload_ctx = (struct upload_status *)userp;
   const char *data;
@@ -145,7 +145,7 @@ int main(void)
     /* We are using a callback function to specify the payload (the headers and
      * body of the message). You could just use the CURLOPT_READDATA option to
      * specify a FILE pointer to read from. */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, payload_source);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_ctx);
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -117,7 +117,7 @@ static SYSTEMTIME LOCALTime;
 #define HTTP_COMMAND_HEAD       0
 #define HTTP_COMMAND_GET        1
 
-static size_t SyncTime_CURL_WriteOutput(void *ptr, size_t size, size_t nmemb,
+static size_t write_cb(void *ptr, size_t size, size_t nmemb,
                                         void *stream)
 {
   fwrite(ptr, size, nmemb, stream);
@@ -187,7 +187,7 @@ static void SyncTime_CURL_Init(CURL *curl, const char *proxy_port,
     curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, proxy_user_password);
 
   curl_easy_setopt(curl, CURLOPT_USERAGENT, SYNCTIME_UA);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, SyncTime_CURL_WriteOutput);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, SyncTime_CURL_WriteHeader);
 }
 

--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -30,7 +30,7 @@
 
 #include <curl/curl.h>
 
-static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
   return written;
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
   static const char *pagefilename = "page.out";
 
   CURLcode res;
-  CURL *curl_handle;
+  CURL *curl;
 
   if(argc < 2) {
     printf("Usage: %s <URL>\n", argv[0]);
@@ -55,38 +55,38 @@ int main(int argc, char *argv[])
   }
 
   /* init the curl session */
-  curl_handle = curl_easy_init();
-  if(curl_handle) {
+  curl = curl_easy_init();
+  if(curl) {
     FILE *pagefile;
 
     /* set URL to get here */
-    curl_easy_setopt(curl_handle, CURLOPT_URL, argv[1]);
+    curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
 
     /* Switch on full protocol/debug output while testing */
-    curl_easy_setopt(curl_handle, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
     /* disable progress meter, set to 0L to enable it */
-    curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
 
     /* send all data to this function  */
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_data);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 
     /* open the file */
     pagefile = fopen(pagefilename, "wb");
     if(pagefile) {
 
       /* write the page body to this file handle */
-      curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, pagefile);
+      curl_easy_setopt(curl, CURLOPT_WRITEDATA, pagefile);
 
       /* get it! */
-      res = curl_easy_perform(curl_handle);
+      res = curl_easy_perform(curl);
 
       /* close the header file */
       fclose(pagefile);
     }
 
     /* cleanup curl stuff */
-    curl_easy_cleanup(curl_handle);
+    curl_easy_cleanup(curl);
   }
 
   curl_global_cleanup();

--- a/docs/examples/usercertinmem.c
+++ b/docs/examples/usercertinmem.c
@@ -156,34 +156,34 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *pointer)
 
 int main(void)
 {
-  CURL *ch;
+  CURL *curl;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
-  ch = curl_easy_init();
-  if(ch) {
-    curl_easy_setopt(ch, CURLOPT_VERBOSE, 0L);
-    curl_easy_setopt(ch, CURLOPT_HEADER, 0L);
-    curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
-    curl_easy_setopt(ch, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, writefunction);
-    curl_easy_setopt(ch, CURLOPT_WRITEDATA, stdout);
-    curl_easy_setopt(ch, CURLOPT_HEADERFUNCTION, writefunction);
-    curl_easy_setopt(ch, CURLOPT_HEADERDATA, stderr);
-    curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 0L);
+    curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunction);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, writefunction);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, stderr);
+    curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
 
     /* both VERIFYPEER and VERIFYHOST are set to 0 in this case because there
        is no CA certificate */
-    curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(ch, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
-    curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
-    curl_easy_setopt(ch, CURLOPT_SSLKEYTYPE, "PEM");
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
+    curl_easy_setopt(curl, CURLOPT_SSLKEYTYPE, "PEM");
 
     /* first try: retrieve page without user certificate and key -> fails */
-    res = curl_easy_perform(ch);
+    res = curl_easy_perform(curl);
     if(res == CURLE_OK)
       printf("*** transfer succeeded ***\n");
     else
@@ -193,14 +193,14 @@ int main(void)
      * load the certificate and key by installing a function doing
      * the necessary "modifications" to the SSL CONTEXT just before link init
      */
-    curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, sslctx_function);
-    res = curl_easy_perform(ch);
+    curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, sslctx_function);
+    res = curl_easy_perform(curl);
     if(res == CURLE_OK)
       printf("*** transfer succeeded ***\n");
     else
       printf("*** transfer failed ***\n");
 
-    curl_easy_cleanup(ch);
+    curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
   return (int)res;

--- a/docs/examples/websocket-cb.c
+++ b/docs/examples/websocket-cb.c
@@ -28,11 +28,11 @@
 #include <stdio.h>
 #include <curl/curl.h>
 
-static size_t writecb(char *b, size_t size, size_t nitems, void *p)
+static size_t write_cb(char *b, size_t size, size_t nitems, void *p)
 {
-  CURL *easy = p;
+  CURL *curl = p;
   size_t i;
-  const struct curl_ws_frame *frame = curl_ws_meta(easy);
+  const struct curl_ws_frame *frame = curl_ws_meta(curl);
   fprintf(stderr, "Type: %s\n", frame->flags & CURLWS_BINARY ?
           "binary" : "text");
   fprintf(stderr, "Bytes: %u", (unsigned int)(nitems * size));
@@ -53,7 +53,7 @@ int main(void)
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "wss://example.com");
 
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     /* pass the easy handle to the callback */
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, curl);
 

--- a/docs/examples/websocket-updown.c
+++ b/docs/examples/websocket-updown.c
@@ -29,12 +29,12 @@
 #include <string.h>
 #include <curl/curl.h>
 
-static size_t writecb(char *b, size_t size, size_t nitems, void *p)
+static size_t write_cb(char *b, size_t size, size_t nitems, void *p)
 {
-  CURL *easy = p;
+  CURL *curl = p;
   size_t i;
   unsigned int blen = (unsigned int)(nitems * size);
-  const struct curl_ws_frame *frame = curl_ws_meta(easy);
+  const struct curl_ws_frame *frame = curl_ws_meta(curl);
   fprintf(stderr, "Type: %s\n", frame->flags & CURLWS_BINARY ?
           "binary" : "text");
   if(frame->flags & CURLWS_BINARY) {
@@ -49,13 +49,13 @@ static size_t writecb(char *b, size_t size, size_t nitems, void *p)
 }
 
 struct read_ctx {
-  CURL *easy;
+  CURL *curl;
   char buf[1024];
   size_t blen;
   size_t nsent;
 };
 
-static size_t readcb(char *buf, size_t nitems, size_t buflen, void *p)
+static size_t read_cb(char *buf, size_t nitems, size_t buflen, void *p)
 {
   struct read_ctx *ctx = p;
   size_t len = nitems * buflen;
@@ -65,7 +65,7 @@ static size_t readcb(char *buf, size_t nitems, size_t buflen, void *p)
   if(!ctx->nsent) {
     /* On first call, set the FRAME information to be used (it defaults
      * to CURLWS_BINARY otherwise). */
-    result = curl_ws_start_frame(ctx->easy, CURLWS_TEXT,
+    result = curl_ws_start_frame(ctx->curl, CURLWS_TEXT,
                                  (curl_off_t)ctx->blen);
     if(result) {
       fprintf(stderr, "error starting frame: %d\n", result);
@@ -85,7 +85,7 @@ static size_t readcb(char *buf, size_t nitems, size_t buflen, void *p)
 
 int main(int argc, const char *argv[])
 {
-  CURL *easy;
+  CURL *curl;
   struct read_ctx rctx;
   const char *payload = "Hello, friend!";
 
@@ -95,33 +95,33 @@ int main(int argc, const char *argv[])
 
   memset(&rctx, 0, sizeof(rctx));
 
-  easy = curl_easy_init();
-  if(easy) {
+  curl = curl_easy_init();
+  if(curl) {
     if(argc == 2)
-      curl_easy_setopt(easy, CURLOPT_URL, argv[1]);
+      curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
     else
-      curl_easy_setopt(easy, CURLOPT_URL, "wss://example.com");
+      curl_easy_setopt(curl, CURLOPT_URL, "wss://example.com");
 
-    curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, writecb);
-    curl_easy_setopt(easy, CURLOPT_WRITEDATA, easy);
-    curl_easy_setopt(easy, CURLOPT_READFUNCTION, readcb);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, curl);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
     /* tell curl that we want to send the payload */
-    rctx.easy = easy;
+    rctx.curl = curl;
     rctx.blen = strlen(payload);
     memcpy(rctx.buf, payload, rctx.blen);
-    curl_easy_setopt(easy, CURLOPT_READDATA, &rctx);
-    curl_easy_setopt(easy, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(curl, CURLOPT_READDATA, &rctx);
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
 
     /* Perform the request, res gets the return code */
-    res = curl_easy_perform(easy);
+    res = curl_easy_perform(curl);
     /* Check for errors */
     if(res != CURLE_OK)
       fprintf(stderr, "curl_easy_perform() failed: %s\n",
               curl_easy_strerror(res));
 
     /* always cleanup */
-    curl_easy_cleanup(easy);
+    curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
   return (int)res;

--- a/docs/examples/xmlstream.c
+++ b/docs/examples/xmlstream.c
@@ -95,8 +95,8 @@ static void endElement(void *userData, const XML_Char *name)
   printf("%5lu   %10lu   %s\n", state->depth, state->characters.size, name);
 }
 
-static size_t parseStreamCallback(void *contents, size_t length, size_t nmemb,
-                                  void *userp)
+static size_t write_cb(void *contents, size_t length, size_t nmemb,
+                       void *userp)
 {
   XML_Parser parser = (XML_Parser) userp;
   size_t real_size = length * nmemb;
@@ -116,14 +116,14 @@ static size_t parseStreamCallback(void *contents, size_t length, size_t nmemb,
 
 int main(void)
 {
-  CURL *curl_handle;
+  CURL *curl;
 
   CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
   if(res)
     return (int)res;
 
   /* Initialize a libcurl handle. */
-  curl_handle = curl_easy_init();
+  curl = curl_easy_init();
   if(curl) {
     XML_Parser parser;
     struct ParserStruct state;
@@ -138,15 +138,15 @@ int main(void)
     XML_SetElementHandler(parser, startElement, endElement);
     XML_SetCharacterDataHandler(parser, characterDataHandler);
 
-    curl_easy_setopt(curl_handle, CURLOPT_URL,
+    curl_easy_setopt(curl, CURLOPT_URL,
                      "https://www.w3schools.com/xml/simple.xml");
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, parseStreamCallback);
-    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)parser);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)parser);
 
     printf("Depth   Characters   Closing Tag\n");
 
     /* Perform the request and any follow-up parsing. */
-    res = curl_easy_perform(curl_handle);
+    res = curl_easy_perform(curl);
     if(res != CURLE_OK) {
       fprintf(stderr, "curl_easy_perform() failed: %s\n",
               curl_easy_strerror(res));
@@ -168,7 +168,7 @@ int main(void)
     free(state.characters.memory);
     XML_ParserFree(parser);
 
-    curl_easy_cleanup(curl_handle);
+    curl_easy_cleanup(curl);
   }
 
   curl_global_cleanup();


### PR DESCRIPTION
- 'CURL *' handles are called 'curl'
- 'CURLM *' handles are called 'multi'
- write callbacks are called 'write_cb'
- read callbacs are called 'read_cb'
- CURLcode variables are called 'res'

It makes the examples look and feel more consistent. It allows for easier copy and pasting between examples.