### PR TITLE
tidy-up: replace banned `printf()` with `puts()`

### DIFF
--- a/src/curlinfo.c
+++ b/src/curlinfo.c
@@ -253,8 +253,7 @@ int main(int argc, char **argv)
   (void)argv;
 
   for(i = 0; i < CURL_ARRAYSIZE(disabled); i++)
-    /* !checksrc! disable BANNEDFUNC 1 */
-    printf("%s\n", disabled[i]);
+    puts(disabled[i]);
 
   return 0;
 }

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -27,7 +27,9 @@
 int main(int argc, char **argv)
 {
   (void)argc;
-  /* !checksrc! disable BANNEDFUNC 1 */
-  printf("libcurl test: |%s|%s|\n", argv[0], curl_version());
+  puts("libcurl test:");
+  puts(argv[0]);
+  puts(curl_version());
+  puts("---");
   return 0;
 }


### PR DESCRIPTION
In `curlinfo` and CMake integration test app.
