### PR TITLE
socks_sspi: use free() not FreeContextBuffer()

### DIFF
--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -588,12 +588,9 @@ error:
     Curl_pSecFn->FreeContextBuffer(sspi_send_token.pvBuffer);
   if(names.sUserName)
     Curl_pSecFn->FreeContextBuffer(names.sUserName);
-  if(sspi_w_token[0].pvBuffer)
-    Curl_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
-  if(sspi_w_token[1].pvBuffer)
-    Curl_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
-  if(sspi_w_token[2].pvBuffer)
-    Curl_pSecFn->FreeContextBuffer(sspi_w_token[2].pvBuffer);
+  free(sspi_w_token[0].pvBuffer);
+  free(sspi_w_token[1].pvBuffer);
+  free(sspi_w_token[2].pvBuffer);
   free(etbuf);
   return result;
 }


### PR DESCRIPTION
The memory is allocated with malloc().

This reverts commit 1d01d4975f540f3a363b38e1296aead62130fc6d.

Reported-by: Stanislav Fort (Aisle Research)