### PR TITLE
tests/data: avoid tag markup in comments

### DIFF
--- a/tests/data/test2700
+++ b/tests/data/test2700
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A TEXT/BINARY/PING/PONG/CLOSE message with payload
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -66,7 +66,7 @@ close [7] %hex[%03%e8]hex%close
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2701
+++ b/tests/data/test2701
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   An empty frame with the reserved opcode 0x3
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2702
+++ b/tests/data/test2702
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   An empty frame with the reserved opcode 0xB
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2703
+++ b/tests/data/test2703
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   An empty frame with the RSV1 bit set
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2704
+++ b/tests/data/test2704
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   An empty frame with the RSV2 bit set
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2705
+++ b/tests/data/test2705
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   An empty frame with the RSV3 bit set
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2706
+++ b/tests/data/test2706
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   An empty frame with masking
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2707
+++ b/tests/data/test2707
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 # Frames with sizes around special cases of the frame encoding
 #   see https://datatracker.ietf.org/doc/html/rfc6455#section-5.2
 #    - 0: empty frame
@@ -74,7 +74,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2708
+++ b/tests/data/test2708
@@ -64,7 +64,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2709
+++ b/tests/data/test2709
@@ -63,7 +63,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2710
+++ b/tests/data/test2710
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   An unsolicited PONG with and without payload
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -63,7 +63,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2711
+++ b/tests/data/test2711
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A PING/PONG/CLOSE message without payload
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -64,7 +64,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2712
+++ b/tests/data/test2712
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A PING/PONG/CLOSE with 125 bytes payload each
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -64,7 +64,7 @@ close [125] %hex[%03%e8]hex%%repeat[123 x _]%
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2713
+++ b/tests/data/test2713
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A 126 byte long PING
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2714
+++ b/tests/data/test2714
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A 126 byte long PONG
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2715
+++ b/tests/data/test2715
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A 126 byte long CLOSE
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2716
+++ b/tests/data/test2716
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A fragmented PING
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2717
+++ b/tests/data/test2717
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A fragmented PONG
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2718
+++ b/tests/data/test2718
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A fragmented CLOSE
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -62,7 +62,7 @@ Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2719
+++ b/tests/data/test2719
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   Fragmented TEXT/BINARY messages, each with 2/3 fragments
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -71,7 +71,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2720
+++ b/tests/data/test2720
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   1st a message with an empty fragment at the beginning
 #   2nd a message with an empty fragment in the middle
 #   3rd a message with an empty fragment at the end
@@ -76,7 +76,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2721
+++ b/tests/data/test2721
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   A TEXT/BINARY message fragmented into two frames each, with pongs in the middle
 <data nocheck="yes" nonewline="yes">
 HTTP/1.1 101 Switching to WebSockets
@@ -67,7 +67,7 @@ close [0]
 0
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2722
+++ b/tests/data/test2722
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   First a valid BINARY frame
 #   Second a fragmented message with the first frame missing
 <data nocheck="yes" nonewline="yes">
@@ -63,7 +63,7 @@ bin fin [1] b
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*

--- a/tests/data/test2723
+++ b/tests/data/test2723
@@ -32,7 +32,7 @@ CURL_WS_FORCE_ZERO_MASK=1
 upgrade
 </servercmd>
 
-# Full list of frames: see <verify.stdout> below
+# Full list of frames: see 'verify.stdout' below
 #   First a fragmented TEXT message with the last frame missing
 #   Second a valid BINARY frame
 <data nocheck="yes" nonewline="yes">
@@ -64,7 +64,7 @@ txt --- [2] t2
 56
 </errorcode>
 
-# Strip HTTP header from <protocol>
+# Strip HTTP header from 'protocol'
 <strip>
 ^GET /.*
 ^(Host|User-Agent|Accept|Upgrade|Connection|Sec-WebSocket-(Version|Key)): .*


### PR DESCRIPTION
To avoid confusing `xmllint`, and reducing the number of files failing
`xmllint --format` from 169 to 144.
