### PR TITLE
runtests: add missing Perl semicolon

### DIFF
--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -229,7 +229,7 @@ sub loadtest {
 
     if(open(my $xmlh, "<", "$file")) {
         if($original) {
-            binmode $xmlh, ':crlf'
+            binmode $xmlh, ':crlf';
         }
         else {
             binmode $xmlh; # for crapage systems, use binary


### PR DESCRIPTION
Follow-up to f477f3efc3ec58f7effc2aa01e7f4565b12be976 #19398