### PR TITLE
curl_setup.h: fix `FMT_SOCKET_T` to be unsigned on Windows

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -519,9 +519,13 @@
 #endif
 
 #if SIZEOF_CURL_SOCKET_T < 8
+#ifdef _WIN32
+#  define FMT_SOCKET_T "u"
+#else
 #  define FMT_SOCKET_T "d"
-#elif defined(__MINGW32__)
-#  define FMT_SOCKET_T "zd"
+#endif
+#elif defined(_WIN32)
+#  define FMT_SOCKET_T "zu"
 #else
 #  define FMT_SOCKET_T "qd"
 #endif


### PR DESCRIPTION
To match the Windows socket type.

Ref: https://learn.microsoft.com/windows/win32/winsock/socket-data-type-2

Cherry-picked from #18343
