### PR TITLE
openssl: respect system crypto policy for TLS max version

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2955,18 +2955,16 @@ ossl_set_ssl_version_min_max(struct Curl_cfilter *cf, SSL_CTX *ctx,
     ossl_ssl_version_max = TLS1_3_VERSION;
     break;
 #endif
-  case CURL_SSLVERSION_MAX_NONE:  /* none selected */
-  case CURL_SSLVERSION_MAX_DEFAULT:  /* max selected */
-  default:
-    /* SSL_CTX_set_max_proto_version states that: setting the maximum to 0
-       will enable protocol versions up to the highest version supported by
-       the library */
-    ossl_ssl_version_max = 0;
-    break;
   }
 
-  if(!SSL_CTX_set_max_proto_version(ctx, ossl_ssl_version_max)) {
-    return CURLE_SSL_CONNECT_ERROR;
+  /* Only set max version if user explicitly requested a specific version.
+     Otherwise, stay with the OpenSSL default (respects crypto-policies).
+     This mirrors the min version logic above. */
+  if(curl_ssl_version_max != CURL_SSLVERSION_MAX_NONE &&
+     curl_ssl_version_max != CURL_SSLVERSION_MAX_DEFAULT) {
+    if(!SSL_CTX_set_max_proto_version(ctx, ossl_ssl_version_max)) {
+      return CURLE_SSL_CONNECT_ERROR;
+    }
   }
 
   return CURLE_OK;


### PR DESCRIPTION
When no explicit --tls-max option is provided, curl should respect OpenSSL's system-wide crypto policy configuration instead of overriding it.

Previously, curl called SSL_CTX_set_max_proto_version(ctx, 0) for the default case, which explicitly enables all TLS versions up to the highest supported by the library, overriding any system crypto policy restrictions.

This breaks FIPS compliance, Common Criteria certification, and renders curl unusable on systems with restrictive crypto policies (e.g., FIPS:OSPP which limits to TLS 1.2 only).

The fix mirrors the existing logic for minimum version - only call SSL_CTX_set_max_proto_version() when the user explicitly requests a specific maximum version. Otherwise, let OpenSSL use its default configuration from crypto-policies.

Tested on RHEL 9.4+, RHEL 10, and Fedora Rawhide with FIPS:OSPP crypto policy enabled.