### PR TITLE
runtests: fix Perl warning after recent patch

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1403,11 +1403,13 @@ sub singletest_check {
             }
         }
 
-        if($hash{'crlf'} eq "headers") {
-            subnewlines(0, \$_) for @protocol;
-        }
-        elsif($hash{'crlf'}) {
-            subnewlines(1, \$_) for @protocol;
+        if($hash{'crlf'}) {
+            if($hash{'crlf'} eq "headers") {
+                subnewlines(0, \$_) for @protocol;
+            }
+            else {
+                subnewlines(1, \$_) for @protocol;
+            }
         }
 
         if((!$out[0] || ($out[0] eq "")) && $protocol[0]) {


### PR DESCRIPTION
```
Use of uninitialized value $hash{"crlf"} in string eq at tests/runtests.pl line 1406.
```

Follow-up to 6cf3d7b1b161bc45501d17b401225befe3c43943 #19318