### PR TITLE
autotools: fix LargeFile feature display on Windows (after prev patch)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5317,7 +5317,7 @@ fi
 
 if test ${ac_cv_sizeof_curl_off_t} -gt 4; then
   if test ${ac_cv_sizeof_off_t} -gt 4 -o \
-     test "$curl_cv_native_windows" = "yes"; then
+     "$curl_cv_native_windows" = "yes"; then
     SUPPORT_FEATURES="$SUPPORT_FEATURES Largefile"
   fi
 fi


### PR DESCRIPTION
Always show it on Windows, regardless of the `--disable-largefile`
build option.

Follow-up to 163705db756557e6c07ac9386663f0576ebfd64e #19888
