### PR TITLE
GHA/windows: re-enable `taskkill`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,6 @@ permissions: {}
 
 env:
   CURL_CI: github
-  CURL_TEST_NO_TASKKILL: '1'
 
 jobs:
   cygwin:


### PR DESCRIPTION
Nothing conclusive for the last ~30 days when `taskkill` was made
a no-op. Jobs remained flaky with all known failure modes. Sometimes
they finish green on the first run, sometimes they fail. Hard to say
more without comparing detailed stats for this period and the
preceding (or upcoming) one.

In almost all runs, the PID to be killed did not exist at the time of
check.

Follow-up to 2701ac6a4d16a62130dad05be1c484903b8545c7 #19421
