### PR TITLE
Fix typo in copyright

### DIFF
--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) Danieal Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms


### PR DESCRIPTION
Followup to 193cb00ce9b47e75d