### PR TITLE
configure: delete unused variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4066,7 +4066,6 @@ CPPFLAGS=$o
 AC_CHECK_TYPE(long long,
   [AC_DEFINE(HAVE_LONGLONG, 1,
     [Define to 1 if the compiler supports the 'long long' data type.])]
-  longlong="yes"
 )
 
 if test ${ac_cv_sizeof_curl_off_t} -lt 8; then


### PR DESCRIPTION
Follow-up to 4d73854462f30948acab12984b611e9e33ee41e6 #9044