### PR TITLE
INTERNALS.md: add release dates to build dependencies

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -51,7 +51,6 @@ versions of libs and build tools.
  - GNU automake 1.7 (2002-09-25)
  - GNU m4       1.4 (2007-09-21)
  - perl         5.8 (2002-07-19), on Windows: 5.22 (2015-06-01)
- - roffit       0.5 (2004-02-03)
  - cmake        3.7 (2016-11-11)
 
 Library Symbols


### PR DESCRIPTION
Also:
- delete `roffit`, that's not used anymore.
  Follow-up to ea0b575dab86a3c44dd1d547dc500276266aa382 #12753

Follow-up to 92d9dbe4c008646dd467d23dea963fa32e16cf85 #19611
