### PR TITLE
pytest: socksd startup delay

### DIFF
--- a/tests/http/test_40_socks.py
+++ b/tests/http/test_40_socks.py
@@ -26,6 +26,7 @@
 #
 import logging
 import os
+import time
 from typing import Generator
 import pytest
 
@@ -42,6 +43,7 @@ class TestSocks:
     def danted(self, env: Env) -> Generator[Dante, None, None]:
         danted = Dante(env=env)
         assert danted.initial_start()
+        time.sleep(1)
         yield danted
         danted.stop()
 


### PR DESCRIPTION
Add a small delay after the startup of the danted socks daemon to give it more time to become responsive.