### PR TITLE
renovate: try bumping Fil-C on releases, not tags

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,7 +58,7 @@ env:
   OPENLDAP_VERSION: 2.6.10
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
   NGHTTP2_VERSION: 1.68.0
-  # renovate: datasource=github-tags depName=pizlonator/fil-c versioning=semver-coerced registryUrl=https://github.com
+  # renovate: datasource=github-releases depName=pizlonator/fil-c versioning=semver-coerced registryUrl=https://github.com
   FIL_C_VERSION: 0.676
 
 jobs:


### PR DESCRIPTION
CI needs the binary packages attached to the release, which appears some
time after tagging. Hopefully this patch helps getting a clean build
by the time Renovate opens its PR.

Ref: https://docs.renovatebot.com/modules/datasource/github-releases/
Ref: #19905, #19974
