### PR TITLE
quiche: eliminate size_t casts

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -777,7 +777,7 @@ static CURLcode write_resp_raw(struct Curl_cfilter *cf,
     return result;
 
   if(!flow)
-    stream->recv_buf_nonflow += (size_t)nwritten;
+    stream->recv_buf_nonflow += nwritten;
 
   if(nwritten < memlen) {
     /* This MUST not happen. Our recbuf is dimensioned to hold the


### PR DESCRIPTION
Use new curlx_sotouz_fits() instead.

Remove an unnecessary cast in osslq code while we are here.