### PR TITLE
docs: Line endings are no longer significant in test files

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -12,9 +12,9 @@ mark the beginning and the end of all sections, and each label must be written
 in its own line. Comments are either XML-style (enclosed with `<!--` and
 `-->`) or shell script style (beginning with `#`) and must appear on their own
 lines and not alongside actual test data. Most test data files are
-syntactically valid XML, although a few files are not (lack of support for
-character entities and the preservation of CR/LF characters at the end of
-lines are the biggest differences).
+syntactically-valid XML (a few files are not); lack of support for character
+entities is a big difference but macros like %CR fill that particular role
+here.
 
 Each test case source exists as a file matching the format
 `tests/data/testNUM`, where `NUM` is the unique test number, and must begin


### PR DESCRIPTION
Since commit f477f3efc, CR/LF characters in test files are no longer
significant, making the files a little more XML-like.

Closes #19469