### PR TITLE
rtmp: stop redefining `setsockopt` system symbol on Windows

### DIFF
--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -37,8 +37,7 @@
 #include <curl/curl.h>
 #include <librtmp/rtmp.h>
 
-#if (defined(_WIN32) && !defined(USE_LWIPSOCK)) || \
-  defined(LWIP_SO_SNDRCVTIMEO_NONSTANDARD)
+#if defined(USE_WINSOCK) || defined(LWIP_SO_SNDRCVTIMEO_NONSTANDARD)
 #define SET_RCVTIMEO(tv,s)   int tv = s*1000
 #else
 #define SET_RCVTIMEO(tv,s)   struct timeval tv = {s,0}


### PR DESCRIPTION
Before this patch it added Windows-specific casts. In unity builds this
also affected other source files.

`setsockopt()` is called without special casts in other places in
the code, and passing a non-const char ptr to a const char ptr arg also
should work.

Basic compile test with mingw-w64 confirms. In case of issues, a cast to
`curl_socklen_t` can be used, or do the special case in an `#if` branch.

Also: merge Windows-specific guards for `SET_RCVTIMEO()`.

Follow-up to 639d052e4499c663a578d940713e40cd466268fa #3155
Follow-up to 04cb15ae9dc0e863487ee55de2226cf5033311c0
