### PR TITLE
tftp: release filename if conn_get_remote_addr fails

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -479,6 +479,7 @@ static CURLcode tftp_send_first(struct tftp_conn *state,
                    state->blksize,
                    "%s%c%s%c", filename, '\0', mode, '\0');
     sbytes = 4 + strlen(filename) + strlen(mode);
+    free(filename);
 
     /* optional addition of TFTP options */
     if(!data->set.tftp_no_options) {
@@ -517,7 +518,6 @@ static CURLcode tftp_send_first(struct tftp_conn *state,
 
       if(result != CURLE_OK) {
         failf(data, "TFTP buffer too small for options");
-        free(filename);
         return CURLE_TFTP_ILLEGAL;
       }
     }
@@ -530,16 +530,13 @@ static CURLcode tftp_send_first(struct tftp_conn *state,
 #define CURL_SENDTO_ARG5(x) (x)
 #endif
     remote_addr = Curl_conn_get_remote_addr(data, FIRSTSOCKET);
-    if(!remote_addr) {
-      free(filename);
+    if(!remote_addr)
       return CURLE_FAILED_INIT;
-    }
 
     senddata = sendto(state->sockfd, (void *)state->spacket.data,
                       (SEND_TYPE_ARG3)sbytes, 0,
                       CURL_SENDTO_ARG5(&remote_addr->curl_sa_addr),
                       (curl_socklen_t)remote_addr->addrlen);
-    free(filename);
     if(senddata != (ssize_t)sbytes) {
       char buffer[STRERROR_LEN];
       failf(data, "%s", curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));


### PR DESCRIPTION
When Curl_conn_get_remote_addr (at line 532 of the orginal code) fails, the original code does not properly release `filename`.
This PR releases `filename` immediately after it becomes useless, so that we do not need to take care of it on the subsequent error paths.