### PR TITLE
docs: fix time_posttransfer output unit as seconds

### DIFF
--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -245,8 +245,8 @@ The time, in seconds, it took from the start until the name resolving was
 completed.
 
 ## `time_posttransfer`
-The time it took from the start until the last byte is sent by libcurl.
-In microseconds. (Added in 8.10.0)
+The time, in seconds, it took from the start until the last byte is sent
+by libcurl. (Added in 8.10.0)
 
 ## `time_pretransfer`
 The time, in seconds, it took from the start until the file transfer was just

--- a/docs/libcurl/opts/CURLINFO_POSTTRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_POSTTRANSFER_TIME_T.md
@@ -53,7 +53,7 @@ int main(void)
       res = curl_easy_getinfo(curl, CURLINFO_POSTTRANSFER_TIME_T,
                               &posttransfer);
       if(CURLE_OK == res) {
-        printf("Request sent after: %" CURL_FORMAT_CURL_OFF_T ".%06ld us",
+        printf("Request sent after: %" CURL_FORMAT_CURL_OFF_T ".%06ld s",
                posttransfer / 1000000, (long)(posttransfer % 1000000));
       }
     }


### PR DESCRIPTION
In a couple of places in docs `time_posttransfer`'s output is mentioned as milliseconds while it is actually unit of seconds.