### PR TITLE
verify-release: update to avoid shellcheck warning SC2034

### DIFF
--- a/scripts/verify-release
+++ b/scripts/verify-release
@@ -40,12 +40,7 @@ if [ -z "$tarball" ]; then
     exit
 fi
 
-i="0"
-
-# shellcheck disable=SC2034
-for dl in curl-*; do
-    i=$((i + 1))
-done
+i="$(find . -maxdepth 1 -type d -name 'curl-*' | wc -l)"
 
 if test "$i" -gt 1; then
     echo "multiple curl-* entries found, disambiguate please"


### PR DESCRIPTION
```
SC2034: dl appears unused
```

Also to shorten the code.
