### PR TITLE
quiche: fix version for skip due to flakiness

### DIFF
--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -61,7 +61,7 @@ class TestErrors:
         if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip("openssl-quic is flaky in yielding proper error codes")
         if proto == 'h3' and env.curl_uses_lib('quiche') and \
-                not env.curl_lib_version_at_least('quiche', '0.24.5'):
+                not env.curl_lib_version_at_least('quiche', '0.24.7'):
             pytest.skip("quiche issue #2277 not fixed")
         count = 20
         curl = CurlClient(env=env)


### PR DESCRIPTION
0.24.6 is the quiche version without the fix for proper handling fo RESET streams. Require a verion higher than that to run test_05_02.