### PR TITLE
vtls: properly handle SSL shutdown timeout

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1858,7 +1858,8 @@ static CURLcode vtls_shutdown_blocking(struct Curl_cfilter *cf,
     if(timeout_ms < 0) {
       /* no need to continue if time is already up */
       failf(data, "SSL shutdown timeout");
-      return CURLE_OPERATION_TIMEDOUT;
+      result = CURLE_OPERATION_TIMEDOUT;
+      goto out;
     }
 
     result = connssl->ssl_impl->shut_down(cf, data, send_shutdown, done);


### PR DESCRIPTION
This PR fixes CF_DATA_RESTORE when the SSL shutdown time is already up.