### PR TITLE
build: exclude clang prereleases from compiler warning options

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -232,20 +232,20 @@ if(PICKY_COMPILER)
           -Wcast-function-type-strict      # clang 16.0            appleclang 16.0
         )
       endif()
-      if(CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 21.0)
+      if(CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 21.1)
         list(APPEND _picky_enable
-          -Warray-compare                  # clang 20.0  gcc 12.0  appleclang ?
-          -Wc++-hidden-decl                # clang 21.0            appleclang ?
-          -Wno-implicit-void-ptr-cast      # clang 21.0            appleclang ?
-          -Wtentative-definition-compat    # clang 21.0            appleclang ?
+          -Warray-compare                  # clang 20.1  gcc 12.0  appleclang ?
+          -Wc++-hidden-decl                # clang 21.1            appleclang ?
+          -Wno-implicit-void-ptr-cast      # clang 21.1            appleclang ?
+          -Wtentative-definition-compat    # clang 21.1            appleclang ?
         )
         if(WIN32)
           list(APPEND _picky_enable
-            -Wno-c++-keyword               # clang 21.0            appleclang ?  # `wchar_t` triggers it on Windows
+            -Wno-c++-keyword               # clang 21.1            appleclang ?  # `wchar_t` triggers it on Windows
           )
         else()
           list(APPEND _picky_enable
-            -Wc++-keyword                  # clang 21.0            appleclang ?
+            -Wc++-keyword                  # clang 21.1            appleclang ?
           )
         endif()
       endif()

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -937,11 +937,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type-strict])  # with Apple clang it requires 16.0 or above
           fi
           dnl clang 20 or later
-          if test "$compiler_num" -ge "2000"; then
+          if test "$compiler_num" -ge "2001"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [array-compare])
           fi
           dnl clang 21 or later
-          if test "$compiler_num" -ge "2100"; then
+          if test "$compiler_num" -ge "2101"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c++-hidden-decl])
             tmp_CFLAGS="$tmp_CFLAGS -Wno-implicit-void-ptr-cast"
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [tentative-definition-compat])


### PR DESCRIPTION
Starting with clang 18, stable clang releases start with minor version 1.
Exclude pre-releases with minor version 0 from the compiler warning
options for that major version.

This fixes the build with Android NDK r29, which uses a prerelease
version of clang 21 that doesn't know the new options yet.
