### PR TITLE
gssapi: fix regression by including gssapi_krb5.h for SCB flag to be defined

### DIFF
--- a/lib/curl_gssapi.h
+++ b/lib/curl_gssapi.h
@@ -29,10 +29,6 @@
 
 #ifdef HAVE_GSSAPI
 
-#ifdef GSS_C_CHANNEL_BOUND_FLAG  /* MIT Kerberos 1.19+, missing from GNU GSS */
-#define CURL_GSSAPI_HAS_CHANNEL_BINDING
-#endif
-
 extern gss_OID_desc Curl_spnego_mech_oid;
 extern gss_OID_desc Curl_krb5_mech_oid;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -196,6 +196,12 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 #  else
 #   include <gssapi/gssapi.h>
 #  endif
+#  ifdef HAVE_GSSAPI_GSSAPI_KRB5_H
+#   include <gssapi/gssapi_krb5.h>
+#  endif
+# endif
+# ifdef GSS_C_CHANNEL_BOUND_FLAG
+#  define CURL_GSSAPI_HAS_CHANNEL_BINDING
 # endif
 #endif
 

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -26,6 +26,7 @@
 
 #include <curl/curl.h>
 
+#include "../urldata.h"
 #include "../bufref.h"
 #include "../curlx/dynbuf.h"
 
@@ -242,12 +243,6 @@ CURLcode Curl_auth_create_xoauth_bearer_message(const char *user,
 #  else
 #   include <gssapi/gssapi.h>
 #  endif
-#  ifdef HAVE_GSSAPI_GSSAPI_KRB5_H
-#   include <gssapi/gssapi_krb5.h>
-#  endif
-# endif
-# ifdef GSS_C_CHANNEL_BOUND_FLAG
-#  define CURL_GSSAPI_HAS_CHANNEL_BINDING
 # endif
 #endif
 


### PR DESCRIPTION
The GSS_C_CHANNEL_BOUND_FLAG is only in gssapi_krb5.h, which the previous PR didn't include. This broke SecureChannelBinding on systems with MIT Kerberos 1.19+.

Fixed regression from #19164