### PR TITLE
speedlimit: also reset on send unpausing

### DIFF
--- a/lib/progress.c
+++ b/lib/progress.c
@@ -196,6 +196,14 @@ void Curl_pgrsRecvPause(struct Curl_easy *data, bool enable)
   }
 }
 
+void Curl_pgrsSendPause(struct Curl_easy *data, bool enable)
+{
+  if(!enable) {
+    data->progress.speeder_c = 0; /* reset speed records */
+    pgrs_speedinit(data); /* reset low speed measurements */
+  }
+}
+
 /*
  *
  * Curl_pgrsTimeWas(). Store the timestamp time at the given label.

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -59,8 +59,9 @@ void Curl_pgrsUpdate_nometer(struct Curl_easy *data);
 /* perform progress update with callbacks and speed checks */
 CURLcode Curl_pgrsCheck(struct Curl_easy *data);
 
-/* Inform progress/speedcheck about receive pausing */
+/* Inform progress/speedcheck about receive/send pausing */
 void Curl_pgrsRecvPause(struct Curl_easy *data, bool enable);
+void Curl_pgrsSendPause(struct Curl_easy *data, bool enable);
 
 /* Reset sizes and couners for up- and download. */
 void Curl_pgrsReset(struct Curl_easy *data);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -925,6 +925,7 @@ CURLcode Curl_xfer_pause_send(struct Curl_easy *data, bool enable)
   Curl_rlimit_block(&data->progress.ul.rlimit, enable, curlx_now());
   if(!enable && Curl_creader_is_paused(data))
     result = Curl_creader_unpause(data);
+  Curl_pgrsSendPause(data, enable);
   return result;
 }
 


### PR DESCRIPTION
The low speedlimit currently counts both up- and download speed accumulated. So, when unpausing upload, also reset the counter.