### PR TITLE
OS400/ccsidcurl: fix curl_easy_setopt_ccsid for non-converted blobs

### DIFF
--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1286,7 +1286,7 @@ curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...)
         blob.flags = bp->flags | CURL_BLOB_COPY;
         bp = &blob;
       }
-      result = curl_easy_setopt(easy, tag, &blob);
+      result = curl_easy_setopt(easy, tag, bp);
       break;
     }
     FALLTHROUGH();


### PR DESCRIPTION
When a blob option is used and it does not convert, the code would erroneously pass along an uninitialized stack struct.

Reported-by: Stanislav Fort (Aisle Research)