### PR TITLE
GHA/linux: disable test 776 in valgrind jobs to avoid delay

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -741,7 +741,7 @@ jobs:
         run: |
           if [ "${TEST_TARGET}" = 'test-ci' ] && [[ "${MATRIX_INSTALL_PACKAGES}" = *'valgrind'* ]]; then
             TFLAGS+=' -j6'
-            TFLAGS+=' !776'  # skip flaky test
+            TFLAGS+=' !776'  # skip long-running flaky test
             if [[ "${MATRIX_INSTALL_PACKAGES}" = *'libgss-dev'* ]]; then
               TFLAGS+=' ~2077 ~2078'  # memory leaks from Curl_auth_decode_spnego_message() -> gss_init_sec_context()
             fi


### PR DESCRIPTION
Saving ~30 seconds in jobs affected.
