### PR TITLE
examples/crawler: fix variable

### DIFF
--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -232,7 +232,7 @@ int main(void)
               if(is_html(ctype) && mem->size > 100) {
                 if(pending < max_requests &&
                    (complete + pending) < max_total) {
-                  pending += follow_links(multi_curl, mem, url);
+                  pending += follow_links(multi, mem, url);
                   still_running = 1;
                 }
               }


### PR DESCRIPTION
A variable missed in the previous rename cleanup

Follow-up to 928363f28ca533d743adcb70597c3e30917
Reported-by: Gisle Vanem