### PR TITLE
appveyor: add VS2010 x86 Release VS project job and switch VS2013 to x64

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -95,7 +95,8 @@ elif [ "${BUILD_SYSTEM}" = 'VisualStudioSolution' ]; then
     msbuild.exe -maxcpucount "-property:Configuration=${PRJ_CFG}" "-property:Platform=${PLAT}" "Windows/${VC_VERSION}/curl-all.sln"
   )
   [ "${PLAT}" = 'x64' ] && platdir='Win64' || platdir='Win32'
-  curl="build/${platdir}/${VC_VERSION}/${PRJ_CFG}/curld.exe"
+  [[ "${PRJ_CFG}" = *'Debug'* ]] && binsuffix='d' || binsuffix=''
+  curl="build/${platdir}/${VC_VERSION}/${PRJ_CFG}/curl${binsuffix}.exe"
 fi
 
 find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -exec file -- '{}' \;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -148,10 +148,10 @@ environment:
 
     # generated VisualStudioSolution-based builds
 
-    - job_name: 'VisualStudioSolution VS2010, Debug, x86, Schannel, Build-only'
+    - job_name: 'VisualStudioSolution VS2010, Release, x86, Schannel, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2013'
       BUILD_SYSTEM: VisualStudioSolution
-      PRJ_CFG: 'DLL Debug - DLL Windows SSPI - DLL WinIDN'
+      PRJ_CFG: 'DLL Release - DLL Windows SSPI - DLL WinIDN'
       PLAT: 'Win32'
       VC_VERSION: VC10
     - job_name: 'VisualStudioSolution VS2013, Debug, x64, Schannel, Build-only'


### PR DESCRIPTION
To have a test case for VS2010 after bumping to minimum Vista.

Ref: #18009
