### PR TITLE
cf-socket: limit use of `TCP_KEEP*` to Windows 10.0.16299+ at runtime

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -182,8 +182,7 @@ tcpkeepalive(struct Curl_cfilter *cf,
        setsockopt() TCP_KEEP*. Older versions return with failure. */
     if(curlx_verify_windows_version(10, 0, 16299, PLATFORM_WINNT,
                                     VERSION_GREATER_THAN_EQUAL)) {
-      CURL_TRC_CF(data, cf, "Using TCP_KEEP* on fd "
-                  "%" FMT_SOCKET_T, sockfd);
+      CURL_TRC_CF(data, cf, "Set TCP_KEEP* on fd=%" FMT_SOCKET_T, sockfd);
       optval = curlx_sltosi(data->set.tcp_keepidle);
       if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,
                     (const char *)&optval, sizeof(optval)) < 0) {


### PR DESCRIPTION
Before this patch `TCP_KEEP*` socket options were unconditionally used
if the build-time SDK supported them. This caused curl logging errors
(or trace messages since #19527) on Windows versions missing support
for them. After this patch, use them only when the runtime environment
supports it and fall back to the alternate method (`SIO_KEEPALIVE_VALS`)
dynamically.

Also:
- log a trace message when using the Win10 method.
- document which SDK versions offer `TCP_KEEP*` macros.

Ref: https://learn.microsoft.com/windows/win32/winsock/ipproto-tcp-socket-options
Ref: https://learn.microsoft.com/windows/win32/winsock/sio-keepalive-vals

Reported-by: Aleksandr Sergeev
Fixes #19520
Follow-up to dc34498d18d3303d67364423b4aa0daab4afb3ba #19527

---

w/o sp https://github.com/curl/curl/pull/19559/files?w=1
