### PR TITLE
ldap: drop PP logic for old, unsupported, Windows SDKs

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -71,7 +71,7 @@
 #  include <lber.h>
 # endif
 # include <ldap.h>
-# if (defined(HAVE_LDAP_SSL) && defined(HAVE_LDAP_SSL_H))
+# if defined(HAVE_LDAP_SSL) && defined(HAVE_LDAP_SSL_H)
 #  include <ldap_ssl.h>
 # endif /* HAVE_LDAP_SSL && HAVE_LDAP_SSL_H */
 #endif


### PR DESCRIPTION
`LDAP_VENDOR_NAME` and `winber.h` are available in all supported
MS SDK and mingw-w64 versions. Stop checking for them.

Also drop redundant parenthesis in PP expression.
