### PR TITLE
curl_gssapi: make sure Curl_gss_log_error() has an initialized buffer

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -428,7 +428,7 @@ static size_t display_gss_error(OM_uint32 status, int type,
 void Curl_gss_log_error(struct Curl_easy *data, const char *prefix,
                         OM_uint32 major, OM_uint32 minor)
 {
-  char buf[GSS_LOG_BUFFER_LEN];
+  char buf[GSS_LOG_BUFFER_LEN] = "";
   size_t len = 0;
 
   if(major != GSS_S_FAILURE)


### PR DESCRIPTION
Reported-by: Stanislav Fort (Aisle Research)