### PR TITLE
CURLOPT_COPYPOSTFIELDS.md: used with MQTT and RTSP as well

### DIFF
--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
@@ -11,6 +11,8 @@ See-also:
   - CURLOPT_UPLOAD (3)
 Protocol:
   - HTTP
+  - MQTT
+  - RTSP
 Added-in: 7.17.1
 ---
 


### PR DESCRIPTION
Follow-up to 5ec87346a9bfad1a24f97c3785