### PR TITLE
GHA/checkurls: add dry run on push

### DIFF
--- a/.github/workflows/checkurls.yml
+++ b/.github/workflows/checkurls.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 'mdlinkcheck'
-        if: ${{ github.event_name == 'schedule' }}
-        run: ./scripts/mdlinkcheck
-
       - name: 'mdlinkcheck (dry run)'
         if: ${{ github.event_name != 'schedule' }}
         run: ./scripts/mdlinkcheck --dry-run
+
+      - name: 'mdlinkcheck'
+        if: ${{ github.event_name == 'schedule' }}
+        run: ./scripts/mdlinkcheck


### PR DESCRIPTION
To verify if the basics work.

Downside is that the scheduled (live) runs are intermixed with the dry
runs and less obvious to find in the default list:
https://github.com/curl/curl/actions/workflows/checkurls.yml

This URL filters for scheduled runs only:
https://github.com/curl/curl/actions/workflows/checkurls.yml?query=event%3Aschedule

Seems fine, because we're only interested in the red runs.
