### PR TITLE
tests/data: replace Perl `&&` with `and` for XML-compliance

### DIFF
--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -4,7 +4,6 @@
 HTTP
 multi
 verbose logs
-notxml
 </keywords>
 </info>
 
@@ -93,7 +92,7 @@ Accept: */*
 * Connection #3 to host server4.example.com:%HTTPPORT left intact
 </file>
 <stripfile>
-$_ = '' if(($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if(($_ !~ /left intact/) and ($_ !~ /Closing connection/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1510
+++ b/tests/data/test1510
@@ -4,7 +4,6 @@
 HTTP
 verbose logs
 flaky
-notxml
 </keywords>
 </info>
 
@@ -90,7 +89,7 @@ Accept: */*
 * Connection #3 to host server4.example.com:%HTTPPORT left intact
 </file>
 <stripfile>
-$_ = '' if(($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if(($_ !~ /left intact/) and ($_ !~ /Closing connection/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1512
+++ b/tests/data/test1512
@@ -3,7 +3,6 @@
 <keywords>
 HTTP
 GLOBAL DNS CACHE
-notxml
 </keywords>
 </info>
 
@@ -75,7 +74,7 @@ Accept: */*
 ^Host:.*
 </strip>
 <stripfile>
-$_ = '' if(($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if(($_ !~ /left intact/) and ($_ !~ /Closing connection/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -6,7 +6,6 @@ connection reuse
 persistent connection
 CURLOPT_MAXLIFETIME_CONN
 verbose logs
-notxml
 </keywords>
 </info>
 
@@ -66,7 +65,7 @@ Accept: */*
 == Info: Connection #1 to host %HOSTIP:%HTTPPORT left intact
 </file>
 <stripfile>
-$_ = '' if(($_ !~ /left intact/) && ($_ !~ /(closing|shutting down) connection #\d+/))
+$_ = '' if(($_ !~ /left intact/) and ($_ !~ /(closing|shutting down) connection #\d+/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test2402
+++ b/tests/data/test2402
@@ -5,7 +5,6 @@ HTTP
 HTTP/2
 multi
 verbose logs
-notxml
 </keywords>
 </info>
 
@@ -104,7 +103,7 @@ Via: 2 nghttpx
 * Connection #0 to host localhost:%HTTP2TLSPORT left intact
 </file>
 <stripfile>
-$_ = '' if(($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if(($_ !~ /left intact/) and ($_ !~ /Closing connection/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test2404
+++ b/tests/data/test2404
@@ -5,7 +5,6 @@ HTTP
 HTTP/2
 multi
 verbose logs
-notxml
 </keywords>
 </info>
 
@@ -104,7 +103,7 @@ Via: 2 nghttpx
 * Connection #0 to host localhost:%HTTP2TLSPORT left intact
 </file>
 <stripfile>
-$_ = '' if(($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if(($_ !~ /left intact/) and ($_ !~ /Closing connection/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -5,7 +5,6 @@ HTTP
 HTTP/3
 multi
 verbose logs
-notxml
 </keywords>
 </info>
 
@@ -99,7 +98,7 @@ Via: 3 nghttpx
 == Info: Connection #0 to host localhost:%HTTP3PORT left intact
 </file>
 <stripfile>
-$_ = '' if(($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if(($_ !~ /left intact/) and ($_ !~ /Closing connection/))
 </stripfile>
 <limits>
 Maximum allocated: 1800000

--- a/tests/data/test96
+++ b/tests/data/test96
@@ -2,7 +2,6 @@
 <info>
 <keywords>
 TrackMemory
-notxml
 </keywords>
 </info>
 
@@ -37,7 +36,7 @@ MEM tool_cfgable.c
 MEM tool_cfgable.c
 </file>
 <stripfile>
-$_ = '' if((($_ !~ /tool_paramhlp/) && ($_ !~ /tool_cfgable/)) || ($_ =~ /free\(\(nil\)\)/))
+$_ = '' if((($_ !~ /tool_paramhlp/) and ($_ !~ /tool_cfgable/)) || ($_ =~ /free\(\(nil\)\)/))
 s/:\d+.*//
 s:^(MEM )(.*/)(.*):$1$3:
 </stripfile>


### PR DESCRIPTION
Bringing down non-XML-compliant files to 50 (from 58).

Follow-up to 7f3731ce142c1d74023abad183cc8ce0fd527fab #19595
