### PR TITLE
AmigaOS: raise default tool stack size to 32768 bytes

### DIFF
--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -65,7 +65,7 @@ int vms_show = 0;
 #else
 #define CURL_USED
 #endif
-static const char CURL_USED min_stack[] = "$STACK:16384";
+static const char CURL_USED min_stack[] = "$STACK:32768";
 #endif
 
 #ifdef __MINGW32__


### PR DESCRIPTION
This change increases the minimum stack cookie for the AmigaOS build of the curl tool.

In testing, the older stack size of 16384 was causing curl to crash on heavy TLS loads
These operations are significantly more stack-intensive on m68k systems due to soft-float and clib2 stack frame characteristics.
Doubling the stack size allows the TLS tests to pass.

This value has been tested across:

68000
68020
68040
68060
and ensures curl runs reliably across all TLS-enabled scenarios on AmigaOS 3.x, without affecting any other platforms.

This change affects only the AmigaOS 3.2+ builds and does not modify behavior on any other platform.