### PR TITLE
GHA/windows: switch a dl-mingw job to skeeto/w64devkit gcc 15.1.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -421,7 +421,7 @@ jobs:
             sys: 'mingw64'
             dir: 'w64devkit'
             env: 'x86_64'
-            ver: '15.2.0'
+            ver: '15.1.0'
             url: 'https://github.com/skeeto/w64devkit/releases/download/v2.2.0/w64devkit-x64-2.2.0.7z.exe'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'


### PR DESCRIPTION
To add another, so far untested standalone toolchain variant to the mix.
This distro is a fairly compact, GCC mingw-w64.

Replacing an existing 15.0.1 snapshot toolchain build job.

Ref: https://github.com/skeeto/w64devkit/releases
