### PR TITLE
GHA/linux-old: add support for using custom CMake versions

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -61,7 +61,7 @@ jobs:
     container: 'debian:stretch'
 
     env:
-      CMAKE_VERSION: '3.7.2'
+      CMAKE_VERSION: '3.7.0'  # Earliest version supported by curl
     steps:
       - name: 'install prereqs'
         # Remember, this shell is dash, not bash


### PR DESCRIPTION
Install CMake from the Kitware GitHub release archive. To allow choosing
its version independently from the OS.

Switch to 3.7.0 (from 3.7.2) to test the earliest supported version.
Also tested OK with 3.18.4 and 3.7.2.

The download and install step takes 1-2 seconds.

Follow-up to c9e50e9e393508c6a28c695abcf62980b3c1b023 #19737
