### PR TITLE
cmake: verify minimum CMake version in `curl-config.cmake`

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -26,6 +26,11 @@
 option(CURL_USE_PKGCONFIG "Enable pkg-config to detect @PROJECT_NAME@ dependencies. Default: @CURL_USE_PKGCONFIG@"
   "@CURL_USE_PKGCONFIG@")
 
+if(CMAKE_VERSION VERSION_LESS @CMAKE_MINIMUM_REQUIRED_VERSION@)
+  message(STATUS "@PROJECT_NAME@: @PROJECT_NAME@-specific Find modules require "
+    "CMake @CMAKE_MINIMUM_REQUIRED_VERSION@ or upper, found: ${CMAKE_VERSION}.")
+endif()
+
 include(CMakeFindDependencyMacro)
 
 if("@USE_OPENSSL@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2309,6 +2309,7 @@ if(NOT CURL_DISABLE_INSTALL)
     ${_generated_version_config}")
 
   # Consumed custom variables:
+  #   CMAKE_MINIMUM_REQUIRED_VERSION
   #   CURLVERSION
   #   LIBCURL_PC_LIBS_PRIVATE_LIST
   #   LIB_NAME


### PR DESCRIPTION
Show a message if the CMake version is lower than that when consuming
libcurl via the CMake config.

The minimum CMake version on consumption is for now the same as
the minimum required (v3.7) to build curl itself.

Ref: https://cmake.org/cmake/help/v3.7/variable/CMAKE_MINIMUM_REQUIRED_VERSION.html
Ref: #18704 (discussion)
Follow-up to 16f073ef49f94412000218c9f6ad04e3fd7e4d01 #16973

---

- [x] the scope of the message could be narrowed better, e.g only
  display it when using static libcurl and/or there is an actual Find
  module to find. [Not really. Dependencies are defined first, then
  the targets defined. Not likely to work in reverse.]
- [x] maybe restrict local find modules when using the static libcurl
  target only. [Seems shaky if possible at all.]
- [x] the required version is 3.13 when using pkg-config and static
  libcurl and actual Find module conditions are also true. [see defining
  a separate version.]
- [x] make it a warning? add a way to silence it? [maybe once we know
  more, and perhaps manage to narrow preconditions to avoid noise.]
- [x] perhaps add a way to detach this version from the build-time
  one. Could be lower, higher, depending. [FUTURE]

By merging #16973, the so far private Find modules became public,
also some more tricky code via `curl-config.cmake.in`. These may
run as part of projects consuming (static) libcurl. Thus the CMake
version minium also applies to the consuming side.

Rolling two parallel version requirements (one to build curl and one
to consume curl) is technically an option. Can't think of another for
now, because the target is defined by referencing CURL::<module>
targets, that need to be resolved. Probably something to test and
explore more. For now I go with showing a warning:
