### PR TITLE
cmake: save and restore `CMAKE_MODULE_PATH` in `curl-config.cmake`

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -27,7 +27,7 @@ option(CURL_USE_PKGCONFIG "Enable pkg-config to detect @PROJECT_NAME@ dependenci
 
 include(CMakeFindDependencyMacro)
 
-set(_cmake_module_path_save ${CMAKE_MODULE_PATH})
+set(_curl_cmake_module_path_save ${CMAKE_MODULE_PATH})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
 set(_libs "")
@@ -128,7 +128,7 @@ if("@HAVE_ZSTD@")
   list(APPEND _libs CURL::zstd)
 endif()
 
-set(CMAKE_MODULE_PATH ${_cmake_module_path_save})
+set(CMAKE_MODULE_PATH ${_curl_cmake_module_path_save})
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND WIN32 AND NOT TARGET CURL::win32_winsock)
   add_library(CURL::win32_winsock INTERFACE IMPORTED)


### PR DESCRIPTION
Reported-by: Kai Pastor
Bug: https://github.com/curl/curl/pull/16973#discussion_r2572957270
Follow-up to 16f073ef49f94412000218c9f6ad04e3fd7e4d01 #16973
