### PR TITLE
ldap: improve detection of Apple LDAP

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -1029,7 +1029,7 @@ void Curl_ldap_version(char *buf, size_t bufsz)
 #ifdef USE_WIN32_LDAP
   curl_msnprintf(buf, bufsz, "WinLDAP");
 #else
-#ifdef __APPLE__
+#ifdef LDAP_OPT_X_TLS_PASSPHRASE
   static const char *flavor = "/Apple";
 #else
   static const char *flavor = "";


### PR DESCRIPTION
When detecting the Apple fork of "legacy" LDAP, replace the `__APPLE__`
macro (which can be present also when using an old mainline OpenLDAP
while building for an Apple platform) with `LDAP_OPT_X_TLS_PASSPHRASE`
which is an Apple-specific macro, merged by Apple in 2007, later adding
the comment 'Apple Specific code'. This macro hasn't been retrofitted
to OpenLDAP since then, and unlikely to happen in the future.

Refs:
https://github.com/apple-oss-distributions/OpenLDAP/commit/c4d990a6cfa0cb71d6dffe6f6aeeb722fd7c627b#diff-0f7a5f85bae4de860b70aabf34aa12b0ecc37e748cd96e203e2d8ddb30a207c3R145
https://github.com/apple-oss-distributions/OpenLDAP/commit/49ac28a486d72f36cd9713b41180b41d34f18ef6#diff-0f7a5f85bae4de860b70aabf34aa12b0ecc37e748cd96e203e2d8ddb30a207c3R166

Follow-up to 859ce48de12986f5bf846c2800dacab893ff12c1 #19832
