### PR TITLE
vquic: do not pass invalid mode flags to `open()` (Windows)

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -665,7 +665,11 @@ CURLcode Curl_qlogdir(struct Curl_easy *data,
     if(!result) {
       int qlogfd = curlx_open(curlx_dyn_ptr(&fname),
                               O_WRONLY | O_CREAT | CURL_O_BINARY,
-                              data->set.new_file_perms);
+                              data->set.new_file_perms
+#ifdef _WIN32
+                              & (_S_IREAD | _S_IWRITE)
+#endif
+                              );
       if(qlogfd != -1)
         *qlogfdp = qlogfd;
     }


### PR DESCRIPTION
Follow-up to 82013066a6149aa906b1fda3f8f1f27bd272a6c2 #19647