### PR TITLE
test363: delete stray character (typo) from a section tag

### DIFF
--- a/tests/data/test363
+++ b/tests/data/test363
@@ -21,7 +21,7 @@ Content-Length: 9
 
 contents
 </data>
-<connect crlf="headers"t>
+<connect crlf="headers">
 HTTP/1.1 200 Mighty fine indeed
 
 </connect>


### PR DESCRIPTION
Did not cause an issue in runtests. Caught by `xmllint`.

Follow-up to 63e9721b63d01518db83a664bc1e8373c352879e #19313
