### PR TITLE
httpsrr-altsvc-size_t

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -136,10 +136,8 @@ static struct altsvc *altsvc_create(struct Curl_str *srchost,
                                     size_t srcport,
                                     size_t dstport)
 {
-  enum alpnid dstalpnid =
-    Curl_alpn2alpnid(curlx_str(dstalpn), curlx_strlen(dstalpn));
-  enum alpnid srcalpnid =
-    Curl_alpn2alpnid(curlx_str(srcalpn), curlx_strlen(srcalpn));
+  enum alpnid dstalpnid = Curl_str2alpnid(dstalpn);
+  enum alpnid srcalpnid = Curl_str2alpnid(srcalpn);
   if(!srcalpnid || !dstalpnid)
     return NULL;
   return altsvc_createid(curlx_str(srchost), curlx_strlen(srchost),
@@ -545,8 +543,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
   do {
     if(!curlx_str_single(&p, '=')) {
       /* [protocol]="[host][:port], [protocol]="[host][:port]" */
-      enum alpnid dstalpnid =
-        Curl_alpn2alpnid(curlx_str(&alpn), curlx_strlen(&alpn));
+      enum alpnid dstalpnid = Curl_str2alpnid(&alpn);
       if(!curlx_str_single(&p, '\"')) {
         struct Curl_str dsthost;
         curl_off_t port = 0;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -66,6 +66,7 @@
 #include "sockaddr.h" /* required for Curl_sockaddr_storage */
 #include "curlx/inet_ntop.h"
 #include "curlx/inet_pton.h"
+#include "curlx/strparse.h"
 #include "vtls/vtls.h" /* for vtsl cfilters */
 #include "progress.h"
 #include "curlx/warnless.h"
@@ -81,21 +82,27 @@
 
 #if !defined(CURL_DISABLE_ALTSVC) || defined(USE_HTTPSRR)
 
-enum alpnid Curl_alpn2alpnid(const char *name, size_t len)
+enum alpnid Curl_alpn2alpnid(const unsigned char *name, size_t len)
 {
   if(len == 2) {
-    if(curl_strnequal(name, "h1", 2))
+    if(!memcmp(name, "h1", 2))
       return ALPN_h1;
-    if(curl_strnequal(name, "h2", 2))
+    if(!memcmp(name, "h2", 2))
       return ALPN_h2;
-    if(curl_strnequal(name, "h3", 2))
+    if(!memcmp(name, "h3", 2))
       return ALPN_h3;
   }
   else if(len == 8) {
-    if(curl_strnequal(name, "http/1.1", 8))
+    if(!memcmp(name, "http/1.1", 8))
       return ALPN_h1;
   }
   return ALPN_none; /* unknown, probably rubbish input */
+}
+
+enum alpnid Curl_str2alpnid(const struct Curl_str *cstr)
+{
+  return Curl_alpn2alpnid((const unsigned char *)curlx_str(cstr),
+                          curlx_strlen(cstr));
 }
 
 #endif

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -31,8 +31,10 @@
 
 struct Curl_dns_entry;
 struct ip_quadruple;
+struct Curl_str;
 
-enum alpnid Curl_alpn2alpnid(const char *name, size_t len);
+enum alpnid Curl_alpn2alpnid(const unsigned char *name, size_t len);
+enum alpnid Curl_str2alpnid(const struct Curl_str *str);
 
 /* generic function that returns how much time there is left to run, according
    to the timeouts set */

--- a/lib/httpsrr.c
+++ b/lib/httpsrr.c
@@ -37,7 +37,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-static CURLcode httpsrr_decode_alpn(const char *cp, size_t len,
+static CURLcode httpsrr_decode_alpn(const uint8_t *cp, size_t len,
                                     unsigned char *alpns)
 {
   /*
@@ -49,7 +49,7 @@ static CURLcode httpsrr_decode_alpn(const char *cp, size_t len,
   int idnum = 0;
 
   while(len > 0) {
-    size_t tlen = (size_t) *cp++;
+    size_t tlen = *cp++;
     enum alpnid id;
     len--;
     if(tlen > len)
@@ -84,7 +84,7 @@ CURLcode Curl_httpsrr_set(struct Curl_easy *data,
     CURL_TRC_DNS(data, "HTTPS RR MANDATORY left to implement");
     break;
   case HTTPS_RR_CODE_ALPN: /* str_list */
-    result = httpsrr_decode_alpn((const char *)val, vlen, hi->alpns);
+    result = httpsrr_decode_alpn(val, vlen, hi->alpns);
     CURL_TRC_DNS(data, "HTTPS RR ALPN: %u %u %u %u",
                  hi->alpns[0], hi->alpns[1], hi->alpns[2], hi->alpns[3]);
     break;


### PR DESCRIPTION
Treat alpn raw data as unsigned chars, avoids size_t and char* casts. Add method to convert a struct Curl_str to an alpnid.