### PR TITLE
mk-ca-bundle.pl: default to SHA256 fingerprints with `-t` option

### DIFF
--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -60,7 +60,7 @@ $opt_d = 'release';
 # If the OpenSSL commandline is not in search path you can configure it here!
 my $openssl = 'openssl';
 
-my $version = '1.29';
+my $version = '1.30';
 
 $opt_w = 76; # default base64 encoded lines length
 


### PR DESCRIPTION
Replacing previous default: MD5.

You can use the existing `-s` option to override the default.

Also bump version to 1.30.
