### PR TITLE
cmake: fix `ws2_32` reference in `curl-config.cmake`

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -133,7 +133,7 @@ set(CMAKE_MODULE_PATH ${_curl_cmake_module_path_save})
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND WIN32 AND NOT TARGET CURL::win32_winsock)
   add_library(CURL::win32_winsock INTERFACE IMPORTED)
-  set_target_properties(CURL::win32_winsock PROPERTIES INTERFACE_LINK_LIBRARIES "@_win32_winsock@")
+  set_target_properties(CURL::win32_winsock PROPERTIES INTERFACE_LINK_LIBRARIES "ws2_32")
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2340,7 +2340,6 @@ if(NOT CURL_DISABLE_INSTALL)
   #   USE_RUSTLS
   #   USE_WIN32_LDAP CURL_DISABLE_LDAP
   #   USE_WOLFSSL
-  #   _win32_winsock
   configure_package_config_file("CMake/curl-config.cmake.in"
     "${_project_config}"
     INSTALL_DESTINATION ${_install_cmake_dir}


### PR DESCRIPTION
Follow-up to 16f073ef49f94412000218c9f6ad04e3fd7e4d01 #16973
Follow-up to 554dfa556886c3d7425f6690f3fc408128bf4744 #17927
