### PR TITLE
mqtt: properly handle the message which exceeds maxsize

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -613,8 +613,10 @@ static CURLcode mqtt_publish(struct Curl_easy *data)
 
   remaininglength = payloadlen + 2 + topiclen;
   encodelen = mqtt_encode_len(encodedbytes, remaininglength);
-  if(MAX_MQTT_MESSAGE_SIZE - remaininglength - 1 < encodelen)
-    return CURLE_TOO_LARGE;
+  if(MAX_MQTT_MESSAGE_SIZE - remaininglength - 1 < encodelen) {
+    result = CURLE_TOO_LARGE;
+    goto fail;
+  }
 
   /* add the control byte and the encoded remaining length */
   pkt = malloc(remaininglength + 1 + encodelen);


### PR DESCRIPTION
We should goto fail as `topic` is allocated.

Follow-up to 92fd791f310eb5b1dec6bc4708631fd7f5e87598.