### PR TITLE
tool_help: add checks to avoid unsigned wrap around

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -98,7 +98,7 @@ static void print_category(unsigned int category, unsigned int cols)
       size_t opt = longopt;
       size_t desclen = strlen(helptext[i].desc);
       /* avoid wrap-around */
-      if(cols >= 3 && opt + desclen >= (cols - 2)) {
+      if(cols >= 2 && opt + desclen >= (cols - 2)) {
         if(desclen < (cols - 2))
           opt = (cols - 3) - desclen;
         else


### PR DESCRIPTION
[`get_terminal_columns()`](https://github.com/curl/curl/blob/60dd72b1be7b06110922f5f0690de0b88592667c/src/terminal.c#L44) can return `cols` from 1-10000 (21-10000 only via env `COLUMNS`), while the `longdesc` in option `--help all` is `47`.
When `cols < 47`, the unsigned subtraction `cols - longdesc` wraps around to a large value, which is then passed as negative width to `curl_mprintf` after conversion to int. 
Therefore, it is better to properly check the unsigned boundary to avoid unsigned wrap around and any other unexpected/undefined behavior.