### PR TITLE
pytest: quiche flakiness

### DIFF
--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -60,6 +60,9 @@ class TestErrors:
     def test_05_02_partial_20(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip("openssl-quic is flaky in yielding proper error codes")
+        if proto == 'h3' and env.curl_uses_lib('quiche') and \
+                not env.curl_lib_version_at_least('quiche', '0.24.5'):
+            pytest.skip("quiche issue #2277 not fixed")
         count = 20
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -107,8 +107,9 @@ class TestAuth:
             '--basic', '--user', f'test:{password}',
             '--trace-config', 'http/2,http/3'
         ])
-        # but apache denies on length limit
-        r.check_response(http_status=431)
+        # but apache either denies on length limit or gives a 400
+        r.check_exit_code(0)
+        assert r.stats[0]['http_code'] in [400, 431]
 
     # PUT data, basic auth with very large pw
     @pytest.mark.parametrize("proto", Env.http_mplx_protos())

--- a/tests/http/testenv/nghttpx.py
+++ b/tests/http/testenv/nghttpx.py
@@ -247,7 +247,6 @@ class NghttpxQuic(Nghttpx):
                 '--frontend-quic-early-data',
             ])
         args.extend([
-            f'--backend=127.0.0.1,{self.env.https_port};{self._domain};sni={self._domain};proto=h2;tls',
             f'--backend=127.0.0.1,{self.env.http_port}',
             '--log-level=ERROR',
             f'--pid-file={self._pid_file}',


### PR DESCRIPTION
Let nhttpx only use http/1.1 to backend. This reproduces the bug in quiche with higher frequency. Allow test_14_05 to now return a 400 in addition to the 431 we get from a h2 backend to nghttpx.

Skip test_05_02 in h3 on quiche not newer than version 0.24.4 in which its bug is fixed (https://github.com/cloudflare/quiche/pull/2278)