### PR TITLE
runtests: drop `notxml` keyword, verify all test data files as XML

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -139,8 +139,8 @@ jobs:
       - name: 'check'
         run: |
           {
-            git grep -z -i -l -E '^<\?xml' || true
-            git grep -z -L -F 'notxml' 'tests/data/test*' || true
+            git grep -i -l -E '^<\?xml' -z || true
+            git ls-files 'tests/data/test*' -z || true
           } | xargs -0 -r xmllint >/dev/null
 
   miscchecks:

--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -257,11 +257,6 @@ often run on overloaded machines with unpredictable timing.
 Tests using non-7-bit-ASCII characters must provide them with `%hex[]` or
 similar.
 
-In most cases test files comply with the XML format, and pass xmllint cleanly.
-If the data file uses the `&` character, or has other, non-compliant content,
-and making it XML-compliant is not possible or unpractical, use the `notxml`
-keyword to exclude it from linter checks.
-
 ## `<reply>`
 
 ### `<data [nocheck="yes"] [sendzero="yes"] [hex="yes"] [nonewline="yes"] [crlf="yes|headers"]>`


### PR DESCRIPTION
Follow-up to 7f3731ce142c1d74023abad183cc8ce0fd527fab #19595
