### PR TITLE
tool_operate: fix memory leak

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1025,8 +1025,11 @@ static CURLcode setup_outfile(struct OperationConfig *config,
 
   if(config->output_dir && *config->output_dir) {
     char *d = curl_maprintf("%s/%s", config->output_dir, per->outfile);
-    if(!d)
+    if(!d) {
+      free(per->outfile);
+      per->outfile = NULL;
       return CURLE_WRITE_ERROR;
+    }
     free(per->outfile);
     per->outfile = d;
   }


### PR DESCRIPTION
When curl_maprintf return NULL and per->outfile got memory in get_url_file_name function.