### PR TITLE
cshutdn: acknowledge FD_SETSIZE for shutdown descriptors

### DIFF
--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -503,20 +503,23 @@ void Curl_cshutdn_setfds(struct cshutdn *cshutdn,
         continue;
 
       for(i = 0; i < ps.n; i++) {
+        curl_socket_t sock = ps.sockets[i];
+        if(!FDSET_SOCK(sock))
+          continue;
 #ifdef __DJGPP__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warith-conversion"
 #endif
         if(ps.actions[i] & CURL_POLL_IN)
-          FD_SET(ps.sockets[i], read_fd_set);
+          FD_SET(sock, read_fd_set);
         if(ps.actions[i] & CURL_POLL_OUT)
-          FD_SET(ps.sockets[i], write_fd_set);
+          FD_SET(sock, write_fd_set);
 #ifdef __DJGPP__
 #pragma GCC diagnostic pop
 #endif
         if((ps.actions[i] & (CURL_POLL_OUT | CURL_POLL_IN)) &&
-           ((int)ps.sockets[i] > *maxfd))
-          *maxfd = (int)ps.sockets[i];
+           ((int)sock > *maxfd))
+          *maxfd = (int)sock;
       }
     }
     Curl_pollset_cleanup(&ps);


### PR DESCRIPTION
In the logic called for curl_multi_fdset().

File descriptors larger than FD_SETSIZE size are simply ignored, which of course will make things break but at least it does not trash memory.

Reported-by: Stanislav Fort (Aisle Research)