### PR TITLE
Implement in-memory certificates for GnuTLS

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
@@ -13,6 +13,7 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 TLS-backend:
   - OpenSSL
+  - GnuTLS
   - mbedTLS
   - rustls
   - wolfSSL
@@ -80,7 +81,7 @@ int main(void)
 # HISTORY
 
 This option is supported by the mbedTLS (since 7.81.0), Rustls (since 7.82.0),
-wolfSSL (since 8.2.0), OpenSSL and Schannel backends.
+wolfSSL (since 8.2.0), GnuTLS (since 8.18.0), OpenSSL and Schannel backends.
 
 # %AVAILABILITY%
 


### PR DESCRIPTION
This adds support for in-memory CA certs (using `CURLOPT_CAINFO_BLOB`) to the GnuTLS backend. It mimics the OpenSSL backend by having these certs override any certs added using `CURLOPT_CAINFO`.