### PR TITLE
DEPRECATE: add CMake <3.18 deprecation for April 2026

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -54,6 +54,8 @@ Support for RTMP in libcurl gets removed in April 2026.
 
 We remove support for CMake <3.18 in April 2026.
 
+CMake 3.18 was released on 2020-07-15.
+
 ## Past removals
 
  - axTLS (removed in 7.63.0)


### PR DESCRIPTION
CMake 3.18 was released on 2020-07-15.

It enables using (and/or dropping workarounds) for these features:
LTO support, better performance and pkg-config support, `OBJECT` target,
`-S`, `-B`, `--verbose`, `--install` on the command-line, lib directory
support in interface targets, target_link_options(), LINK_OPTIONS,
FetchContent, `list(PREPEND ...)`, unity, Ninja, fixed imported global
issues.

Ref: https://github.com/curl/curl/discussions/18704
