### PR TITLE
openssl: simplify `HAVE_KEYLOG_CALLBACK` guard

### DIFF
--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -51,7 +51,7 @@
  * BoringSSL: supported since d28f59c27bac (committed 2015-11-19)
  * LibreSSL: not supported. 3.5.0+ has a stub function that does nothing.
  */
-#if !defined(LIBRESSL_VERSION_NUMBER) || defined(HAVE_BORINGSSL_LIKE)
+#ifndef LIBRESSL_VERSION_NUMBER
 #define HAVE_KEYLOG_CALLBACK
 #endif
 


### PR DESCRIPTION
non-LibreSSL always includes BoringSSL and AWS-LC, no need to check for
them explicitly.

Follow-up to 69c89bf3d3137fcbb2b8bc57233182adcf1e2817 #18330