### PR TITLE
tidy-up: URLs

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ GIT
 
   To download the latest source code off the GIT server, do this:
 
-    git clone https://github.com/curl/curl.git
+    git clone https://github.com/curl/curl
 
   (you will get a directory named curl created, filled with the source code)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Visit the [curl website](https://curl.se/) for the latest news and downloads.
 
 Download the latest source from the Git server:
 
-    git clone https://github.com/curl/curl.git
+    git clone https://github.com/curl/curl
 
 ## Security problems
 

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -289,7 +289,7 @@ Just ask if this is what you would want. You are required to have posted
 several high quality patches first, before you can be granted push access.
 
 ## Useful resources
- - [Webinar on getting code into curl](https://www.youtube.com/watch?v=QmZ3W1d6LQI)
+ - [Webinar on getting code into curl](https://youtu.be/QmZ3W1d6LQI)
 
 # Update copyright and license information
 

--- a/docs/DISTROS.md
+++ b/docs/DISTROS.md
@@ -256,7 +256,7 @@ can also be used on other distributions
 ## Rocky Linux
 
 - curl: https://git.rockylinux.org/staging/rpms/curl/-/blob/r9/SPECS/curl.spec
-- curl issues: https://bugs.rockylinux.org
+- curl issues: https://bugs.rockylinux.org/
 - curl patches: https://git.rockylinux.org/staging/rpms/curl/-/tree/r9/SOURCES
 
 ## SerenityOS

--- a/docs/ECH.md
+++ b/docs/ECH.md
@@ -77,7 +77,7 @@ The above works for these test sites:
 ```sh
 https://defo.ie/ech-check.php
 https://crypto.cloudflare.com/cdn-cgi/trace
-https://tls-ech.dev
+https://tls-ech.dev/
 ```
 
 The list above has 4 different server technologies, implemented by 3 different

--- a/docs/FAQ
+++ b/docs/FAQ
@@ -1043,7 +1043,7 @@ FAQ
   you will find that even if D:\blah.txt does exist, curl returns a 'file
   not found' error.
 
-  According to RFC 1738 (https://www.ietf.org/rfc/rfc1738.txt),
+  According to RFC 1738 (https://datatracker.ietf.org/doc/html/rfc1738),
   file:// URLs must contain a host component, but it is ignored by
   most implementations. In the above example, 'D:' is treated as the
   host component, and is taken away. Thus, curl tries to open '/blah.txt'.

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -140,7 +140,7 @@ Build curl:
 
 Build GnuTLS:
 
-     % git clone --depth 1 https://gitlab.com/gnutls/gnutls.git
+     % git clone --depth 1 https://gitlab.com/gnutls/gnutls
      % cd gnutls
      % ./bootstrap
      % ./configure --prefix=<somewhere1>
@@ -182,7 +182,7 @@ Build curl:
 
 Build wolfSSL:
 
-     % git clone https://github.com/wolfSSL/wolfssl.git
+     % git clone https://github.com/wolfSSL/wolfssl
      % cd wolfssl
      % autoreconf -fi
      % ./configure --prefix=<somewhere1> --enable-quic --enable-session-ticket --enable-earlydata --enable-psk --enable-harden --enable-altcertchains
@@ -386,7 +386,7 @@ above.
 
 Get, build and install nghttp2:
 
-     % git clone https://github.com/nghttp2/nghttp2.git
+     % git clone https://github.com/nghttp2/nghttp2
      % cd nghttp2
      % autoreconf -fi
      % PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/home/daniel/build-quictls/lib/pkgconfig:/home/daniel/build-nghttp3/lib/pkgconfig:/home/daniel/build-ngtcp2/lib/pkgconfig LDFLAGS=-L/home/daniel/build-quictls/lib CFLAGS=-I/home/daniel/build-quictls/include ./configure --enable-maintainer-mode --prefix=/home/daniel/build-nghttp2 --disable-shared --enable-app --enable-http3 --without-jemalloc --without-libxml2 --without-systemd

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -18,7 +18,7 @@ libcurl from [source code](https://curl.se/download.html).
 You can download and install curl and libcurl using
 the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 
-    git clone https://github.com/Microsoft/vcpkg.git
+    git clone https://github.com/Microsoft/vcpkg
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
@@ -244,7 +244,7 @@ Either run setup-x86_64.exe, then search and select packages individually, or tr
     setup-x86_64.exe -P binutils -P gcc-core -P libpsl-devel -P libtool -P perl -P make
 
 If the latter, matching packages should appear in the install rows (*is fickle though*) after selecting
-the download site i.e. `https://mirrors.kernel.org`. In either case, follow the GUI prompts
+the download site i.e. `https://mirrors.kernel.org/`. In either case, follow the GUI prompts
 until you reach the "Select Packages" window; then select packages, click next, and finish
 the `cygwin` package installation.
 

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -321,6 +321,8 @@ problems may have been fixed or changed somewhat since this was written.
 
 6.5 NTLM does not support password with Unicode 'SECTION SIGN' character
 
+ Code point: U+00A7
+
  https://en.wikipedia.org/wiki/Section_sign
  https://github.com/curl/curl/issues/2120
 

--- a/docs/TODO
+++ b/docs/TODO
@@ -771,7 +771,7 @@
 
  DNS-Based Authentication of Named Entities (DANE) is a way to provide SSL
  keys and certs over DNS using DNSSEC as an alternative to the CA model.
- https://www.rfc-editor.org/rfc/rfc6698.txt
+ https://datatracker.ietf.org/doc/html/rfc6698
 
  An initial patch was posted by Suresh Krishnaswamy on March 7th 2013
  (https://curl.se/mail/lib-2013-03/0075.html) but it was a too simple

--- a/docs/testcurl.md
+++ b/docs/testcurl.md
@@ -102,7 +102,7 @@ snapshots automatically):
 
     $ mkdir curl-testing
     $ cd curl-testing
-    $ git clone https://github.com/curl/curl.git
+    $ git clone https://github.com/curl/curl
 
 With the curl sources checked out, or downloaded, you can start testing right
 away. If you want to use *testcurl* without command line arguments and to have


### PR DESCRIPTION
- to avoid dupes.
- missing slashes.
- drop `.git` suffix from GitHub git repo URLs for a few outliers.
- use short YouTube URL like curl-www does.
- sync two RFC doc URLs with others.
