### PR TITLE
runtests: drop Python 2 support remains

### DIFF
--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -23,9 +23,6 @@
 #
 """Server for testing SMB."""
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import argparse
 import logging
 import os
@@ -33,14 +30,10 @@ import signal
 import sys
 import tempfile
 import threading
+import configparser
 
 # Import our curl test data helper
 from util import ClosingFileHandler, TestData
-
-if sys.version_info.major >= 3:
-    import configparser
-else:
-    import ConfigParser as configparser
 
 # impacket needs to be installed in the Python environment
 try:

--- a/tests/util.py
+++ b/tests/util.py
@@ -23,9 +23,6 @@
 #
 """Module for extracting test data from the test data folder and other utils."""
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import logging
 import os
 import re


### PR DESCRIPTION
Used in the test SMB and telnet servers.
