### PR TITLE
rustls: fix a potential memory issue

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1098,8 +1098,6 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     &backend->config);
   if(rr != RUSTLS_RESULT_OK) {
     rustls_failf(data, rr, "failed to build client config");
-    rustls_client_config_builder_free(config_builder);
-    rustls_client_config_free(backend->config);
     return CURLE_SSL_CONNECT_ERROR;
   }
 
@@ -1109,6 +1107,8 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
                                     &rconn);
   if(rr != RUSTLS_RESULT_OK) {
     rustls_failf(data, rr, "rustls_client_connection_new");
+    rustls_client_config_free(backend->config);
+    backend->config = NULL;
     return CURLE_COULDNT_CONNECT;
   }
   DEBUGASSERT(rconn);


### PR DESCRIPTION
In [rustls_client_config_builder_build()](https://github.com/rustls/rustls-ffi/blob/main/librustls/src/client.rs#L490), the `config_builder` is consumed via `try_box_from_ptr!(builder)` and ownership is transferred to Rust. Calling  [rustls_client_config_builder_free()](https://github.com/rustls/rustls-ffi/blob/main/librustls/src/client.rs#L560) afterwards would result in double-free.

An additional evidence is from the usage in rustls-ffi's test code at https://github.com/rustls/rustls-ffi/blob/main/librustls/tests/client.c#L431, where the builder is not freed and set to NULL after calling rustls_client_config_builder_build().
> may need to further evaluate its security impact... 

Other: `backend->config` is set if `rustls_client_config_builder_build()` is ok.
