### PR TITLE
progress: only show "raw" numbers up to 99999

### DIFF
--- a/lib/progress.c
+++ b/lib/progress.c
@@ -69,26 +69,25 @@ static char *max6data(curl_off_t bytes, char *max6)
 {
   /* a signed 64-bit value is 8192 petabytes maximum, shown as
      8.0E (exabytes)*/
-  const char unit[] = { 'k', 'M', 'G', 'T', 'P', 'E', 0 };
-  int k = 0;
-  if(bytes < 100000) {
+  if(bytes < 100000)
     curl_msnprintf(max6, 7, "%6" CURL_FORMAT_CURL_OFF_T, bytes);
-    return max6;
+  else {
+    const char unit[] = { 'k', 'M', 'G', 'T', 'P', 'E', 0 };
+    int k = 0;
+    curl_off_t nbytes;
+    do {
+      nbytes = bytes / 1024;
+      if(nbytes < 1000)
+        break;
+      bytes = nbytes;
+      k++;
+      DEBUGASSERT(unit[k]);
+    } while(unit[k]);
+    /* xxx.yU */
+    curl_msnprintf(max6, 7, "%3" CURL_FORMAT_CURL_OFF_T
+                   ".%" CURL_FORMAT_CURL_OFF_T "%c", nbytes,
+                   (bytes%1024) / (1024/10), unit[k]);
   }
-
-  do {
-    curl_off_t nbytes = bytes / 1024;
-    if(nbytes < 1000) {
-      /* xxx.yU */
-      curl_msnprintf(max6, 7, "%3" CURL_FORMAT_CURL_OFF_T
-                     ".%" CURL_FORMAT_CURL_OFF_T "%c", nbytes,
-                     (bytes%1024) / (1024/10), unit[k]);
-      break;
-    }
-    bytes = nbytes;
-    k++;
-    DEBUGASSERT(unit[k]);
-  } while(unit[k]);
   return max6;
 }
 #endif


### PR DESCRIPTION
Probably makes the output easier to read.

Before:

- `999999`
- `99999k`
- `99999M`
- `999.1G`
- `1.2T`

With this PR:

- `99999`
- `999.9k`
- `123.4M`
- `1.2T`

Fixes #19431
Reported-by: Fd929c2CE5fA on github