### PR TITLE
test1498: disable 'HTTP PUT from stdin' test on Windows

### DIFF
--- a/tests/data/test1498
+++ b/tests/data/test1498
@@ -25,6 +25,9 @@ blablabla
 <server>
 http
 </server>
+<features>
+!win32
+</features>
 <name>
 HTTP PUT from stdin using period
 </name>


### PR DESCRIPTION
Test became flaky with memanalyze errors after merging #19845,
in a TrackMemory Windows Unicode c-ares openssl-quic build:
GHA/windows: mingw, AM x86_64 c-ares U.

Disable it until further investigation.

This test uses the Windows-specific multi-threaded stdin code
that caused issues in the past. It's also using `TerminateThread()`,
that apps aren't supposed to.

Examples:
https://github.com/curl/curl/pull/19845#issuecomment-3614921298
https://github.com/curl/curl/actions/runs/19948992659/job/57205061260?pr=19845#step:13:3028
https://github.com/curl/curl/actions/runs/19966429786/job/57259325027?pr=19852#step:13:3030

Also seen to fail earlier while testing torture tests on Windows:
https://github.com/curl/curl/pull/19675#issuecomment-3573154110

Ref: 4e051ff5506319ee87e3656be8f76b01de217103 #19845
