### PR TITLE
GHA/linux: add minimal Fil-C build with tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -216,7 +216,7 @@ jobs:
             configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity
 
           - name: 'Fil-C'
-            install_steps: filc pytest
+            install_steps: filc
             CC: /home/runner/filc/build/bin/filcc
             generate: >-
               -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_UNITY_BUILD=OFF


### PR DESCRIPTION
Requirements for Fil-C:
- not to accidentally pick up system headers. E.g. from `/usr/include`
  on Linux. It can happen when any dependency is auto-detected on this
  header path. This makes Fil-C find the wrong system headers, which
  in turn breaks the configuration step in subtle ways (with CMake) and
  less subtle ways (autotools). Then CMake ends up running into an error
  while compiling.
- build all dependencies with Fil-C too.
  (this patch doesn't build any dependencies yet.)
- "unity" mode disabled. It should work, but needs a lot of memory and
  slower than a standard compiler, or a Fil-C non-unity build.
- x86_64 Linux host platform when using the pre-built toolchain.

Observations on a minimal, static build made with no dependencies and
Fil-C 0.674 (based on clang 20.1.8).
- curl tool sizes:
  - cmake, default, w/o -O: 30 MB (gcc 14.2.0: 1.7 MB)
  - cmake, default, w/o -O, stripped: 29.6 MB (gcc: 1.4 MB)
  - cmake, Release, -O3: 7.2 MB (gcc: 1 MB)
  - cmake, Release, -O3, stripped: 6.8 MB (gcc: 0.93 MB)
  - autotools, default, -O2: 7 MB
- libcurl.a size is 32 MB (cmake, default, w/o -O) (gcc: 2.7 MB)
- build times 3-3.5x longer (compared to system gcc 14.2.0):
- all runtests available pass OK.
- all pytests skipped due to missing features/dependencies.
- shared libcurl builds also work (cmake, default: 25 MB libcurl.so and
  5.75 MB (5.6 stripped) curl tool)
- autotools works fine too, with dependencies disabled or set to avoid
  `/usr/include`.
