### PR TITLE
sectrust: fix verifystatus via sectrust

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5151,6 +5151,9 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
   bool strict = (conn_config->verifypeer || conn_config->verifyhost);
   X509 *server_cert;
   bool verified = FALSE;
+#ifdef USE_APPLE_SECTRUST
+  bool sectrust_verified = FALSE;
+#endif
 
   if(data->set.ssl.certinfo && !octx->reused_session) {
     /* asked to gather certificate info. Reused sessions don't have cert
@@ -5203,6 +5206,7 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
     if(verified) {
       infof(data, "SSL certificate verified via Apple SecTrust.");
       ssl_config->certverifyresult = X509_V_OK;
+      sectrust_verified = TRUE;
     }
   }
 #endif
@@ -5218,7 +5222,13 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
   }
 
 #if !defined(OPENSSL_NO_TLSEXT) && !defined(OPENSSL_NO_OCSP)
-  if(conn_config->verifystatus && !octx->reused_session) {
+  if(conn_config->verifystatus &&
+#ifdef USE_APPLE_SECTRUST
+     !sectrust_verified && /* already verified via apple sectrust, cannot
+                            * verifystate via OpenSSL in that case as it
+                            * does not have the trust anchors */
+#endif
+     !octx->reused_session) {
     /* do not do this after Session ID reuse */
     result = verifystatus(cf, data, octx);
     if(result)


### PR DESCRIPTION
When openssl does not verify the certificate, but apple sectrust does, we also pass it the ocsp stapled response when configured and available.

When openssl does not verify the cert chain, it will also not be able to verify the ocsp stapling. Do not call it if sectrust is the verifier of the cert chain.

refs #19307