### PR TITLE
GHA/non-native: bump to OpenBSD 7.8

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           environment_variables: MATRIX_ARCH
           operating_system: 'openbsd'
-          version: '7.7'
+          version: '7.8'
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/


### PR DESCRIPTION
Follow-up to e5cc5640b37672bd18d7561bc45c5dd91271753a #19367

---

version changes from 7.7 to 7.8:
```diff
-Downloading disk image: https://github.com/cross-platform-actions/openbsd-builder/releases/download/v0.11.0/openbsd-7.7-x86-64.qcow2
+Downloading disk image: https://github.com/cross-platform-actions/openbsd-builder/releases/download/v0.11.0/openbsd-7.8-x86-64.qcow2
--- Using CMake version 3.31.6
+-- Using CMake version 3.31.8
--- The C compiler identification is Clang 16.0.6
+-- The C compiler identification is Clang 19.1.7
--- Found OpenSSL: /usr/lib/libcrypto.so.56.0 (found version "2.0.0")
+-- Found OpenSSL: /usr/lib/libcrypto.so.57.1 (found version "2.0.0")
+--   Found libnghttp2, version 1.67.1
+-- Found NGHTTP2 (via pkg-config): /usr/local/include (found version "1.67.1")
---   Found ldap, version 2.6.9
---   Found lber, version 2.6.9
--- Found LDAP (via pkg-config): /usr/local/include (found version "2.6.9")
+--   Found ldap, version 2.6.10
+--   Found lber, version 2.6.10
+-- Found LDAP (via pkg-config): /usr/local/include (found version "2.6.10")
--- Found Libssh2 (via pkg-config): /usr/local/include (found version "1.11.0")
+-- Found Libssh2 (via pkg-config): /usr/local/include;/usr/include (found version "1.11.0")
```