### PR TITLE
runtests: enable torture testing with threaded resolver

### DIFF
--- a/tests/data/test3207
+++ b/tests/data/test3207
@@ -37,7 +37,7 @@ concurrent HTTPS GET using shared ssl session cache
 lib%TESTNUMBER
 </tool>
 # provide URL and ca-cert
-<command>
+<command option="no-memdebug">
 https://localhost:%HTTPSPORT/%TESTNUMBER %CERTDIR/certs/test-ca.crt
 </command>
 </client>


### PR DESCRIPTION
Since a7bebd850291 made it possible.

~~Also enable memdebug in test 3207 again.~~