### PR TITLE
CI: bump Circle CI jobs to Ubuntu 22.04 runners for OpenSSL 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ commands:
 executors:
   ubuntu:
     machine:
-      image: ubuntu-2004:2024.01.1
+      image: ubuntu-2204:2025.09.1
 
 jobs:
   basic:
@@ -161,7 +161,7 @@ jobs:
 
   arm:
     machine:
-      image: ubuntu-2004:2024.01.1
+      image: ubuntu-2204:2025.09.1
     resource_class: arm.medium
     steps:
       - checkout
@@ -172,7 +172,7 @@ jobs:
 
   arm-cares:
     machine:
-      image: ubuntu-2004:2024.01.1
+      image: ubuntu-2204:2025.09.1
     resource_class: arm.medium
     steps:
       - checkout


### PR DESCRIPTION
Ref: https://packages.ubuntu.com/jammy/libssl-dev

Follow-up to 69c89bf3d3137fcbb2b8bc57233182adcf1e2817 #18330
