### PR TITLE
curl_setup.h: drop superfluous parenthesis from `Curl_safefree` macro

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -941,7 +941,7 @@ extern curl_calloc_callback Curl_ccalloc;
  * This macro also assigns NULL to given pointer when free'd.
  */
 #define Curl_safefree(ptr) \
-  do { free((ptr)); (ptr) = NULL;} while(0)
+  do { free(ptr); (ptr) = NULL;} while(0)
 
 #include <curl/curl.h> /* for CURL_EXTERN, mprintf.h */
 


### PR DESCRIPTION
Cherry-picked from #19626