### PR TITLE
synctime: tidy up, make it work on all platforms

### DIFF
--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -64,15 +64,12 @@
 #endif
 
 #include <stdio.h>
+#include <string.h>
+#include <time.h>
 
-#ifndef _WIN32
-int main(void)
-{
-  printf("Platform not supported.\n");
-  return 1;
-}
-#else
+#include <curl/curl.h>
 
+#ifdef _WIN32
 #if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
   defined(WINAPI_FAMILY)
 #  include <winapifamily.h>
@@ -80,41 +77,27 @@ int main(void)
      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #    define CURL_WINDOWS_UWP
 #  endif
-#endif
-
-#ifdef CURL_WINDOWS_UWP
-int main(void)
-{
-  printf("Platform not supported.\n");
-  return 1;
-}
-#else
-
-#include <time.h>
-
-#include <curl/curl.h>
-
 #include <windows.h>
+#endif
+#endif
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf
 #endif
 
-#define MAX_STRING  256
-#define MAX_STRING1 (MAX_STRING + 1)
-
 #define SYNCTIME_UA "synctime/1.0"
 
 struct conf {
-  char http_proxy[MAX_STRING1];
-  char proxy_user[MAX_STRING1];
-  char timeserver[MAX_STRING1];
+  char http_proxy[256];
+  char proxy_user[256];
+  char timeserver[256];
 };
 
-static const char DefaultTimeServer[3][MAX_STRING1] = {
-  "https://nist.time.gov/",
-  "https://www.google.com/"
-};
+static int ShowAllHeader;
+static int AutoSyncTime;
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
+static SYSTEMTIME SYSTime;
+static SYSTEMTIME LOCALTime;
 
 static const char *DayStr[] = {
   "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
@@ -123,11 +106,7 @@ static const char *MthStr[] = {
   "Jan", "Feb", "Mar", "Apr", "May", "Jun",
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 };
-
-static int ShowAllHeader;
-static int AutoSyncTime;
-static SYSTEMTIME SYSTime;
-static SYSTEMTIME LOCALTime;
+#endif
 
 #define HTTP_COMMAND_HEAD 0
 #define HTTP_COMMAND_GET  1
@@ -142,8 +121,6 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 static size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
                                         void *stream)
 {
-  char TmpStr1[26], TmpStr2[26];
-
   (void)stream;
 
   if(ShowAllHeader == 1)
@@ -154,6 +131,8 @@ static size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
       fprintf(stderr, "HTTP Server. %.*s", (int)nmemb, (char *)ptr);
 
     if(AutoSyncTime == 1) {
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
+      char TmpStr1[26], TmpStr2[26];
       int RetVal = 0;
       char *field = ptr;
       *TmpStr1 = 0;
@@ -180,6 +159,7 @@ static size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
       else {
         AutoSyncTime = 0;  /* Error in sscanf() fields conversion */
       }
+#endif
     }
   }
 
@@ -223,7 +203,7 @@ static CURLcode SyncTime_CURL_Fetch(CURL *curl, const char *URL_Str,
   res = curl_easy_perform(curl);
   if(outfile)
     fclose(outfile);
-  return res; /* (CURLE_OK) */
+  return res; /* CURLE_OK */
 }
 
 static void showUsage(void)
@@ -246,34 +226,25 @@ static void showUsage(void)
   return;
 }
 
-static int conf_init(struct conf *conf)
-{
-  int i;
-
-  *conf->http_proxy = 0;
-  for(i = 0; i < MAX_STRING1; i++)
-    conf->proxy_user[i] = 0;  /* Clean up password from memory */
-  *conf->timeserver = 0;
-  return 1;
-}
-
 int main(int argc, char *argv[])
 {
   CURLcode res;
   CURL *curl;
-  struct conf conf[1];
+  struct conf conf;
   int RetValue;
 
   ShowAllHeader = 0;  /* Do not show HTTP Header */
   AutoSyncTime = 0;   /* Do not synchronise computer clock */
   RetValue = 0;       /* Successful Exit */
-  conf_init(conf);
+
+  memset(&conf, 0, sizeof(conf));
 
   if(argc > 1) {
     int OptionIndex = 1;
     while(OptionIndex < argc) {
       if(strncmp(argv[OptionIndex], "--server=", 9) == 0)
-        snprintf(conf->timeserver, MAX_STRING, "%s", &argv[OptionIndex][9]);
+        snprintf(conf.timeserver, sizeof(conf.timeserver) - 1, "%s",
+                 &argv[OptionIndex][9]);
 
       if(strcmp(argv[OptionIndex], "--showall") == 0)
         ShowAllHeader = 1;
@@ -282,10 +253,12 @@ int main(int argc, char *argv[])
         AutoSyncTime = 1;
 
       if(strncmp(argv[OptionIndex], "--proxy-user=", 13) == 0)
-        snprintf(conf->proxy_user, MAX_STRING, "%s", &argv[OptionIndex][13]);
+        snprintf(conf.proxy_user, sizeof(conf.proxy_user) - 1, "%s",
+                 &argv[OptionIndex][13]);
 
       if(strncmp(argv[OptionIndex], "--proxy=", 8) == 0)
-        snprintf(conf->http_proxy, MAX_STRING, "%s", &argv[OptionIndex][8]);
+        snprintf(conf.http_proxy, sizeof(conf.http_proxy) - 1, "%s",
+                 &argv[OptionIndex][8]);
 
       if((strcmp(argv[OptionIndex], "--help") == 0) ||
          (strcmp(argv[OptionIndex], "/?") == 0)) {
@@ -296,8 +269,9 @@ int main(int argc, char *argv[])
     }
   }
 
-  if(*conf->timeserver == 0)  /* Use default server for time information */
-    snprintf(conf->timeserver, MAX_STRING, "%s", DefaultTimeServer[0]);
+  if(*conf.timeserver == 0)  /* Use default server for time information */
+    snprintf(conf.timeserver, sizeof(conf.timeserver) - 1, "%s",
+             "https://www.ntp.org/");
 
   /* Init CURL before usage */
   res = curl_global_init(CURL_GLOBAL_ALL);
@@ -316,7 +290,7 @@ int main(int argc, char *argv[])
     char timeBuf[61];
     char tzoneBuf[16];
 
-    SyncTime_CURL_Init(curl, conf->http_proxy, conf->proxy_user);
+    SyncTime_CURL_Init(curl, conf.http_proxy, conf.proxy_user);
 
     /* Calculating time diff between GMT and localtime */
     tt       = time(0);
@@ -332,6 +306,7 @@ int main(int argc, char *argv[])
     else
       snprintf(tzoneBuf, sizeof(tzoneBuf), "%+03d'30'", tzonediffWord);
 
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
     /* Get current system time and local time */
     GetSystemTime(&SYSTime);
     GetLocalTime(&LOCALTime);
@@ -339,14 +314,15 @@ int main(int argc, char *argv[])
              DayStr[LOCALTime.wDayOfWeek], LOCALTime.wDay,
              MthStr[LOCALTime.wMonth - 1], LOCALTime.wYear, LOCALTime.wHour,
              LOCALTime.wMinute, LOCALTime.wSecond, LOCALTime.wMilliseconds);
+#endif
 
-    fprintf(stderr, "Fetch: %s\n\n", conf->timeserver);
+    fprintf(stderr, "Fetch: %s\n\n", conf.timeserver);
     fprintf(stderr, "Before HTTP. Date: %s%s\n\n", timeBuf, tzoneBuf);
 
     /* HTTP HEAD command to the Webserver */
-    SyncTime_CURL_Fetch(curl, conf->timeserver, "index.htm",
-                        HTTP_COMMAND_HEAD);
+    SyncTime_CURL_Fetch(curl, conf.timeserver, "index.htm", HTTP_COMMAND_HEAD);
 
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
     GetLocalTime(&LOCALTime);
     snprintf(timeBuf, 60, "%s, %02d %s %04d %02d:%02d:%02d.%03d, ",
              DayStr[LOCALTime.wDayOfWeek], LOCALTime.wDay,
@@ -371,9 +347,10 @@ int main(int argc, char *argv[])
         fprintf(stderr, "\nNew System's Date: %s%s\n", timeBuf, tzoneBuf);
       }
     }
+#endif
 
     /* Cleanup before exit */
-    conf_init(conf);
+    memset(&conf, 0, sizeof(conf));
     curl_easy_cleanup(curl);
   }
 
@@ -381,5 +358,3 @@ int main(int argc, char *argv[])
 
   return RetValue;
 }
-#endif /* CURL_WINDOWS_UWP */
-#endif /* _WIN32 */


### PR DESCRIPTION
The `--synctime` option remains non-UWP-Windows-specific.

Also:
- replace default URL with `ntp.org`.
- delete unused example URL.

---

`ntp.org`'s web server is used, which is of course not meant
to pull a precise time from, but fit to use as an example.