### PR TITLE
unit1653: replace local macro with `Curl_safefree()`

### DIFF
--- a/tests/unit/unit1653.c
+++ b/tests/unit/unit1653.c
@@ -27,8 +27,6 @@
 #include "curl/urlapi.h"
 #include "urlapi-int.h"
 
-#define free_and_clear(x) free(x); x = NULL
-
 static CURLUcode parse_port(CURLU *url, char *h, bool has_scheme)
 {
   struct dynbuf host;
@@ -62,7 +60,7 @@ static CURLcode test_unit1653(const char *arg)
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, CURLU_NO_DEFAULT_PORT);
   fail_unless(ret != CURLUE_OK, "curl_url_get portnum returned something");
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Invalid IPv6 */
@@ -74,7 +72,7 @@ static CURLcode test_unit1653(const char *arg)
     goto fail;
   ret = parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "parse_port true on error");
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   u = curl_url();
@@ -90,7 +88,7 @@ static CURLcode test_unit1653(const char *arg)
   fail_unless(portnum && !strcmp(portnum, "808"), "Check portnumber");
 
   curl_free(portnum);
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Valid IPv6 with zone index and port number */
@@ -106,7 +104,7 @@ static CURLcode test_unit1653(const char *arg)
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
   fail_unless(portnum && !strcmp(portnum, "80"), "Check portnumber");
   curl_free(portnum);
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Valid IPv6 with zone index without port number */
@@ -118,7 +116,7 @@ static CURLcode test_unit1653(const char *arg)
     goto fail;
   ret = parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Valid IPv6 with port number */
@@ -134,7 +132,7 @@ static CURLcode test_unit1653(const char *arg)
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
   fail_unless(portnum && !strcmp(portnum, "81"), "Check portnumber");
   curl_free(portnum);
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Valid IPv6 with syntax error in the port number */
@@ -146,7 +144,7 @@ static CURLcode test_unit1653(const char *arg)
     goto fail;
   ret = parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "parse_port true on error");
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   u = curl_url();
@@ -157,7 +155,7 @@ static CURLcode test_unit1653(const char *arg)
     goto fail;
   ret = parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "parse_port true on error");
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Valid IPv6 with no port after the colon, should use default if a scheme
@@ -170,7 +168,7 @@ static CURLcode test_unit1653(const char *arg)
     goto fail;
   ret = parse_port(u, ipv6port, TRUE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Incorrect zone index syntax, but the port extractor does not care */
@@ -186,7 +184,7 @@ static CURLcode test_unit1653(const char *arg)
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
   fail_unless(portnum && !strcmp(portnum, "180"), "Check portnumber");
   curl_free(portnum);
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* Non percent-encoded zone index */
@@ -198,7 +196,7 @@ static CURLcode test_unit1653(const char *arg)
     goto fail;
   ret = parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
-  free_and_clear(ipv6port);
+  Curl_safefree(ipv6port);
   curl_url_cleanup(u);
 
   /* No scheme and no digits following the colon - not accepted. Because that


### PR DESCRIPTION
Cherry-picked from #19626
