### PR TITLE
hostcheck: fail wildcard match if host starts with a dot

### DIFF
--- a/lib/vtls/hostcheck.c
+++ b/lib/vtls/hostcheck.c
@@ -92,8 +92,8 @@ static bool hostmatch(const char *hostname,
   if(strncmp(pattern, "*.", 2))
     return pmatch(hostname, hostlen, pattern, patternlen);
 
-  /* detect IP address as hostname and fail the match if so */
-  else if(Curl_host_is_ipnum(hostname))
+  /* detect host as IP address or starting with a dot and fail if so */
+  else if(Curl_host_is_ipnum(hostname) || (hostname[0] == '.'))
     return FALSE;
 
   /* We require at least 2 dots in the pattern to avoid too wide wildcard

--- a/tests/unit/unit1397.c
+++ b/tests/unit/unit1397.c
@@ -39,6 +39,8 @@ static CURLcode test_unit1397(const char *arg)
   };
 
   static const struct testcase tests[] = {
+    {".hello.com", "*.hello.com", FALSE },
+    {"a.hello.com", "*.hello.com", TRUE },
     { "", "", FALSE },
     { "a", "", FALSE },
     { "", "b", FALSE },


### PR DESCRIPTION
A hostname cannot start with a dot when DNS is used, but there are other ways.

Amend unit test 1397