### PR TITLE
tool_ipfs: check the return value of curl_url_get for gwpath

### DIFF
--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -176,6 +176,7 @@ CURLcode ipfs_url_rewrite(CURLU *uh, const char *protocol, char **url,
   }
 
   curl_url_get(gatewayurl, CURLUPART_PORT, &gwport, CURLU_URLDECODE);
+
   if(curl_url_get(gatewayurl, CURLUPART_PATH, &gwpath, CURLU_URLDECODE))
     goto clean;
 
@@ -192,7 +193,6 @@ CURLcode ipfs_url_rewrite(CURLU *uh, const char *protocol, char **url,
   /* if the input path is just a slash, clear it */
   if(inputpath && (inputpath[0] == '/') && !inputpath[1])
     *inputpath = '\0';
-
 
   pathbuffer = curl_maprintf("%s%s%s/%s%s", gwpath,
                              has_trailing_slash(gwpath) ? "" : "/",


### PR DESCRIPTION
`gwpath` will be accessed later when generating `pathbuffer`.
Check the return value of curl_url_get for `gwpath` to catch potential memory error in time.
