### PR TITLE
test3214: allow a larger struct Curl_easy

### DIFF
--- a/tests/unit/unit3214.c
+++ b/tests/unit/unit3214.c
@@ -41,7 +41,7 @@ static void checksize(const char *name, size_t size, size_t allowed)
 }
 
 /* the maximum sizes we allow specific structs to grow to */
-#define MAX_CURL_EASY           5800
+#define MAX_CURL_EASY           5850
 #define MAX_CONNECTDATA         1300
 #define MAX_CURL_MULTI          850
 #define MAX_CURL_HTTPPOST       112


### PR DESCRIPTION
In my local build it is now 5840 bytes.