### PR TITLE
Added paths to error messages for quote commands

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2067,8 +2067,8 @@ static CURLcode ssh_state_sftp_quote_setstat(struct Curl_easy *data,
 
   if(rc && !sshc->acceptfail) {
     unsigned long sftperr = libssh2_sftp_last_error(sshc->sftp_session);
-    failf(data, "Attempt to set SFTP stats failed: %s",
-          sftp_libssh2_strerror(sftperr));
+    failf(data, "Attempt to set SFTP stats for \"%s\" failed: %s",
+          sshc->quote_path2, sftp_libssh2_strerror(sftperr));
     Curl_safefree(sshc->quote_path1);
     Curl_safefree(sshc->quote_path2);
     myssh_state(data, sshc, SSH_SFTP_CLOSE);


### PR DESCRIPTION
We really like to know what path curl parsed from our input.