### PR TITLE
ldap: detect version of "legacy" LDAP

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -1024,6 +1024,35 @@ static void ldap_free_urldesc_low(LDAPURLDesc *ludp)
 }
 #endif /* !HAVE_LDAP_URL_PARSE */
 
+void Curl_ldap_version(char *buf, size_t bufsz)
+{
+#ifdef USE_WIN32_LDAP
+  curl_msnprintf(buf, bufsz, "WinLDAP");
+#else
+#ifdef __APPLE__
+  static const char *flavor = "/Apple";
+#else
+  static const char *flavor = "";
+#endif
+  LDAPAPIInfo api;
+  api.ldapai_info_version = LDAP_API_INFO_VERSION;
+
+  if(ldap_get_option(NULL, LDAP_OPT_API_INFO, &api) == LDAP_OPT_SUCCESS) {
+    unsigned int patch = (unsigned int)(api.ldapai_vendor_version % 100);
+    unsigned int major = (unsigned int)(api.ldapai_vendor_version / 10000);
+    unsigned int minor =
+      (((unsigned int)api.ldapai_vendor_version - major * 10000)
+       - patch) / 100;
+    curl_msnprintf(buf, bufsz, "%s/%u.%u.%u%s",
+                   api.ldapai_vendor_name, major, minor, patch, flavor);
+    ldap_memfree(api.ldapai_vendor_name);
+    ber_memvfree((void **)api.ldapai_extensions);
+  }
+  else
+    curl_msnprintf(buf, bufsz, "LDAP/1");
+#endif
+}
+
 #if defined(__GNUC__) && defined(__APPLE__)
 #pragma GCC diagnostic pop
 #endif

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -25,11 +25,8 @@
 
 #include "curl_setup.h"
 
-#ifndef CURL_DISABLE_LDAP
+#if !defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP)
 
-#include "curl_ldap.h"
-
-#ifdef USE_OPENLDAP
 /*
  * Notice that USE_OPENLDAP is only a source code selection switch. When
  * libcurl is built with USE_OPENLDAP defined the libcurl source code that
@@ -49,6 +46,7 @@
 #include "sendf.h"
 #include "vtls/vtls.h"
 #include "transfer.h"
+#include "curl_ldap.h"
 #include "curlx/base64.h"
 #include "cfilters.h"
 #include "connect.h"
@@ -1327,23 +1325,8 @@ static ber_slen_t ldapsb_tls_write(Sockbuf_IO_Desc *sbiod, void *buf,
 }
 #endif /* USE_SSL */
 
-#endif /* USE_OPENLDAP */
-
-#if defined(__GNUC__) && defined(__APPLE__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 void Curl_ldap_version(char *buf, size_t bufsz)
 {
-#ifdef USE_WIN32_LDAP
-  curl_msnprintf(buf, bufsz, "WinLDAP");
-#else
-#if !defined(USE_OPENLDAP) && defined(__APPLE__)
-  static const char *flavor = "/Apple";
-#else
-  static const char *flavor = "";
-#endif
   LDAPAPIInfo api;
   api.ldapai_info_version = LDAP_API_INFO_VERSION;
 
@@ -1353,22 +1336,13 @@ void Curl_ldap_version(char *buf, size_t bufsz)
     unsigned int minor =
       (((unsigned int)api.ldapai_vendor_version - major * 10000)
        - patch) / 100;
-    curl_msnprintf(buf, bufsz, "%s/%u.%u.%u%s",
-                   api.ldapai_vendor_name, major, minor, patch, flavor);
+    curl_msnprintf(buf, bufsz, "%s/%u.%u.%u",
+                   api.ldapai_vendor_name, major, minor, patch);
     ldap_memfree(api.ldapai_vendor_name);
     ber_memvfree((void **)api.ldapai_extensions);
   }
   else
-#ifdef USE_OPENLDAP
     curl_msnprintf(buf, bufsz, "OpenLDAP");
-#else
-    curl_msnprintf(buf, bufsz, "LDAP/1");
-#endif
-#endif /* USE_WIN32_LDAP */
 }
 
-#if defined(__GNUC__) && defined(__APPLE__)
-#pragma GCC diagnostic pop
-#endif
-
-#endif /* !CURL_DISABLE_LDAP */
+#endif /* !CURL_DISABLE_LDAP && USE_OPENLDAP */


### PR DESCRIPTION
Legacy LDAP means an OpenLDAP-compatible implementation
without the private API `ldap_init_fd()` introduced in OpenLDAP
2.4.6+ (2007-10-31), and not WinLDAP.

One known example is Apple's LDAP build, which is based on
OpenLDAP 2.4.28 (2011-11-25), without providing this private API.

The version query API was introduced around 1998-1999, before
the minimum (2.0 2000-08-01) required by curl.

Follow-up to 3e2a946926853608d67805bd9f4a58345fff364a #19808
