### PR TITLE
hostip: don't store negative lookup on OOM

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -904,8 +904,10 @@ CURLcode Curl_resolv(struct Curl_easy *data,
 
 #ifndef USE_RESOLVE_ON_IPS
   /* allowed to convert, hostname is IP address, then NULL means error */
-  if(is_ipaddr)
+  if(is_ipaddr) {
+    keep_negative = FALSE;
     goto error;
+  }
 #endif
 
   /* Really need a resolver for hostname. */


### PR DESCRIPTION
When convert_ipaddr_direct() returns error due to OOM, it must not be stored as a negative cache result.