### PR TITLE
ldap: provide version for "legacy" ldap as well

### DIFF
--- a/lib/curl_ldap.h
+++ b/lib/curl_ldap.h
@@ -32,5 +32,6 @@ extern const struct Curl_handler Curl_handler_ldap;
 extern const struct Curl_handler Curl_handler_ldaps;
 #endif
 
+void Curl_ldap_version(char *buf, size_t bufsz);
 #endif
 #endif /* HEADER_CURL_LDAP_H */

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -1037,6 +1037,15 @@ static void ldap_free_urldesc_low(LDAPURLDesc *ludp)
 }
 #endif /* !HAVE_LDAP_URL_PARSE */
 
+void Curl_ldap_version(char *buf, size_t bufsz)
+{
+#ifdef USE_WIN32_LDAP
+  curl_msnprintf(buf, bufsz, "WinLDAP");
+#else
+  curl_msnprintf(buf, bufsz, "LDAP/1");
+#endif
+}
+
 #if defined(__GNUC__) && defined(__APPLE__)
 #pragma GCC diagnostic pop
 #endif

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1331,4 +1331,24 @@ ldapsb_tls_write(Sockbuf_IO_Desc *sbiod, void *buf, ber_len_t len)
 }
 #endif /* USE_SSL */
 
+void Curl_ldap_version(char *buf, size_t bufsz)
+{
+  LDAPAPIInfo api;
+  api.ldapai_info_version = LDAP_API_INFO_VERSION;
+
+  if(ldap_get_option(NULL, LDAP_OPT_API_INFO, &api) == LDAP_OPT_SUCCESS) {
+    unsigned int patch = (unsigned int)(api.ldapai_vendor_version % 100);
+    unsigned int major = (unsigned int)(api.ldapai_vendor_version / 10000);
+    unsigned int minor =
+      (((unsigned int)api.ldapai_vendor_version - major * 10000)
+       - patch) / 100;
+    curl_msnprintf(buf, bufsz, "%s/%u.%u.%u",
+                   api.ldapai_vendor_name, major, minor, patch);
+    ldap_memfree(api.ldapai_vendor_name);
+    ber_memvfree((void **)api.ldapai_extensions);
+  }
+  else
+    curl_msnprintf(buf, bufsz, "OpenLDAP");
+}
+
 #endif /* !CURL_DISABLE_LDAP && USE_OPENLDAP */

--- a/lib/version.c
+++ b/lib/version.c
@@ -77,8 +77,8 @@
 #include <gsasl.h>
 #endif
 
-#ifdef USE_OPENLDAP
-#include <ldap.h>
+#ifndef CURL_DISABLE_LDAP
+#include "curl_ldap.h"
 #endif
 
 #ifdef HAVE_BROTLI
@@ -100,28 +100,6 @@ static void zstd_version(char *buf, size_t bufsz)
   unsigned int minor = (version - (major * 100 * 100)) / 100;
   unsigned int patch = version - (major * 100 * 100) - (minor * 100);
   (void)curl_msnprintf(buf, bufsz, "zstd/%u.%u.%u", major, minor, patch);
-}
-#endif
-
-#ifdef USE_OPENLDAP
-static void oldap_version(char *buf, size_t bufsz)
-{
-  LDAPAPIInfo api;
-  api.ldapai_info_version = LDAP_API_INFO_VERSION;
-
-  if(ldap_get_option(NULL, LDAP_OPT_API_INFO, &api) == LDAP_OPT_SUCCESS) {
-    unsigned int patch = (unsigned int)(api.ldapai_vendor_version % 100);
-    unsigned int major = (unsigned int)(api.ldapai_vendor_version / 10000);
-    unsigned int minor =
-      (((unsigned int)api.ldapai_vendor_version - major * 10000)
-       - patch) / 100;
-    curl_msnprintf(buf, bufsz, "%s/%u.%u.%u",
-                   api.ldapai_vendor_name, major, minor, patch);
-    ldap_memfree(api.ldapai_vendor_name);
-    ber_memvfree((void **)api.ldapai_extensions);
-  }
-  else
-    curl_msnprintf(buf, bufsz, "OpenLDAP");
 }
 #endif
 
@@ -211,7 +189,7 @@ char *curl_version(void)
 #ifdef HAVE_GSSAPI
   char gss_buf[40];
 #endif
-#ifdef USE_OPENLDAP
+#ifndef CURL_DISABLE_LDAP
   char ldap_buf[30];
 #endif
   int i = 0;
@@ -289,8 +267,8 @@ char *curl_version(void)
 #endif
   src[i++] = gss_buf;
 #endif /* HAVE_GSSAPI */
-#ifdef USE_OPENLDAP
-  oldap_version(ldap_buf, sizeof(ldap_buf));
+#ifndef CURL_DISABLE_LDAP
+  Curl_ldap_version(ldap_buf, sizeof(ldap_buf));
   src[i++] = ldap_buf;
 #endif
 


### PR DESCRIPTION
It displays in version output as WinLDAP and LDAP/1, compared to OpenLDAP/[version] for the OpenLDAP backend code.