### PR TITLE
tftpd: fix/tidy up `open()` mode flags

### DIFF
--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -445,7 +445,15 @@ static ssize_t write_behind(struct testcase *test, int convert)
   if(!test->ofile) {
     char outfile[256];
     snprintf(outfile, sizeof(outfile), "%s/upload.%ld", logdir, test->testno);
-    test->ofile = open(outfile, O_CREAT|O_RDWR|CURL_O_BINARY, 0777);
+    test->ofile = open(outfile, O_CREAT | O_RDWR | CURL_O_BINARY,
+#ifdef _WIN32
+                       S_IREAD | S_IWRITE
+#else
+                       S_IRUSR | S_IWUSR | S_IXUSR |
+                       S_IRGRP | S_IWGRP | S_IXGRP |
+                       S_IROTH | S_IWOTH | S_IXOTH
+#endif
+                       );
     if(test->ofile == -1) {
       logmsg("Could not create and/or open file %s for upload!", outfile);
       return -1; /* failure! */


### PR DESCRIPTION
- replace 0777 with `S_I*` macros.
- fix to not pass invalid flags on Windows.

Follow-up to 537987d8c66aac6ec96cde098ab45525e156b54e #19645