### PR TITLE
GHA/linux: stop disabling TLS-SRP tests in event-based & duphandle jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -304,12 +304,12 @@ jobs:
           - name: 'event-based'
             install_packages: libssh-dev
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
-            tflags: '-n --test-event !TLS-SRP'
+            tflags: '-n --test-event'
 
           - name: 'duphandle'
             install_packages: libssh-dev
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
-            tflags: '-n --test-duphandle !TLS-SRP'
+            tflags: '-n --test-duphandle'
 
           - name: 'rustls valgrind'
             install_packages: libnghttp2-dev libldap-dev valgrind


### PR DESCRIPTION
They were disabled since these jobs ran in Zuul. The tests are 320, 321,
322, 323, 324. Of which, 323 runs in CI, the rest needs `gnutls-serv`
with SRP enabled, which is not available in current jobs and no longer
offered by Ubuntu's `gnutls-bin` package. 324 doesn't appear as
a skipped test, 323 seems to be running fine, the rest are logged as
skipped. This suggests it's safe to drop the exceptions.
