### PR TITLE
lib/sendf.h: forward declare two structs

### DIFF
--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -52,6 +52,10 @@
 #define CLIENTWRITE_EOS     (1<<7) /* End Of transfer download Stream */
 #define CLIENTWRITE_0LEN    (1<<8) /* write even 0-length buffers */
 
+/* Forward declarations */
+struct Curl_creader;
+struct Curl_cwriter;
+
 /**
  * Write `len` bytes at `prt` to the client. `type` indicates what
  * kind of data is being written.


### PR DESCRIPTION
To fix non-unity builds using certain header orders (seen in ntlm.c with
the include order changed):
```
lib/vauth/../sendf.h:117:27: error: ‘struct Curl_cwriter’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
  117 |                    struct Curl_cwriter *writer);
      |                           ^~~~~~~~~~~~
lib/vauth/../sendf.h:215:54: error: ‘struct Curl_creader’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
  215 |   CURLcode (*do_init)(struct Curl_easy *data, struct Curl_creader *reader);
      |                                                      ^~~~~~~~~~~~
[...]
```
Ref: https://github.com/curl/curl/actions/runs/19785420705/job/56691185397?pr=19760

Ref: #19760