### PR TITLE
http_aws_sigv4: check the return value of curl_maprintf()

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -329,6 +329,8 @@ static CURLcode make_headers(struct Curl_easy *data,
       goto fail;
     head = tmp_head;
     *date_header = curl_maprintf("%s: %s\r\n", date_hdr_key, timestamp);
+    if(!*date_header)
+      goto fail;
   }
   else {
     const char *value;


### PR DESCRIPTION
Check the return value of curl_maprintf() to catch the potential memory error in time.