### PR TITLE
pytest fixes and improvements

### DIFF
--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -39,10 +39,9 @@ log = logging.getLogger(__name__)
 class TestGoAway:
 
     # download files sequentially with delay, reload server for GOAWAY
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_03_01_h2_goaway(self, env: Env, httpd, nghttpx):
         proto = 'h2'
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         count = 3
         self.r = None
 

--- a/tests/http/test_04_stuttered.py
+++ b/tests/http/test_04_stuttered.py
@@ -39,12 +39,8 @@ log = logging.getLogger(__name__)
 class TestStuttered:
 
     # download 1 file, check that delayed response works in general
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_04_01_download_1(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 1
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
@@ -56,12 +52,8 @@ class TestStuttered:
     # download 50 files in 100 chunks a 100 bytes with 10ms delay between
     # prepend 100 file requests to warm up connection processing limits
     # (Apache2 increases # of parallel processed requests after successes)
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_04_02_100_100_10(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 50
         warmups = 100
         curl = CurlClient(env=env)
@@ -80,12 +72,8 @@ class TestStuttered:
     # download 50 files in 1000 chunks a 10 bytes with 1ms delay between
     # prepend 100 file requests to warm up connection processing limits
     # (Apache2 increases # of parallel processed requests after successes)
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_04_03_1000_10_1(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 50
         warmups = 100
         curl = CurlClient(env=env)
@@ -104,12 +92,8 @@ class TestStuttered:
     # download 50 files in 10000 chunks a 1 byte with 10us delay between
     # prepend 100 file requests to warm up connection processing limits
     # (Apache2 increases # of parallel processed requests after successes)
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_04_04_1000_10_1(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 50
         warmups = 100
         curl = CurlClient(env=env)

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -51,12 +51,8 @@ class TestUpload:
         env.make_data_file(indir=env.gen_dir, fname="data-10m", fsize=10*1024*1024)
 
     # upload small data, check that this is what was echoed
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_01_upload_1_small(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         data = '0123456789'
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
@@ -66,12 +62,8 @@ class TestUpload:
         assert respdata == [data]
 
     # upload large data, check that this is what was echoed
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_02_upload_1_large(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
@@ -82,12 +74,8 @@ class TestUpload:
         assert respdata == indata
 
     # upload data sequentially, check that they were echoed
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_10_upload_sequential(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 20
         data = '0123456789'
         curl = CurlClient(env=env)
@@ -99,12 +87,8 @@ class TestUpload:
             assert respdata == [data]
 
     # upload data parallel, check that they were echoed
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_07_11_upload_parallel(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1
         count = 20
         data = '0123456789'
@@ -118,12 +102,8 @@ class TestUpload:
             assert respdata == [data]
 
     # upload large data sequentially, check that this is what was echoed
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_12_upload_seq_large(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
         count = 10
         curl = CurlClient(env=env)
@@ -137,12 +117,8 @@ class TestUpload:
             assert respdata == indata
 
     # upload very large data sequentially, check that this is what was echoed
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_13_upload_seq_large(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         count = 2
         curl = CurlClient(env=env)
@@ -155,15 +131,11 @@ class TestUpload:
             assert respdata == indata
 
     # upload from stdin, issue #14870
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     @pytest.mark.parametrize("indata", [
         '', '1', '123\n456andsomething\n\n'
     ])
     def test_07_14_upload_stdin(self, env: Env, httpd, nghttpx, proto, indata):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?id=[0-{count-1}]'
@@ -173,12 +145,8 @@ class TestUpload:
             respdata = open(curl.response_file(i)).readlines()
             assert respdata == [f'{len(indata)}']
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_15_hx_put(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 2
         upload_size = 128*1024
         url = f'https://localhost:{env.https_port}/curltest/put'
@@ -191,12 +159,8 @@ class TestUpload:
         r.check_exit_code(0)
         self.check_downloads(client, r, [f"{upload_size}"], count)
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_16_hx_put_reuse(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 2
         upload_size = 128*1024
         url = f'https://localhost:{env.https_port}/curltest/put'
@@ -209,12 +173,8 @@ class TestUpload:
         r.check_exit_code(0)
         self.check_downloads(client, r, [f"{upload_size}"], count)
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_17_hx_post_reuse(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 2
         upload_size = 128*1024
         url = f'https://localhost:{env.https_port}/curltest/echo'
@@ -228,12 +188,8 @@ class TestUpload:
         self.check_downloads(client, r, ["x" * upload_size], count)
 
     # upload data parallel, check that they were echoed
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_07_20_upload_parallel(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1
         count = 10
         data = '0123456789'
@@ -247,12 +203,8 @@ class TestUpload:
             assert respdata == [data]
 
     # upload large data parallel, check that this is what was echoed
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_07_21_upload_parallel_large(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
         # limit since we use a separate connection in h1
         count = 10
@@ -267,12 +219,8 @@ class TestUpload:
     # (We used to do this for 20 parallel transfers, but the triggered
     #  stream resets make nghttpx drop the connection after several, which
     #  then gives a non-deterministic number of completely failed transfers)
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_07_22_upload_fail(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         count = 1
         curl = CurlClient(env=env)
@@ -285,12 +233,8 @@ class TestUpload:
         r.check_stats(count=count, exitcode=[18, 55, 56, 92, 95])
 
     # PUT 100k
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_30_put_100k(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
         count = 1
         curl = CurlClient(env=env)
@@ -305,12 +249,8 @@ class TestUpload:
             assert respdata == exp_data
 
     # PUT 10m
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_31_put_10m(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         count = 1
         curl = CurlClient(env=env)
@@ -325,12 +265,8 @@ class TestUpload:
             assert respdata == exp_data
 
     # issue #10591
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_32_issue_10591(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         count = 1
         curl = CurlClient(env=env)
@@ -340,10 +276,9 @@ class TestUpload:
 
     # issue #11157, upload that is 404'ed by server, needs to terminate
     # correctly and not time out on sending
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_07_33_issue_11157a(self, env: Env, httpd, nghttpx):
         proto = 'h2'
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         # send a POST to our PUT handler which will send immediately a 404 back
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put'
@@ -363,10 +298,9 @@ class TestUpload:
         r.check_stats(1, 404)
 
     # issue #11157, send upload that is slowly read in
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_07_33_issue_11157b(self, env: Env, httpd, nghttpx):
         proto = 'h2'
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         # tell our test PUT handler to read the upload more slowly, so
         # that the send buffering and transfer loop needs to wait
@@ -387,10 +321,9 @@ class TestUpload:
         assert r.exit_code == 0, r.dump_logs()
         r.check_stats(1, 200)
 
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_07_34_issue_11194(self, env: Env, httpd, nghttpx):
         proto = 'h2'
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         # tell our test PUT handler to read the upload more slowly, so
         # that the send buffering and transfer loop needs to wait
         fdata = os.path.join(env.gen_dir, 'data-100k')
@@ -409,9 +342,8 @@ class TestUpload:
         r.check_stats(1, 200)
 
     # upload large data on a h1 to h2 upgrade
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_07_35_h1_h2_upgrade_upload(self, env: Env, httpd, nghttpx):
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-100k')
         curl = CurlClient(env=env)
         url = f'http://{env.domain1}:{env.http_port}/curltest/echo?id=[0-0]'
@@ -427,12 +359,8 @@ class TestUpload:
 
     # upload to a 301,302,303 response
     @pytest.mark.parametrize("redir", ['301', '302', '303'])
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_36_upload_30x(self, env: Env, httpd, nghttpx, redir, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip("OpenSSL's own QUIC is flaky here")
         data = '0123456789' * 10
@@ -446,12 +374,8 @@ class TestUpload:
         assert respdata == []  # was transformed to a GET
 
     # upload to a 307 response
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_37_upload_307(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip("OpenSSL's own QUIC is flaky here")
         data = '0123456789' * 10
@@ -465,12 +389,8 @@ class TestUpload:
         assert respdata == [data]  # was POST again
 
     # POST form data, yet another code path in transfer
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_38_form_small(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_form(urls=[url], alpn_proto=proto, form={
@@ -479,12 +399,8 @@ class TestUpload:
         r.check_stats(count=1, http_status=200, exitcode=0)
 
     # POST data urlencoded, small enough to be sent with request headers
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_39_post_urlenc_small(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-63k')
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
@@ -497,12 +413,8 @@ class TestUpload:
         assert respdata == indata
 
     # POST data urlencoded, large enough to be sent separate from request headers
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_40_post_urlenc_large(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         fdata = os.path.join(env.gen_dir, 'data-64k')
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
@@ -519,12 +431,8 @@ class TestUpload:
     # than our default upload buffer length (64KB).
     # Unfixed, this will fail when run with CURL_DBG_SOCK_WBLOCK=80 most
     # of the time
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_41_post_urlenc_small(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_lib('quiche'):
             pytest.skip("quiche has CWND issues with large requests")
         fdata = os.path.join(env.gen_dir, 'data-63k')
@@ -554,12 +462,8 @@ class TestUpload:
 
     # upload data, pause, let connection die with an incomplete response
     # issues #11769 #13260
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_42a_upload_disconnect(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         client = LocalClient(name='cli_upload_pausing', env=env, timeout=60)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
@@ -576,12 +480,8 @@ class TestUpload:
             r.check_exit_code(18)  # will fail as it should
 
     # upload data, pause, let connection die without any response at all
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_42b_upload_disconnect(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         client = LocalClient(name='cli_upload_pausing', env=env, timeout=60)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
@@ -593,12 +493,8 @@ class TestUpload:
         r.check_exit_code(exp_code)  # GOT_NOTHING
 
     # upload data, pause, let connection die after 100 continue
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_42c_upload_disconnect(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         client = LocalClient(name='cli_upload_pausing', env=env, timeout=60)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
@@ -609,12 +505,8 @@ class TestUpload:
             exp_code = 0  # we get a 500 from the server
         r.check_exit_code(exp_code)  # GOT_NOTHING
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_43_upload_denied(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip("openssl-quic is flaky in filed PUTs")
         fdata = os.path.join(env.gen_dir, 'data-10m')
@@ -627,13 +519,9 @@ class TestUpload:
                           extra_args=['--trace-config', 'all'])
         r.check_stats(count=count, http_status=413, exitcode=0)
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     @pytest.mark.parametrize("httpcode", [301, 302, 307, 308])
     def test_07_44_put_redir(self, env: Env, httpd, nghttpx, proto, httpcode):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 1
         upload_size = 128*1024
         url = f'https://localhost:{env.https_port}/curltest/put-redir-{httpcode}'
@@ -654,12 +542,8 @@ class TestUpload:
             assert httpcodes[0] == httpcode, f'{r}'
 
     # speed limited on put handler
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_50_put_speed_limit(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 1
         fdata = os.path.join(env.gen_dir, 'data-100k')
         up_len = 100 * 1024
@@ -676,12 +560,8 @@ class TestUpload:
         assert (speed_limit * 0.5) <= up_speed <= (speed_limit * 1.5), f'{r.stats[0]}'
 
     # speed limited on echo handler
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_07_51_echo_speed_limit(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 1
         fdata = os.path.join(env.gen_dir, 'data-100k')
         speed_limit = 50 * 1024

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -68,24 +68,16 @@ class TestCaddy:
         env.make_data_file(indir=env.gen_dir, fname="data-10m", fsize=10*1024*1024)
 
     # download 1 file
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_08_01_download_1(self, env: Env, caddy: Caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3_curl():
-            pytest.skip("h3 not supported in curl")
         curl = CurlClient(env=env)
         url = f'https://{env.domain1}:{caddy.port}/data.json'
         r = curl.http_download(urls=[url], alpn_proto=proto)
         r.check_response(count=1, http_status=200)
 
     # download 1MB files sequentially
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_08_02_download_1mb_sequential(self, env: Env, caddy: Caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3_curl():
-            pytest.skip("h3 not supported in curl")
         count = 50
         curl = CurlClient(env=env)
         urln = f'https://{env.domain1}:{caddy.port}/data1.data?[0-{count-1}]'
@@ -93,12 +85,8 @@ class TestCaddy:
         r.check_response(count=count, http_status=200, connect_count=1)
 
     # download 1MB files parallel
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_08_03_download_1mb_parallel(self, env: Env, caddy: Caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3_curl():
-            pytest.skip("h3 not supported in curl")
         count = 20
         curl = CurlClient(env=env)
         urln = f'https://{env.domain1}:{caddy.port}/data1.data?[0-{count-1}]'
@@ -114,12 +102,8 @@ class TestCaddy:
 
     # download 5MB files sequentially
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_08_04a_download_10mb_sequential(self, env: Env, caddy: Caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3_curl():
-            pytest.skip("h3 not supported in curl")
         count = 40
         curl = CurlClient(env=env)
         urln = f'https://{env.domain1}:{caddy.port}/data5.data?[0-{count-1}]'
@@ -128,12 +112,8 @@ class TestCaddy:
 
     # download 10MB files sequentially
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_08_04b_download_10mb_sequential(self, env: Env, caddy: Caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3_curl():
-            pytest.skip("h3 not supported in curl")
         count = 20
         curl = CurlClient(env=env)
         urln = f'https://{env.domain1}:{caddy.port}/data10.data?[0-{count-1}]'
@@ -142,12 +122,8 @@ class TestCaddy:
 
     # download 10MB files parallel
     @pytest.mark.skipif(condition=Env().slow_network, reason="not suitable for slow network tests")
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_08_05_download_1mb_parallel(self, env: Env, caddy: Caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3_curl():
-            pytest.skip("h3 not supported in curl")
         if proto == 'http/1.1' and env.curl_uses_lib('mbedtls'):
             pytest.skip("mbedtls 3.6.0 fails on 50 connections with: "
                         "ssl_handshake returned: (-0x7F00) SSL - Memory allocation failed")
@@ -165,12 +141,8 @@ class TestCaddy:
             assert r.total_connects == 1, r.dump_logs()
 
     # post data parallel, check that they were echoed
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_08_06_post_parallel(self, env: Env, httpd, caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1
         count = 20
         data = '0123456789'
@@ -184,12 +156,8 @@ class TestCaddy:
             assert respdata == [data]
 
     # put large file, check that they length were echoed
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_08_07_put_large(self, env: Env, httpd, caddy, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         # limit since we use a separate connection in h1<
         count = 1
         fdata = os.path.join(env.gen_dir, 'data-10m')
@@ -202,15 +170,12 @@ class TestCaddy:
             respdata = open(curl.response_file(i)).readlines()
             assert respdata == exp_data
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_08_08_earlydata(self, env: Env, httpd, caddy, proto):
         if not env.curl_can_early_data():
             pytest.skip('TLS earlydata not implemented')
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and \
-           (not env.have_h3() or not env.curl_can_h3_early_data()):
-            pytest.skip("h3 not supported")
+        if proto == 'h3' and not env.curl_can_h3_early_data():
+            pytest.skip("h3 early data not supported")
         count = 2
         docname = 'data10k.data'
         url = f'https://{env.domain1}:{caddy.port}/{docname}'

--- a/tests/http/test_09_push.py
+++ b/tests/http/test_09_push.py
@@ -60,9 +60,8 @@ class TestPush:
         httpd.reload_if_config_changed()
 
     # download a file that triggers a "103 Early Hints" response
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_09_01_h2_early_hints(self, env: Env, httpd, configures_httpd):
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'https://{env.domain1}:{env.https_port}/push/data1'
@@ -74,9 +73,8 @@ class TestPush:
         assert 'link' in r.responses[0]['header'], f'{r.responses[0]}'
         assert r.responses[0]['header']['link'] == '</push/data2>; rel=preload', f'{r.responses[0]}'
 
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_09_02_h2_push(self, env: Env, httpd, configures_httpd):
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         # use localhost as we do not have resolve support in local client
         url = f'https://localhost:{env.https_port}/push/data1'

--- a/tests/http/test_13_proxy_auth.py
+++ b/tests/http/test_13_proxy_auth.py
@@ -121,11 +121,9 @@ class TestProxyAuth:
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.skipif(condition=not Env.curl_is_debug(), reason="needs curl debug")
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
-    @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", Env.http_h1_h2_protos())
+    @pytest.mark.parametrize("tunnel", Env.http_h1_h2_protos())
     def test_13_07_tunnels_no_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd, proto, tunnel):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
@@ -143,11 +141,9 @@ class TestProxyAuth:
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.skipif(condition=not Env.curl_is_debug(), reason="needs curl debug")
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
-    @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", Env.http_h1_h2_protos())
+    @pytest.mark.parametrize("tunnel", Env.http_h1_h2_protos())
     def test_13_08_tunnels_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd, proto, tunnel):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         self.httpd_configure(env, httpd)
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -41,26 +41,18 @@ class TestAuth:
         env.make_data_file(indir=env.gen_dir, fname="data-10m", fsize=10*1024*1024)
 
     # download 1 file, not authenticated
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_14_01_digest_get_noauth(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/restricted/digest/data.json'
         r = curl.http_download(urls=[url], alpn_proto=proto)
         r.check_response(http_status=401)
 
     # download 1 file, authenticated
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_14_02_digest_get_auth(self, env: Env, httpd, nghttpx, proto):
         if not env.curl_has_feature('digest'):
             pytest.skip("curl built without digest")
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/restricted/digest/data.json'
         r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
@@ -69,14 +61,10 @@ class TestAuth:
         r.check_response(http_status=200)
 
     # PUT data, authenticated
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_14_03_digest_put_auth(self, env: Env, httpd, nghttpx, proto):
         if not env.curl_has_feature('digest'):
             pytest.skip("curl built without digest")
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip("openssl-quic is flaky in retrying POST")
         data='0123456789'
@@ -88,14 +76,10 @@ class TestAuth:
         r.check_response(http_status=200)
 
     # PUT data, digest auth large pw
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_14_04_digest_large_pw(self, env: Env, httpd, nghttpx, proto):
         if not env.curl_has_feature('digest'):
             pytest.skip("curl built without digest")
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         data='0123456789'
         password = 'x' * 65535
         curl = CurlClient(env=env)
@@ -109,12 +93,8 @@ class TestAuth:
         r.check_response(http_status=401)
 
     # PUT data, basic auth large pw
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_14_05_basic_large_pw(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if proto == 'h3' and not env.curl_uses_lib('ngtcp2'):
             # See <https://github.com/cloudflare/quiche/issues/1573>
             pytest.skip("quiche/openssl-quic have problems with large requests")
@@ -131,12 +111,8 @@ class TestAuth:
         r.check_response(http_status=431)
 
     # PUT data, basic auth with very large pw
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_14_06_basic_very_large_pw(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if proto == 'h3' and env.curl_uses_lib('quiche'):
             # See <https://github.com/cloudflare/quiche/issues/1573>
             pytest.skip("quiche has problems with large requests")

--- a/tests/http/test_16_info.py
+++ b/tests/http/test_16_info.py
@@ -45,12 +45,8 @@ class TestInfo:
         env.make_data_file(indir=env.gen_dir, fname="data-100k", fsize=100*1024)
 
     # download plain file
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_16_01_info_download(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 2
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-{count-1}]'
@@ -62,12 +58,8 @@ class TestInfo:
             self.check_stat(idx, s, r, dl_size=30, ul_size=0)
 
     # download plain file with a 302 redirect
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_16_02_info_302_download(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 2
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json.302?[0-{count-1}]'
@@ -80,12 +72,8 @@ class TestInfo:
         for idx, s in enumerate(r.stats):
             self.check_stat(idx, s, r, dl_size=30, ul_size=0)
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_16_03_info_upload(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 2
         fdata = os.path.join(env.gen_dir, 'data-100k')
         fsize = 100 * 1024

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -116,12 +116,8 @@ class TestSSLUse:
                 assert djson['SSL_SESSION_RESUMED'] == exp_resumed, f'{i}: {djson}\n{r.dump_logs()}'
 
     # use host name with trailing dot, verify handshake
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_03_trailing_dot(self, env: Env, proto, httpd, nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         domain = f'{env.domain1}.'
         url = f'https://{env.authority_for(domain, proto)}/curltest/sslinfo'
@@ -133,12 +129,8 @@ class TestSSLUse:
             assert r.json['SSL_TLS_SNI'] == env.domain1, f'{r.json}'
 
     # use host name with double trailing dot, verify handshake
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_04_double_dot(self, env: Env, proto, httpd, nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         domain = f'{env.domain1}..'
         url = f'https://{env.authority_for(domain, proto)}/curltest/sslinfo'
@@ -157,14 +149,10 @@ class TestSSLUse:
         assert r.exit_code in [7, 35, 60], f'{r}'
 
     # use ip address for connect
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_05_good_ip_addr(self, env: Env, proto, httpd, nghttpx):
         if env.curl_uses_lib('mbedtls'):
             pytest.skip("mbedTLS does use IP addresses in SNI")
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         domain = '127.0.0.1'
         url = f'https://{env.authority_for(domain, proto)}/curltest/sslinfo'
@@ -176,14 +164,10 @@ class TestSSLUse:
             assert 'SSL_TLS_SNI' not in r.json, f'{r.json}'
 
     # use IP address that is not in cert
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_05_bad_ip_addr(self, env: Env, proto,
                                httpd, configures_httpd,
                                nghttpx, configures_nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         httpd.set_domain1_cred_name('domain1-no-ip')
         httpd.reload_if_config_changed()
         if proto == 'h3':
@@ -195,14 +179,10 @@ class TestSSLUse:
         assert r.exit_code == 60, f'{r}'
 
     # use IP address that is in cert as DNS name (not really legal)
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_05_very_bad_ip_addr(self, env: Env, proto,
                                     httpd, configures_httpd,
                                     nghttpx, configures_nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if env.curl_uses_lib('mbedtls'):
             pytest.skip("mbedtls falsely verifies a DNS: altname as IP address")
         if env.curl_uses_lib('wolfssl') and \
@@ -219,12 +199,8 @@ class TestSSLUse:
         assert r.exit_code == 60, f'{r}'
 
     # use localhost for connect
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_06_localhost(self, env: Env, proto, httpd, nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         domain = 'localhost'
         url = f'https://{env.authority_for(domain, proto)}/curltest/sslinfo'
@@ -310,12 +286,8 @@ class TestSSLUse:
         else:
             assert r.exit_code != 0, r.dump_logs()
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_08_cert_status(self, env: Env, proto, httpd, nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if not env.curl_uses_lib('openssl') and \
            not env.curl_uses_lib('gnutls') and \
            not env.curl_uses_lib('quictls'):
@@ -433,12 +405,8 @@ class TestSSLUse:
         assert reused_session, f'{r}\n{r.dump_logs()}'
 
     # use host name server has no certificate for
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_11_wrong_host(self, env: Env, proto, httpd, nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         domain = f'insecure.{env.tld}'
         url = f'https://{domain}:{env.port_for(proto)}/curltest/sslinfo'
@@ -446,12 +414,8 @@ class TestSSLUse:
         assert r.exit_code == 60, f'{r}'
 
     # use host name server has no cert for with --insecure
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_12_insecure(self, env: Env, proto, httpd, nghttpx):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         domain = f'insecure.{env.tld}'
         url = f'https://{domain}:{env.port_for(proto)}/curltest/sslinfo'
@@ -462,10 +426,8 @@ class TestSSLUse:
         assert r.json, f'{r}'
 
     # connect to an expired certificate
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", Env.http_h1_h2_protos())
     def test_17_14_expired_cert(self, env: Env, proto, httpd):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.expired_domain}:{env.port_for(proto)}/'
         r = curl.http_get(url=url, alpn_proto=proto)
@@ -588,12 +550,8 @@ class TestSSLUse:
         else:
             assert r.exit_code != 0, r.dump_logs()
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_19_wrong_pin(self, env: Env, proto, httpd):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
+    @pytest.mark.parametrize("proto", Env.http_protos())
+    def test_17_19_wrong_pin(self, env: Env, proto, httpd, nghttpx):
         if env.curl_uses_lib('rustls-ffi'):
             pytest.skip('TLS backend ignores --pinnedpubkey')
         curl = CurlClient(env=env)
@@ -604,12 +562,8 @@ class TestSSLUse:
         # expect NOT_IMPLEMENTED or CURLE_SSL_PINNEDPUBKEYNOTMATCH
         assert r.exit_code in [2, 90], f'{r.dump_logs()}'
 
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_20_correct_pin(self, env: Env, proto, httpd):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
+    @pytest.mark.parametrize("proto", Env.http_protos())
+    def test_17_20_correct_pin(self, env: Env, proto, httpd, nghttpx):
         curl = CurlClient(env=env)
         creds = env.get_credentials(env.domain1)
         assert creds

--- a/tests/http/test_18_methods.py
+++ b/tests/http/test_18_methods.py
@@ -43,12 +43,8 @@ class TestMethods:
         env.make_data_file(indir=indir, fname="data-1m", fsize=1024*1024)
 
     # download 1 file
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_18_01_delete(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak?id=[0-{count-1}]'
@@ -59,10 +55,9 @@ class TestMethods:
     # - HEADER frame with 204 and eos=0
     # - 10ms later DATA frame length=0 and eos=1
     # should be accepted
+    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
     def test_18_02_delete_h2_special(self, env: Env, httpd, nghttpx):
         proto = 'h2'
-        if not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak?id=[0-{count-1}]'\

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -66,10 +66,8 @@ class TestShutdown:
 
     # check with `tcpdump` that we do NOT see TCP RST when CURL_GRACEFUL_SHUTDOWN set
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", Env.http_h1_h2_protos())
     def test_19_02_check_shutdown(self, env: Env, httpd, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         if not env.curl_is_debug():
             pytest.skip('only works for curl debug builds')
         run_env = os.environ.copy()
@@ -164,12 +162,8 @@ class TestShutdown:
         assert len(removes) == count, f'{removes}'
 
     # check graceful shutdown on multiplexed http
-    @pytest.mark.parametrize("proto", ['h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_19_06_check_shutdown(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         if not env.curl_is_debug():
             pytest.skip('only works for curl debug builds')
         if not env.curl_is_verbose():

--- a/tests/http/test_40_socks.py
+++ b/tests/http/test_40_socks.py
@@ -61,12 +61,8 @@ class TestSocks:
         r.check_response(http_status=200)
 
     @pytest.mark.parametrize("sproto", ['socks4', 'socks5'])
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_40_02_socks_https(self, env: Env, sproto, proto, danted: Dante, httpd):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         curl = CurlClient(env=env, socks_args=[
             f'--{sproto}', f'127.0.0.1:{danted.port}'
         ])
@@ -78,10 +74,8 @@ class TestSocks:
             r.check_response(http_status=200)
 
     @pytest.mark.parametrize("sproto", ['socks4', 'socks5'])
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", Env.http_h1_h2_protos())
     def test_40_03_dl_serial(self, env: Env, httpd, danted, proto, sproto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         count = 3
         urln = f'https://{env.authority_for(env.domain1, proto)}/data-10m?[0-{count-1}]'
         curl = CurlClient(env=env, socks_args=[
@@ -91,10 +85,8 @@ class TestSocks:
         r.check_response(count=count, http_status=200)
 
     @pytest.mark.parametrize("sproto", ['socks4', 'socks5'])
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", Env.http_h1_h2_protos())
     def test_40_04_ul_serial(self, env: Env, httpd, danted, proto, sproto):
-        if proto == 'h2' and not env.have_h2_curl():
-            pytest.skip("h2 not supported")
         fdata = os.path.join(env.gen_dir, 'data-10m')
         count = 2
         curl = CurlClient(env=env, socks_args=[

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -507,6 +507,36 @@ class Env:
             Env.curl_uses_lib('ngtcp2')
 
     @staticmethod
+    def http_protos() -> List[str]:
+        # http protocols we can test
+        if Env.have_h2_curl():
+            if Env.have_h3():
+                return ['http/1.1', 'h2', 'h3']
+            else:
+                return ['http/1.1', 'h2']
+        else:
+            return ['http/1.1']
+
+    @staticmethod
+    def http_h1_h2_protos() -> List[str]:
+        # http 1+2 protocols we can test
+        if Env.have_h2_curl():
+            return ['http/1.1', 'h2']
+        else:
+            return ['http/1.1']
+
+    @staticmethod
+    def http_mplx_protos() -> List[str]:
+        # http multiplexing protocols we can test
+        if Env.have_h2_curl():
+            if Env.have_h3():
+                return ['h2', 'h3']
+            else:
+                return ['h2']
+        else:
+            return []
+
+    @staticmethod
     def have_h3() -> bool:
         return Env.have_h3_curl() and Env.have_h3_server()
 
@@ -560,7 +590,8 @@ class Env:
 
     def issue_certs(self):
         if self._ca is None:
-            ca_dir = os.path.join(self.CONFIG.gen_root, 'ca')
+            # ca_dir = os.path.join(self.CONFIG.gen_root, 'ca')
+            ca_dir = os.path.join(self.gen_dir, 'ca')
             os.makedirs(ca_dir, exist_ok=True)
             lock_file = os.path.join(ca_dir, 'ca.lock')
             with FileLock(lock_file):


### PR DESCRIPTION
- fix test_17_20 flakiness: the test case did not have `nghttpx` in its parameters, causing it to no check if a reload was necessary. When that test ran behind one that gave nghttpx another certificate, eg. in parallel mode, it used the wrong pinned pubkey.
- Have `env` provide lists of HTTP protocol versions available for testing. Replace parameterized tests on a fixed protocol list with the dynamic one from env. This makes checks for protocol availability in the test function bodies superfluous.

refs #19489