### PR TITLE
Revert "GHA: update gnutls/gnutls to 3.8.11 from 3.8.10"

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -47,7 +47,7 @@ env:
   # renovate: datasource=github-tags depName=google/boringssl versioning=semver registryUrl=https://github.com
   BORINGSSL_VERSION: 0.20251110.0
   # renovate: datasource=github-tags depName=gnutls/gnutls versioning=semver registryUrl=https://github.com
-  GNUTLS_VERSION: 3.8.11
+  GNUTLS_VERSION: 3.8.10
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   WOLFSSL_VERSION: 5.8.4
   # renovate: datasource=github-tags depName=ngtcp2/nghttp3 versioning=semver registryUrl=https://github.com


### PR DESCRIPTION
This reverts commit a439fc0e372c3de7df3b8ae3ca7752bc3cbca826.

It requires a version of libnettle that is not included in these Ubuntu versions.

~~~
configure: error: 
  ***
  *** Libnettle 3.10 was not found.