### PR TITLE
rustls: verify that verifier_builder is not NULL

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -750,6 +750,10 @@ init_config_builder_verifier(struct Curl_easy *data,
   }
 
   verifier_builder = rustls_web_pki_server_cert_verifier_builder_new(roots);
+  if(!verifier_builder) {
+    result = CURLE_OUT_OF_MEMORY;
+    goto cleanup;
+  }
 
   if(conn_config->CRLfile) {
     result = init_config_builder_verifier_crl(data,


### PR DESCRIPTION
Since this function returns allocated resources there is probably at least a theoretical risk this can return NULL.

Pointed out by ZeroPath