### PR TITLE
urlapi: fix mem-leaks in curl_url_get error paths

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1373,6 +1373,7 @@ static CURLUcode urlget_format(const CURLU *u, CURLUPart what,
     /* this unconditional rejection of control bytes is documented
        API behavior */
     CURLcode res = Curl_urldecode(part, partlen, &decoded, &dlen, REJECT_CTRL);
+    free(part);
     if(res)
       return CURLUE_URLDECODE;
     part = decoded;


### PR DESCRIPTION
Reported-by: Stanislav Fort (Aisle Research)