### PR TITLE
conncache: silence `-Wnull-dereference` on gcc 14 RISC-V 64

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -536,6 +536,9 @@ bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
   struct cpool *cpool = cpool_get_instance(data);
   bool kept = TRUE;
 
+  if(!data)
+    return kept;
+
   if(!data->multi->maxconnects) {
     unsigned int running = Curl_multi_xfers_running(data->multi);
     maxconnects = (running <= UINT_MAX / 4) ? running * 4 : UINT_MAX;


### PR DESCRIPTION
A false positive that appeared after a recent patch for no reason.

Seen in curl-for-win unity native Linux builds on debian:testing and
debian:trixie with gcc 14.3.0 and 14.2.0 respectively:
```
-- curl version=[8.17.1-DEV]
-- The C compiler identification is GNU 14.2.0
-- Cross-compiling: Linux/x86_64 -> Linux/riscv64
[...]
lib/conncache.c: In function 'Curl_cpool_conn_now_idle':
lib/conncache.c:539:11: error: null pointer dereference [-Werror=null-dereference]
  539 |   if(!data->multi->maxconnects) {
      |       ~~~~^~~~~~~
```
Ref: https://github.com/curl/curl-for-win/actions/runs/19111497271/job/54609512969#step:3:5788

```
-- The C compiler identification is GNU 14.3.0
```
Ref: https://github.com/curl/curl-for-win/actions/runs/19111497271/job/54609512899#step:3:5801

Patch confirmed silencing:
https://github.com/curl/curl-for-win/actions/runs/19112580362/job/54613288202

Follow-up to fbc4d59151dc4a56052f3a92da3682dc97b32148 #19271
