### PR TITLE
rtmp: precaution for a potential integer truncation

### DIFF
--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -257,7 +257,7 @@ static CURLcode rtmp_connect(struct Curl_easy *data, bool *done)
     return CURLE_FAILED_INIT;
 
   if(conn->sock[FIRSTSOCKET] > INT_MAX) {
-    failf(data, "RTMP: The socket value is invalid for rtmp");
+    /* The socket value is invalid for rtmp. */
     return CURLE_FAILED_INIT;
   }
 


### PR DESCRIPTION
Add a safety check to prevent integer truncation when converting socket descriptors to int for the RTMP library.
On some platforms, socket descriptors may use types larger than int.
When these values exceed INT_MAX, conversion to int can truncate to negative values causing RTMP connection failures, and even accidentally affect other socket when high-value descriptors map to existing lower-value sockets after integer conversion.
This check ensures socket values are within the safe range before passing them to the RTMP library.