### PR TITLE
runtests: log the required minimum number of tests in CI

### DIFF
--- a/docs/runtests.md
+++ b/docs/runtests.md
@@ -98,7 +98,7 @@ Display test results in automake style output (`PASS/FAIL: [number] [name]`).
 
 ## `--buildinfo`
 
-Dump `buildinfo.txt`, and the minimum number of tests to run.
+Dump `buildinfo.txt`.
 
 ## `-c \<curl\>`
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -885,8 +885,8 @@ sub checksystemfeatures {
     if(system("diff $TESTDIR/DISABLED $TESTDIR/DISABLED 2>$dev_null") != 0) {
         logmsg "* diff: missing\n";
     }
-    if($buildinfo) {
-        logmsg "* Minimum: $mintotal\n";
+    if($mintotal) {
+        logmsg "* Min tests: $mintotal\n";
     }
 }
 
@@ -2534,7 +2534,7 @@ Usage: runtests.pl [options] [test selection(s)]
   -a       continue even if a test fails
   -ac path use this curl only to talk to APIs (currently only CI test APIs)
   -am      automake style output PASS/FAIL: [number] [name]
-  --buildinfo dump `buildinfo.txt`, and the minimum number of tests to run
+  --buildinfo dump buildinfo.txt
   -c path  use this curl executable
   -d       display server debug info
   -e, --test-event  event-based execution


### PR DESCRIPTION
For Test Clutch.

If set (via env or tflags), include the minimum number of tests required
in runtests' log output:
```
* Min tests: 1750
```

Follow-up to 3f1cd809eeae05f39fec72fe780f3a69d21972fb #19942
