### PR TITLE
runtests: fix Perl warning

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1750,7 +1750,7 @@ sub singletest_check {
         if(! -f "$logdir/$MEMDUMP") {
             my %cmdhash = getpartattr("client", "command");
             my $cmdtype = $cmdhash{'type'} || "default";
-            if($cmdhash{'option'} !~ /no-memdebug/) {
+            if($cmdhash{'option'} && $cmdhash{'option'} !~ /no-memdebug/) {
                 logmsg "\n** ALERT! memory tracking with no output file?\n"
                     if($cmdtype ne "perl");
             }


### PR DESCRIPTION
```
Use of uninitialized value $cmdhash{"option"} in pattern match (m//) at tests/runtests.pl line 1753.
```
Ref: https://github.com/curl/curl/actions/runs/19833947198/job/56831923295?pr=19794#step:13:3694

Follow-up to 02aa75a8c240af1a8912145497806e8925859a87 #19752