### PR TITLE
runtests: allow a test to switch off memdebug

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -586,7 +586,7 @@ command has been run.
 If the variable name has no assignment, no `=`, then that variable is just
 deleted.
 
-### `<command [option="no-q/no-output/no-include/force-output/binary-trace"] [timeout="secs"][delay="secs"][type="perl/shell"]>`
+### `<command [option="no-q/no-output/no-include/no-memdebug/force-output/binary-trace"] [timeout="secs"][delay="secs"][type="perl/shell"]>`
 Command line to run.
 
 If the command spans multiple lines, they are concatenated with a space added
@@ -607,6 +607,9 @@ otherwise written to verify stdout.
 
 Set `option="no-include"` to prevent the test script to slap on the
 `--include` argument.
+
+Set `option="no-memdebug"` to make the test run without the memdebug tracking
+system. For tests that are incompatible - multi-threaded for example.
 
 Set `option="no-q"` avoid using `-q` as the first argument in the curl command
 line.

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -111,8 +111,6 @@ void curl_dbg_memdebug(const char *logname)
   if(!curl_dbg_logfile) {
     if(logname && *logname)
       curl_dbg_logfile = CURLX_FOPEN_LOW(logname, FOPEN_WRITETEXT);
-    else
-      curl_dbg_logfile = stderr;
 #ifdef MEMDEBUG_LOG_SYNC
     /* Flush the log file after every line so the log is not lost in a crash */
     if(curl_dbg_logfile)

--- a/tests/data/test3207
+++ b/tests/data/test3207
@@ -37,7 +37,7 @@ concurrent HTTPS GET using shared ssl session cache
 lib%TESTNUMBER
 </tool>
 # provide URL and ca-cert
-<command>
+<command option="no-memdebug">
 https://localhost:%HTTPSPORT/%TESTNUMBER %CERTDIR/certs/test-ca.crt
 </command>
 </client>

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -840,6 +840,7 @@ sub singletest_run {
         $tool = $tool_name . exe_ext('TOOL');
     }
 
+    my $oldmemdebug;
     my $disablevalgrind;
     my $CMDLINE="";
     my $cmdargs;
@@ -1025,6 +1026,11 @@ sub singletest_run {
     # timestamp starting of test command
     $$testtimings{"timetoolini"} = Time::HiRes::time();
 
+    if($cmdhash{'option'} && ($cmdhash{'option'} =~ /no-memdebug/)) {
+        $oldmemdebug = $ENV{'CURL_MEMDEBUG'};
+        delete $ENV{'CURL_MEMDEBUG'};
+    }
+
     # run the command line we built
     if($torture) {
         $cmdres = torture($CMDLINE,
@@ -1046,6 +1052,11 @@ sub singletest_run {
     else {
         # Convert the raw result code into a more useful one
         ($cmdres, $dumped_core) = normalize_cmdres(runclient("$CMDLINE"));
+    }
+
+    # restore contents
+    if($oldmemdebug) {
+        $ENV{'CURL_MEMDEBUG'} = $oldmemdebug;
     }
 
     # timestamp finishing of test command

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1763,8 +1763,10 @@ sub singletest_check {
         if(! -f "$logdir/$MEMDUMP") {
             my %cmdhash = getpartattr("client", "command");
             my $cmdtype = $cmdhash{'type'} || "default";
-            logmsg "\n** ALERT! memory tracking with no output file?\n"
-                if($cmdtype ne "perl");
+            if($cmdhash{'option'} !~ /no-memdebug/) {
+                logmsg "\n** ALERT! memory tracking with no output file?\n"
+                    if($cmdtype ne "perl");
+            }
             $ok .= "-"; # problem with memory checking
         }
         else {


### PR DESCRIPTION
Test 3207 now uses this as its multi-threading is not fully memdebug compliant.