### PR TITLE
test567: add a header separating CRLF

### DIFF
--- a/tests/data/test567
+++ b/tests/data/test567
@@ -16,6 +16,7 @@ Server: RTSPD/libcurl-test
 CSeq: 1
 Public: DESCRIBE, OPTIONS, SETUP, TEARDOWN, PLAY, PAUSE
 Curl-Private: swsclose
+
 </data>
 </reply>
 


### PR DESCRIPTION
To make it a valid response.