### PR TITLE
tool_operate: fix a case of ignoring return code

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -37,6 +37,7 @@
 #include "tool_cb_see.h"
 #include "tool_cb_dbg.h"
 #include "tool_helpers.h"
+#include "tool_version.h"
 
 #define BUFFER_SIZE 102400L
 
@@ -874,7 +875,8 @@ CURLcode config2setopts(struct OperationConfig *config,
 
   if(proto_http || proto_rtsp) {
     MY_SETOPT_STR(curl, CURLOPT_REFERER, config->referer);
-    MY_SETOPT_STR(curl, CURLOPT_USERAGENT, config->useragent);
+    MY_SETOPT_STR(curl, CURLOPT_USERAGENT, config->useragent ?
+                  config->useragent : CURL_NAME "/" CURL_VERSION);
   }
 
   if(use_proto == proto_http || use_proto == proto_https) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2321,17 +2321,19 @@ CURLcode operate(int argc, argv_item_t argv[])
             operation = operation->next;
           } while(!result && operation);
 
-          /* Set the current operation pointer */
-          global->current = global->first;
+          if(!result) {
+            /* Set the current operation pointer */
+            global->current = global->first;
 
-          /* now run! */
-          result = run_all_transfers(share, result);
+            /* now run! */
+            result = run_all_transfers(share, result);
 
-          if(global->ssl_sessions && feature_ssls_export) {
-            CURLcode r2 = tool_ssls_save(global->first, share,
-                                         global->ssl_sessions);
-            if(r2 && !result)
-              result = r2;
+            if(global->ssl_sessions && feature_ssls_export) {
+              CURLcode r2 = tool_ssls_save(global->first, share,
+                                           global->ssl_sessions);
+              if(r2 && !result)
+                result = r2;
+            }
           }
         }
 

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -650,14 +650,6 @@ long delegation(const char *str)
   return CURLGSSAPI_DELEGATION_NONE;
 }
 
-/*
- * my_useragent: returns allocated string with default user agent
- */
-static char *my_useragent(void)
-{
-  return strdup(CURL_NAME "/" CURL_VERSION);
-}
-
 #define isheadersep(x) ((((x)==':') || ((x)==';')))
 
 /*
@@ -704,15 +696,6 @@ CURLcode get_args(struct OperationConfig *config, const size_t i)
   /* Check if we have a password for the given proxy user */
   if(!result && config->proxyuserpwd)
     result = checkpasswd("proxy", i, last, &config->proxyuserpwd);
-
-  /* Check if we have a user agent */
-  if(!result && !config->useragent) {
-    config->useragent = my_useragent();
-    if(!config->useragent) {
-      errorf("out of memory");
-      result = CURLE_OUT_OF_MEMORY;
-    }
-  }
 
   return result;
 }


### PR DESCRIPTION
If get_args() returns error, do not overwrite the variable in the next call.

Also, avoid allocating memory for the default user-agent.