### PR TITLE
tool_urlglob: clean up used memory on errors better

### DIFF
--- a/src/tool_urlglob.h
+++ b/src/tool_urlglob.h
@@ -40,6 +40,7 @@ struct URLPattern {
       char **elem;
       curl_off_t size;
       curl_off_t idx;
+      size_t palloc; /* elem entries allocated */
     } set;
     struct {
       int min;
@@ -64,7 +65,7 @@ struct URLGlob {
   struct dynbuf buf;
   struct URLPattern *pattern;
   size_t palloc; /* number of pattern entries allocated */
-  size_t size;
+  size_t pnum; /* number of patterns used */
   char beenhere;
   const char *error; /* error message */
   size_t pos;        /* column position of error or 0 */


### PR DESCRIPTION
Previously it had to realloc the pattern array to store the last entry even when that last entry triggered an error and could be only half filled in.

Reported-by: letshack9707 on hackerone