### PR TITLE
tests/data: add `%PERL` to postcheck commands where missing

### DIFF
--- a/tests/data/test1013
+++ b/tests/data/test1013
@@ -25,7 +25,7 @@ Compare curl --version with curl-config --protocols
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%SRCDIR/libtest/test%TESTNUMBER.pl ../curl-config %LOGDIR/stdout%TESTNUMBER protocols
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl ../curl-config %LOGDIR/stdout%TESTNUMBER protocols
 </postcheck>
 <errorcode>
 0

--- a/tests/data/test1014
+++ b/tests/data/test1014
@@ -25,7 +25,7 @@ Compare curl --version with curl-config --features
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%SRCDIR/libtest/test1013.pl ../curl-config %LOGDIR/stdout%TESTNUMBER features > %LOGDIR/result%TESTNUMBER
+%PERL %SRCDIR/libtest/test1013.pl ../curl-config %LOGDIR/stdout%TESTNUMBER features > %LOGDIR/result%TESTNUMBER
 </postcheck>
 <errorcode>
 0

--- a/tests/data/test1022
+++ b/tests/data/test1022
@@ -25,7 +25,7 @@ Compare curl --version with curl-config --version
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%SRCDIR/libtest/test%TESTNUMBER.pl ../curl-config %LOGDIR/stdout%TESTNUMBER version
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl ../curl-config %LOGDIR/stdout%TESTNUMBER version
 </postcheck>
 <errorcode>
 0

--- a/tests/data/test1023
+++ b/tests/data/test1023
@@ -25,7 +25,7 @@ Compare curl --version with curl-config --vernum
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%SRCDIR/libtest/test1022.pl ../curl-config %LOGDIR/stdout%TESTNUMBER vernum
+%PERL %SRCDIR/libtest/test1022.pl ../curl-config %LOGDIR/stdout%TESTNUMBER vernum
 </postcheck>
 <errorcode>
 0


### PR DESCRIPTION
To avoid potentially executing a different Perl than used by the rest
of the build and tests.

Also to be more portable by not relying on shebang support, though these
particular tests require POSIX shell anyway.
