### PR TITLE
admin handle processing

### DIFF
--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -574,8 +574,7 @@ CURLMcode Curl_multi_ev_assign(struct Curl_multi *multi,
 }
 
 void Curl_multi_ev_dirty_xfers(struct Curl_multi *multi,
-                               curl_socket_t s,
-                               bool *run_cpool)
+                               curl_socket_t s)
 {
   struct mev_sh_entry *entry;
 
@@ -606,7 +605,7 @@ void Curl_multi_ev_dirty_xfers(struct Curl_multi *multi,
     }
 
     if(entry->conn)
-      *run_cpool = TRUE;
+      Curl_multi_mark_dirty(multi->admin);
   }
 }
 

--- a/lib/multi_ev.h
+++ b/lib/multi_ev.h
@@ -63,8 +63,7 @@ CURLMcode Curl_multi_ev_assess_conn(struct Curl_multi *multi,
 
 /* Mark all transfers tied to the given socket as dirty */
 void Curl_multi_ev_dirty_xfers(struct Curl_multi *multi,
-                               curl_socket_t s,
-                               bool *run_cpool);
+                               curl_socket_t s);
 
 /* Socket will be closed, forget anything we know about it. */
 void Curl_multi_ev_socket_done(struct Curl_multi *multi,


### PR DESCRIPTION
Fold the special connection pool shutdown handling in multi the things the admin handle cares about. Add the admin handle to the 'process' bitset, deduce it from the 'running' count.

The admin handle is the processed like any other transfer, but has a special case in `multi_runsingle()`. Simplifies all other multi processing parts.