### PR TITLE
lib/vtls: simplify rustls init err path

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -744,9 +744,7 @@ init_config_builder_verifier(struct Curl_easy *data,
   if(rr != RUSTLS_RESULT_OK) {
     rustls_failf(data, rr, "failed to build trusted root certificate store");
     result = CURLE_SSL_CACERT_BADFILE;
-    if(result) {
-      goto cleanup;
-    }
+    goto cleanup;
   }
 
   verifier_builder = rustls_web_pki_server_cert_verifier_builder_new(roots);


### PR DESCRIPTION
AFAICT there's no need to check `result` is non-zero immediately after assigning it such, and other similar instantiations of this pattern unconditionally `goto` after assigning an err code.

I missed this when it was added in d3b2ba92c7ed587d48afd1bbc58de19eab6645bf for a ZeroPath fix (sorry!) but noticed it alongside https://github.com/curl/curl/pull/19756