### PR TITLE
GHA/linux: build and test LibreSSL with Fil-C curl, enable pytests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -217,7 +217,7 @@ jobs:
 
           - name: 'libressl Fil-C'
             install_steps: filc libressl-filc pytest
-            tflags: '!776'
+            tflags: '!776'  # adds 1-9 minutes to the test run step, and fails consistently
             CC: /home/runner/filc/build/bin/filcc
             generate: >-
               -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_UNITY_BUILD=OFF


### PR DESCRIPTION
Build and cache LibreSSL locally with Fil-C and enable it in the Fil-C
job.

Also:
- disable test 776 in the Fil-C job. It fails consistently, and due to
  flakiness seen earlier its result is disabled. In this job it seems to
  be adding 1 to 9 minues to the test run step and fails consistently.
- include Fil-C version in the LibreSSL cache key to prepare for Fil-C
  ABI changes.
- GHA/linux: fully quote `tflags` values to avoid breaking YAML.

Tested and confirmed working with OpenSSL too, but ended up with
LibreSSL for faster, smaller builds.

---

runtests times are fluctuating, for reasons not discovered yet. If it
causes flakiness or timeouts, tests or TLS support may be disabled
for Fil-C.

- [x] rebase on #19412.