### PR TITLE
pytest: skip H2 tests if feature missing from curl

### DIFF
--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -56,6 +56,8 @@ class TestBasic:
     # simple https: GET, h2 wanted and got
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
     def test_01_03_h2_get(self, env: Env, httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.domain1}:{env.https_port}/data.json'
         r = curl.http_get(url=url, extra_args=['--http2'])
@@ -65,6 +67,8 @@ class TestBasic:
     # simple https: GET, h2 unsupported, fallback to h1
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
     def test_01_04_h2_unsupported(self, env: Env, httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.domain2}:{env.https_port}/data.json'
         r = curl.http_get(url=url, extra_args=['--http2'])
@@ -84,6 +88,8 @@ class TestBasic:
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_01_06_timings(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -100,6 +106,8 @@ class TestBasic:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
     def test_01_07_head(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -115,6 +123,8 @@ class TestBasic:
 
     # http: GET for HTTP/2, see Upgrade:, 101 switch
     def test_01_08_h2_upgrade(self, env: Env, httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'http://{env.domain1}:{env.http_port}/data.json'
         r = curl.http_get(url=url, extra_args=['--http2'])
@@ -127,6 +137,8 @@ class TestBasic:
 
     # http: GET for HTTP/2 with prior knowledge
     def test_01_09_h2_prior_knowledge(self, env: Env, httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'http://{env.domain1}:{env.http_port}/data.json'
         r = curl.http_get(url=url, extra_args=['--http2-prior-knowledge'])
@@ -138,6 +150,8 @@ class TestBasic:
 
     # http: strip TE header in HTTP/2 requests
     def test_01_10_te_strip(self, env: Env, httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, "h2")}/data.json'
         r = curl.http_get(url=url, extra_args=['--http2', '-H', 'TE: gzip'])
@@ -152,6 +166,8 @@ class TestBasic:
     # RSTing the stream correctly when its internal limits are exceeded.
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_01_11_large_resp_headers(self, env: Env, httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -167,6 +183,8 @@ class TestBasic:
                         reason='httpd must be at least 2.4.64')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_01_12_xlarge_resp_headers(self, env: Env, httpd, configures_httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         httpd.set_extra_config('base', [
             f'H2MaxHeaderBlockLen {130 * 1024}',
         ])
@@ -184,6 +202,8 @@ class TestBasic:
                         reason='httpd must be at least 2.4.64')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_01_13_megalarge_resp_headers(self, env: Env, httpd, configures_httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         httpd.set_extra_config('base', [
             'LogLevel http2:trace2',
             f'H2MaxHeaderBlockLen {130 * 1024}',
@@ -204,6 +224,8 @@ class TestBasic:
                         reason='httpd must be at least 2.4.64')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_01_14_gigalarge_resp_headers(self, env: Env, httpd, configures_httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         httpd.set_extra_config('base', [
             'LogLevel http2:trace2',
             f'H2MaxHeaderBlockLen {1024 * 1024}',
@@ -223,6 +245,8 @@ class TestBasic:
                         reason='httpd must be at least 2.4.64')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_01_15_gigalarge_resp_headers(self, env: Env, httpd, configures_httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         httpd.set_extra_config('base', [
             'LogLevel http2:trace2',
             f'H2MaxHeaderBlockLen {1024 * 1024}',
@@ -240,6 +264,8 @@ class TestBasic:
     # http: invalid request headers, GET, issue #16998
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_01_16_inv_req_get(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -263,6 +289,8 @@ class TestBasic:
     ])
     def test_01_17_TE(self, env: Env, httpd, te_in, te_out):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_stats=True,
@@ -277,6 +305,8 @@ class TestBasic:
     # check that an existing https: connection is not reused for http:
     def test_01_18_tls_reuse(self, env: Env, httpd):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url1 = f'https://{env.authority_for(env.domain1, proto)}/data.json'
         url2 = f'http://{env.authority_for(env.domain1, proto)}/data.json'
@@ -287,6 +317,8 @@ class TestBasic:
     # check that an existing http: connection is not reused for https:
     def test_01_19_plain_reuse(self, env: Env, httpd):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url1 = f'http://{env.domain1}:{env.http_port}/data.json'
         url2 = f'https://{env.domain1}:{env.http_port}/data.json'

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -55,6 +55,8 @@ class TestDownload:
     # download 1 file
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_01_download_1(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -65,6 +67,8 @@ class TestDownload:
     # download 2 files
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_02_download_2(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -75,6 +79,8 @@ class TestDownload:
     # download 100 files sequentially
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_03_download_sequential(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if (proto == 'http/1.1' or proto == 'h2') and env.curl_uses_lib('mbedtls') and \
@@ -89,6 +95,8 @@ class TestDownload:
     # download 100 files parallel
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_04_download_parallel(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h2' and env.curl_uses_lib('mbedtls') and \
@@ -112,6 +120,8 @@ class TestDownload:
     # download 500 files sequential
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_05_download_many_sequential(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h2' and env.curl_uses_lib('mbedtls') and \
@@ -132,6 +142,8 @@ class TestDownload:
     # download 500 files parallel
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_06_download_many_parallel(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h2' and env.curl_uses_lib('mbedtls') and \
@@ -149,6 +161,8 @@ class TestDownload:
     # download files parallel, check connection reuse/multiplex
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_07_download_reuse(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 200
@@ -180,6 +194,8 @@ class TestDownload:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_08_1MB_serial(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 5
@@ -190,6 +206,8 @@ class TestDownload:
 
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_09_1MB_parallel(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 5
@@ -204,6 +222,8 @@ class TestDownload:
     @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_10_10MB_serial(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 3
@@ -216,6 +236,8 @@ class TestDownload:
     @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_11_10MB_parallel(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 3
@@ -228,6 +250,8 @@ class TestDownload:
 
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_12_head_serial_https(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 5
@@ -240,6 +264,8 @@ class TestDownload:
 
     @pytest.mark.parametrize("proto", ['h2'])
     def test_02_13_head_serial_h2c(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 5
@@ -252,6 +278,8 @@ class TestDownload:
 
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_14_not_found(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 5
@@ -266,6 +294,8 @@ class TestDownload:
 
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_02_15_fail_not_found(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 5
@@ -280,6 +310,8 @@ class TestDownload:
 
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
     def test_02_20_h2_small_frames(self, env: Env, httpd, configures_httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         # Test case to reproduce content corruption as observed in
         # https://github.com/curl/curl/issues/10525
         # To reliably reproduce, we need an Apache httpd that supports
@@ -328,6 +360,8 @@ class TestDownload:
     @pytest.mark.parametrize("swin_max", [0, 10*1024])
     def test_02_21_h2_lib_serial(self, env: Env, httpd, pause_offset, swin_max):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         count = 2
         docname = 'data-10m'
         url = f'https://localhost:{env.https_port}/{docname}'
@@ -349,6 +383,8 @@ class TestDownload:
     @pytest.mark.parametrize("pause_offset", [100*1023])
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_22_lib_parallel_resume(self, env: Env, httpd, nghttpx, proto, pause_offset):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -369,6 +405,8 @@ class TestDownload:
     # download, several at a time, pause and abort paused
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_23a_lib_abort_paused(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -398,6 +436,8 @@ class TestDownload:
     # download, several at a time, abort after n bytes
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_23b_lib_abort_offset(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -427,6 +467,8 @@ class TestDownload:
     # download, several at a time, abort after n bytes
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_23c_lib_fail_offset(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -456,6 +498,8 @@ class TestDownload:
     # speed limited download
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_24_speed_limit(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -485,6 +529,8 @@ class TestDownload:
     # TODO: just uses a single connection for h2/h3. Not sure how to prevent that
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_26_session_shared_reuse(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}/data-100k'
@@ -497,6 +543,8 @@ class TestDownload:
     # test on paused transfers, based on issue #11982
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_27a_paused_no_cl(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}' \
@@ -508,6 +556,8 @@ class TestDownload:
     # test on paused transfers, based on issue #11982
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_27b_paused_no_cl(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}' \
@@ -519,6 +569,8 @@ class TestDownload:
     # test on paused transfers, based on issue #11982
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_27c_paused_no_cl(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}' \
@@ -529,6 +581,8 @@ class TestDownload:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_28_get_compressed(self, env: Env, httpd, nghttpx, proto):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -557,6 +611,8 @@ class TestDownload:
     @pytest.mark.parametrize("pause_offset", [0, 10*1024, 100*1023, 640000])
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_29_h2_lib_serial(self, env: Env, httpd, nghttpx, proto, pause_offset):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -574,6 +630,8 @@ class TestDownload:
 
     # download parallel with prior knowledge
     def test_02_30_parallel_prior_knowledge(self, env: Env, httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         count = 3
         curl = CurlClient(env=env)
         urln = f'http://{env.domain1}:{env.http_port}/data.json?[0-{count-1}]'
@@ -585,6 +643,8 @@ class TestDownload:
 
     # download parallel with h2 "Upgrade:"
     def test_02_31_parallel_upgrade(self, env: Env, httpd, nghttpx):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         count = 3
         curl = CurlClient(env=env)
         urln = f'http://{env.domain1}:{env.http_port}/data.json?[0-{count-1}]'
@@ -605,6 +665,8 @@ class TestDownload:
     def test_02_32_earlydata(self, env: Env, httpd, nghttpx, proto):
         if not env.curl_can_early_data():
             pytest.skip('TLS earlydata not implemented')
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and \
            (not env.have_h3() or not env.curl_can_h3_early_data()):
             pytest.skip("h3 not supported")
@@ -661,6 +723,8 @@ class TestDownload:
             pytest.skip('only works for curl debug builds')
         if not env.curl_is_verbose():
             pytest.skip('only works for curl with verbose strings')
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 50
@@ -701,6 +765,8 @@ class TestDownload:
             pytest.skip('only works for curl debug builds')
         if not env.curl_is_verbose():
             pytest.skip('only works for curl with verbose strings')
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 50
@@ -746,6 +812,8 @@ class TestDownload:
     #   to be received, requiring buffering.
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_35_pause_bomb(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -765,6 +833,8 @@ class TestDownload:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     @pytest.mark.parametrize("url_junk", [1024, 16*1024, 32*1024, 64*1024, 80*1024, 96*1024])
     def test_02_36_looong_urls(self, env: Env, httpd, nghttpx, proto, url_junk):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_lib('quiche'):

--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -41,6 +41,8 @@ class TestGoAway:
     # download files sequentially with delay, reload server for GOAWAY
     def test_03_01_h2_goaway(self, env: Env, httpd, nghttpx):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         count = 3
         self.r = None
 

--- a/tests/http/test_04_stuttered.py
+++ b/tests/http/test_04_stuttered.py
@@ -41,6 +41,8 @@ class TestStuttered:
     # download 1 file, check that delayed response works in general
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_04_01_download_1(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -56,6 +58,8 @@ class TestStuttered:
     # (Apache2 increases # of parallel processed requests after successes)
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_04_02_100_100_10(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 50
@@ -78,6 +82,8 @@ class TestStuttered:
     # (Apache2 increases # of parallel processed requests after successes)
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_04_03_1000_10_1(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 50
@@ -100,6 +106,8 @@ class TestStuttered:
     # (Apache2 increases # of parallel processed requests after successes)
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_04_04_1000_10_1(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 50

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -40,6 +40,8 @@ class TestErrors:
     # download 1 file, check that we get CURLE_PARTIAL_FILE
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_05_01_partial_1(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -60,6 +62,8 @@ class TestErrors:
     # download files, check that we get CURLE_PARTIAL_FILE for all
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_05_02_partial_20(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -82,6 +86,8 @@ class TestErrors:
 
     # access a resource that, on h2, RST the stream with HTTP_1_1_REQUIRED
     def test_05_03_required(self, env: Env, httpd, nghttpx):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         proto = 'http/1.1'
         urln = f'https://{env.authority_for(env.domain1, proto)}/curltest/1_1'
@@ -107,6 +113,8 @@ class TestErrors:
     #   and not see the "unclean" close either
     @pytest.mark.parametrize("proto", ['http/1.0', 'http/1.1', 'h2'])
     def test_05_04_unclean_tls_shutdown(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 10 if proto == 'h2' else 1

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -53,6 +53,8 @@ class TestUpload:
     # upload small data, check that this is what was echoed
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_01_upload_1_small(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         data = '0123456789'
@@ -66,6 +68,8 @@ class TestUpload:
     # upload large data, check that this is what was echoed
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_02_upload_1_large(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
@@ -80,6 +84,8 @@ class TestUpload:
     # upload data sequentially, check that they were echoed
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_10_upload_sequential(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 20
@@ -95,6 +101,8 @@ class TestUpload:
     # upload data parallel, check that they were echoed
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_07_11_upload_parallel(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1
@@ -112,6 +120,8 @@ class TestUpload:
     # upload large data sequentially, check that this is what was echoed
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_12_upload_seq_large(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
@@ -129,6 +139,8 @@ class TestUpload:
     # upload very large data sequentially, check that this is what was echoed
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_13_upload_seq_large(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
@@ -148,6 +160,8 @@ class TestUpload:
         '', '1', '123\n456andsomething\n\n'
     ])
     def test_07_14_upload_stdin(self, env: Env, httpd, nghttpx, proto, indata):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -161,6 +175,8 @@ class TestUpload:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_15_hx_put(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -177,6 +193,8 @@ class TestUpload:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_16_hx_put_reuse(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -193,6 +211,8 @@ class TestUpload:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_17_hx_post_reuse(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -210,6 +230,8 @@ class TestUpload:
     # upload data parallel, check that they were echoed
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_07_20_upload_parallel(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1
@@ -227,6 +249,8 @@ class TestUpload:
     # upload large data parallel, check that this is what was echoed
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_07_21_upload_parallel_large(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
@@ -242,6 +266,8 @@ class TestUpload:
     # upload large data parallel to a URL that denies uploads
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_07_22_upload_parallel_fail(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
@@ -258,6 +284,8 @@ class TestUpload:
     # PUT 100k
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_30_put_100k(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
@@ -276,6 +304,8 @@ class TestUpload:
     # PUT 10m
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_31_put_10m(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
@@ -294,6 +324,8 @@ class TestUpload:
     # issue #10591
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_32_issue_10591(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
@@ -307,6 +339,8 @@ class TestUpload:
     # correctly and not time out on sending
     def test_07_33_issue_11157a(self, env: Env, httpd, nghttpx):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         # send a POST to our PUT handler which will send immediately a 404 back
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put'
@@ -328,6 +362,8 @@ class TestUpload:
     # issue #11157, send upload that is slowly read in
     def test_07_33_issue_11157b(self, env: Env, httpd, nghttpx):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         # tell our test PUT handler to read the upload more slowly, so
         # that the send buffering and transfer loop needs to wait
@@ -350,6 +386,8 @@ class TestUpload:
 
     def test_07_34_issue_11194(self, env: Env, httpd, nghttpx):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         # tell our test PUT handler to read the upload more slowly, so
         # that the send buffering and transfer loop needs to wait
         fdata = os.path.join(env.gen_dir, 'data-100k')
@@ -369,6 +407,8 @@ class TestUpload:
 
     # upload large data on a h1 to h2 upgrade
     def test_07_35_h1_h2_upgrade_upload(self, env: Env, httpd, nghttpx):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
         curl = CurlClient(env=env)
         url = f'http://{env.domain1}:{env.http_port}/curltest/echo?id=[0-0]'
@@ -386,6 +426,8 @@ class TestUpload:
     @pytest.mark.parametrize("redir", ['301', '302', '303'])
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_36_upload_30x(self, env: Env, httpd, nghttpx, redir, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -403,6 +445,8 @@ class TestUpload:
     # upload to a 307 response
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_37_upload_307(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -420,6 +464,8 @@ class TestUpload:
     # POST form data, yet another code path in transfer
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_38_form_small(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -432,6 +478,8 @@ class TestUpload:
     # POST data urlencoded, small enough to be sent with request headers
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_39_post_urlenc_small(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-63k')
@@ -448,6 +496,8 @@ class TestUpload:
     # POST data urlencoded, large enough to be sent separate from request headers
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_40_post_urlenc_large(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-64k')
@@ -468,6 +518,8 @@ class TestUpload:
     # of the time
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_41_post_urlenc_small(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_lib('quiche'):
@@ -501,6 +553,8 @@ class TestUpload:
     # issues #11769 #13260
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_42a_upload_disconnect(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         client = LocalClient(name='cli_upload_pausing', env=env, timeout=60)
@@ -521,6 +575,8 @@ class TestUpload:
     # upload data, pause, let connection die without any response at all
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_42b_upload_disconnect(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         client = LocalClient(name='cli_upload_pausing', env=env, timeout=60)
@@ -536,6 +592,8 @@ class TestUpload:
     # upload data, pause, let connection die after 100 continue
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_42c_upload_disconnect(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         client = LocalClient(name='cli_upload_pausing', env=env, timeout=60)
@@ -550,6 +608,8 @@ class TestUpload:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_43_upload_denied(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -567,6 +627,8 @@ class TestUpload:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     @pytest.mark.parametrize("httpcode", [301, 302, 307, 308])
     def test_07_44_put_redir(self, env: Env, httpd, nghttpx, proto, httpcode):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -591,6 +653,8 @@ class TestUpload:
     # speed limited on put handler
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_50_put_speed_limit(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -611,6 +675,8 @@ class TestUpload:
     # speed limited on echo handler
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_07_51_echo_speed_limit(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -707,6 +773,8 @@ class TestUpload:
     def test_07_70_put_earlydata(self, env: Env, httpd, nghttpx, proto, upload_size, exp_early):
         if not env.curl_can_early_data():
             pytest.skip('TLS earlydata not implemented')
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and \
            (not env.have_h3() or not env.curl_can_h3_early_data()):
             pytest.skip("h3 not supported")

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -70,6 +70,8 @@ class TestCaddy:
     # download 1 file
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_08_01_download_1(self, env: Env, caddy: Caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3_curl():
             pytest.skip("h3 not supported in curl")
         curl = CurlClient(env=env)
@@ -80,6 +82,8 @@ class TestCaddy:
     # download 1MB files sequentially
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_08_02_download_1mb_sequential(self, env: Env, caddy: Caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3_curl():
             pytest.skip("h3 not supported in curl")
         count = 50
@@ -91,6 +95,8 @@ class TestCaddy:
     # download 1MB files parallel
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_08_03_download_1mb_parallel(self, env: Env, caddy: Caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3_curl():
             pytest.skip("h3 not supported in curl")
         count = 20
@@ -110,6 +116,8 @@ class TestCaddy:
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_08_04a_download_10mb_sequential(self, env: Env, caddy: Caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3_curl():
             pytest.skip("h3 not supported in curl")
         count = 40
@@ -122,6 +130,8 @@ class TestCaddy:
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_08_04b_download_10mb_sequential(self, env: Env, caddy: Caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3_curl():
             pytest.skip("h3 not supported in curl")
         count = 20
@@ -134,6 +144,8 @@ class TestCaddy:
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_08_05_download_1mb_parallel(self, env: Env, caddy: Caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3_curl():
             pytest.skip("h3 not supported in curl")
         if proto == 'http/1.1' and env.curl_uses_lib('mbedtls'):
@@ -155,6 +167,8 @@ class TestCaddy:
     # post data parallel, check that they were echoed
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_08_06_post_parallel(self, env: Env, httpd, caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1
@@ -172,6 +186,8 @@ class TestCaddy:
     # put large file, check that they length were echoed
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_08_07_put_large(self, env: Env, httpd, caddy, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1<
@@ -190,6 +206,8 @@ class TestCaddy:
     def test_08_08_earlydata(self, env: Env, httpd, caddy, proto):
         if not env.curl_can_early_data():
             pytest.skip('TLS earlydata not implemented')
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and \
            (not env.have_h3() or not env.curl_can_h3_early_data()):
             pytest.skip("h3 not supported")

--- a/tests/http/test_09_push.py
+++ b/tests/http/test_09_push.py
@@ -61,6 +61,8 @@ class TestPush:
 
     # download a file that triggers a "103 Early Hints" response
     def test_09_01_h2_early_hints(self, env: Env, httpd, configures_httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'https://{env.domain1}:{env.https_port}/push/data1'
@@ -73,6 +75,8 @@ class TestPush:
         assert r.responses[0]['header']['link'] == '</push/data2>; rel=preload', f'{r.responses[0]}'
 
     def test_09_02_h2_push(self, env: Env, httpd, configures_httpd):
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         # use localhost as we do not have resolve support in local client
         url = f'https://localhost:{env.https_port}/push/data1'

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -73,6 +73,8 @@ class TestProxy:
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_10_02_proxys_down(self, env: Env, httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -95,6 +97,8 @@ class TestProxy:
                         reason="no nghttpx available")
     def test_10_02_proxys_up(self, env: Env, httpd, nghttpx, proto,
                              fname, fcount):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         count = fcount
@@ -136,6 +140,8 @@ class TestProxy:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
     def test_10_05_proxytunnel_http(self, env: Env, httpd, nghttpx_fwd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'https://localhost:{env.https_port}/data.json'
         xargs = curl.get_proxy_args(proxys=False, tunnel=True)
@@ -153,6 +159,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.curl_is_debug(), reason="needs curl debug")
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_10_06_proxytunnel_https(self, env: Env, httpd, nghttpx_fwd, proto, tunnel):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -181,6 +189,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx available")
     def test_10_07_pts_down_small(self, env: Env, httpd, nghttpx_fwd, proto,
                                   tunnel, fname, fcount):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         if env.curl_uses_lib('mbedtls') and \
@@ -215,6 +225,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx available")
     def test_10_08_upload_seq_large(self, env: Env, httpd, nghttpx, proto,
                                     tunnel, fname, fcount):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         if env.curl_uses_lib('mbedtls') and \
@@ -241,6 +253,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.curl_is_debug(), reason="needs curl debug")
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_10_09_reuse_server(self, env: Env, httpd, nghttpx_fwd, tunnel):
+        if tunnel == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -266,6 +280,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_10_10_reuse_proxy(self, env: Env, httpd, nghttpx_fwd, tunnel):
         # url twice via https: proxy separated with '--next', will reuse
+        if tunnel == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         if env.curl_uses_lib('mbedtls') and \
@@ -295,6 +311,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_10_11_noreuse_proxy_https(self, env: Env, httpd, nghttpx_fwd, tunnel):
         # different --proxy-tls13-ciphers, no reuse of connection for https:
+        if tunnel == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
@@ -322,6 +340,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_10_12_noreuse_proxy_http(self, env: Env, httpd, nghttpx_fwd, tunnel):
         # different --proxy-tls13-ciphers, no reuse of connection for http:
+        if tunnel == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -349,6 +369,8 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_10_13_noreuse_https(self, env: Env, httpd, nghttpx_fwd, tunnel):
         # different --tls13-ciphers on https: same proxy config
+        if tunnel == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -373,6 +395,8 @@ class TestProxy:
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_10_14_proxys_ip_addr(self, env: Env, httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)

--- a/tests/http/test_13_proxy_auth.py
+++ b/tests/http/test_13_proxy_auth.py
@@ -124,6 +124,8 @@ class TestProxyAuth:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
     def test_13_07_tunnels_no_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd, proto, tunnel):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
@@ -144,6 +146,8 @@ class TestProxyAuth:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
     def test_13_08_tunnels_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd, proto, tunnel):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -43,6 +43,8 @@ class TestAuth:
     # download 1 file, not authenticated
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_14_01_digest_get_noauth(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -55,6 +57,8 @@ class TestAuth:
     def test_14_02_digest_get_auth(self, env: Env, httpd, nghttpx, proto):
         if not env.curl_has_feature('digest'):
             pytest.skip("curl built without digest")
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -69,6 +73,8 @@ class TestAuth:
     def test_14_03_digest_put_auth(self, env: Env, httpd, nghttpx, proto):
         if not env.curl_has_feature('digest'):
             pytest.skip("curl built without digest")
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
@@ -86,6 +92,8 @@ class TestAuth:
     def test_14_04_digest_large_pw(self, env: Env, httpd, nghttpx, proto):
         if not env.curl_has_feature('digest'):
             pytest.skip("curl built without digest")
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         data='0123456789'
@@ -103,6 +111,8 @@ class TestAuth:
     # PUT data, basic auth large pw
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_14_05_basic_large_pw(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and not env.curl_uses_lib('ngtcp2'):
@@ -123,6 +133,8 @@ class TestAuth:
     # PUT data, basic auth with very large pw
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_14_06_basic_very_large_pw(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_lib('quiche'):

--- a/tests/http/test_16_info.py
+++ b/tests/http/test_16_info.py
@@ -47,6 +47,8 @@ class TestInfo:
     # download plain file
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_16_01_info_download(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -62,6 +64,8 @@ class TestInfo:
     # download plain file with a 302 redirect
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_16_02_info_302_download(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2
@@ -78,6 +82,8 @@ class TestInfo:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_16_03_info_upload(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 2

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -118,6 +118,8 @@ class TestSSLUse:
     # use host name with trailing dot, verify handshake
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_03_trailing_dot(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -133,6 +135,8 @@ class TestSSLUse:
     # use host name with double trailing dot, verify handshake
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_04_double_dot(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -157,6 +161,8 @@ class TestSSLUse:
     def test_17_05_good_ip_addr(self, env: Env, proto, httpd, nghttpx):
         if env.curl_uses_lib('mbedtls'):
             pytest.skip("mbedTLS does use IP addresses in SNI")
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -174,6 +180,8 @@ class TestSSLUse:
     def test_17_05_bad_ip_addr(self, env: Env, proto,
                                httpd, configures_httpd,
                                nghttpx, configures_nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         httpd.set_domain1_cred_name('domain1-no-ip')
@@ -191,6 +199,8 @@ class TestSSLUse:
     def test_17_05_very_bad_ip_addr(self, env: Env, proto,
                                     httpd, configures_httpd,
                                     nghttpx, configures_nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if env.curl_uses_lib('mbedtls'):
@@ -211,6 +221,8 @@ class TestSSLUse:
     # use localhost for connect
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_06_localhost(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -300,6 +312,8 @@ class TestSSLUse:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_08_cert_status(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if not env.curl_uses_lib('openssl') and \
@@ -421,6 +435,8 @@ class TestSSLUse:
     # use host name server has no certificate for
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_11_wrong_host(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -432,6 +448,8 @@ class TestSSLUse:
     # use host name server has no cert for with --insecure
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_12_insecure(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -446,8 +464,8 @@ class TestSSLUse:
     # connect to an expired certificate
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_17_14_expired_cert(self, env: Env, proto, httpd):
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.expired_domain}:{env.port_for(proto)}/'
         r = curl.http_get(url=url, alpn_proto=proto)
@@ -572,6 +590,8 @@ class TestSSLUse:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_19_wrong_pin(self, env: Env, proto, httpd):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if env.curl_uses_lib('rustls-ffi'):
@@ -586,6 +606,8 @@ class TestSSLUse:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_20_correct_pin(self, env: Env, proto, httpd):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)

--- a/tests/http/test_18_methods.py
+++ b/tests/http/test_18_methods.py
@@ -45,6 +45,8 @@ class TestMethods:
     # download 1 file
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_18_01_delete(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 1
@@ -59,6 +61,8 @@ class TestMethods:
     # should be accepted
     def test_18_02_delete_h2_special(self, env: Env, httpd, nghttpx):
         proto = 'h2'
+        if not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak?id=[0-{count-1}]'\

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -68,6 +68,8 @@ class TestShutdown:
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_19_02_check_shutdown(self, env: Env, httpd, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if not env.curl_is_debug():
             pytest.skip('only works for curl debug builds')
         run_env = os.environ.copy()
@@ -164,6 +166,8 @@ class TestShutdown:
     # check graceful shutdown on multiplexed http
     @pytest.mark.parametrize("proto", ['h2', 'h3'])
     def test_19_06_check_shutdown(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if not env.curl_is_debug():

--- a/tests/http/test_40_socks.py
+++ b/tests/http/test_40_socks.py
@@ -63,6 +63,8 @@ class TestSocks:
     @pytest.mark.parametrize("sproto", ['socks4', 'socks5'])
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_40_02_socks_https(self, env: Env, sproto, proto, danted: Dante, httpd):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env, socks_args=[
@@ -78,6 +80,8 @@ class TestSocks:
     @pytest.mark.parametrize("sproto", ['socks4', 'socks5'])
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_40_03_dl_serial(self, env: Env, httpd, danted, proto, sproto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         count = 3
         urln = f'https://{env.authority_for(env.domain1, proto)}/data-10m?[0-{count-1}]'
         curl = CurlClient(env=env, socks_args=[
@@ -89,6 +93,8 @@ class TestSocks:
     @pytest.mark.parametrize("sproto", ['socks4', 'socks5'])
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_40_04_ul_serial(self, env: Env, httpd, danted, proto, sproto):
+        if proto == 'h2' and not env.have_h2_curl():
+            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         count = 2
         curl = CurlClient(env=env, socks_args=[


### PR DESCRIPTION
To allow running pytests on more curl configurations.

Also delete a redundant H3 feature check from test_17_14_expired_cert.

Cherry-picked from #19407