### PR TITLE
connection: give send methods/prototypes an uint8_t buffer

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -246,7 +246,7 @@ CURLcode Curl_cf_recv(struct Curl_easy *data, int num, char *buf,
 }
 
 CURLcode Curl_cf_send(struct Curl_easy *data, int num,
-                      const void *mem, size_t len, bool eos,
+                      const uint8_t *mem, size_t len, bool eos,
                       size_t *pnwritten)
 {
   struct Curl_cfilter *cf;

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -508,7 +508,7 @@ CURLcode Curl_cf_recv(struct Curl_easy *data, int sockindex, char *buf,
  * in `*pnwritten` or on error.
  */
 CURLcode Curl_cf_send(struct Curl_easy *data, int sockindex,
-                      const void *buf, size_t len, bool eos,
+                      const uint8_t *buf, size_t len, bool eos,
                       size_t *pnwritten);
 
 /**

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -356,7 +356,7 @@ static CURLcode rtmp_recv(struct Curl_easy *data, int sockindex, char *buf,
 }
 
 static CURLcode rtmp_send(struct Curl_easy *data, int sockindex,
-                          const void *buf, size_t len, bool eos,
+                          const uint8_t *buf, size_t len, bool eos,
                           size_t *pnwritten)
 {
   struct connectdata *conn = data->conn;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -162,7 +162,7 @@ typedef unsigned int curl_prot_t;
 /* On error return, the value of `pnwritten` has no meaning */
 typedef CURLcode (Curl_send)(struct Curl_easy *data,   /* transfer */
                              int sockindex,            /* socketindex */
-                             const void *buf,          /* data to write */
+                             const uint8_t *buf,       /* data to write */
                              size_t len,               /* amount to send */
                              bool eos,                 /* last chunk */
                              size_t *pnwritten);       /* how much sent */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2877,7 +2877,7 @@ static CURLcode scp_done(struct Curl_easy *data, CURLcode status,
 }
 
 static CURLcode scp_send(struct Curl_easy *data, int sockindex,
-                         const void *mem, size_t len, bool eos,
+                         const uint8_t *mem, size_t len, bool eos,
                          size_t *pnwritten)
 {
   int rc;
@@ -3038,7 +3038,7 @@ static CURLcode sftp_done(struct Curl_easy *data, CURLcode status,
 
 /* return number of sent bytes */
 static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
-                          const void *mem, size_t len, bool eos,
+                          const uint8_t *mem, size_t len, bool eos,
                           size_t *pnwritten)
 {
   struct connectdata *conn = data->conn;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3703,7 +3703,7 @@ static CURLcode scp_done(struct Curl_easy *data, CURLcode status,
 }
 
 static CURLcode scp_send(struct Curl_easy *data, int sockindex,
-                         const void *mem, size_t len, bool eos,
+                         const uint8_t *mem, size_t len, bool eos,
                          size_t *pnwritten)
 {
   struct connectdata *conn = data->conn;
@@ -3719,7 +3719,8 @@ static CURLcode scp_send(struct Curl_easy *data, int sockindex,
     return CURLE_FAILED_INIT;
 
   /* libssh2_channel_write() returns int! */
-  nwritten = (ssize_t) libssh2_channel_write(sshc->ssh_channel, mem, len);
+  nwritten = (ssize_t) libssh2_channel_write(sshc->ssh_channel,
+                                             (const char *)mem, len);
 
   ssh_block2waitfor(data, sshc, (nwritten == LIBSSH2_ERROR_EAGAIN));
 
@@ -3862,7 +3863,7 @@ static CURLcode sftp_done(struct Curl_easy *data, CURLcode status,
 
 /* return number of sent bytes */
 static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
-                          const void *mem, size_t len, bool eos,
+                          const uint8_t *mem, size_t len, bool eos,
                           size_t *pnwritten)
 {
   struct connectdata *conn = data->conn;
@@ -3876,7 +3877,7 @@ static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
   if(!sshc)
     return CURLE_FAILED_INIT;
 
-  nwrite = libssh2_sftp_write(sshc->sftp_handle, mem, len);
+  nwrite = libssh2_sftp_write(sshc->sftp_handle, (const char *)mem, len);
 
   ssh_block2waitfor(data, sshc, (nwrite == LIBSSH2_ERROR_EAGAIN));
 


### PR DESCRIPTION
To conclude changing the send buffer type from `const void *` to `const uint8_t *`, change the top level send function and its implementations.