### PR TITLE
Curl_timeleft_ms

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -394,47 +394,47 @@ CURLcode Curl_async_await(struct Curl_easy *data,
 {
   struct async_ares_ctx *ares = &data->state.async.ares;
   CURLcode result = CURLE_OK;
-  timediff_t timeout;
+  timediff_t timeout_ms;
   struct curltime now = curlx_now();
 
   DEBUGASSERT(entry);
   *entry = NULL; /* clear on entry */
 
-  timeout = Curl_timeleft(data, &now, TRUE);
-  if(timeout < 0) {
+  timeout_ms = Curl_timeleft_ms(data, &now, TRUE);
+  if(timeout_ms < 0) {
     /* already expired! */
     connclose(data->conn, "Timed out before name resolve started");
     return CURLE_OPERATION_TIMEDOUT;
   }
-  if(!timeout)
-    timeout = CURL_TIMEOUT_RESOLVE * 1000; /* default name resolve timeout */
+  if(!timeout_ms)
+    timeout_ms = CURL_TIMEOUT_RESOLVE * 1000; /* default name resolve */
 
   /* Wait for the name resolve query to complete. */
   while(!result) {
-    struct timeval *tvp, tv, store;
-    int itimeout;
-    timediff_t timeout_ms;
+    struct timeval *real_timeout, time_buf, max_timeout;
+    int itimeout_ms;
+    timediff_t call_timeout_ms;
 
 #if TIMEDIFF_T_MAX > INT_MAX
-    itimeout = (timeout > INT_MAX) ? INT_MAX : (int)timeout;
+    itimeout_ms = (timeout_ms > INT_MAX) ? INT_MAX : (int)timeout_ms;
 #else
-    itimeout = (int)timeout;
+    itimeout_ms = (int)timeout_ms;
 #endif
 
-    store.tv_sec = itimeout/1000;
-    store.tv_usec = (itimeout%1000)*1000;
+    max_timeout.tv_sec = itimeout_ms/1000;
+    max_timeout.tv_usec = (itimeout_ms%1000)*1000;
 
-    tvp = ares_timeout(ares->channel, &store, &tv);
+    real_timeout = ares_timeout(ares->channel, &max_timeout, &time_buf);
 
     /* use the timeout period ares returned to us above if less than one
        second is left, otherwise just use 1000ms to make sure the progress
        callback gets called frequent enough */
-    if(!tvp->tv_sec)
-      timeout_ms = (timediff_t)(tvp->tv_usec/1000);
+    if(!real_timeout->tv_sec)
+      call_timeout_ms = (timediff_t)(real_timeout->tv_usec/1000);
     else
-      timeout_ms = 1000;
+      call_timeout_ms = 1000;
 
-    if(Curl_ares_perform(ares->channel, timeout_ms) < 0)
+    if(Curl_ares_perform(ares->channel, call_timeout_ms) < 0)
       return CURLE_UNRECOVERABLE_POLL;
 
     result = Curl_async_is_resolved(data, entry);
@@ -447,14 +447,14 @@ CURLcode Curl_async_await(struct Curl_easy *data,
       struct curltime now2 = curlx_now();
       timediff_t timediff = curlx_timediff(now2, now); /* spent time */
       if(timediff <= 0)
-        timeout -= 1; /* always deduct at least 1 */
-      else if(timediff > timeout)
-        timeout = -1;
+        timeout_ms -= 1; /* always deduct at least 1 */
+      else if(timediff > timeout_ms)
+        timeout_ms = -1;
       else
-        timeout -= timediff;
+        timeout_ms -= timediff;
       now = now2; /* for next loop */
     }
-    if(timeout < 0)
+    if(timeout_ms < 0)
       result = CURLE_OPERATION_TIMEDOUT;
   }
 

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -535,10 +535,8 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
     return CURLE_RECV_ERROR; /* Need a cfilter close and new bootstrap */
 
   do {
-    timediff_t check;
 
-    check = Curl_timeleft(data, NULL, TRUE);
-    if(check <= 0) {
+    if(Curl_timeleft_ms(data, NULL, TRUE) < 0) {
       failf(data, "Proxy CONNECT aborted due to timeout");
       result = CURLE_OPERATION_TIMEDOUT;
       goto out;

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1073,7 +1073,6 @@ static CURLcode cf_h2_proxy_connect(struct Curl_cfilter *cf,
   struct cf_h2_proxy_ctx *ctx = cf->ctx;
   CURLcode result = CURLE_OK;
   struct cf_call_data save;
-  timediff_t check;
   struct tunnel_stream *ts = &ctx->tunnel;
 
   if(cf->connected) {
@@ -1098,8 +1097,7 @@ static CURLcode cf_h2_proxy_connect(struct Curl_cfilter *cf,
   }
   DEBUGASSERT(ts->authority);
 
-  check = Curl_timeleft(data, NULL, TRUE);
-  if(check <= 0) {
+  if(Curl_timeleft_ms(data, NULL, TRUE) < 0) {
     failf(data, "Proxy CONNECT aborted due to timeout");
     result = CURLE_OPERATION_TIMEDOUT;
     goto out;

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -505,7 +505,7 @@ out:
     bool more_possible;
 
     /* when do we need to be called again? */
-    next_expire_ms = Curl_timeleft(data, &now, TRUE);
+    next_expire_ms = Curl_timeleft_ms(data, &now, TRUE);
     if(next_expire_ms <= 0) {
       failf(data, "Connection timeout after %" FMT_OFF_T " ms",
             curlx_timediff(now, data->progress.t_startsingle));
@@ -707,7 +707,7 @@ static CURLcode start_connect(struct Curl_cfilter *cf,
   if(!dns)
     return CURLE_FAILED_INIT;
 
-  if(Curl_timeleft(data, NULL, TRUE) < 0) {
+  if(Curl_timeleft_ms(data, NULL, TRUE) < 0) {
     /* a precaution, no need to continue if time already is up */
     failf(data, "Connection time-out");
     return CURLE_OPERATION_TIMEDOUT;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -2020,7 +2020,7 @@ static timediff_t cf_tcp_accept_timeleft(struct Curl_cfilter *cf,
 {
   struct cf_socket_ctx *ctx = cf->ctx;
   timediff_t timeout_ms = DEFAULT_ACCEPT_TIMEOUT;
-  timediff_t other;
+  timediff_t other_ms;
   struct curltime now;
 
 #ifndef CURL_DISABLE_FTP
@@ -2030,11 +2030,11 @@ static timediff_t cf_tcp_accept_timeleft(struct Curl_cfilter *cf,
 
   now = curlx_now();
   /* check if the generic timeout possibly is set shorter */
-  other = Curl_timeleft(data, &now, FALSE);
-  if(other && (other < timeout_ms))
-    /* note that this also works fine for when other happens to be negative
+  other_ms = Curl_timeleft_ms(data, &now, FALSE);
+  if(other_ms && (other_ms < timeout_ms))
+    /* note that this also works fine for when other_ms happens to be negative
        due to it already having elapsed */
-    timeout_ms = other;
+    timeout_ms = other_ms;
   else {
     /* subtract elapsed time */
     timeout_ms -= curlx_timediff(now, ctx->started_at);

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -526,7 +526,7 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
       goto out;
     else {
       /* check allowed time left */
-      const timediff_t timeout_ms = Curl_timeleft(data, NULL, TRUE);
+      const timediff_t timeout_ms = Curl_timeleft_ms(data, NULL, TRUE);
       curl_socket_t sockfd = Curl_conn_cf_get_socket(cf, data);
       int rc;
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -101,7 +101,7 @@ enum alpnid Curl_alpn2alpnid(const char *name, size_t len)
 #endif
 
 /*
- * Curl_timeleft() returns the amount of milliseconds left allowed for the
+ * Curl_timeleft_ms() returns the amount of milliseconds left allowed for the
  * transfer/connection. If the value is 0, there is no timeout (ie there is
  * infinite time left). If the value is negative, the timeout time has already
  * elapsed.
@@ -110,9 +110,9 @@ enum alpnid Curl_alpn2alpnid(const char *name, size_t len)
  * @param duringconnect TRUE iff connect timeout is also taken into account.
  * @unittest: 1303
  */
-timediff_t Curl_timeleft(struct Curl_easy *data,
-                         struct curltime *nowp,
-                         bool duringconnect)
+timediff_t Curl_timeleft_ms(struct Curl_easy *data,
+                            struct curltime *nowp,
+                            bool duringconnect)
 {
   timediff_t timeleft_ms = 0;
   timediff_t ctimeleft_ms = 0;

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -36,9 +36,9 @@ enum alpnid Curl_alpn2alpnid(const char *name, size_t len);
 
 /* generic function that returns how much time there is left to run, according
    to the timeouts set */
-timediff_t Curl_timeleft(struct Curl_easy *data,
-                         struct curltime *nowp,
-                         bool duringconnect);
+timediff_t Curl_timeleft_ms(struct Curl_easy *data,
+                            struct curltime *nowp,
+                            bool duringconnect);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -311,7 +311,7 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
     goto error;
   }
 
-  timeout_ms = Curl_timeleft(data, NULL, TRUE);
+  timeout_ms = Curl_timeleft_ms(data, NULL, TRUE);
   if(timeout_ms <= 0) {
     result = CURLE_OPERATION_TIMEDOUT;
     goto error;

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -202,7 +202,7 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
     else
       break;
 
-    timeout_ms = Curl_timeleft(data, NULL, FALSE);
+    timeout_ms = Curl_timeleft_ms(data, NULL, FALSE);
     if(timeout_ms < 0) {
       result = CURLE_OPERATION_TIMEDOUT;
       break;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1739,7 +1739,7 @@ static bool multi_handle_timeout(struct Curl_easy *data,
                                  CURLcode *result)
 {
   bool connect_timeout = data->mstate < MSTATE_DO;
-  timediff_t timeout_ms = Curl_timeleft(data, now, connect_timeout);
+  timediff_t timeout_ms = Curl_timeleft_ms(data, now, connect_timeout);
   if(timeout_ms < 0) {
     /* Handle timed out */
     struct curltime since;

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -65,13 +65,13 @@ timediff_t Curl_pp_state_timeout(struct Curl_easy *data,
 
   if(data->set.timeout && !disconnecting) {
     /* if timeout is requested, find out how much overall remains */
-    timediff_t timeout2_ms = Curl_timeleft(data, &now, FALSE);
+    timediff_t timeout2_ms = Curl_timeleft_ms(data, &now, FALSE);
     /* pick the lowest number */
     timeout_ms = CURLMIN(timeout_ms, timeout2_ms);
   }
 
   if(disconnecting) {
-    timediff_t total_left_ms = Curl_timeleft(data, NULL, FALSE);
+    timediff_t total_left_ms = Curl_timeleft_ms(data, NULL, FALSE);
     timeout_ms = CURLMIN(timeout_ms, CURLMAX(total_left_ms, 0));
   }
 

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -137,7 +137,7 @@ CURLcode Curl_blockread_all(struct Curl_cfilter *cf,
 
   *pnread = 0;
   for(;;) {
-    timediff_t timeout_ms = Curl_timeleft(data, NULL, TRUE);
+    timediff_t timeout_ms = Curl_timeleft_ms(data, NULL, TRUE);
     if(timeout_ms < 0) {
       /* we already got the timeout */
       return CURLE_OPERATION_TIMEDOUT;

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -211,7 +211,7 @@ static CURLcode tftp_set_timeouts(struct tftp_conn *state)
   bool start = (state->state == TFTP_STATE_START);
 
   /* Compute drop-dead time */
-  timeout_ms = Curl_timeleft(state->data, NULL, start);
+  timeout_ms = Curl_timeleft_ms(state->data, NULL, start);
 
   if(timeout_ms < 0) {
     /* time-out, bail out, go home */
@@ -1199,8 +1199,8 @@ static timediff_t tftp_state_timeout(struct tftp_conn *state,
   if(event)
     *event = TFTP_EVENT_NONE;
 
-  timeout_ms = Curl_timeleft(state->data, NULL,
-                             (state->state == TFTP_STATE_START));
+  timeout_ms = Curl_timeleft_ms(state->data, NULL,
+                                (state->state == TFTP_STATE_START));
   if(timeout_ms < 0) {
     state->error = TFTP_ERR_TIMEOUT;
     state->state = TFTP_STATE_FIN;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -422,7 +422,7 @@ CURLcode Curl_sendrecv(struct Curl_easy *data, struct curltime *nowp)
     goto out;
 
   if(k->keepon) {
-    if(0 > Curl_timeleft(data, nowp, FALSE)) {
+    if(Curl_timeleft_ms(data, nowp, FALSE) < 0) {
       if(k->size != -1) {
         failf(data, "Operation timed out after %" FMT_TIMEDIFF_T
               " milliseconds with %" FMT_OFF_T " out of %"

--- a/lib/url.c
+++ b/lib/url.c
@@ -3217,7 +3217,7 @@ static CURLcode resolve_server(struct Curl_easy *data,
 {
   struct hostname *ehost;
   int eport;
-  timediff_t timeout_ms = Curl_timeleft(data, NULL, TRUE);
+  timediff_t timeout_ms = Curl_timeleft_ms(data, NULL, TRUE);
   const char *peertype = "host";
   CURLcode result;
 

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2481,7 +2481,7 @@ static CURLcode myssh_block_statemach(struct Curl_easy *data,
 
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
-    timediff_t left = 1000;
+    timediff_t left_ms = 1000;
     struct curltime now = curlx_now();
 
     result = myssh_statemach_act(data, sshc, sshp, &block);
@@ -2496,8 +2496,8 @@ static CURLcode myssh_block_statemach(struct Curl_easy *data,
       if(result)
         break;
 
-      left = Curl_timeleft(data, NULL, FALSE);
-      if(left < 0) {
+      left_ms = Curl_timeleft_ms(data, NULL, FALSE);
+      if(left_ms < 0) {
         failf(data, "Operation timed out");
         return CURLE_OPERATION_TIMEDOUT;
       }
@@ -2506,8 +2506,8 @@ static CURLcode myssh_block_statemach(struct Curl_easy *data,
     if(block) {
       curl_socket_t fd_read = conn->sock[FIRSTSOCKET];
       /* wait for the socket to become ready */
-      (void)Curl_socket_check(fd_read, CURL_SOCKET_BAD,
-                              CURL_SOCKET_BAD, left > 1000 ? 1000 : left);
+      (void)Curl_socket_check(fd_read, CURL_SOCKET_BAD, CURL_SOCKET_BAD,
+                              left_ms > 1000 ? 1000 : left_ms);
     }
 
   }

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3129,7 +3129,7 @@ static CURLcode ssh_block_statemach(struct Curl_easy *data,
 
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
-    timediff_t left = 1000;
+    timediff_t left_ms = 1000;
     struct curltime now = curlx_now();
 
     result = ssh_statemachine(data, sshc, sshp, &block);
@@ -3144,8 +3144,8 @@ static CURLcode ssh_block_statemach(struct Curl_easy *data,
       if(result)
         break;
 
-      left = Curl_timeleft(data, NULL, FALSE);
-      if(left < 0) {
+      left_ms = Curl_timeleft_ms(data, NULL, FALSE);
+      if(left_ms < 0) {
         failf(data, "Operation timed out");
         return CURLE_OPERATION_TIMEDOUT;
       }
@@ -3168,7 +3168,7 @@ static CURLcode ssh_block_statemach(struct Curl_easy *data,
         fd_write = sock;
       /* wait for the socket to become ready */
       (void)Curl_socket_check(fd_read, CURL_SOCKET_BAD, fd_write,
-                              left > 1000 ? 1000 : left);
+                              left_ms > 1000 ? 1000 : left_ms);
     }
   }
 

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1703,7 +1703,7 @@ static CURLcode ws_send_raw_blocking(struct Curl_easy *data,
 
       CURL_TRC_WS(data, "ws_send_raw_blocking() partial, %zu left to send",
                   buflen);
-      left_ms = Curl_timeleft(data, NULL, FALSE);
+      left_ms = Curl_timeleft_ms(data, NULL, FALSE);
       if(left_ms < 0) {
         failf(data, "[WS] Timeout waiting for socket becoming writable");
         return CURLE_SEND_ERROR;

--- a/tests/data/test1303
+++ b/tests/data/test1303
@@ -2,7 +2,7 @@
 <info>
 <keywords>
 unittest
-Curl_timeleft
+Curl_timeleft_ms
 </keywords>
 </info>
 
@@ -13,7 +13,7 @@ Curl_timeleft
 unittest
 </features>
 <name>
-Curl_timeleft unit tests
+Curl_timeleft_ms unit tests
 </name>
 </client>
 </testcase>

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -148,7 +148,7 @@ static CURLcode test_unit1303(const char *arg)
     timediff_t timeout;
     NOW(run[i].now_s, run[i].now_us);
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
-    timeout = Curl_timeleft(easy, &now, run[i].connecting);
+    timeout = Curl_timeleft_ms(easy, &now, run[i].connecting);
     if(timeout != run[i].result)
       fail(run[i].comment);
   }


### PR DESCRIPTION
Rename `Curl_timeleft()` to `Curl_timeleft_ms()` to make the units in the returned `timediff_t` clear. (We used to always have ms there, but with QUIC started to sometimes calc `us` as well).

Rename some assigned vars without `_ms` suffix for clarity as well.