### PR TITLE
Add a note about "--compressed" to the binary output terminal warning

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -313,7 +313,9 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     if(memchr(buffer, 0, bytes)) {
       warnf("Binary output can mess up your terminal. "
             "Use \"--output -\" to tell curl to output it to your terminal "
-            "anyway, or consider \"--output <FILE>\" to save to a file.");
+            "anyway, or consider \"--output <FILE>\" to save to a file."
+            "If the output may be compressed, use \"--compressed\" to tell"
+            "curl to decompress it");
       config->synthetic_error = TRUE;
       return CURL_WRITEFUNC_ERROR;
     }


### PR DESCRIPTION
I recently encountered the

> Binary output can mess up your terminal.

warning where I didn't expect it and - seeking for help - a co-worker noted "oh yeah, you need to add --compressed to the command" which did indeed fix the output for me.

So I thought it would be really neat to actually add that tip to the warning that is displayed. That definitely would have saved me some time, at least. And in a quick search I found https://github.com/curl/curl/issues/2062 so it seems at the very least I'm not the only person getting binary output unexpectedly.

So here's a quick PR that just adds a little note to the warning message. Note that this is my first time contributing here, so please let me know if I did anything wrong.