### PR TITLE
test787: fix possible typo `&` -> `%` in curl option

### DIFF
--- a/tests/data/test787
+++ b/tests/data/test787
@@ -3,7 +3,6 @@
 <keywords>
 HTTP
 --variable
-notxml
 </keywords>
 </info>
 
@@ -22,7 +21,7 @@ http
 --variable with a file byte range, bad range
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER --variable "name[15-14]@&LOGDIR/fooo" --expand-data '{{name}}'
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --variable "name[15-14]@%LOGDIR/fooo" --expand-data '{{name}}'
 </command>
 </client>
 


### PR DESCRIPTION
They are close on the keyboard and don't affect test results.

To make this test XML-compliant.

Ref: #14479
Follow-up to 40c264db617d025ca5053bc0964a185d11101301 #15739