### PR TITLE
test1165: drop reference to deleted `CURL_DISABLE_TESTS`

### DIFF
--- a/tests/test1165.pl
+++ b/tests/test1165.pl
@@ -70,7 +70,7 @@ sub scanconf_cmake {
     while(<S>) {
         if(/(CURL_DISABLE_[A-Z0-9_]+)/g) {
             my ($sym)=($1);
-            if(not $sym =~ /^(CURL_DISABLE_INSTALL|CURL_DISABLE_TESTS|CURL_DISABLE_SRP)$/) {
+            if(not $sym =~ /^(CURL_DISABLE_INSTALL|CURL_DISABLE_SRP)$/) {
                 $hashr->{$sym} = 1;
             }
         }


### PR DESCRIPTION
Follow-up to bf823397bad09791277e983e44e8f0edc3c089b2 #16134