### PR TITLE
progress: remove two redundant variable checks

### DIFF
--- a/lib/progress.c
+++ b/lib/progress.c
@@ -134,7 +134,7 @@ UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
       data->state.keeps_speed.tv_sec = 0;
   }
 
-  /* if low speed limit is enabled, set the expire timer to make this
+  /* since low speed limit is enabled, set the expire timer to make this
      connection's speed get checked again in a second */
   Curl_expire(data, 1000, EXPIRE_SPEEDCHECK);
 


### PR DESCRIPTION
The entry condition in the function already exits early if either low_speed_time or low_speed_limit is not set.

Pointed out by CodeSonar