### PR TITLE
tool: Log when loading .curlrc and in verbose mode

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2225,7 +2225,7 @@ static ParameterError opt_file(struct OperationConfig *config,
       err = PARAM_BAD_USE;
     }
     else {
-      err = parseconfig(nextarg, max_recursive);
+      err = parseconfig(nextarg, max_recursive, NULL);
     }
     break;
   case C_CRLFILE: /* --crlfile */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2227,6 +2227,8 @@ CURLcode operate(int argc, argv_item_t argv[])
 {
   CURLcode result = CURLE_OK;
   const char *first_arg;
+  char *curlrc_path = NULL;
+  bool found_curlrc = FALSE;
 
   first_arg = argc > 1 ? convert_tchar_to_UTF8(argv[1]) : NULL;
 
@@ -2240,7 +2242,8 @@ CURLcode operate(int argc, argv_item_t argv[])
   if((argc == 1) ||
      (first_arg && strncmp(first_arg, "-q", 2) &&
       strcmp(first_arg, "--disable"))) {
-    parseconfig(NULL, CONFIG_MAX_LEVELS); /* ignore possible failure */
+    if(!parseconfig(NULL, CONFIG_MAX_LEVELS, &curlrc_path))
+      found_curlrc = TRUE;
 
     /* If we had no arguments then make sure a URL was specified in .curlrc */
     if((argc < 2) && (!global->first->url_list)) {
@@ -2254,6 +2257,11 @@ CURLcode operate(int argc, argv_item_t argv[])
   if(!result) {
     /* Parse the command line arguments */
     ParameterError res = parse_args(argc, argv);
+    if(found_curlrc) {
+      /* After parse_args so notef knows the verbosity */
+      notef("Read config file from '%s'", curlrc_path);
+      free(curlrc_path);
+    }
     if(res) {
       result = CURLE_OK;
 

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -81,7 +81,8 @@ static int unslashquote(const char *line, struct dynbuf *param)
 #define MAX_CONFIG_LINE_LENGTH (10*1024*1024)
 
 /* return 0 on everything-is-fine, and non-zero otherwise */
-ParameterError parseconfig(const char *filename, int max_recursive)
+ParameterError parseconfig(const char *filename, int max_recursive,
+                           char **resolved)
 {
   FILE *file = NULL;
   bool usedarg = FALSE;
@@ -264,6 +265,11 @@ ParameterError parseconfig(const char *filename, int max_recursive)
   if((err == PARAM_READ_ERROR) && filename)
     errorf("cannot read config from '%s'", filename);
 
+  if(!err && resolved) {
+    *resolved = strdup(filename);
+    if(!*resolved)
+      err = PARAM_NO_MEM;
+  }
   free(pathalloc);
   return err;
 }

--- a/src/tool_parsecfg.h
+++ b/src/tool_parsecfg.h
@@ -27,7 +27,8 @@
 
 /* only allow this many levels of recursive --config use */
 #define CONFIG_MAX_LEVELS 5
-ParameterError parseconfig(const char *filename, int max_recursive);
+ParameterError parseconfig(const char *filename, int max_recursive,
+                           char **resolved);
 bool my_get_line(FILE *fp, struct dynbuf *db, bool *error);
 
 #endif /* HEADER_CURL_TOOL_PARSECFG_H */


### PR DESCRIPTION
Inspired by @vszakats in https://github.com/curl/curl/pull/19631#issuecomment-3560803674

I'm note sure this is the best way to do this? I don't love adding the output variable, so open for other suggestions.