### PR TITLE
schannel_verify: fix a memory leak of cert_context

### DIFF
--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -234,8 +234,6 @@ static CURLcode add_certs_data_to_store(HCERTSTORE trust_store,
           case CERT_QUERY_CONTENT_SERIALIZED_CTL:
             CertFreeCTLContext((PCCTL_CONTEXT)cert_context);
             break;
-          default:
-            break;
           }
         }
       }


### PR DESCRIPTION
When `CryptQueryObject` returns a context of unexpected type, the `cert_context` was not freed.
This could be exploited by malicious servers providing specially crafted CA files.