### PR TITLE
test2405: report `fd_count*` variables on failure

### DIFF
--- a/tests/libtest/lib2405.c
+++ b/tests/libtest/lib2405.c
@@ -49,7 +49,7 @@
     goto test_cleanup; \
   } \
   else if(fd_count != expected_fds) { \
-    curl_mfprintf(stderr, "Max number of waitfds: %d not as expected: %d\n", \
+    curl_mfprintf(stderr, "Max number of waitfds: %u not as expected: %u\n", \
       fd_count, expected_fds); \
     res = TEST_ERR_FAILURE; \
     goto test_cleanup; \
@@ -69,7 +69,7 @@ enum {
 };
 
 static size_t emptyWriteFunc(void *ptr, size_t size, size_t nmemb,
-    void *data) {
+                             void *data) {
   (void)ptr; (void)data;
   return size * nmemb;
 }
@@ -218,7 +218,7 @@ static CURLcode test_run(const char *URL, long option,
     if(fd_count_chk < fd_count) {
       curl_mfprintf(stderr,
                     "curl_multi_waitfds() should return at least the number "
-                    "of fds needed\n");
+                    "of fds needed (%u vs. %u)\n", fd_count_chk, fd_count);
       res = TEST_ERR_FAILURE;
       break;
     }
@@ -236,7 +236,8 @@ static CURLcode test_run(const char *URL, long option,
     if(fd_count_chk < fd_count) {
       curl_mfprintf(stderr,
                     "curl_multi_waitfds() should return the amount of fds "
-                    "needed if enough isn't passed in.\n");
+                    "needed if enough isn't passed in (%u vs. %u).\n",
+                    fd_count_chk, fd_count);
       res = TEST_ERR_FAILURE;
       break;
     }
@@ -263,7 +264,8 @@ static CURLcode test_run(const char *URL, long option,
     if(fd_count_chk < fd_count) {
       curl_mfprintf(stderr,
                     "curl_multi_waitfds() should return the amount of fds "
-                    "needed if enough isn't passed in.\n");
+                    "needed if enough isn't passed in (%u vs. %u).\n",
+                    fd_count_chk, fd_count);
       res = TEST_ERR_FAILURE;
       break;
     }
@@ -275,7 +277,7 @@ static CURLcode test_run(const char *URL, long option,
     mc = curl_multi_poll(multi1, ufds, fd_count, 500, &numfds);
 
     if(mc != CURLM_OK) {
-      curl_mfprintf(stderr, "curl_multi_poll() failed, code %d.\\n", mc);
+      curl_mfprintf(stderr, "curl_multi_poll() failed, code %d.\n", mc);
       res = TEST_ERR_FAILURE;
       break;
     }


### PR DESCRIPTION
This test is frequently failing in macOS !ssl jobs:

"curl_multi_waitfds() should return at least the number of fds needed":
https://github.com/curl/curl/actions/runs/19290229745/job/55159015942 AM clang !ssl !debug brotli zstd
https://github.com/curl/curl/actions/runs/19289578332/job/55157058146 AM clang !ssl !debug brotli zstd
https://github.com/curl/curl/actions/runs/19188515879/job/54859474947 AM clang !ssl
https://github.com/curl/curl/actions/runs/19165077858/job/54783776869 AM clang !ssl libssh2 AppleIDN
https://github.com/curl/curl/actions/runs/19046554157/job/54396096298 AM gcc-12 !ssl !debug

"curl_multi_waitfds() should return the amount of fds needed if enough isn't passed in":
https://github.com/curl/curl/actions/runs/19184546172/job/54848549080 AM gcc-13 !ssl !debug

Also high on the test clutch list:
2405 FAIL times: 165
Ref: https://testclutch.curl.se/static/reports/results-count.html

```
libtests returned 44, when expecting 0

FAIL 2405: 'checking curl_multi_waitfds functionality' multi, HTTP, HTTP/2
```
44 = `CURLE_OBSOLETE44` = `TEST_ERR_FAILURE`

Also: fix a newline in log output.

Follow-up to c78044c07e97cb720049579f4fe3cab33a7ea8d3 #15146 #15155
