### PR TITLE
mbedtls: fix potential use of uninitialized `nread`

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -215,6 +215,7 @@ static int mbedtls_bio_cf_read(void *bio, unsigned char *buf, size_t blen)
               blen, result, nread);
   if(CURLE_AGAIN == result)
     return MBEDTLS_ERR_SSL_WANT_READ;
+  /* nread is never larger than int here */
   return result ? -1 : (int)nread;
 }
 


### PR DESCRIPTION
When Curl_conn_cf_recv() returns error, the variable might not be assigned and the tracing output may (harmlessly) use it uninitialized.

Also add a comment about the typecast from size_t to int being fine.

Pointed out by ZeroPath