### PR TITLE
REUSE: add copyright header to two files

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,7 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
 Guenter Knauf <lists@gknw.net> <gk@gknw.de>
 Gisle Vanem <gvanem@yahoo.no> <gisle.vanem@gmail.com>
 Gisle Vanem <gvanem@yahoo.no> <gvanem@broadpark.no>

--- a/GIT-INFO.md
+++ b/GIT-INFO.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
                                   _   _ ____  _
                               ___| | | |  _ \| |
                              / __| | | | |_) | |

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -13,7 +13,6 @@ SPDX-PackageDownloadLocation = "https://curl.se/"
 
 [[annotations]]
 path = [
-  ".mailmap",
   "docs/FAQ",
   "docs/INSTALL",
   "docs/KNOWN_BUGS",
@@ -22,7 +21,6 @@ path = [
   "docs/options-in-versions",
   "docs/THANKS",
   "docs/TODO",
-  "GIT-INFO.md",
   "lib/libcurl.vers.in",
   "lib/libcurl.def",
   "packages/OS400/README.OS400",


### PR DESCRIPTION
`.mailmap` supports comments and empty lines since at least 2.31.0:
https://git-scm.com/docs/gitmailmap/2.31.0
