### PR TITLE
GHA/checksrc: switch xmllint job to Linux (from macOS)

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -120,9 +120,17 @@ jobs:
 
   xmllint:
     name: 'xmllint'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
+      - name: 'install prereqs'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo rm -f /var/lib/man-db/auto-update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
+            libxml2-utils
+
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false


### PR DESCRIPTION
macOS was chosen because xmllint comes preinstalled, saving the prereq
install step. But, macOS's xmllint jobs sometimes doesn't finish in 1m
(instead of under 1 second) and gets cancelled, causing flaky failures.
Go with Linux and an install phase (of 15s) instead.

Examples:
https://github.com/curl/curl/actions/runs/19558021722/job/56004334495
