### PR TITLE
DEPRECATE.md: remove OpenSSL-QUIC in January 2026 instead

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -36,7 +36,7 @@ stack.
  - curl users building with vanilla OpenSSL can still use QUIC through the
    means of ngtcp2
 
-We remove the OpenSSL-QUIC backend in March 2026.
+We remove the OpenSSL-QUIC backend in January 2026.
 
 ## RTMP
 


### PR DESCRIPTION
Move it up two months. It was only ever experimental so this cannot interfere with any production code so shorten the "quarantine".