### PR TITLE
test320: fix `strippart` section to not strip CR character

### DIFF
--- a/tests/data/test1631
+++ b/tests/data/test1631
@@ -59,7 +59,7 @@ proxy
 # opens for us, so we can't compare with a known pre-existing number!
 <strippart>
 s/((https.proxy):(\d+))/$2:12345/
-s/^(User-Agent: curl)\S*/$1/
+s/^(User-Agent: curl).*/$1/
 </strippart>
 <proxy crlf="headers">
 CONNECT ftp.site.thru.https.proxy:12345 HTTP/1.1

--- a/tests/data/test1632
+++ b/tests/data/test1632
@@ -11,7 +11,7 @@ flaky
 <reply>
 
 # This is the HTTPS proxy response
-<connect crlf="yes">
+<connect crlf="headers">
 HTTP/1.1 200 OK
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
@@ -69,7 +69,7 @@ proxy
 
 <strippart>
 s/((https.proxy):(\d+))/$2:12345/
-s/^(User-Agent: curl)\S*/$1/
+s/^(User-Agent: curl).*/$1/
 </strippart>
 <proxy crlf="headers">
 CONNECT ftp.site.thru.https.proxy:12345 HTTP/1.1


### PR DESCRIPTION
This test do not run in CI (or perhaps anywhere else?) due to
the `httptls+srp` server requirement.

Follow-up to 63e9721b63d01518db83a664bc1e8373c352879e #19313

---

Originally meant to fix #19355, but dropped that part in favor of #19356.
