### PR TITLE
badwords.pl: fix variable in printf mask

### DIFF
--- a/.github/scripts/badwords.pl
+++ b/.github/scripts/badwords.pl
@@ -94,7 +94,7 @@ sub file {
                 }
 
                 print STDERR  "$f:$l:$c: error: found bad word \"$w\"\n";
-                printf STDERR " %4d | $in\n", $l;
+                printf STDERR " %4d | %s\n", $l, $in;
                 printf STDERR "      | %*s^%s\n", length($p), " ",
                     "~" x (length($w)-1);
                 printf STDERR " maybe use \"%s\" instead?\n", $alt{$w};


### PR DESCRIPTION
Causing warnings if a matched line has mask patterns.
