### PR TITLE
multibyte: limit `curlx_convert_*wchar*()` functions to Unicode builds

### DIFF
--- a/lib/curlx/multibyte.c
+++ b/lib/curlx/multibyte.c
@@ -29,7 +29,7 @@
 
 #include "../curl_setup.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(UNICODE)
 
 #include "multibyte.h"
 
@@ -81,4 +81,4 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w)
   return str_utf8;
 }
 
-#endif /* _WIN32 */
+#endif /* _WIN32 && UNICODE */

--- a/lib/curlx/multibyte.h
+++ b/lib/curlx/multibyte.h
@@ -52,14 +52,14 @@
 #define CURLX_FREE(x)   curlx_free(x)
 #endif
 
-/* MultiByte conversions using Windows kernel32 library. */
-wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8);
-char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
-
 /* the purpose of this macro is to free() without being traced by memdebug */
 #define curlx_unicodefree(ptr) CURLX_FREE(ptr)
 
 #ifdef UNICODE
+
+/* MultiByte conversions using Windows kernel32 library. */
+wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8);
+char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
 
 #define curlx_convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
 #define curlx_convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))


### PR DESCRIPTION
Follow-up to ccb68d2e3b602b24a8cb52f473b96938ac998db6 #19790