### PR TITLE
GHA/macos: replace deleted gcc-12 with gcc-13/gcc-14

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -580,6 +580,7 @@ jobs:
           - { image: macos-26, compiler: 'llvm@15' }
           - { image: macos-26, compiler: 'llvm@18' }
           # Reduce build combinations, by dropping less interesting ones
+          - { image: macos-26, compiler: 'gcc-13' }
           - { compiler: gcc-14, build: cmake }
           - { compiler: gcc-15, build: autotools }
     steps:


### PR DESCRIPTION
GitHub dropped gcc-12 for the remaining two macos runner images.
Replace it with gcc-13 in normal jobs, and gcc-14 in combination jobs.

Ref: https://github.com/actions/runner-images/commit/f7e2c3f34b4985282b39ba42de9f6862a2f8a242
Ref: https://github.com/actions/runner-images/pull/13249

Ref: https://github.com/actions/runner-images/commit/1c1351b6350d920e6c5c524f3eb80cc48c8069a4
Ref: https://github.com/actions/runner-images/pull/13253