### PR TITLE
GHA/http3-linux: fix broken h3 server in non-openssl jobs, for more pytests

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -486,7 +486,6 @@ jobs:
           echo 'CXX=g++-12' >> "$GITHUB_ENV"
 
       - name: 'cache openssl'
-        if: ${{ matrix.build.name == 'openssl' || matrix.build.name == 'openssl-quic' }}
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache-openssl-http3-no-deprecated
         env:


### PR DESCRIPTION
It also revealed 3 failing earlydata tests with two backends on Linux,
seen earlier on macOS:
```
LibreSSL     before: 571 passed, 141 skipped in 45.34s
LibreSSL      after: 736 passed,  95 skipped in 68.08s

aws-lc       before: 571 passed, 141 skipped in 78.87s
aws-lc        after: 736 passed,  95 skipped in 66.71s

BoringSSL    before: 511 passed, 201 skipped in 46.47s
BoringSSL     after: 676 passed, 155 skipped in 63.96s

GnuTLS       before: 515 passed, 197 skipped in 48.31s
GnuTLS        after: 688 passed, 140 skipped in 67.79s (3 failed)

wolfSSL      before: 541 passed, 171 skipped in 52.49s
wolfSSL       after: 714 passed, 114 skipped in 83.84s (3 failed)

OpenSSL      before: 757 passed,  74 skipped in 65.43s
OpenSSL       after: 757 passed,  74 skipped in 65.06s

OpenSSL-quic before: 741 passed,  90 skipped in 62.85s
OpenSSL-quic  after: 741 passed,  90 skipped in 57.20s

quiche       before: 511 passed, 201 skipped in 45.94s
quiche        after: 664 passed, 167 skipped in 59.57s
```
Before: https://github.com/curl/curl/actions/runs/19734972379
After: https://github.com/curl/curl/actions/runs/19736703398?pr=19723

Failures address via: 0081c5b12627ddfb5d6e71198475dc9f95c0a53e #19730

Ref: #19724
