### PR TITLE
mdlinkcheck: add --dry-run to only show all found URLs

### DIFF
--- a/scripts/mdlinkcheck
+++ b/scripts/mdlinkcheck
@@ -85,8 +85,9 @@ my %url;
 my %flink;
 
 my $dry;
-if($ARGV[0] eq "--dry-run") {
+if(defined $ARGV[0] && $ARGV[0] eq "--dry-run") {
     $dry = 1;
+    shift @ARGV;
 }
 
 # list all files to scan for links


### PR DESCRIPTION
- remove the debug tracing leftovers from d9d2e339ced3fa02 that made exit unconditonally