### PR TITLE
tests: allow 2500-2503 to use ~2MB malloc

### DIFF
--- a/tests/data/test2500
+++ b/tests/data/test2500
@@ -73,5 +73,9 @@ via: 1.1 nghttpx
 <stripfile>
 s/^server: nghttpx.*\r?\n//
 </stripfile>
+<limits>
+Allocations: 150
+Maximum allocated: 1800000
+</limits>
 </verify>
 </testcase>

--- a/tests/data/test2501
+++ b/tests/data/test2501
@@ -65,5 +65,8 @@ Via: 3 nghttpx
 
 moo
 </protocol>
+<limits>
+Maximum allocated: 1900000
+</limits>
 </verify>
 </testcase>

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -101,5 +101,8 @@ Via: 3 nghttpx
 <stripfile>
 $_ = '' if(($_ !~ /left intact/) && ($_ !~ /Closing connection/))
 </stripfile>
+<limits>
+Maximum allocated: 1800000
+</limits>
 </verify>
 </testcase>

--- a/tests/data/test2503
+++ b/tests/data/test2503
@@ -65,5 +65,8 @@ via: 1.1 nghttpx
 "via":["1.1 nghttpx"]
 }
 </stdout>
+<limits>
+Maximum allocated: 1800000
+</limits>
 </verify>
 </testcase>


### PR DESCRIPTION
On Linux using UDP_GRO, curl might allocate a (single) 1.5MB buffer for maximum performance.

Fixes #19716