### PR TITLE
rustls: minor adjustment of sizeof()

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -586,7 +586,7 @@ init_config_builder(struct Curl_easy *data,
   }
 #endif /* USE_ECH */
 
-  cipher_suites = malloc(sizeof(cipher_suites) * (cipher_suites_len));
+  cipher_suites = malloc(sizeof(*cipher_suites) * (cipher_suites_len));
   if(!cipher_suites) {
     result = CURLE_OUT_OF_MEMORY;
     goto cleanup;


### PR DESCRIPTION
The mistake is harmless because it is still a size of a pointer, but this is the correct pointer.