### PR TITLE
http1: parse header from uint8_t buffer

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -81,7 +81,7 @@ static CURLcode trim_line(struct h1_req_parser *parser, int options)
 }
 
 static CURLcode detect_line(struct h1_req_parser *parser,
-                            const char *buf, const size_t buflen,
+                            const uint8_t *buf, const size_t buflen,
                             size_t *pnread)
 {
   const char *line_end;
@@ -91,14 +91,14 @@ static CURLcode detect_line(struct h1_req_parser *parser,
   line_end = memchr(buf, '\n', buflen);
   if(!line_end)
     return CURLE_AGAIN;
-  parser->line = buf;
-  parser->line_len = line_end - buf + 1;
+  parser->line = (const char *)buf;
+  parser->line_len = line_end - parser->line + 1;
   *pnread = parser->line_len;
   return CURLE_OK;
 }
 
 static CURLcode next_line(struct h1_req_parser *parser,
-                          const char *buf, const size_t buflen, int options,
+                          const uint8_t *buf, const size_t buflen, int options,
                           size_t *pnread)
 {
   CURLcode result;
@@ -266,7 +266,7 @@ out:
 }
 
 CURLcode Curl_h1_req_parse_read(struct h1_req_parser *parser,
-                                const char *buf, size_t buflen,
+                                const uint8_t *buf, size_t buflen,
                                 const char *scheme_default,
                                 const char *custom_method,
                                 int options, size_t *pnread)

--- a/lib/http1.h
+++ b/lib/http1.h
@@ -49,7 +49,7 @@ void Curl_h1_req_parse_init(struct h1_req_parser *parser, size_t max_line_len);
 void Curl_h1_req_parse_free(struct h1_req_parser *parser);
 
 CURLcode Curl_h1_req_parse_read(struct h1_req_parser *parser,
-                                const char *buf, size_t buflen,
+                                const uint8_t *buf, size_t buflen,
                                 const char *scheme_default,
                                 const char *custom_method,
                                 int options, size_t *pnread);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2281,7 +2281,7 @@ static CURLcode h2_submit(struct h2_stream_ctx **pstream,
   if(result)
     goto out;
 
-  result = Curl_h1_req_parse_read(&stream->h1, (const char *)buf, len, NULL,
+  result = Curl_h1_req_parse_read(&stream->h1, buf, len, NULL,
                                   !data->state.http_ignorecustom ?
                                   data->set.str[STRING_CUSTOMREQUEST] : NULL,
                                   0, &nwritten);

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1552,7 +1552,7 @@ static CURLcode h3_stream_open(struct Curl_cfilter *cf,
     goto out;
   }
 
-  result = Curl_h1_req_parse_read(&stream->h1, (const char *)buf, len, NULL,
+  result = Curl_h1_req_parse_read(&stream->h1, buf, len, NULL,
                                   !data->state.http_ignorecustom ?
                                   data->set.str[STRING_CUSTOMREQUEST] : NULL,
                                   0, pnwritten);

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1903,7 +1903,7 @@ static CURLcode h3_stream_open(struct Curl_cfilter *cf,
     goto out;
   }
 
-  result = Curl_h1_req_parse_read(&stream->h1, (const char *)buf, len, NULL,
+  result = Curl_h1_req_parse_read(&stream->h1, buf, len, NULL,
                                   !data->state.http_ignorecustom ?
                                   data->set.str[STRING_CUSTOMREQUEST] : NULL,
                                   0, pnwritten);

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -980,7 +980,7 @@ static CURLcode h3_open_stream(struct Curl_cfilter *cf,
 
   DEBUGASSERT(stream);
 
-  result = Curl_h1_req_parse_read(&stream->h1, (const char *)buf, blen, NULL,
+  result = Curl_h1_req_parse_read(&stream->h1, buf, blen, NULL,
                                     !data->state.http_ignorecustom ?
                                     data->set.str[STRING_CUSTOMREQUEST] : NULL,
                                     0, pnwritten);

--- a/tests/unit/unit2603.c
+++ b/tests/unit/unit2603.c
@@ -63,7 +63,7 @@ struct tcase {
 static void parse_success(const struct tcase *t)
 {
   struct h1_req_parser p;
-  const char *buf;
+  const uint8_t *buf;
   size_t buflen, i, in_len, in_consumed;
   CURLcode err;
   size_t nread;
@@ -71,8 +71,8 @@ static void parse_success(const struct tcase *t)
   Curl_h1_req_parse_init(&p, 1024);
   in_len = in_consumed = 0;
   for(i = 0; t->input[i]; ++i) {
-    buf = t->input[i];
-    buflen = strlen(buf);
+    buf = (const uint8_t *)t->input[i];
+    buflen = strlen(t->input[i]);
     in_len += buflen;
     err = Curl_h1_req_parse_read(&p, buf, buflen, t->default_scheme,
                                  t->custom_method, 0, &nread);


### PR DESCRIPTION
To save casting the passed buffer when parsing HTTP/1 request headers from an uint8_t buffer.