### PR TITLE
manage: expand the 'libcurl support required' message

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -854,7 +854,7 @@ sub single {
 
     if($requires) {
         my $l = manpageify($long, $manpage);
-        push @foot, "$l requires that libcurl".
+        push @foot, "For $l to work, it requires that the underlying libcurl".
             " is built to support $requires.\n";
     }
     if($mutexed) {


### PR DESCRIPTION
Example of old text:

 --dns-ipv4-addr requires that libcurl is built to support c-ares.

New version:

 For --dns-ipv4-addr to work, it requires that the underlying libcurl is
 built to support c-ares.