### PR TITLE
smb: fix a size check to be overflow safe

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -668,12 +668,12 @@ static CURLcode smb_send_message(struct Curl_easy *data,
                                  unsigned char cmd,
                                  const void *msg, size_t msg_len)
 {
-  smb_format_message(smbc, req, (struct smb_header *)smbc->send_buf,
-                     cmd, msg_len);
-  if((sizeof(struct smb_header) + msg_len) > MAX_MESSAGE_SIZE) {
+  if((MAX_MESSAGE_SIZE - sizeof(struct smb_header)) < msg_len) {
     DEBUGASSERT(0);
     return CURLE_SEND_ERROR;
   }
+  smb_format_message(smbc, req, (struct smb_header *)smbc->send_buf,
+                     cmd, msg_len);
   memcpy(smbc->send_buf + sizeof(struct smb_header), msg, msg_len);
 
   return smb_send(data, smbc, sizeof(struct smb_header) + msg_len, 0);


### PR DESCRIPTION
In smb_send_message, although it could never actually overflow it might as well be done correctly. Also do the check earlier.