### PR TITLE
memdebug: log socket close before closing

### DIFF
--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -469,9 +469,8 @@ void curl_dbg_mark_sclose(curl_socket_t sockfd, int line, const char *source)
 /* this is our own defined way to close sockets on *ALL* platforms */
 int curl_dbg_sclose(curl_socket_t sockfd, int line, const char *source)
 {
-  int res = CURL_SCLOSE(sockfd);
   curl_dbg_mark_sclose(sockfd, line, source);
-  return res;
+  return CURL_SCLOSE(sockfd);
 }
 
 ALLOC_FUNC


### PR DESCRIPTION
To not get a mixup in the memdebug log order.