### PR TITLE
GHA/non-native: drop OpenBSD CI job (due to fail at package install)

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -84,51 +84,6 @@ jobs:
             time cmake --build bld --target curl-examples-build
             echo '::endgroup::'
 
-  openbsd:
-    name: 'OpenBSD, CM clang libressl ${{ matrix.arch }}'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        arch: ['x86_64']
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-        with:
-          persist-credentials: false
-      - name: 'cmake'
-        uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda # v0.30.0
-        env:
-          MATRIX_ARCH: '${{ matrix.arch }}'
-        with:
-          environment_variables: MATRIX_ARCH
-          operating_system: 'openbsd'
-          version: '7.7'
-          architecture: ${{ matrix.arch }}
-          run: |
-            # https://openbsd.app/
-            # https://www.openbsd.org/faq/faq15.html
-            time sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
-            time cmake -B bld -G Ninja \
-              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-              -DCURL_USE_OPENSSL=ON \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld
-            time cmake --install bld
-            bld/src/curl --disable --version
-            if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
-              time cmake --build bld --target testdeps
-              export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
-              time cmake --build bld --target test-ci
-            fi
-            echo '::group::build examples'
-            time cmake --build bld --target curl-examples-build
-            echo '::endgroup::'
-
   freebsd:
     name: "FreeBSD, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
7.8 made tests flaky, had to revert to 7.7 in
8d00e28136baf661455f1fe5980a0d18c4d872e3. Today 7.7 broke at package
install possibly due to upstream Python version bump:
https://github.com/curl/curl/actions/runs/19540298028/job/55944536626?pr=19626

```
Can't install python-3.12.11 because of libraries
|library c.102.0 not found
[...]
Can't install py3-six-1.17.0p0: can't resolve python-3.12.11
| /usr/lib/libc.so.100.3 (system): bad major
```
