### PR TITLE
renovate: leave bumping GitHub Actions to Dependabot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,15 +7,6 @@
   "semanticCommitType": "ci",
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "commitMessagePrefix": "GHA: ",
-      "labels": [
-        "CI"
-      ]
-    },
-    {
       "matchUpdateTypes": [
         "pin",
         "pinDigest",
@@ -47,7 +38,6 @@
     {
       "description": "Schedule package updates on the 10th of each month",
       "matchPackageNames": [
-        "/codeql/i",
         "/ruff/i"
       ],
       "groupName": "monthly updates by name",


### PR DESCRIPTION
To avoid update noise. Renovate bumps everything instantly, meaning
a major version a couple hours after release, then all minor bugfix
releases throughout the next 1-2 days. Also putting major versions in
a different group than the bugfix release, and there is no support for
a cooldown period.

After this patch GitHub's Dependabot remains the single tool responsible
to bump GitHub Actions, once a month, grouped, with a cooldown period.
In sync with most other curl repos.

Both Renovate and Dependabot keep bumping pinned pips for now. Also
Renovate keeps updating C dependencies and Dockerfile.

---

Dependabot can be run manually if there is an important update we'd
like to do out of the monthly schedule.