### PR TITLE
GHA/codeql: add tweak to successfully build libtests for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -109,9 +109,10 @@ jobs:
             # MultiSSL
             export PKG_CONFIG_PATH; PKG_CONFIG_PATH="$(brew --prefix c-ares)/lib/pkgconfig:$(brew --prefix mbedtls)/lib/pkgconfig:$(brew --prefix rustls-ffi)/lib/pkgconfig:$(brew --prefix gsasl)/lib/pkgconfig"
             cmake -B _bld1 -G Ninja -DENABLE_DEBUG=ON \
+              -DCMAKE_C_FLAGS=-DCURL_DISABLE_TYPECHECK \
               -DCURL_USE_GNUTLS=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_RUSTLS=ON -DCURL_USE_WOLFSSL=ON \
               -DUSE_LIBRTMP=ON -DCURL_USE_GSASL=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON -DUSE_ECH=ON -DENABLE_ARES=ON \
-              -DCURL_DISABLE_VERBOSE_STRINGS=ON -DCMAKE_C_FLAGS=-DCURL_DISABLE_TYPECHECK
+              -DCURL_DISABLE_VERBOSE_STRINGS=ON
             cmake --build _bld1
             cmake --build _bld1 --target testdeps
             cmake --build _bld1 --target curl-examples-build
@@ -119,6 +120,7 @@ jobs:
             # HTTP/3
             export PKG_CONFIG_PATH; PKG_CONFIG_PATH="$(brew --prefix libnghttp3)/lib/pkgconfig:$(brew --prefix libngtcp2)/lib/pkgconfig:$(brew --prefix gsasl)/lib/pkgconfig"
             cmake -B _bld2 -G Ninja \
+              -DCMAKE_C_FLAGS=-DCURL_DISABLE_TYPECHECK \
               -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR="$(brew --prefix openssl)" -DUSE_NGTCP2=ON \
               -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON \
               -DUSE_LIBRTMP=ON -DCURL_USE_GSASL=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON


### PR DESCRIPTION
Turns out the cause of CodeQL hangs (or probably just extreme long
compile) is the header `curl/typecheck-gcc.h`. By accident I noticed
that the preprocessed output of libtests.c is 75 MB (megabytes). This
is much higher than the amounf of source code hinted, also compared to
e.g. units.c or other build targets. The reason for the extreme size
is each easy option call pulling in the large checker logic defined
in this header.

By compiling with `-DCURL_DISABLE_TYPECHECK`, preprocessed output drops
to 2.2 MB (34x), and the libtests target builds without issues.

Also build all tests and examples with the Linux HTTP/3 config, covering
3 more files.

With these, CodeQL C coverage is 893 out of 930 (96%) (was: 645 69%)

Follow-up to 71fc11e6bbf530b90bf6e93a02cb32bdaecc933b #18695
Follow-up to a333fd4411b95fc0c3061b2d675de9287b6123e0 #18557
Follow-up to b4922b1295333dc6679eb1d588ddc2fb6b7fd5b7 #18564

Closes https://github.com/vszakats/curl/pull/11
