### PR TITLE
digest_sspi: properly free sspi identity

### DIFF
--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -502,6 +502,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
       /* Populate our identity domain */
       if(Curl_override_sspi_http_realm((const char *) digest->input_token,
                                        &identity)) {
+        Curl_sspi_free_identity(&identity);
         free(output_token);
         return CURLE_OUT_OF_MEMORY;
       }


### PR DESCRIPTION
The content of `identity` is created by `Curl_create_sspi_identity()`, but does not properly freed when `Curl_override_sspi_http_realm` fails.