### PR TITLE
file: do not pass invalid mode flags to `open()` on upload (Windows)

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -344,7 +344,8 @@ static CURLcode file_upload(struct Curl_easy *data,
     mode |= O_TRUNC;
 
 #ifdef _WIN32
-  fd = curlx_open(file->path, mode, _S_IWRITE);
+  fd = curlx_open(file->path, mode,
+                  data->set.new_file_perms & (_S_IREAD | _S_IWRITE));
 #elif (defined(ANDROID) || defined(__ANDROID__)) && \
   (defined(__i386__) || defined(__arm__))
   fd = curlx_open(file->path, mode, (mode_t)data->set.new_file_perms);


### PR DESCRIPTION
Ref: https://learn.microsoft.com/cpp/c-runtime-library/reference/open-wopen

Ref: #19645
Cherry-picked from #19643

---

- [x] try honoring `data->set.new_file_perms`
