### PR TITLE
pytest: improve stragglers

### DIFF
--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -164,8 +164,3 @@ Make a blocking, graceful shutdown of all remaining connections when
 a multi handle is destroyed. This implicitly triggers for easy handles
 that are run via easy_perform. The value of the environment variable
 gives the shutdown timeout in milliseconds.
-
-## `CURL_H2_STREAM_WIN_MAX`
-
-Set to a positive 32-bit number to override the HTTP/2 stream window's
-default of 10MB. Used in testing to verify correct window update handling.

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -277,38 +277,12 @@ class TestDownload:
 
     # download serial via lib client, pause/resume at different offsets
     @pytest.mark.parametrize("pause_offset", [0, 10*1024, 100*1023, 640000])
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h3'])
+    @pytest.mark.parametrize("proto", Env.http_protos())
     def test_02_21_lib_serial(self, env: Env, httpd, nghttpx, proto, pause_offset):
-        if proto == 'h3' and not env.have_h3():
-            pytest.skip("h3 not supported")
         count = 2
-        docname = 'data-10m'
+        docname = 'data-1m'
         url = f'https://localhost:{env.https_port}/{docname}'
         client = LocalClient(name='cli_hx_download', env=env)
-        if not client.exists():
-            pytest.skip(f'example client not built: {client.name}')
-        r = client.run(args=[
-             '-n', f'{count}', '-P', f'{pause_offset}', '-V', proto, url
-        ])
-        r.check_exit_code(0)
-        srcfile = os.path.join(httpd.docs_dir, docname)
-        self.check_downloads(client, srcfile, count)
-
-    # h2 download parallel via lib client, pause/resume at different offsets
-    # debug-override stream window size to reproduce #16955
-    @pytest.mark.parametrize("pause_offset", [0, 10*1024, 100*1023, 640000])
-    @pytest.mark.parametrize("swin_max", [0, 10*1024])
-    @pytest.mark.skipif(condition=not Env.have_h2_curl(), reason="curl without h2")
-    def test_02_21_h2_lib_serial(self, env: Env, httpd, pause_offset, swin_max):
-        proto = 'h2'
-        count = 2
-        docname = 'data-10m'
-        url = f'https://localhost:{env.https_port}/{docname}'
-        run_env = os.environ.copy()
-        run_env['CURL_DEBUG'] = 'multi,http/2'
-        if swin_max > 0:
-            run_env['CURL_H2_STREAM_WIN_MAX'] = f'{swin_max}'
-        client = LocalClient(name='cli_hx_download', env=env, run_env=run_env)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         r = client.run(args=[

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -570,6 +570,10 @@ cleanup:
     APR_BRIGADE_INSERT_TAIL(bb, b);
     ap_pass_brigade(r->output_filters, bb);
   }
+  if(rv == APR_ECONNRESET) {
+    r->connection->aborted = 1;
+    return rv;
+  }
   return AP_FILTER_ERROR;
 }
 

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -449,7 +449,7 @@ static CURLcode test_cli_hx_download(const char *URL)
 
     if(still_running) {
       /* wait for activity, timeout or "nothing" */
-      mc = curl_multi_poll(multi, NULL, 0, 1000, NULL);
+      mc = curl_multi_poll(multi, NULL, 0, 500, NULL);
     }
 
     if(mc)


### PR DESCRIPTION
A fix for the tests that took the longest:
- test_05: make the server close the HTTP/1.1 connection when simulating an error during a download. This eliminates waiting for a keepalive timeout
- test_02: pause tests with slightly smaller documents, eliminate special setup for HTTP/2. We test stream window handling now elsewhere already
- cli_hx_download: run loop in 500ms steps instead of 1sec, resuming paused tranfers earlier.