### PR TITLE
lib: create unitprotos.h in the builddir, not srcdir

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -165,7 +165,7 @@ UNITV_ = $(UNITV_0)
 
 # UNITPROTOS depends on every C file in the lib/ dir
 $(UNITPROTOS): $(CSOURCES)
-	$(UNIT_V)(cd $(srcdir) && @PERL@ ../scripts/extract-unit-protos $(CSOURCES) > $(top_builddir)/lib/$(UNITPROTOS))
+	$(UNIT_V)(cd $(srcdir) && @PERL@ ../scripts/extract-unit-protos $(CSOURCES)) > $(top_builddir)/lib/$(UNITPROTOS)
 
 # disable the tests that are mostly causing false positives
 TIDYFLAGS := -checks=-clang-analyzer-security.insecureAPI.bzero,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-optin.performance.Padding,-clang-analyzer-security.ArrayBound,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling -quiet


### PR DESCRIPTION
The make rule confused automake by changing directories before creating
the file, causing unitprotos.h to be created in the srcdir instead of
the builddir. This results in a stale file and confusing compile errors
in out-of-tree builds.

Fixes #19966
Closes #19993