### PR TITLE
tests: add a standard log line for alloc failures

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1763,6 +1763,7 @@ sub singletest_check {
             if($leak) {
                 logmsg "\n** MEMORY FAILURE\n";
                 logmsg @memdata;
+                logmsg " $testnum: memory FAILED\n";
                 # timestamp test result verification end
                 $timevrfyend{$testnum} = Time::HiRes::time();
                 return -1;
@@ -1801,6 +1802,7 @@ sub singletest_check {
             if($allocs > $lim_allocs) {
                 logmsg "\n** TOO MANY ALLOCS\n";
                 logmsg "$lim_allocs allocations allowed, did $allocs\n";
+                logmsg " $testnum: allocs FAILED\n";
                 # timestamp test result verification end
                 $timevrfyend{$testnum} = Time::HiRes::time();
                 return -1;
@@ -1808,6 +1810,7 @@ sub singletest_check {
             if($max > $lim_max) {
                 logmsg "\n** TOO MUCH TOTAL ALLOCATION\n";
                 logmsg "$lim_max maximum allocation allowed, did $max\n";
+                logmsg " $testnum: allocsize FAILED\n";
                 # timestamp test result verification end
                 $timevrfyend{$testnum} = Time::HiRes::time();
                 return -1;
@@ -1826,7 +1829,7 @@ sub singletest_check {
             my $fname = shift @notexists;
             chomp $fname;
             if(-e $fname) {
-                logmsg "Found '$fname' when not supposed to exist.\n";
+                logmsg "ERROR: Found '$fname' when not supposed to exist.\n";
                 $err++;
             }
             elsif($verbose) {


### PR DESCRIPTION
This type of test failure requires a test status line in order to be
consistent with other failures and to be parsed properly by Test Clutch.
This is the same style as an exit or postcheck failure.

Closes #19995