### PR TITLE
gtls: check the return value of gnutls_pubkey_init()

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1291,8 +1291,10 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
   do {
     int ret;
 
-    /* Begin Gyrations to get the public key     */
-    gnutls_pubkey_init(&key);
+    /* Begin Gyrations to get the public key */
+    ret = gnutls_pubkey_init(&key);
+    if(ret < 0)
+      break; /* failed */
 
     ret = gnutls_pubkey_import_x509(key, cert, 0);
     if(ret < 0)


### PR DESCRIPTION
This PR adds a check for the return value of gnutls_pubkey_init().
According to the source code of [gnutls_pubkey_init()](https://gitlab.com/gnutls/gnutls/-/blob/master/lib/pubkey.c#L124), it returns a negative error value on error and `key` will be NULL.
However, according to the source of [gnutls_pubkey_import_x509()](https://gitlab.com/gnutls/gnutls/-/blob/master/lib/pubkey.c#L165), gnutls_pubkey_import_x509() would not check the validity of `key`.
Therefore, I believe that it is necessary to check the return value of gnutls_pubkey_init().