### PR TITLE
test1475: Consistently use %CR in headers

### DIFF
--- a/tests/data/test1475
+++ b/tests/data/test1475
@@ -15,7 +15,7 @@ Resume
 HTTP/1.1 416 Invalid range%CR
 Connection: close%CR
 Content-Length: 0%CR
-Content-Range: */100
+Content-Range: */100%CR
 %CR
 </data>
 
@@ -35,7 +35,7 @@ Content-Range: */100
 HTTP/1.1 416 Invalid range%CR
 Connection: close%CR
 Content-Length: 0%CR
-Content-Range: */100
+Content-Range: */100%CR
 %CR
 </datacheck>
 


### PR DESCRIPTION
Gets the test working when using Privoxy as proxy.