### PR TITLE
tool_operate: fix case of ignoring return code in single_transfer

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1199,7 +1199,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
     if(u->infile) {
       if(!config->globoff && !glob_inuse(&state->inglob))
         result = glob_url(&state->inglob, u->infile, &state->upnum, err);
-      if(!state->uploadfile) {
+      if(!result && !state->uploadfile) {
         if(glob_inuse(&state->inglob))
           result = glob_next_url(&state->uploadfile, &state->inglob);
         else if(!state->upidx) {


### PR DESCRIPTION
When glob_url() returns error, stop.