### PR TITLE
CURLINFO: remove 'get' and 'get the' from each short desc

### DIFF
--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
@@ -16,7 +16,7 @@ Added-in: 7.45.0
 
 # NAME
 
-CURLINFO_ACTIVESOCKET - get the active socket
+CURLINFO_ACTIVESOCKET - active socket
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
@@ -15,7 +15,7 @@ Added-in: 7.19.0
 
 # NAME
 
-CURLINFO_APPCONNECT_TIME - get the time until the SSL/SSH handshake is completed
+CURLINFO_APPCONNECT_TIME - time until the SSL/SSH handshake is completed
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CAINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.md
@@ -17,7 +17,7 @@ Added-in: 7.84.0
 
 # NAME
 
-CURLINFO_CAINFO - get the default built-in CA certificate path
+CURLINFO_CAINFO - default built-in CA certificate path
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CAPATH.md
+++ b/docs/libcurl/opts/CURLINFO_CAPATH.md
@@ -20,7 +20,7 @@ Added-in: 7.84.0
 
 # NAME
 
-CURLINFO_CAPATH - get the default built-in CA path string
+CURLINFO_CAPATH - default built-in CA path string
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.md
@@ -20,7 +20,7 @@ Added-in: 7.19.1
 
 # NAME
 
-CURLINFO_CERTINFO - get the TLS certificate chain
+CURLINFO_CERTINFO - TLS certificate chain
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
@@ -16,7 +16,7 @@ Added-in: 7.19.4
 
 # NAME
 
-CURLINFO_CONDITION_UNMET - get info on unmet time conditional or 304 HTTP response.
+CURLINFO_CONDITION_UNMET - unmet time conditional or 304 HTTP response
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME.md
@@ -15,7 +15,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_CONNECT_TIME - get the time until connect
+CURLINFO_CONNECT_TIME - time to connect
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.md
@@ -16,7 +16,7 @@ Added-in: 7.61.0
 
 # NAME
 
-CURLINFO_CONNECT_TIME_T - get the time until connect
+CURLINFO_CONNECT_TIME_T - time to connect
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONN_ID.md
+++ b/docs/libcurl/opts/CURLINFO_CONN_ID.md
@@ -15,7 +15,7 @@ Added-in: 8.2.0
 
 # NAME
 
-CURLINFO_CONN_ID - get the ID of the last connection used by the handle
+CURLINFO_CONN_ID - ID of the last connection
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
@@ -15,7 +15,7 @@ Added-in: 7.6.1
 
 # NAME
 
-CURLINFO_CONTENT_LENGTH_DOWNLOAD - get content-length of download
+CURLINFO_CONTENT_LENGTH_DOWNLOAD - content-length of download
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
@@ -15,7 +15,7 @@ Added-in: 7.55.0
 
 # NAME
 
-CURLINFO_CONTENT_LENGTH_DOWNLOAD_T - get content-length of download
+CURLINFO_CONTENT_LENGTH_DOWNLOAD_T - content-length of download
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
@@ -15,7 +15,7 @@ Added-in: 7.6.1
 
 # NAME
 
-CURLINFO_CONTENT_LENGTH_UPLOAD - get the specified size of the upload
+CURLINFO_CONTENT_LENGTH_UPLOAD - specified size of the upload
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
@@ -15,7 +15,7 @@ Added-in: 7.55.0
 
 # NAME
 
-CURLINFO_CONTENT_LENGTH_UPLOAD_T - get the specified size of the upload
+CURLINFO_CONTENT_LENGTH_UPLOAD_T - specified size of the upload
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
@@ -16,7 +16,7 @@ Added-in: 7.9.4
 
 # NAME
 
-CURLINFO_CONTENT_TYPE - get Content-Type
+CURLINFO_CONTENT_TYPE - Content-Type of response
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.md
@@ -15,7 +15,7 @@ Added-in: 7.14.1
 
 # NAME
 
-CURLINFO_COOKIELIST - get all known cookies
+CURLINFO_COOKIELIST - all known cookies
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_EARLYDATA_SENT_T.md
+++ b/docs/libcurl/opts/CURLINFO_EARLYDATA_SENT_T.md
@@ -16,7 +16,7 @@ Added-in: 8.11.0
 
 # NAME
 
-CURLINFO_EARLYDATA_SENT_T - get the number of bytes sent as TLS early data
+CURLINFO_EARLYDATA_SENT_T - number of bytes sent as TLS early data
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.md
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.md
@@ -16,7 +16,7 @@ Added-in: 7.72.0
 
 # NAME
 
-CURLINFO_EFFECTIVE_METHOD - get the last used HTTP method
+CURLINFO_EFFECTIVE_METHOD - last used HTTP request method
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.md
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.md
@@ -15,7 +15,7 @@ Added-in: 7.4
 
 # NAME
 
-CURLINFO_EFFECTIVE_URL - get the last used URL
+CURLINFO_EFFECTIVE_URL - last used URL
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_FILETIME.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME.md
@@ -17,7 +17,7 @@ Added-in: 7.5
 
 # NAME
 
-CURLINFO_FILETIME - get the remote time of the retrieved document
+CURLINFO_FILETIME - remote time of the retrieved document
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_FILETIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME_T.md
@@ -17,7 +17,7 @@ Added-in: 7.59.0
 
 # NAME
 
-CURLINFO_FILETIME_T - get the remote time of the retrieved document
+CURLINFO_FILETIME_T - remote time of the retrieved resource
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
+++ b/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
@@ -15,7 +15,7 @@ Added-in: 7.15.4
 
 # NAME
 
-CURLINFO_FTP_ENTRY_PATH - get entry path in FTP server
+CURLINFO_FTP_ENTRY_PATH - entry path in FTP server
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
@@ -16,7 +16,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_HEADER_SIZE - get size of retrieved headers
+CURLINFO_HEADER_SIZE - size of response headers
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
@@ -16,7 +16,7 @@ Added-in: 7.10.8
 
 # NAME
 
-CURLINFO_HTTPAUTH_AVAIL - get available HTTP authentication methods
+CURLINFO_HTTPAUTH_AVAIL - available HTTP authentication methods
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_USED.md
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_USED.md
@@ -15,7 +15,7 @@ Added-in: 8.12.0
 
 # NAME
 
-CURLINFO_HTTPAUTH_USED - get used HTTP authentication method
+CURLINFO_HTTPAUTH_USED - used HTTP authentication method
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
+++ b/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
@@ -15,7 +15,7 @@ Added-in: 7.10.7
 
 # NAME
 
-CURLINFO_HTTP_CONNECTCODE - get the CONNECT response code
+CURLINFO_HTTP_CONNECTCODE - CONNECT response code
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLINFO_HTTP_VERSION.md
@@ -15,7 +15,7 @@ Added-in: 7.50.0
 
 # NAME
 
-CURLINFO_HTTP_VERSION - get the http version used in the connection
+CURLINFO_HTTP_VERSION - HTTP version used in the transfer
 
 # SYNOPSIS
 
@@ -27,10 +27,10 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_HTTP_VERSION, long *p);
 
 # DESCRIPTION
 
-Pass a pointer to a long to receive the version used in the last http
-connection done using this handle. The returned value is
-CURL_HTTP_VERSION_1_0, CURL_HTTP_VERSION_1_1, CURL_HTTP_VERSION_2_0,
-CURL_HTTP_VERSION_3 or 0 if the version cannot be determined.
+Pass a pointer to a long to receive the version used in the last http transfer
+done using this handle. The returned value is CURL_HTTP_VERSION_1_0,
+CURL_HTTP_VERSION_1_1, CURL_HTTP_VERSION_2_0, CURL_HTTP_VERSION_3 or 0 if the
+version cannot be determined.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
@@ -16,7 +16,7 @@ Added-in: 7.15.2
 
 # NAME
 
-CURLINFO_LASTSOCKET - get the last socket used
+CURLINFO_LASTSOCKET - last socket used
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
@@ -17,7 +17,7 @@ Added-in: 7.21.0
 
 # NAME
 
-CURLINFO_LOCAL_IP - get local IP address of last connection
+CURLINFO_LOCAL_IP - local IP address of last connection
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
@@ -17,7 +17,7 @@ Added-in: 7.21.0
 
 # NAME
 
-CURLINFO_LOCAL_PORT - get the latest local port number
+CURLINFO_LOCAL_PORT - latest local port number
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.md
@@ -15,7 +15,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_NAMELOOKUP_TIME - get the name lookup time
+CURLINFO_NAMELOOKUP_TIME - name lookup time
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.md
@@ -15,7 +15,7 @@ Added-in: 7.61.0
 
 # NAME
 
-CURLINFO_NAMELOOKUP_TIME_T - get the name lookup time in microseconds
+CURLINFO_NAMELOOKUP_TIME_T - name lookup time in microseconds
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
@@ -14,7 +14,7 @@ Added-in: 7.12.3
 
 # NAME
 
-CURLINFO_NUM_CONNECTS - get number of created connections
+CURLINFO_NUM_CONNECTS - number of created connections
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
@@ -14,7 +14,7 @@ Added-in: 7.12.2
 
 # NAME
 
-CURLINFO_OS_ERRNO - get errno number from last connect failure
+CURLINFO_OS_ERRNO - errno number from last connect failure
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_POSTTRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_POSTTRANSFER_TIME_T.md
@@ -16,7 +16,7 @@ Added-in: 8.10.0
 
 # NAME
 
-CURLINFO_POSTTRANSFER_TIME_T - get the time until the last byte is sent
+CURLINFO_POSTTRANSFER_TIME_T - time to last byte sent
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.md
@@ -16,7 +16,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_PRETRANSFER_TIME - get the time until the file transfer start
+CURLINFO_PRETRANSFER_TIME - time to transfer start
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.md
@@ -16,7 +16,7 @@ Added-in: 7.61.0
 
 # NAME
 
-CURLINFO_PRETRANSFER_TIME_T - get the time until the file transfer start
+CURLINFO_PRETRANSFER_TIME_T - time to transfer start
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_IP.md
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_IP.md
@@ -17,7 +17,7 @@ Added-in: 7.19.0
 
 # NAME
 
-CURLINFO_PRIMARY_IP - get IP address of last connection
+CURLINFO_PRIMARY_IP - IP address of last connection
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
@@ -16,7 +16,7 @@ Added-in: 7.21.0
 
 # NAME
 
-CURLINFO_PRIMARY_PORT - get the latest destination port number
+CURLINFO_PRIMARY_PORT - last destination port number
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PRIVATE.md
+++ b/docs/libcurl/opts/CURLINFO_PRIVATE.md
@@ -15,7 +15,7 @@ Added-in: 7.10.3
 
 # NAME
 
-CURLINFO_PRIVATE - get the private pointer
+CURLINFO_PRIVATE - private pointer
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PROTOCOL.md
+++ b/docs/libcurl/opts/CURLINFO_PROTOCOL.md
@@ -15,7 +15,7 @@ Added-in: 7.52.0
 
 # NAME
 
-CURLINFO_PROTOCOL - get the protocol used in the connection
+CURLINFO_PROTOCOL - protocol used in the connection
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
@@ -15,7 +15,7 @@ Added-in: 7.10.8
 
 # NAME
 
-CURLINFO_PROXYAUTH_AVAIL - get available HTTP proxy authentication methods
+CURLINFO_PROXYAUTH_AVAIL - HTTP proxy authentication methods
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_USED.md
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_USED.md
@@ -15,7 +15,7 @@ Added-in: 8.12.0
 
 # NAME
 
-CURLINFO_PROXYAUTH_USED - get used HTTP proxy authentication method
+CURLINFO_PROXYAUTH_USED - HTTP proxy authentication method
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
@@ -16,7 +16,7 @@ Added-in: 7.73.0
 
 # NAME
 
-CURLINFO_PROXY_ERROR - get the detailed (SOCKS) proxy error
+CURLINFO_PROXY_ERROR - detailed (SOCKS) proxy error
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
@@ -18,7 +18,7 @@ Added-in: 7.52.0
 
 # NAME
 
-CURLINFO_PROXY_SSL_VERIFYRESULT - get the result of the proxy certificate verification
+CURLINFO_PROXY_SSL_VERIFYRESULT - result of proxy certificate verification
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.md
@@ -16,7 +16,7 @@ Added-in: 7.9.7
 
 # NAME
 
-CURLINFO_REDIRECT_COUNT - get the number of redirects
+CURLINFO_REDIRECT_COUNT - number of redirects
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.md
@@ -17,7 +17,7 @@ Added-in: 7.9.7
 
 # NAME
 
-CURLINFO_REDIRECT_TIME - get the time for all redirection steps
+CURLINFO_REDIRECT_TIME - time for all redirection steps
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.md
@@ -17,7 +17,7 @@ Added-in: 7.61.0
 
 # NAME
 
-CURLINFO_REDIRECT_TIME_T - get the time for all redirection steps
+CURLINFO_REDIRECT_TIME_T - time for all redirection steps
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_URL.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_URL.md
@@ -17,7 +17,7 @@ Added-in: 7.18.2
 
 # NAME
 
-CURLINFO_REDIRECT_URL - get the URL a redirect would go to
+CURLINFO_REDIRECT_URL - URL a redirect would go to
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_REFERER.md
+++ b/docs/libcurl/opts/CURLINFO_REFERER.md
@@ -16,7 +16,7 @@ Added-in: 7.76.0
 
 # NAME
 
-CURLINFO_REFERER - get the used referrer request header
+CURLINFO_REFERER - used HTTP referrer request header
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
@@ -16,7 +16,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_REQUEST_SIZE - get size of sent request
+CURLINFO_REQUEST_SIZE - size of sent request
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.md
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.md
@@ -18,7 +18,7 @@ Added-in: 7.10.8
 
 # NAME
 
-CURLINFO_RESPONSE_CODE - get the last response code
+CURLINFO_RESPONSE_CODE - last response code
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.md
@@ -16,7 +16,7 @@ Added-in: 7.20.0
 
 # NAME
 
-CURLINFO_RTSP_CLIENT_CSEQ - get the next RTSP client CSeq
+CURLINFO_RTSP_CLIENT_CSEQ - next RTSP client CSeq
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.md
@@ -15,7 +15,7 @@ Added-in: 7.20.0
 
 # NAME
 
-CURLINFO_RTSP_CSEQ_RECV - get the recently received CSeq
+CURLINFO_RTSP_CSEQ_RECV - last received RTSP CSeq
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
@@ -15,7 +15,7 @@ Added-in: 7.20.0
 
 # NAME
 
-CURLINFO_RTSP_SERVER_CSEQ - get the next RTSP server CSeq
+CURLINFO_RTSP_SERVER_CSEQ - next RTSP server CSeq
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.md
@@ -15,7 +15,7 @@ Added-in: 7.20.0
 
 # NAME
 
-CURLINFO_RTSP_SESSION_ID - get RTSP session ID
+CURLINFO_RTSP_SESSION_ID - RTSP session ID
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SCHEME.md
+++ b/docs/libcurl/opts/CURLINFO_SCHEME.md
@@ -17,7 +17,7 @@ Added-in: 7.52.0
 
 # NAME
 
-CURLINFO_SCHEME - get the URL scheme (sometimes called protocol) used in the connection
+CURLINFO_SCHEME - URL scheme used in transfer
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
@@ -17,7 +17,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_SIZE_DOWNLOAD - get the number of downloaded bytes
+CURLINFO_SIZE_DOWNLOAD - number of downloaded bytes
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
@@ -17,7 +17,7 @@ Added-in: 7.55.0
 
 # NAME
 
-CURLINFO_SIZE_DOWNLOAD_T - get the number of downloaded bytes
+CURLINFO_SIZE_DOWNLOAD_T - number of downloaded bytes
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
@@ -16,7 +16,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_SIZE_UPLOAD - get the number of uploaded bytes
+CURLINFO_SIZE_UPLOAD - number of uploaded bytes
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
@@ -16,7 +16,7 @@ Added-in: 7.55.0
 
 # NAME
 
-CURLINFO_SIZE_UPLOAD_T - get the number of uploaded bytes
+CURLINFO_SIZE_UPLOAD_T - number of uploaded bytes
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
@@ -16,7 +16,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_SPEED_DOWNLOAD - get download speed
+CURLINFO_SPEED_DOWNLOAD - download speed
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
@@ -16,7 +16,7 @@ Added-in: 7.55.0
 
 # NAME
 
-CURLINFO_SPEED_DOWNLOAD_T - get download speed
+CURLINFO_SPEED_DOWNLOAD_T - download speed
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
@@ -15,7 +15,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_SPEED_UPLOAD - get upload speed
+CURLINFO_SPEED_UPLOAD - upload speed
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
@@ -15,7 +15,7 @@ Added-in: 7.55.0
 
 # NAME
 
-CURLINFO_SPEED_UPLOAD_T - get upload speed
+CURLINFO_SPEED_UPLOAD_T - upload speed
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
@@ -17,7 +17,7 @@ Added-in: 7.12.3
 
 # NAME
 
-CURLINFO_SSL_ENGINES - get an slist of OpenSSL crypto-engines
+CURLINFO_SSL_ENGINES - an slist of OpenSSL crypto-engines
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
@@ -18,7 +18,7 @@ Added-in: 7.5
 
 # NAME
 
-CURLINFO_SSL_VERIFYRESULT - get the result of the certificate verification
+CURLINFO_SSL_VERIFYRESULT - result of the certificate verification
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.md
@@ -16,7 +16,7 @@ Added-in: 7.9.2
 
 # NAME
 
-CURLINFO_STARTTRANSFER_TIME - get the time until the first byte is received
+CURLINFO_STARTTRANSFER_TIME - time to first byte received
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.md
@@ -16,7 +16,7 @@ Added-in: 7.61.0
 
 # NAME
 
-CURLINFO_STARTTRANSFER_TIME_T - get the time until the first byte is received
+CURLINFO_STARTTRANSFER_TIME_T - time to first byte received
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
@@ -18,7 +18,7 @@ Added-in: 7.34.0
 
 # NAME
 
-CURLINFO_TLS_SESSION - get TLS session info
+CURLINFO_TLS_SESSION - TLS session info
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -21,7 +21,7 @@ Added-in: 7.48.0
 
 # NAME
 
-CURLINFO_TLS_SESSION, CURLINFO_TLS_SSL_PTR - get TLS session info
+CURLINFO_TLS_SSL_PTR - TLS session info
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME.md
@@ -16,7 +16,7 @@ Added-in: 7.4.1
 
 # NAME
 
-CURLINFO_TOTAL_TIME - get total time of previous transfer
+CURLINFO_TOTAL_TIME - total time of previous transfer
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.md
@@ -15,7 +15,7 @@ Added-in: 7.61.0
 ---
 # NAME
 
-CURLINFO_TOTAL_TIME_T - get total time of previous transfer in microseconds
+CURLINFO_TOTAL_TIME_T - total time of previous transfer
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLINFO_XFER_ID.md
+++ b/docs/libcurl/opts/CURLINFO_XFER_ID.md
@@ -15,7 +15,7 @@ Added-in: 8.2.0
 
 # NAME
 
-CURLINFO_XFER_ID - get the ID of a transfer
+CURLINFO_XFER_ID - ID of the transfer
 
 # SYNOPSIS
 


### PR DESCRIPTION
The short descriptions describe the data each info retrieves. The info itself does not 'get' the data.

This simplifies and shortens the descriptions and make them more consistent.