### PR TITLE
setopt: when setting bad protocols, don't store them

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2361,17 +2361,27 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #endif /* USE_LIBSSH2 */
 #endif /* USE_SSH */
   case CURLOPT_PROTOCOLS_STR:
-    if(ptr)
-      return protocol2num(ptr, &s->allowed_protocols);
-    /* make a NULL argument reset to default */
-    s->allowed_protocols = (curl_prot_t) CURLPROTO_ALL;
+    if(ptr) {
+      curl_prot_t protos;
+      result = protocol2num(ptr, &protos);
+      if(!result)
+        s->allowed_protocols = protos;
+    }
+    else
+      /* make a NULL argument reset to default */
+      s->allowed_protocols = (curl_prot_t) CURLPROTO_ALL;
     break;
 
   case CURLOPT_REDIR_PROTOCOLS_STR:
-    if(ptr)
-      return protocol2num(ptr, &s->redir_protocols);
-    /* make a NULL argument reset to default */
-    s->redir_protocols = (curl_prot_t) CURLPROTO_REDIR;
+    if(ptr) {
+      curl_prot_t protos;
+      result = protocol2num(ptr, &protos);
+      if(!result)
+        s->redir_protocols = protos;
+    }
+    else
+      /* make a NULL argument reset to default */
+      s->redir_protocols = (curl_prot_t) CURLPROTO_REDIR;
     break;
 
   case CURLOPT_DEFAULT_PROTOCOL:


### PR DESCRIPTION
Both CURLOPT_PROTOCOLS_STR and CURLOPT_REDIR_PROTOCOLS_STR would previously return error on bad input but would wrongly still store and keep the partial (unacceptable) result in the handle.