### PR TITLE
krb5: fix detecting channel binding feature

### DIFF
--- a/lib/curl_gssapi.h
+++ b/lib/curl_gssapi.h
@@ -28,11 +28,6 @@
 #include "urldata.h"
 
 #ifdef HAVE_GSSAPI
-
-#ifdef GSS_C_CHANNEL_BOUND_FLAG  /* MIT Kerberos 1.19+, missing from GNU GSS */
-#define CURL_GSSAPI_HAS_CHANNEL_BINDING
-#endif
-
 extern gss_OID_desc Curl_spnego_mech_oid;
 extern gss_OID_desc Curl_krb5_mech_oid;
 

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -121,7 +121,6 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
 #endif
   /* Check if the connection is using SSL and get the channel binding data */
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
-#warning DETECTED-HTTP_NEGOTIATE_C_1
 #ifdef USE_SSL
   curlx_dyn_init(&neg_ctx->channel_binding_data, SSL_CB_MAX_SIZE + 1);
   if(Curl_conn_is_ssl(conn, FIRSTSOCKET)) {
@@ -142,7 +141,6 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
                                            host, header, neg_ctx);
 
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
-#warning DETECTED-HTTP_NEGOTIATE_C_2
   curlx_dyn_free(&neg_ctx->channel_binding_data);
 #endif
 

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -121,6 +121,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
 #endif
   /* Check if the connection is using SSL and get the channel binding data */
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#warning DETECTED-HTTP_NEGOTIATE_C_1
 #ifdef USE_SSL
   curlx_dyn_init(&neg_ctx->channel_binding_data, SSL_CB_MAX_SIZE + 1);
   if(Curl_conn_is_ssl(conn, FIRSTSOCKET)) {
@@ -141,6 +142,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
                                            host, header, neg_ctx);
 
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#warning DETECTED-HTTP_NEGOTIATE_C_2
   curlx_dyn_free(&neg_ctx->channel_binding_data);
 #endif
 

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -120,7 +120,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
   neg_ctx->sslContext = conn->sslContext;
 #endif
   /* Check if the connection is using SSL and get the channel binding data */
-#ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#ifdef GSS_C_CHANNEL_BOUND_FLAG
 #ifdef USE_SSL
   curlx_dyn_init(&neg_ctx->channel_binding_data, SSL_CB_MAX_SIZE + 1);
   if(Curl_conn_is_ssl(conn, FIRSTSOCKET)) {
@@ -134,13 +134,13 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
 #else
   curlx_dyn_init(&neg_ctx->channel_binding_data, 1);
 #endif /* USE_SSL */
-#endif /* CURL_GSSAPI_HAS_CHANNEL_BINDING */
+#endif /* GSS_C_CHANNEL_BOUND_FLAG */
 
   /* Initialize the security context and decode our challenge */
   result = Curl_auth_decode_spnego_message(data, userp, passwdp, service,
                                            host, header, neg_ctx);
 
-#ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#ifdef GSS_C_CHANNEL_BOUND_FLAG
   curlx_dyn_free(&neg_ctx->channel_binding_data);
 #endif
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -198,6 +198,9 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 #   include <gssapi/gssapi.h>
 #  endif
 # endif
+# ifdef GSS_C_CHANNEL_BOUND_FLAG /* MIT Kerberos 1.19+, missing from GNU GSS */
+# define CURL_GSSAPI_HAS_CHANNEL_BINDING
+# endif
 #endif
 
 #ifdef USE_LIBSSH2

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -191,13 +191,11 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 #ifdef HAVE_GSSAPI
 # ifdef HAVE_GSSGNU
 #  include <gss.h>
+# elif defined(HAVE_GSSAPI_H)
+#  include <gssapi.h>
 # else
-#  ifdef HAVE_GSSAPI_H
-#   include <gssapi.h>
-#  else
-#   include <gssapi/gssapi.h>
-#   include <gssapi/gssapi_krb5.h> /* for GSS_C_CHANNEL_BOUND_FLAG */
-#  endif
+#  include <gssapi/gssapi.h>
+#  include <gssapi/gssapi_krb5.h> /* for GSS_C_CHANNEL_BOUND_FLAG */
 # endif
 # ifdef GSS_C_CHANNEL_BOUND_FLAG /* MIT Kerberos 1.19+, missing from GNU GSS */
 # define CURL_GSSAPI_HAS_CHANNEL_BINDING

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -199,6 +199,7 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 # endif
 # ifdef GSS_C_CHANNEL_BOUND_FLAG /* MIT Kerberos 1.19+, missing from GNU GSS */
 # define CURL_GSSAPI_HAS_CHANNEL_BINDING
+#warning DETECTED-MAIN
 # endif
 #endif
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -196,6 +196,7 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 #   include <gssapi.h>
 #  else
 #   include <gssapi/gssapi.h>
+#   include <gssapi/gssapi_krb5.h> /* for GSS_C_CHANNEL_BOUND_FLAG */
 #  endif
 # endif
 # ifdef GSS_C_CHANNEL_BOUND_FLAG /* MIT Kerberos 1.19+, missing from GNU GSS */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -199,7 +199,6 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 # endif
 # ifdef GSS_C_CHANNEL_BOUND_FLAG /* MIT Kerberos 1.19+, missing from GNU GSS */
 # define CURL_GSSAPI_HAS_CHANNEL_BINDING
-#warning DETECTED-MAIN
 # endif
 #endif
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -193,7 +193,7 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 #  include <gss.h>
 # elif defined(HAVE_GSSAPI_H)
 #  include <gssapi.h>
-# else
+# else /* MIT Kerberos */
 #  include <gssapi/gssapi.h>
 #  include <gssapi/gssapi_krb5.h> /* for GSS_C_CHANNEL_BOUND_FLAG */
 # endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -195,10 +195,7 @@ typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
 #  include <gssapi.h>
 # else /* MIT Kerberos */
 #  include <gssapi/gssapi.h>
-#  include <gssapi/gssapi_krb5.h> /* for GSS_C_CHANNEL_BOUND_FLAG */
-# endif
-# ifdef GSS_C_CHANNEL_BOUND_FLAG /* MIT Kerberos 1.19+, missing from GNU GSS */
-# define CURL_GSSAPI_HAS_CHANNEL_BINDING
+#  include <gssapi/gssapi_krb5.h> /* for GSS_C_CHANNEL_BOUND_FLAG, in 1.19+ */
 # endif
 #endif
 

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -32,7 +32,6 @@
   (!defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP))
 
 #include <curl/curl.h>
-#include "../urldata.h"
 
 #include "vauth.h"
 #include "../curlx/warnless.h"

--- a/lib/vauth/cram.c
+++ b/lib/vauth/cram.c
@@ -29,7 +29,6 @@
 #ifndef CURL_DISABLE_DIGEST_AUTH
 
 #include <curl/curl.h>
-#include "../urldata.h"
 
 #include "vauth.h"
 #include "../curl_hmac.h"

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -33,7 +33,6 @@
 
 #include "vauth.h"
 #include "digest.h"
-#include "../urldata.h"
 #include "../curlx/base64.h"
 #include "../curl_hmac.h"
 #include "../curl_md5.h"

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -33,7 +33,6 @@
 
 #include "vauth.h"
 #include "digest.h"
-#include "../urldata.h"
 #include "../curlx/warnless.h"
 #include "../curlx/multibyte.h"
 #include "../sendf.h"

--- a/lib/vauth/gsasl.c
+++ b/lib/vauth/gsasl.c
@@ -31,7 +31,6 @@
 #include <curl/curl.h>
 
 #include "vauth.h"
-#include "../urldata.h"
 #include "../sendf.h"
 
 #include <gsasl.h>

--- a/lib/vauth/krb5_gssapi.c
+++ b/lib/vauth/krb5_gssapi.c
@@ -33,7 +33,6 @@
 
 #include "vauth.h"
 #include "../curl_sasl.h"
-#include "../urldata.h"
 #include "../curl_gssapi.h"
 #include "../sendf.h"
 

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -31,7 +31,6 @@
 #include <curl/curl.h>
 
 #include "vauth.h"
-#include "../urldata.h"
 #include "../curlx/warnless.h"
 #include "../curlx/multibyte.h"
 #include "../sendf.h"

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -44,7 +44,6 @@
 #include "../rand.h"
 #include "../vtls/vtls.h"
 #include "../strdup.h"
-
 #include "../curl_endian.h"
 
 /* NTLM buffer fixed size, large enough for long user + host + domain */

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -35,7 +35,6 @@
 
 #define DEBUG_ME 0
 
-#include "../urldata.h"
 #include "../sendf.h"
 #include "../curl_ntlm_core.h"
 #include "../curl_gethostname.h"

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -35,6 +35,7 @@
 
 #define DEBUG_ME 0
 
+#include "vauth.h"
 #include "../sendf.h"
 #include "../curl_ntlm_core.h"
 #include "../curl_gethostname.h"
@@ -44,7 +45,6 @@
 #include "../vtls/vtls.h"
 #include "../strdup.h"
 
-#include "vauth.h"
 #include "../curl_endian.h"
 
 /* NTLM buffer fixed size, large enough for long user + host + domain */

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -29,7 +29,6 @@
 #include <curl/curl.h>
 
 #include "vauth.h"
-#include "../urldata.h"
 #include "../curl_ntlm_core.h"
 #include "../curlx/warnless.h"
 #include "../curlx/multibyte.h"

--- a/lib/vauth/oauth2.c
+++ b/lib/vauth/oauth2.c
@@ -31,7 +31,6 @@
   (!defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP))
 
 #include <curl/curl.h>
-#include "../urldata.h"
 
 #include "vauth.h"
 #include "../curlx/warnless.h"

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -91,7 +91,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   gss_buffer_desc input_token = GSS_C_EMPTY_BUFFER;
   gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
   gss_channel_bindings_t chan_bindings = GSS_C_NO_CHANNEL_BINDINGS;
-#ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#ifdef GSS_C_CHANNEL_BOUND_FLAG
   struct gss_channel_bindings_struct chan;
 #endif
 
@@ -154,7 +154,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   }
 
   /* Set channel binding data if available */
-#ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#ifdef GSS_C_CHANNEL_BOUND_FLAG
   if(curlx_dyn_len(&nego->channel_binding_data)) {
     memset(&chan, 0, sizeof(struct gss_channel_bindings_struct));
     chan.application_data.length = curlx_dyn_len(&nego->channel_binding_data);

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -92,7 +92,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
   gss_channel_bindings_t chan_bindings = GSS_C_NO_CHANNEL_BINDINGS;
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
-#warning DETECTED-SPNEGO_GSSAPI_C_1
   struct gss_channel_bindings_struct chan;
 #endif
 
@@ -156,7 +155,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
   /* Set channel binding data if available */
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
-#warning DETECTED-SPNEGO_GSSAPI_C_2
   if(curlx_dyn_len(&nego->channel_binding_data)) {
     memset(&chan, 0, sizeof(struct gss_channel_bindings_struct));
     chan.application_data.length = curlx_dyn_len(&nego->channel_binding_data);

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -92,6 +92,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
   gss_channel_bindings_t chan_bindings = GSS_C_NO_CHANNEL_BINDINGS;
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#warning DETECTED-SPNEGO_GSSAPI_C_1
   struct gss_channel_bindings_struct chan;
 #endif
 
@@ -155,6 +156,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
   /* Set channel binding data if available */
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#warning DETECTED-SPNEGO_GSSAPI_C_2
   if(curlx_dyn_len(&nego->channel_binding_data)) {
     memset(&chan, 0, sizeof(struct gss_channel_bindings_struct));
     chan.application_data.length = curlx_dyn_len(&nego->channel_binding_data);

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -31,7 +31,6 @@
 #include <curl/curl.h>
 
 #include "vauth.h"
-#include "../urldata.h"
 #include "../curlx/base64.h"
 #include "../curl_gssapi.h"
 #include "../curlx/warnless.h"

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -31,7 +31,6 @@
 #include <curl/curl.h>
 
 #include "vauth.h"
-#include "../urldata.h"
 #include "../curlx/base64.h"
 #include "../curlx/warnless.h"
 #include "../curlx/multibyte.h"

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -28,7 +28,6 @@
 
 #include "vauth.h"
 #include "../strdup.h"
-#include "../urldata.h"
 #include "../curlx/multibyte.h"
 #include "../url.h"
 

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -28,6 +28,7 @@
 
 #include "../bufref.h"
 #include "../curlx/dynbuf.h"
+#include "../urldata.h"
 
 struct Curl_easy;
 struct connectdata;

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -300,6 +300,7 @@ struct negotiatedata {
   gss_name_t spn;
   gss_buffer_desc output_token;
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#warning DETECTED-VAUTH_H
   struct dynbuf channel_binding_data;
 #endif
 #else

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -299,7 +299,7 @@ struct negotiatedata {
   gss_ctx_id_t context;
   gss_name_t spn;
   gss_buffer_desc output_token;
-#ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
+#ifdef GSS_C_CHANNEL_BOUND_FLAG
   struct dynbuf channel_binding_data;
 #endif
 #else

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -300,7 +300,6 @@ struct negotiatedata {
   gss_name_t spn;
   gss_buffer_desc output_token;
 #ifdef CURL_GSSAPI_HAS_CHANNEL_BINDING
-#warning DETECTED-VAUTH_H
   struct dynbuf channel_binding_data;
 #endif
 #else

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -234,18 +234,6 @@ CURLcode Curl_auth_create_xoauth_bearer_message(const char *user,
 
 #ifdef USE_KERBEROS5
 
-#ifdef HAVE_GSSAPI
-# ifdef HAVE_GSSGNU
-#  include <gss.h>
-# else
-#  ifdef HAVE_GSSAPI_H
-#   include <gssapi.h>
-#  else
-#   include <gssapi/gssapi.h>
-#  endif
-# endif
-#endif
-
 /* meta key for storing KRB5 meta at connection */
 #define CURL_META_KRB5_CONN   "meta:auth:krb5:conn"
 

--- a/lib/version.c
+++ b/lib/version.c
@@ -77,18 +77,6 @@
 #include <gsasl.h>
 #endif
 
-#ifdef HAVE_GSSAPI
-# ifdef HAVE_GSSGNU
-#  include <gss.h>
-# else
-#  ifdef HAVE_GSSAPI_H
-#   include <gssapi.h>
-#  else
-#   include <gssapi/gssapi.h>
-#  endif
-# endif
-#endif
-
 #ifdef USE_OPENLDAP
 #include <ldap.h>
 #endif


### PR DESCRIPTION
Use the already detected `gssapi/gssapi_krb5.h` MIT Kerberos header
to pull in `gssapi_ext.h`, which in turn sets `GSS_C_CHANNEL_BOUND_FLAG`
if supported. Channel binding is present in MIT Kerberos 1.19+.

Also:
- lib: de-duplicate GSS-API header includes.
- vauth: de-duplicate `urldata.h` includes.
- drop interim feature macro in favor of the native GSS one.

Assisted-by: Max Faxälv
Reported-by: Max Faxälv
Bug: https://github.com/curl/curl/pull/19164#issuecomment-3551687025
Ref: #19603
Follow-up to 8616e5aada9c78fb611c60d913c999c8e78c14ba #19164

---

https://github.com/curl/curl/pull/19760/files?w=1

- [x] rebase on #19761 and possibly drop local workaround. [no need, the workaround matches what's done in other vauth sources. it's fine.
