### PR TITLE
http: add asserts for null terminator for input strings

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -4142,6 +4142,7 @@ static CURLcode http_rw_hd(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   struct SingleRequest *k = &data->req;
   int writetype;
+  DEBUGASSERT(!hd[hdlen]); /* null terminated */
 
   *pconsumed = 0;
   if((0x0a == *hd) || (0x0d == *hd)) {
@@ -4426,6 +4427,7 @@ CURLcode Curl_http_write_resp_hd(struct Curl_easy *data,
   CURLcode result;
   size_t consumed;
   char tmp = 0;
+  DEBUGASSERT(!hd[hdlen]); /* null terminated */
 
   result = http_rw_hd(data, hd, hdlen, &tmp, 0, &consumed);
   if(!result && is_eos) {

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -820,6 +820,7 @@ CURLcode Curl_xfer_write_resp_hd(struct Curl_easy *data,
                                  const char *hd0, size_t hdlen, bool is_eos)
 {
   if(data->conn->handler->write_resp_hd) {
+    DEBUGASSERT(!hd0[hdlen]); /* null terminated */
     /* protocol handlers offering this function take full responsibility
      * for writing all received download data to the client. */
     return data->conn->handler->write_resp_hd(data, hd0, hdlen, is_eos);


### PR DESCRIPTION
http_rw_hd() assumes the null terminator is present. These asserts make sure this remains true.