### PR TITLE
cookie. return proper error on OOM

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1013,6 +1013,7 @@ Curl_cookie_add(struct Curl_easy *data,
   co = Curl_memdup(&comem, sizeof(comem));
   if(!co) {
     co = &comem;
+    result = CURLE_OUT_OF_MEMORY;
     goto fail; /* bail out if we are this low on memory */
   }
 


### PR DESCRIPTION
Follow-up to a78a07d3a9dc808a51