### PR TITLE
tests/Makefile.am: fix 'checksrc' target

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -178,8 +178,6 @@ checksrc:
 	(cd unit && $(MAKE) checksrc)
 	(cd tunit && $(MAKE) checksrc)
 	(cd server && $(MAKE) checksrc)
-	(cd client && $(MAKE) checksrc)
-	(cd http && $(MAKE) checksrc)
 
 all-local: $(MANFILES) build-certs
 


### PR DESCRIPTION
Skip the http and client subdirs as they contain no code to check. The http clients are in libtests/ now.