### PR TITLE
renovate.json: drop parentheses from group names

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,7 @@
         "/codeql/i",
         "/ruff/i"
       ],
-      "groupName": "monthly updates (by name)",
+      "groupName": "monthly updates by name",
       "schedule": [
         "* * 10 * *"
       ]
@@ -60,7 +60,7 @@
       "matchSourceUrls": [
         "**/awslabs/**"
       ],
-      "groupName": "monthly updates (by source URL)",
+      "groupName": "monthly updates by URL",
       "schedule": [
         "* * 10 * *"
       ]


### PR DESCRIPTION
They make git branch names using those parentheses, that need to be quoted when used with git command lines. Avoid parentheses for easier to use branch names.

Follow-up to f77c574445532e3c17e62