### PR TITLE
cw-out: fix EAGAIN handling on pause

### DIFF
--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -302,6 +302,7 @@ static CURLcode cw_out_buf_flush(struct cw_out_ctx *ctx,
                               &consumed);
     if(result && (result != CURLE_AGAIN))
       return result;
+    result = CURLE_OK;
 
     if(consumed) {
       if(consumed == curlx_dyn_len(&cwbuf->b)) {


### PR DESCRIPTION
The interim CURLE_AGAIN result was not always converted to a CURLE_OK and then caused write callers to report a failure.

refs #19334