### PR TITLE
autotools: drop reference to deleted `CURL_CHECK_CURLDEBUG`

### DIFF
--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -73,7 +73,6 @@ dnl --enable-ares or --disable-ares, and
 dnl set shell variable want_ares as appropriate.
 
 AC_DEFUN([CURL_CHECK_OPTION_ARES], [
-dnl   AC_BEFORE([$0],[CURL_CHECK_OPTION_THREADS])dnl
   AC_BEFORE([$0],[CURL_CHECK_LIB_ARES])dnl
   AC_MSG_CHECKING([whether to enable c-ares for DNS lookups])
   OPT_ARES="default"
@@ -109,7 +108,6 @@ dnl --enable-curldebug or --disable-curldebug, and set
 dnl shell variable want_curldebug value as appropriate.
 
 AC_DEFUN([CURL_CHECK_OPTION_CURLDEBUG], [
-  AC_BEFORE([$0],[CURL_CHECK_CURLDEBUG])dnl
   AC_MSG_CHECKING([whether to enable curl debug memory tracking])
   OPT_CURLDEBUG_BUILD="default"
   AC_ARG_ENABLE(curldebug,


### PR DESCRIPTION
The referred function has been deleted earlier.

Also:
- drop commented reference to deleted `CURL_CHECK_OPTION_THREADS`.
  0d4fdbf15d8eec908b3e63b606f112b18a63015e #16054

Follow-up to 96a1a05f662677af64b16d862c4126ed52ea4b30 #14096
