### PR TITLE
asyn-ares: remove hostname free on OOM

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -748,10 +748,8 @@ struct Curl_addrinfo *Curl_async_getaddrinfo(struct Curl_easy *data,
 #ifdef USE_HTTPSRR
   if(port != 443) {
     rrname = curl_maprintf("_%d_.https.%s", port, hostname);
-    if(!rrname) {
-      free(data->state.async.hostname);
+    if(!rrname)
       return NULL;
-    }
   }
 #endif
 


### PR DESCRIPTION
The freeing of the already allocated hostname is done by Curl_async_shutdown(). This extra free in the RR code path made a double-free.

Presumably not detected because the CI torture tests don't run HTTPS-RR enabled?

Follow-up to 8d0bfe74fb