### PR TITLE
vquic: do_sendmsg full init

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -145,6 +145,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
   if(pktlen > gsolen) {
     /* Only set this, when we need it. macOS, for example,
      * does not seem to like a msg_control of length 0. */
+    memset(msg_ctrl, 0, sizeof(msg_ctrl));
     msg.msg_control = msg_ctrl;
     assert(sizeof(msg_ctrl) >= CMSG_SPACE(sizeof(int)));
     msg.msg_controllen = CMSG_SPACE(sizeof(int));


### PR DESCRIPTION
When passing a `msg_ctrl` to sendmsg() as part of GSO handling, zero the complete array. This fixes any false positives by valgrind that complain about uninitialised memory, even though the kernel only ever accesses the first two bytes.

reported-by: Aleksei Bavshin
refs #19714