### PR TITLE
src: move `memdebug.h` to be the last include

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -29,7 +29,6 @@
 #include "tool_sdecls.h"
 #include "tool_urlglob.h"
 #include "var.h"
-#include "memdebug.h" /* keep this as LAST include */
 
 /* the type we use for storing a single boolean bit */
 #ifndef BIT

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -30,6 +30,8 @@
 #include "tool_ssls.h"
 #include "tool_parsecfg.h"
 
+#include "memdebug.h" /* keep this as LAST include */
+
 /* The maximum line length for an ecoded session ticket */
 #define MAX_SSLS_LINE (64 * 1024)
 


### PR DESCRIPTION
`memdebug.h` must be included last within each source. This breaks when
including it in a header, which ends up being included in the middle of
other headers, and `memdebug.h` also ending up in the middle of
includes.

Follow-up to c255d2fdcbf27b4bfd668ae3784bb657449d6889 #19602
