### PR TITLE
curl_setup.h: document more funcs flagged by `_CRT_SECURE_NO_WARNINGS`

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -95,9 +95,10 @@
                                       unlink(), etc. */
 #endif
 #ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS  /* for __sys_errlist, __sys_nerr, _wfopen(),
-                                    _wopen(), freopen(), getenv(), gmtime(),
-                                    sprintf(), strcpy(), wcscpy(), wcsncpy()
+#define _CRT_SECURE_NO_WARNINGS  /* for __sys_errlist, __sys_nerr, _open(),
+                                    _wfopen(), _wopen(), fopen(), freopen(),
+                                    getenv(), gmtime(), mbstowcs(), sprintf(),
+                                    strcpy(), wcscpy(), wcsncpy(), wcstombs(),
                                     in tests: localtime(), open(), sscanf() */
 #endif
 #endif /* _MSC_VER */


### PR DESCRIPTION
Based on these logs (non-Unicode, Unicode Schannel):
https://github.com/curl/curl/actions/runs/19446115443/job/55640968722?pr=19175
https://github.com/curl/curl/actions/runs/19446115443/job/55640968764?pr=19175

Follow-up to 5fa2d8320c4196435c1d554b06dfdcca73824dec #19175
