### PR TITLE
config-win32.h: drop unused/obsolete `CURL_HAS_OPENLDAP_LDAPSDK`

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -353,10 +353,7 @@
 /*                           LDAP SUPPORT                           */
 /* ---------------------------------------------------------------- */
 
-#ifdef CURL_HAS_OPENLDAP_LDAPSDK
-#undef USE_WIN32_LDAP
-#define HAVE_LDAP_URL_PARSE 1
-#elif !defined(CURL_WINDOWS_UWP)
+#ifndef CURL_WINDOWS_UWP
 #undef HAVE_LDAP_URL_PARSE
 #define HAVE_LDAP_SSL 1
 #define USE_WIN32_LDAP 1


### PR DESCRIPTION
Meant for use from `Makefile.mk`. The suggested replacement is CMake or
autotools.

Follow-up to ba8752e5566076acc8bdec7ae4ec78901f7050f4 #12224
