### PR TITLE
GHA/non-native: revert to OpenBSD 7.7 due to test hangs with 7.8

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           environment_variables: MATRIX_ARCH
           operating_system: 'openbsd'
-          version: '7.8'
+          version: '7.7'
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
@@ -122,9 +122,7 @@ jobs:
             bld/src/curl --disable --version
             if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
               time cmake --build bld --target testdeps
-              # Skip 701, 708: sometimes hangs since upgrading to OpenBSD 7.8 (from 7.7)
-              # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs.
-              export TFLAGS='-j8 !701 !708 !2707'
+              export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
               time cmake --build bld --target test-ci
             fi
             echo '::group::build examples'


### PR DESCRIPTION
test 701 (SOCKS5) and 708 (SOCKS4) started hanging occasionally, and
most likely others too.

https://github.com/curl/curl/actions/runs/19081279902/job/54510279013 (701 hangs)
https://github.com/curl/curl/actions/runs/19095657593/job/54555001348?pr=19370 (708 hangs)
https://github.com/curl/curl/actions/runs/19097996671/job/54562669865?pr=19371 (unknown test hangs)

Reverts c3b890b2c005401e18b54dacf9e63d33412e2b4f #19368

---

- [x] or maybe revert to OpenBSD 7.7, because likely other tests will be affected.
