### PR TITLE
test1554: make test output XML-friendly

### DIFF
--- a/tests/data/test1554
+++ b/tests/data/test1554
@@ -19,55 +19,55 @@ Content-Length: 29
 run 1: foobar and so on fun!
 </data>
 <datacheck>
--> Mutex lock SHARE
-<- Mutex unlock SHARE
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
+-] Mutex lock SHARE
+[- Mutex unlock SHARE
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
 run 1: foobar and so on fun!
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock SHARE
-<- Mutex unlock SHARE
--> Mutex lock SHARE
-<- Mutex unlock SHARE
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock SHARE
+[- Mutex unlock SHARE
+-] Mutex lock SHARE
+[- Mutex unlock SHARE
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
 run 1: foobar and so on fun!
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock SHARE
-<- Mutex unlock SHARE
--> Mutex lock SHARE
-<- Mutex unlock SHARE
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock SHARE
+[- Mutex unlock SHARE
+-] Mutex lock SHARE
+[- Mutex unlock SHARE
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
 run 1: foobar and so on fun!
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock CONNECT
-<- Mutex unlock CONNECT
--> Mutex lock SHARE
-<- Mutex unlock SHARE
--> Mutex lock SHARE
-<- Mutex unlock SHARE
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock CONNECT
+[- Mutex unlock CONNECT
+-] Mutex lock SHARE
+[- Mutex unlock SHARE
+-] Mutex lock SHARE
+[- Mutex unlock SHARE
 </datacheck>
 </reply>
 

--- a/tests/libtest/lib1554.c
+++ b/tests/libtest/lib1554.c
@@ -44,7 +44,7 @@ static void t1554_test_lock(CURL *curl, curl_lock_data data,
   (void)data;
   (void)laccess;
   (void)useptr;
-  curl_mprintf("-> Mutex lock %s\n", ldata_names[data]);
+  curl_mprintf("-] Mutex lock %s\n", ldata_names[data]);
 }
 
 static void t1554_test_unlock(CURL *curl, curl_lock_data data, void *useptr)
@@ -52,7 +52,7 @@ static void t1554_test_unlock(CURL *curl, curl_lock_data data, void *useptr)
   (void)curl;
   (void)data;
   (void)useptr;
-  curl_mprintf("<- Mutex unlock %s\n", ldata_names[data]);
+  curl_mprintf("[- Mutex unlock %s\n", ldata_names[data]);
 }
 
 /* test function */


### PR DESCRIPTION
Meaning no `<` and `>` characters.
Reducing the number of `xmllint` failures by 1.
