### PR TITLE
openssl: fix a potential memory leak of bio_out

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1624,8 +1624,8 @@ static CURLcode x509_name_oneline(X509_NAME *a, struct dynbuf *d)
     if(rc != -1) {
       BIO_get_mem_ptr(bio_out, &biomem);
       result = curlx_dyn_addn(d, biomem->data, biomem->length);
-      BIO_free(bio_out);
     }
+    BIO_free(bio_out);
   }
   return result;
 }


### PR DESCRIPTION
This PR properly releases `bio_out` when `X509_NAME_print_ex` fails.