### PR TITLE
GHA: set `--buildinfo` for `test-torture` jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -770,6 +770,8 @@ jobs:
             if [[ "${MATRIX_INSTALL_PACKAGES}" = *'libgss-dev'* ]]; then
               TFLAGS+=' ~2077 ~2078'  # memory leaks from Curl_auth_decode_spnego_message() -> gss_init_sec_context()
             fi
+          elif [ "${TEST_TARGET}" != 'test-ci' ]; then
+            TFLAGS+=' --buildinfo'  # only test-ci sets this by default, set it manually for test-torture
           fi
           [ -f ~/venv/bin/activate ] && source ~/venv/bin/activate
           if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test'* ]]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -497,6 +497,9 @@ jobs:
           TFLAGS: '${{ matrix.build.tflags }}'
         run: |
           TFLAGS="-j20 ${TFLAGS}"
+          if [ "${TEST_TARGET}" != 'test-ci' ]; then
+            TFLAGS+=' --buildinfo'  # only test-ci sets this by default, set it manually for test-torture
+          fi
           source ~/venv/bin/activate
           if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test'* ]]; then
             locale || true


### PR DESCRIPTION
Only the `test-ci` build target sets `--buildinfo` automatically,
since 985f39c0ce78b546e832c250588c14023123edfb. It needs to be set
manually for other targets used in CI, such as `test-torture`,
to enable the `buildinfo.txt` dump in the runtests step.

For Test Clutch. In an attempt to re-sync `targetarch` with the rest of
macOS jobs on the feature matrix page:
https://testclutch.curl.se/static/reports/feature-matrix.html
Before this patch and possibly since the breaking update It's `aarch64e`
for torture jobs and `aarch64` for the rest

(stricly speaking `aarch64e` is the correct value for all macOS jobs, but
autotools and cmake report arm64/aarch64 without the `e`.)

Regression from 985f39c0ce78b546e832c250588c14023123edfb #18147

---

Two more things I noticed on the feature matrix page:
- macOS pytest jobs showing up as `arm`-hosted, while runtests
  have the expected `aarch64`, in both autotools and cmake jobs.
  https://github.com/curl/curl/actions/runs/19483425315/job/55760180604
  https://github.com/curl/curl/actions/runs/19483425315/job/55760180604
- The `[gha] Windows / msvc, CM arm64-windows schannel` job
  showing `x86_64` as host arch, while it's `aarch64`:
  https://github.com/curl/curl/actions/runs/19483425332/job/55760180038
