### PR TITLE
cf-socket: drop feature check for `IPV6_V6ONLY` on Windows

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1100,8 +1100,8 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   if(ctx->addr.family == AF_INET6) {
 #ifdef USE_WINSOCK
     /* Turn on support for IPv4-mapped IPv6 addresses.
-     * Linux kernel, NetBSD, FreeBSD and Darwin: default is off;
-     * Windows Vista and later: default is on (= 1);
+     * Linux kernel, NetBSD, FreeBSD, Darwin, lwIP: default is off;
+     * Windows Vista and later: default is on;
      * DragonFly BSD: acts like off, and dummy setting;
      * OpenBSD and earlier Windows: unsupported.
      * Linux: controlled by /proc/sys/net/ipv6/bindv6only.


### PR DESCRIPTION
The macro is present in all supported Windows toolchains.

It's present in mingw-w64 v3+, and in MS SDK 6.0A+ (maybe earlier).

Also:
- restrict this logic to `USE_WINSOCK` (was: `_WIN32`), to exclude
  alternate socket libraries (i.e. lwIP). lwIP supports `IPV6_V6ONLY`
  since its 2.0.0 (2016-11-10) release and it's disabled by default,
  unlike in Winsock.
  Ref: https://github.com/lwip-tcpip/lwip/commit/e65202f8257e55b09e6309b1aa405b5e6a017f0d
- delete interim setter function/dummy macro `set_ipv6_v6only()`.

Follow-up to a28f5f68b965119d9dd1ab6c2a2ccc66c6ed5d1f #18010
Follow-up to ca3f6decb927a4c3eb4c10fba09848b626a526d6 #10975
