### PR TITLE
CURLMOPT_SOCKETFUNCTION.md: fix the callback

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -109,7 +109,7 @@ struct priv {
 
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
-  struct priv *p = sockp;
+  struct priv *p = cbp;
   printf("our ptr: %p\n", p->ours);
 
   if(what == CURL_POLL_REMOVE) {


### PR DESCRIPTION
The example code does not use curl_multi_assign(), but its callback function used socketp (called sockp in the function) to get the struct priv pointer instead of the correct clientp (cbp).

Reported-by: Greg Hudson
Fixes #19840