### PR TITLE
async-resolves: make Curl_async_getaddrinfo return CURLcode

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -718,25 +718,17 @@ static void async_ares_rr_done(void *user_data, ares_status_t status,
 /*
  * Curl_async_getaddrinfo() - when using ares
  *
- * Returns name information about the given hostname and port number. If
- * successful, the 'hostent' is returned and the fourth argument will point to
- * memory we need to free after use. That memory *MUST* be freed with
- * Curl_freeaddrinfo(), nothing else.
+ * Starts an asynchronous name resolve for the given hostname and port number.
  */
-struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
-                                             const char *hostname,
-                                             int port,
-                                             int ip_version,
-                                             int *waitp)
+CURLcode Curl_async_getaddrinfo(struct Curl_easy *data, const char *hostname,
+                                int port, int ip_version)
 {
   struct async_ares_ctx *ares = &data->state.async.ares;
 #ifdef USE_HTTPSRR
   char *rrname = NULL;
 #endif
-  *waitp = 0; /* default to synchronous response */
-
   if(async_ares_init_lazy(data))
-    return NULL;
+    return CURLE_FAILED_INIT;
 
   data->state.async.done = FALSE;   /* not done */
   data->state.async.dns = NULL;     /* clear */
@@ -744,13 +736,13 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
   data->state.async.ip_version = ip_version;
   data->state.async.hostname = strdup(hostname);
   if(!data->state.async.hostname)
-    return NULL;
+    return CURLE_OUT_OF_MEMORY;
 #ifdef USE_HTTPSRR
   if(port != 443) {
     rrname = curl_maprintf("_%d_.https.%s", port, hostname);
     if(!rrname) {
       free(data->state.async.hostname);
-      return NULL;
+      return CURLE_OUT_OF_MEMORY;
     }
   }
 #endif
@@ -838,9 +830,8 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
                       async_ares_rr_done, data, NULL);
   }
 #endif
-  *waitp = 1; /* expect asynchronous response */
 
-  return NULL; /* no struct yet */
+  return CURLE_OK;
 }
 
 /* Set what DNS server are is to use. This is called in 2 situations:

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -730,24 +730,20 @@ CURLcode Curl_async_pollset(struct Curl_easy *data, struct easy_pollset *ps)
 /*
  * Curl_async_getaddrinfo() - for platforms without getaddrinfo
  */
-struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
-                                             const char *hostname,
-                                             int port,
-                                             int ip_version,
-                                             int *waitp)
+CURLcode Curl_async_getaddrinfo(struct Curl_easy *data,
+                                const char *hostname,
+                                int port,
+                                int ip_version,
+                                struct Curl_addrinfo **addrp)
 {
-  (void)ip_version;
-  *waitp = 0; /* default to synchronous response */
+  *addrp = NULL;
 
   /* fire up a new resolver thread! */
-  if(async_thrdd_init(data, hostname, port, ip_version, NULL)) {
-    *waitp = 1; /* expect asynchronous response */
-    return NULL;
-  }
+  if(async_thrdd_init(data, hostname, port, ip_version, NULL))
+    return CURLE_OK;
 
   failf(data, "getaddrinfo() thread failed");
-
-  return NULL;
+  return CURLE_FAILED_INIT;
 }
 
 #else /* !HAVE_GETADDRINFO */
@@ -755,15 +751,13 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
 /*
  * Curl_async_getaddrinfo() - for getaddrinfo
  */
-struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
-                                             const char *hostname,
-                                             int port,
-                                             int ip_version,
-                                             int *waitp)
+CURLcode Curl_async_getaddrinfo(struct Curl_easy *data,
+                                const char *hostname,
+                                int port,
+                                int ip_version)
 {
   struct addrinfo hints;
   int pf = PF_INET;
-  *waitp = 0; /* default to synchronous response */
 
   CURL_TRC_DNS(data, "init threaded resolve of %s:%d", hostname, port);
 #ifdef CURLRES_IPV6
@@ -785,14 +779,12 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
     SOCK_STREAM : SOCK_DGRAM;
 
   /* fire up a new resolver thread! */
-  if(async_thrdd_init(data, hostname, port, ip_version, &hints)) {
-    *waitp = 1; /* expect asynchronous response */
-    return NULL;
-  }
+  if(async_thrdd_init(data, hostname, port, ip_version, &hints))
+    /* expect asynchronous response */
+    return CURLE_OK;
 
   failf(data, "getaddrinfo() thread failed to start");
-  return NULL;
-
+  return CURLE_FAILED_INIT;
 }
 
 #endif /* !HAVE_GETADDRINFO */

--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -110,19 +110,13 @@ CURLcode Curl_async_await(struct Curl_easy *data,
 /*
  * Curl_async_getaddrinfo() - when using this resolver
  *
- * Returns name information about the given hostname and port number. If
- * successful, the 'hostent' is returned and the fourth argument will point to
- * memory we need to free after use. That memory *MUST* be freed with
- * Curl_freeaddrinfo(), nothing else.
+ * Starts a name resolve for the given hostname and port number.
  *
  * Each resolver backend must of course make sure to return data in the
  * correct format to comply with this.
  */
-struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
-                                             const char *hostname,
-                                             int port,
-                                             int ip_version,
-                                             int *waitp);
+CURLcode Curl_async_getaddrinfo(struct Curl_easy *data, const char *hostname,
+                                int port, int ip_version);
 
 #ifdef USE_ARES
 /* common functions for c-ares and threaded resolver with HTTPSRR */

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -116,11 +116,8 @@ struct doh_probes {
  * and returns a 'Curl_addrinfo *' with the address information.
  */
 
-struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
-                               const char *hostname,
-                               int port,
-                               int ip_version,
-                               int *waitp);
+CURLcode Curl_doh(struct Curl_easy *data, const char *hostname,
+                  int port, int ip_version);
 
 CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
                               struct Curl_dns_entry **dns);


### PR DESCRIPTION
This function previously returned 'struct Curl_addrinfo *' but none of the implementions ever return anything but NULL because they don't yet have the results.

By returning CURLcode, they can be made to return an accurate error code for out of memory and similar.