### PR TITLE
GHA/checksrc: fix `-z` position, also use `--output` with `xmllint`

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -135,7 +135,7 @@ jobs:
           persist-credentials: false
 
       - name: 'check'
-        run: git grep -i -l -E '^<\?xml' -z | xargs -0 -r xmllint >/dev/null
+        run: git grep -z -i -l -E '^<\?xml' | xargs -0 -r xmllint --output /dev/null
 
   miscchecks:
     name: 'misc checks'


### PR DESCRIPTION
Fixing:
```
fatal: option '-z' must come before non-option arguments
```
Ref: https://github.com/curl/curl/actions/runs/20183280533/job/57948203944#step:4:5

Follow-up to b5ea0736bbeeae717925d8eccbdb15057d8e88e9 #19946
