### PR TITLE
GHA/curl-for-win: drop WINE install, do not run curl after build

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -159,7 +159,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-win-x64'
+          export CW_CONFIG='-main-werror-unitybatch-win-x64-noWINE'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default
@@ -186,7 +186,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-win-x64-gcc-zlibold'
+          export CW_CONFIG='-main-werror-unitybatch-win-x64-gcc-zlibold-noWINE'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default


### PR DESCRIPTION
To reduce to amount of Debian packages to install, which hopefully
removes some flakiness due to sometimes very slow Azure package
distro servers. Also making these jobs finish 20s faster.

Windows from Debian | llvm               | gcc
:------------------ | :----------------: | :----------------:
build time          |  2m41s  ->  2m20s  |  3m19s  ->  2m57s
installed packages  |  288    ->  142    |  247    ->  99
downloads           |  403 MB ->  240 MB |  297 MB -> 134 MB
disk space          | 2132 MB -> 1289 MB | 1582 MB -> 739 MB

Before: https://github.com/curl/curl/actions/runs/19765983026
After: https://github.com/curl/curl/actions/runs/19766373960?pr=19749

Ref: https://github.com/curl/curl-for-win/commit/02149b7e364a1830d8fa2c947cfc713d925c186d
