### PR TITLE
formdata: validate callback is non-NULL before use

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -636,6 +636,10 @@ int curl_formget(struct curl_httppost *form, void *arg,
   CURLcode result;
   curl_mimepart toppart;
 
+  /* Validate callback is provided */
+  if(!append)
+    return (int)CURLE_BAD_FUNCTION_ARGUMENT;
+
   Curl_mime_initpart(&toppart); /* default form is empty */
   result = Curl_getformdata(NULL, &toppart, form, NULL);
   if(!result)


### PR DESCRIPTION
curl_formget() accepts a user-provided callback function but does not validate it is non-NULL before calling it. If a caller passes NULL, the function will crash with SIGSEGV.

Add NULL check at the start of the function to return an appropriate error code instead of crashing.