### PR TITLE
tool_urlglob: support globs as long as config line lengths

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -38,6 +38,8 @@
 #endif
 #endif
 
+#define MAX_CONFIG_LINE_LENGTH (10*1024*1024)
+
 #define checkprefix(a, b) curl_strnequal(b, STRCONST(a))
 
 #define tool_safefree(ptr) \

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -77,8 +77,6 @@ static int unslashquote(const char *line, struct dynbuf *param)
   return 0; /* ok */
 }
 
-#define MAX_CONFIG_LINE_LENGTH (10*1024*1024)
-
 /* return 0 on everything-is-fine, and non-zero otherwise */
 ParameterError parseconfig(const char *filename, int max_recursive,
                            char **resolved)

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -500,7 +500,7 @@ CURLcode glob_url(struct URLGlob *glob, char *url, curl_off_t *urlnum,
   CURLcode res;
 
   memset(glob, 0, sizeof(struct URLGlob));
-  curlx_dyn_init(&glob->buf, 1024 * 1024);
+  curlx_dyn_init(&glob->buf, MAX_CONFIG_LINE_LENGTH);
   glob->pattern = curlx_malloc(2 * sizeof(struct URLPattern));
   if(!glob->pattern)
     return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
libcurl supports up to 8MB string inputs, the config file accepts up to 10MB line lengths. It did not make sense to limit the globs to a maximum of one megabyte.