### PR TITLE
mdlinkcheck: only look for markdown links in markdown files

### DIFF
--- a/scripts/mdlinkcheck
+++ b/scripts/mdlinkcheck
@@ -159,7 +159,7 @@ sub findlinks {
         return;
 
     # is it a markdown extension?
-    my $md = ($f =~ /\.md$/);
+    my $md = ($f =~ /\.md$/i);
 
     while(<F>) {
         chomp;


### PR DESCRIPTION
It finds debug outputs in source code otherwise.

Output the whitelist "warnings" to stderr to better allow us to count URLs with `./mdlinkcheck --dry-run | wc -l`.