### PR TITLE
speedcheck: do not trigger low speed cancelation on transfers paused with CURL_READFUNC_PAUSE

### DIFF
--- a/lib/speedcheck.c
+++ b/lib/speedcheck.c
@@ -42,7 +42,7 @@ void Curl_speedinit(struct Curl_easy *data)
 CURLcode Curl_speedcheck(struct Curl_easy *data,
                          struct curltime now)
 {
-  if(Curl_xfer_recv_is_paused(data))
+  if(Curl_xfer_recv_is_paused(data) || Curl_xfer_send_is_paused(data))
     /* A paused transfer is not qualified for speed checks */
     return CURLE_OK;
 


### PR DESCRIPTION
I have encountered an issue similar to https://github.com/curl/curl/issues/6358.

When pausing an upload, it is not actually excluded from the low speed cancelation. The issue seems to be that the condition in the code only checks if the "recv direction" of the transfer is paused, but not the "send direction".

Adding `Curl_xfer_send_is_paused` to the condition fixed the issue

libcurl version: 8.17
tested with protocols: http/https