### PR TITLE
ngtcp2+openssl: fix leak of session

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2277,7 +2277,6 @@ static int quic_ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
 #endif
     Curl_ossl_add_session(cf, data, ctx->peer.scache_key, ssl_sessionid,
                           SSL_version(ssl), "h3", quic_tp, quic_tp_len);
-    return 1;
   }
   return 0;
 }


### PR DESCRIPTION
Fix return value indicating to OpenSSL if reference to session is kept (it is not), so OpenSSL frees it.

refs #19717