### PR TITLE
CI: avoid restart prompt on libssh-dev install in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
     steps:
       - run:
           command: |
-            sudo apt-get update && sudo apt-get install -y libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev python3-pip libpsl-dev
+            sudo apt-get update && sudo apt-get install -y libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev python3-pip
             python3 -m venv ~/venv
             ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/requirements.txt
 


### PR DESCRIPTION
By setting `DEBIAN_FRONTEND=noninteractive`.

Also:
- add `curl -V` step to CircleCI jobs.
- drop duplicate `libpsl` from `apt install`.
- replace sudo pip with venv, fixing a warning and syncing with GHA.
- Note that test 1459 was disabled on Ubuntu 20.04 due to past issues.
  When running on newer CircleCI Ubuntu runners (22.04 or 24.04), the
  test is not disabled, and also fails with the issue seen in the past.
  I've identified the root cause and will fix it in a separate PR.

Ref: https://circleci.com/developer/images?imageType=machine
Ref: https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q3-current-release/51856/7
Ref: https://app.circleci.com/pipelines/github/curl/curl/16450/workflows/af1f2a99-6452-4cc3-96c1-18a217ebabfc/jobs/155194

Follow-up to 8ba10a790a39dd48536c38e1d4569ab9fac537a1 #19546
