### PR TITLE
curl_setup.h: drop stray `#undef stat` (Windows)

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -493,7 +493,6 @@
 #    define lseek(fdes, offset, whence)  _lseeki64(fdes, offset, whence)
 #    undef  fstat
 #    define fstat(fdes,stp)              _fstati64(fdes, stp)
-#    undef  stat
 #    define struct_stat                  struct _stati64
 #    define LSEEK_ERROR                  (__int64)-1
 #  else


### PR DESCRIPTION
Follow-up to 9678ff5b1bfea1c847aee4f9edf023e8f01c9293 #18776
