### PR TITLE
runtests: limit `memanalyze.pl` post-processing to torture tests

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1746,7 +1746,7 @@ sub singletest_check {
         return -1;
     }
 
-    if($feature{"TrackMemory"} && $torture) {
+    if($torture) {
         if(! -f "$logdir/$MEMDUMP") {
             my %cmdhash = getpartattr("client", "command");
             my $cmdtype = $cmdhash{'type'} || "default";


### PR DESCRIPTION
Before this patch runtests with TrackMemory-enabled curl run
`memanalyze.pl` twice after each executed test. Except for the common
case of AsynchDNS + non-c-ares (aka thread-resolver) builds, where 
this step was skipped.

Patch #19786 removed this exception, which caused many CI jobs to run
memanalyze, resulting in a 10 (Linux) to 100% (2x, on Windows) increase
in test run times.

The intent before the patch above may have been to disable TrackMemory
for AsynchDNS builds, but what it really did was disabling tests 96,
558, 1330 that verified if TrackMemory is operating, displaying
a warning saying TrackMemory is disabled, but leaving memory tracking
enabled in curl (it's build-time option), which kept generating a
`memdump`, (but without runtests deleting it first). It also disabled
`memanalyze.pl`, to post-process `memdump` files.

The patch above removed the above logic, but with side-effects.

Fix by limiting `memanalyze.pl` post-processing to torture tests, which
seems to have been the original use-case for it, and the intent of
#19786 to enable it for all builds.

This also sped up existing jobs where memanalyze was accidentally run,
e.g. two c-ares Windows jobs, saving 4.5m per CI run.

Remaining questions: Why is `memanalyze.pl` so slow, esp. on Windows.
Could it be made faster? Could be run just once per test, not twice?
Could Windows torture tests made usable by making it fast? #19675

Bug: https://github.com/curl/curl/pull/19786#issuecomment-3598679397
Follow-up to fb7033d7600dfb59de06e7af8a0d6ab2a4163578 #19786
