### PR TITLE
GHA/linux: build and enable nghttp2 for Fil-C job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -217,7 +217,7 @@ jobs:
           - name: '!ssl !http !smtp !imap'
             configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity
 
-          - name: 'libressl nghttp2 Fil-C'
+          - name: 'libressl Fil-C'
             install_steps: filc libressl-filc nghttp2-filc pytest
             tflags: '!776'  # adds 1-9 minutes to the test run step, and fails consistently
             CC: /home/runner/filc/build/bin/filcc


### PR DESCRIPTION
pytests after: 527 passed, 286 skipped
pytests before: 392 passed, 423 skipped

runtests after: TESTDONE: 1646 tests out of 1646 reported OK: 100%
runtests before: TESTDONE: 1643 tests out of 1643 reported OK: 100%

Ref: b81d30ade314af7c3197dfcef2d978428b96b009 #19458
