### PR TITLE
docs: fix checksrc `EQUALSPACE` warnings

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
@@ -81,8 +81,8 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *pointer)
 
 int main(void)
 {
-  CURL *ch;
-  CURLcode rv;
+  CURL *curl;
+  CURLcode res;
   /* CA cert in PEM format, replace the XXXs */
   char *mypem =
     "-----BEGIN CERTIFICATE-----\n"
@@ -95,23 +95,23 @@ int main(void)
     "-----END CERTIFICATE-----\n";
 
   curl_global_init(CURL_GLOBAL_ALL);
-  ch = curl_easy_init();
+  curl = curl_easy_init();
 
-  curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
-  curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 1L);
-  curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
+  curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+  curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
 
-  curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
-  curl_easy_setopt(ch, CURLOPT_SSL_CTX_DATA, mypem);
-  rv = curl_easy_perform(ch);
-  if(!rv)
+  curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
+  curl_easy_setopt(curl, CURLOPT_SSL_CTX_DATA, mypem);
+  res = curl_easy_perform(curl);
+  if(!res)
     printf("*** transfer succeeded ***\n");
   else
     printf("*** transfer failed ***\n");
 
-  curl_easy_cleanup(ch);
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return rv;
+  return (int)res;
 }
 ~~~
 

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.md
@@ -134,8 +134,8 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *pointer)
 
 int main(void)
 {
-  CURL *ch;
-  CURLcode rv;
+  CURL *curl;
+  CURLcode res;
   /* CA cert in PEM format, replace the XXXs */
   char *mypem =
     "-----BEGIN CERTIFICATE-----\n"
@@ -148,23 +148,23 @@ int main(void)
     "-----END CERTIFICATE-----\n";
 
   curl_global_init(CURL_GLOBAL_ALL);
-  ch = curl_easy_init();
+  curl = curl_easy_init();
 
-  curl_easy_setopt(ch, CURLOPT_SSLCERTTYPE, "PEM");
-  curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 1L);
-  curl_easy_setopt(ch, CURLOPT_URL, "https://www.example.com/");
+  curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+  curl_easy_setopt(curl, CURLOPT_URL, "https://www.example.com/");
 
-  curl_easy_setopt(ch, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
-  curl_easy_setopt(ch, CURLOPT_SSL_CTX_DATA, mypem);
-  rv = curl_easy_perform(ch);
-  if(!rv)
+  curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, *sslctx_function);
+  curl_easy_setopt(curl, CURLOPT_SSL_CTX_DATA, mypem);
+  res = curl_easy_perform(curl);
+  if(!res)
     printf("*** transfer succeeded ***\n");
   else
     printf("*** transfer failed ***\n");
 
-  curl_easy_cleanup(ch);
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return rv;
+  return (int)res;
 }
 ~~~
 


### PR DESCRIPTION
```
docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md:86:16
docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.md:139:16
```

Also sync `CURL *` and result variable names with rest of docs.

Follow-up to 6d7e924e80096a7e2cebad16235674fd3d3012af #19375
