### PR TITLE
time-keeping: keep timestamp in multi

### DIFF
--- a/docs/internals/TIME-KEEPING.md
+++ b/docs/internals/TIME-KEEPING.md
@@ -11,10 +11,6 @@ time function is `curlx_now()` and it uses a **monotonic** clock on most platfor
 ensures that time only ever increases (the timestamps it gives are however not the "real"
 world clock).
 
-The simplest handling of transfer time would be to just always call `curlx_now()`. However
-there is a performance penalty to that - varying by platform - so this is not a desirable
-strategy. Processing thousands of transfers in a loop needs a smarter approach.
-
 ## Initial Approach (now historic)
 
 The loop processing functions called `curlx_now()` at the beginning and then passed
@@ -34,49 +30,16 @@ in the correct order: *queue -> nameloopup -> connect -> appconnect ->...*.)
 
 The strategy of handling transfer's time is now:
 
-* Keep a "now" timestamp in `data->progress.now`.
-* Perform time checks and event recording using `data->progress.now`.
-* Set `data->progress.now` at the start of API calls (e.g. `curl_multi_perform()`, etc.).
-* Set `data->progress.now` when recorded events happen (for precision).
-* Set `data->progress.now` on multi state changes.
-* Set `data->progress.now` in `pingpong` timeout handling, since `pingpong` is old and not always non-blocking.
+* Keep a "now" timestamp in the multi handle. Keep a fallback "now" timestamp in the easy handle.
+* Always use `Curl_pgrs_now(data)` to get the current time of a transfer.
+* Do not use `curlx_now()` directly for transfer handling (exceptions apply for loops).
 
-In addition to *setting* `data->progress.now` this timestamp can be *advanced* using 2 new methods:
+This has the following advantages:
 
-* `Curl_pgrs_now_at_least(data, &now)`: code that has a "now" timestamp can progress the `data`'s own "now" to be at least as new. If `data->progress.now` is already newer, no change is done. A transfer never goes **back**.
-* `Curl_pgrs_now_update(data1, data2)`: update the "now" in `data1` to be at least as new as the one in `data2`. If it already is newer, nothing changes.
+* No need to pass a `struct curltime` around or pass a pointer to an outdated timestamp to other functions.
+* No need to calculate the exact `now` until it is really used.
+* Passing a `const` pointer is better than struct passing. Updating and passing a pointer to the same memory location for all transfers is even better.
 
-### Time Advancing Loops
+Caveats:
 
-This advancing is used in the following way in loop like `curl_multi_perform()`:
-
-```C
-struct curltime now = curlx_now(); /* start of API call */
-forall data in transfers {
-  Curl_pgrs_set_at_least(data, now);
-  progress(data);   /* may update "now" */
-  now = data->progress.now;
-}
-```
-
-Transfers that update their "now" pass that timestamp to the next transfer processed.
-
-### Transfers triggering other transfers
-
-In HTTP/2 and HTTP/3 processing, incoming data causes actions on transfers other than
-the calling one. The protocols may receive data for any transfer on the connection and need
-to dispatch it:
-
-* a Close/Reset comes in for another transfer. That transfer is marked as "dirty", making sure it is processed in a timely manner.
-* Response Data arrives: this data is written out to the client. Before this is done, the "now" timestamp is updated via `Curl_pgrs_now_update(data, calling)` from the "calling" transfer.
-
-## Blocking Operations
-
-We still have places in `libcurl` where we do blocking operations. We should always use `Curl_pgrs_now_set(data)` afterwards since we cannot be sure how much time has passed. Since loop processing passed an updated "now" to the next transfer, a delay due to blocking is passed on.
-
-There are other places where we may lose track of time:
-
-* Cache/Pool Locks: no "now" updates happen after a lock has been acquired. These locks should not be kept for a longer time.
-* User Callbacks: no "now" updates happen after callbacks have been invoked. The expectation is that those do not take long.
-
-Should these assumptions prove wrong, we need to add updates.
+* do not store the pointer returned by `Curl_pgrs_now(data)` anywhere that outlives the current code invocation.

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -63,6 +63,7 @@
 #include "url.h"
 #include "multiif.h"
 #include "curl_threads.h"
+#include "progress.h"
 #include "select.h"
 
 #ifdef USE_ARES
@@ -442,7 +443,7 @@ static bool async_thrdd_init(struct Curl_easy *data,
 
   /* passing addr_ctx to the thread adds a reference */
   addr_ctx->ref_count = 2;
-  addr_ctx->start = data->progress.now;
+  addr_ctx->start = *Curl_pgrs_now(data);
 
 #ifdef HAVE_GETADDRINFO
   addr_ctx->thread_hnd = Curl_thread_create(getaddrinfo_thread, addr_ctx);
@@ -655,8 +656,8 @@ CURLcode Curl_async_is_resolved(struct Curl_easy *data,
   else {
     /* poll for name lookup done with exponential backoff up to 250ms */
     /* should be fine even if this converts to 32-bit */
-    timediff_t elapsed = curlx_timediff_ms(data->progress.now,
-                                           data->progress.t_startsingle);
+    timediff_t elapsed = curlx_ptimediff_ms(Curl_pgrs_now(data),
+                                            &data->progress.t_startsingle);
     if(elapsed < 0)
       elapsed = 0;
 
@@ -706,7 +707,8 @@ CURLcode Curl_async_pollset(struct Curl_easy *data, struct easy_pollset *ps)
     result = Curl_pollset_add_in(data, ps, thrdd->addr->sock_pair[0]);
 #else
     timediff_t milli;
-    timediff_t ms = curlx_timediff_ms(data->progress.now, thrdd->addr->start);
+    timediff_t ms =
+      curlx_ptimediff_ms(Curl_pgrs_now(data), &thrdd->addr->start);
     if(ms < 3)
       milli = 0;
     else if(ms <= 50)

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -35,6 +35,7 @@
 #include "multiif.h"
 #include "cf-https-connect.h"
 #include "http2.h"
+#include "progress.h"
 #include "select.h"
 #include "vquic/vquic.h"
 
@@ -149,7 +150,7 @@ static void cf_hc_baller_init(struct cf_hc_baller *b,
   struct Curl_cfilter *save = cf->next;
 
   cf->next = NULL;
-  b->started = data->progress.now;
+  b->started = *Curl_pgrs_now(data);
   switch(b->alpn_id) {
   case ALPN_h3:
     transport = TRNSPRT_QUIC;
@@ -212,12 +213,12 @@ static CURLcode baller_connected(struct Curl_cfilter *cf,
   if(reply_ms >= 0)
     CURL_TRC_CF(data, cf, "connect+handshake %s: %dms, 1st data: %dms",
                 winner->name,
-                (int)curlx_timediff_ms(data->progress.now,
-                                       winner->started), reply_ms);
+                (int)curlx_ptimediff_ms(Curl_pgrs_now(data),
+                                        &winner->started), reply_ms);
   else
     CURL_TRC_CF(data, cf, "deferred handshake %s: %dms",
-                winner->name, (int)curlx_timediff_ms(data->progress.now,
-                                                     winner->started));
+                winner->name, (int)curlx_ptimediff_ms(Curl_pgrs_now(data),
+                                                      &winner->started));
 
   /* install the winning filter below this one. */
   cf->next = winner->cf;
@@ -265,7 +266,7 @@ static bool time_to_start_next(struct Curl_cfilter *cf,
                 ctx->ballers[idx].name);
     return TRUE;
   }
-  elapsed_ms = curlx_timediff_ms(now, ctx->started);
+  elapsed_ms = curlx_ptimediff_ms(&now, &ctx->started);
   if(elapsed_ms >= ctx->hard_eyeballs_timeout_ms) {
     CURL_TRC_CF(data, cf, "hard timeout of %" FMT_TIMEDIFF_T "ms reached, "
                 "starting %s",
@@ -308,7 +309,7 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
     for(i = 0; i < ctx->baller_count; i++)
       DEBUGASSERT(!ctx->ballers[i].cf);
     CURL_TRC_CF(data, cf, "connect, init");
-    ctx->started = data->progress.now;
+    ctx->started = *Curl_pgrs_now(data);
     cf_hc_baller_init(&ctx->ballers[0], cf, data, ctx->ballers[0].transport);
     if(ctx->baller_count > 1) {
       Curl_expire(data, ctx->soft_eyeballs_timeout_ms, EXPIRE_ALPN_EYEBALLS);
@@ -327,7 +328,7 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
       }
     }
 
-    if(time_to_start_next(cf, data, 1, data->progress.now)) {
+    if(time_to_start_next(cf, data, 1, *Curl_pgrs_now(data))) {
       cf_hc_baller_init(&ctx->ballers[1], cf, data, ctx->ballers[1].transport);
     }
 
@@ -468,7 +469,7 @@ static struct curltime cf_get_max_baller_time(struct Curl_cfilter *cf,
     struct Curl_cfilter *cfb = ctx->ballers[i].cf;
     memset(&t, 0, sizeof(t));
     if(cfb && !cfb->cft->query(cfb, data, query, NULL, &t)) {
-      if((t.tv_sec || t.tv_usec) && curlx_timediff_us(t, tmax) > 0)
+      if((t.tv_sec || t.tv_usec) && curlx_ptimediff_us(&t, &tmax) > 0)
         tmax = t;
     }
   }

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -502,7 +502,7 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
        * socket and ip related information. */
       cf_cntrl_update_info(data, data->conn);
       conn_report_connect_stats(cf, data);
-      data->conn->keepalive = data->progress.now;
+      data->conn->keepalive = *Curl_pgrs_now(data);
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
       result = cf_verboseconnect(data, cf);
 #endif

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -208,7 +208,6 @@ void Curl_cpool_destroy(struct cpool *cpool)
                cpool->share ? "[SHARE] " : "", cpool->num_conn);
     /* Move all connections to the shutdown list */
     sigpipe_init(&pipe_st);
-    Curl_pgrs_now_set(cpool->idata);
     CPOOL_LOCK(cpool, cpool->idata);
     conn = cpool_get_first(cpool);
     while(conn) {
@@ -277,7 +276,7 @@ static struct cpool_bundle *cpool_add_bundle(struct cpool *cpool,
 
 static struct connectdata *
 cpool_bundle_get_oldest_idle(struct cpool_bundle *bundle,
-                             struct curltime *pnow)
+                             const struct curltime *pnow)
 {
   struct Curl_llist_node *curr;
   timediff_t highscore = -1;
@@ -291,7 +290,7 @@ cpool_bundle_get_oldest_idle(struct cpool_bundle *bundle,
 
     if(!CONN_INUSE(conn)) {
       /* Set higher score for the age passed since the connection was used */
-      score = curlx_timediff_ms(*pnow, conn->lastused);
+      score = curlx_ptimediff_ms(pnow, &conn->lastused);
 
       if(score > highscore) {
         highscore = score;
@@ -304,7 +303,7 @@ cpool_bundle_get_oldest_idle(struct cpool_bundle *bundle,
 }
 
 static struct connectdata *cpool_get_oldest_idle(struct cpool *cpool,
-                                                 struct curltime *pnow)
+                                                 const struct curltime *pnow)
 {
   struct Curl_hash_iterator iter;
   struct Curl_llist_node *curr;
@@ -327,7 +326,7 @@ static struct connectdata *cpool_get_oldest_idle(struct cpool *cpool,
       if(CONN_INUSE(conn) || conn->bits.close || conn->connect_only)
         continue;
       /* Set higher score for the age passed since the connection was used */
-      score = curlx_timediff_ms(*pnow, conn->lastused);
+      score = curlx_ptimediff_ms(pnow, &conn->lastused);
       if(score > highscore) {
         highscore = score;
         oldest_idle = conn;
@@ -358,7 +357,6 @@ int Curl_cpool_check_limits(struct Curl_easy *data,
   if(!dest_limit && !total_limit)
     return CPOOL_LIMIT_OK;
 
-  Curl_pgrs_now_update(cpool->idata, data);
   CPOOL_LOCK(cpool, cpool->idata);
   if(dest_limit) {
     size_t live;
@@ -379,7 +377,7 @@ int Curl_cpool_check_limits(struct Curl_easy *data,
         /* The bundle is full. Extract the oldest connection that may
          * be removed now, if there is one. */
         oldest_idle = cpool_bundle_get_oldest_idle(bundle,
-                                                   &data->progress.now);
+                                                   Curl_pgrs_now(data));
         if(!oldest_idle)
           break;
         /* disconnect the old conn and continue */
@@ -411,7 +409,7 @@ int Curl_cpool_check_limits(struct Curl_easy *data,
       }
       else {
         struct connectdata *oldest_idle =
-          cpool_get_oldest_idle(cpool, &data->progress.now);
+          cpool_get_oldest_idle(cpool, Curl_pgrs_now(data));
         if(!oldest_idle)
           break;
         /* disconnect the old conn and continue */
@@ -431,7 +429,6 @@ int Curl_cpool_check_limits(struct Curl_easy *data,
 
 out:
   CPOOL_UNLOCK(cpool, cpool->idata);
-  Curl_pgrs_now_update(data, cpool->idata);
   return result;
 }
 
@@ -541,7 +538,7 @@ bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
     maxconnects = data->multi->maxconnects;
   }
 
-  conn->lastused = data->progress.now; /* it was used up until now */
+  conn->lastused = *Curl_pgrs_now(data); /* it was used up until now */
   if(cpool && maxconnects) {
     /* may be called form a callback already under lock */
     bool do_lock = !CPOOL_IS_LOCKED(cpool);
@@ -551,7 +548,7 @@ bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
       infof(data, "Connection pool is full, closing the oldest of %zu/%u",
             cpool->num_conn, maxconnects);
 
-      oldest_idle = cpool_get_oldest_idle(cpool, &data->progress.now);
+      oldest_idle = cpool_get_oldest_idle(cpool, Curl_pgrs_now(data));
       kept = (oldest_idle != conn);
       if(oldest_idle) {
         Curl_conn_terminate(data, oldest_idle, FALSE);
@@ -638,7 +635,6 @@ static void cpool_discard_conn(struct cpool *cpool,
    * If we do a shutdown for an aborted transfer, the server might think
    * it was successful otherwise (for example an ftps: upload). This is
    * not what we want. */
-  Curl_pgrs_now_update(cpool->idata, data);
   if(aborted)
     done = TRUE;
   if(!done) {
@@ -704,13 +700,24 @@ void Curl_conn_terminate(struct Curl_easy *data,
     CPOOL_UNLOCK(cpool, data);
 }
 
+struct cpool_reaper_ctx {
+  size_t checked;
+  size_t reaped;
+};
+
 static int cpool_reap_dead_cb(struct Curl_easy *data,
                               struct connectdata *conn, void *param)
 {
-  (void)param;
-  if((!CONN_INUSE(conn) && conn->bits.no_reuse) ||
-     Curl_conn_seems_dead(conn, data)) {
+  struct cpool_reaper_ctx *reaper = param;
+  bool terminate = !CONN_INUSE(conn) && conn->bits.no_reuse;
+
+  if(!terminate) {
+    reaper->checked++;
+    terminate = Curl_conn_seems_dead(conn, data);
+  }
+  if(terminate) {
     /* stop the iteration here, pass back the connection that was pruned */
+    reaper->reaped++;
     Curl_conn_terminate(data, conn, FALSE);
     return 1;
   }
@@ -727,18 +734,20 @@ static int cpool_reap_dead_cb(struct Curl_easy *data,
 void Curl_cpool_prune_dead(struct Curl_easy *data)
 {
   struct cpool *cpool = cpool_get_instance(data);
+  struct cpool_reaper_ctx reaper;
   timediff_t elapsed;
 
   if(!cpool)
     return;
 
+  memset(&reaper, 0, sizeof(reaper));
   CPOOL_LOCK(cpool, data);
-  elapsed = curlx_timediff_ms(data->progress.now, cpool->last_cleanup);
+  elapsed = curlx_ptimediff_ms(Curl_pgrs_now(data), &cpool->last_cleanup);
 
   if(elapsed >= 1000L) {
-    while(cpool_foreach(data, cpool, NULL, cpool_reap_dead_cb))
+    while(cpool_foreach(data, cpool, &reaper, cpool_reap_dead_cb))
       ;
-    cpool->last_cleanup = data->progress.now;
+    cpool->last_cleanup = *Curl_pgrs_now(data);
   }
   CPOOL_UNLOCK(cpool, data);
 }
@@ -747,8 +756,8 @@ static int conn_upkeep(struct Curl_easy *data,
                        struct connectdata *conn,
                        void *param)
 {
-  struct curltime *now = param;
-  Curl_conn_upkeep(data, conn, now);
+  (void)param;
+  Curl_conn_upkeep(data, conn);
   return 0; /* continue iteration */
 }
 
@@ -760,7 +769,7 @@ CURLcode Curl_cpool_upkeep(struct Curl_easy *data)
     return CURLE_OK;
 
   CPOOL_LOCK(cpool, data);
-  cpool_foreach(data, cpool, &data->progress.now, conn_upkeep);
+  cpool_foreach(data, cpool, NULL, conn_upkeep);
   CPOOL_UNLOCK(cpool, data);
   return CURLE_OK;
 }

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -40,6 +40,9 @@ enum alpnid Curl_str2alpnid(const struct Curl_str *str);
    to the timeouts set */
 timediff_t Curl_timeleft_ms(struct Curl_easy *data,
                             bool duringconnect);
+timediff_t Curl_timeleft_now_ms(struct Curl_easy *data,
+                                const struct curltime *pnow,
+                                bool duringconnect);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 

--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -266,7 +266,7 @@ static void cshutdn_terminate_all(struct cshutdn *cshutdn,
                                   struct Curl_easy *data,
                                   int timeout_ms)
 {
-  struct curltime started = data->progress.now;
+  struct curltime started = *Curl_pgrs_now(data);
   struct Curl_llist_node *e;
   SIGPIPE_VARIABLE(pipe_st);
 
@@ -289,8 +289,7 @@ static void cshutdn_terminate_all(struct cshutdn *cshutdn,
     }
 
     /* wait for activity, timeout or "nothing" */
-    Curl_pgrs_now_set(data); /* update in loop */
-    spent_ms = curlx_timediff_ms(data->progress.now, started);
+    spent_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &started);
     if(spent_ms >= (timediff_t)timeout_ms) {
       CURL_TRC_M(data, "[SHUTDOWN] shutdown finished, %s",
                  (timeout_ms > 0) ? "timeout" : "best effort done");

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -42,6 +42,7 @@
 #include "cf-haproxy.h"
 #include "cf-https-connect.h"
 #include "cf-ip-happy.h"
+#include "progress.h"
 #include "socks.h"
 #include "curlx/strparse.h"
 #include "vtls/vtls.h"
@@ -314,11 +315,12 @@ void Curl_trc_easy_timers(struct Curl_easy *data)
   if(CURL_TRC_TIMER_is_verbose(data)) {
     struct Curl_llist_node *e = Curl_llist_head(&data->state.timeoutlist);
     if(e) {
+      const struct curltime *pnow = Curl_pgrs_now(data);
       while(e) {
         struct time_node *n = Curl_node_elem(e);
         e = Curl_node_next(e);
         CURL_TRC_TIMER(data, n->eid, "expires in %" FMT_TIMEDIFF_T "ns",
-                       curlx_timediff_us(n->time, data->progress.now));
+                       curlx_ptimediff_us(&n->time, pnow));
       }
     }
   }

--- a/lib/curlx/timeval.h
+++ b/lib/curlx/timeval.h
@@ -39,6 +39,7 @@ void curlx_now_init(void);
 #endif
 
 struct curltime curlx_now(void);
+void curlx_pnow(struct curltime *pnow);
 
 /*
  * Make sure that the first argument (newer) is the more recent time and older
@@ -47,6 +48,8 @@ struct curltime curlx_now(void);
  * Returns: the time difference in number of milliseconds.
  */
 timediff_t curlx_timediff_ms(struct curltime newer, struct curltime older);
+timediff_t curlx_ptimediff_ms(const struct curltime *newer,
+                              const struct curltime *older);
 
 /*
  * Make sure that the first argument (newer) is the more recent time and older
@@ -64,6 +67,8 @@ timediff_t curlx_timediff_ceil_ms(struct curltime newer,
  * Returns: the time difference in number of microseconds.
  */
 timediff_t curlx_timediff_us(struct curltime newer, struct curltime older);
+timediff_t curlx_ptimediff_us(const struct curltime *newer,
+                              const struct curltime *older);
 
 CURLcode curlx_gmtime(time_t intime, struct tm *store);
 

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3179,7 +3179,7 @@ static CURLcode ftp_connect(struct Curl_easy *data,
     conn->bits.ftp_use_control_ssl = TRUE;
   }
 
-  Curl_pp_init(pp, &data->progress.now); /* once per transfer */
+  Curl_pp_init(pp, Curl_pgrs_now(data)); /* once per transfer */
 
   /* When we connect, we start in the state where we await the 220
      response */
@@ -3315,7 +3315,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
      * data has been transferred. This happens when doing through NATs etc that
      * abandon old silent connections.
      */
-    pp->response = data->progress.now; /* timeout relative now */
+    pp->response = *Curl_pgrs_now(data); /* timeout relative now */
     result = getftpresponse(data, &nread, &ftpcode);
 
     if(!nread && (CURLE_OPERATION_TIMEDOUT == result)) {
@@ -3435,7 +3435,7 @@ static CURLcode ftp_sendquote(struct Curl_easy *data,
 
       result = Curl_pp_sendf(data, &ftpc->pp, "%s", cmd);
       if(!result) {
-        pp->response = data->progress.now; /* timeout relative now */
+        pp->response = *Curl_pgrs_now(data); /* timeout relative now */
         result = getftpresponse(data, &nread, &ftpcode);
       }
       if(result)

--- a/lib/http.c
+++ b/lib/http.c
@@ -4950,7 +4950,7 @@ static CURLcode cr_exp100_read(struct Curl_easy *data,
     DEBUGF(infof(data, "cr_exp100_read, start AWAITING_CONTINUE, "
            "timeout %dms", data->set.expect_100_timeout));
     ctx->state = EXP100_AWAITING_CONTINUE;
-    ctx->start = data->progress.now;
+    ctx->start = *Curl_pgrs_now(data);
     Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
     *nread = 0;
     *eos = FALSE;
@@ -4961,7 +4961,7 @@ static CURLcode cr_exp100_read(struct Curl_easy *data,
     *eos = FALSE;
     return CURLE_READ_ERROR;
   case EXP100_AWAITING_CONTINUE:
-    ms = curlx_timediff_ms(data->progress.now, ctx->start);
+    ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &ctx->start);
     if(ms < data->set.expect_100_timeout) {
       DEBUGF(infof(data, "cr_exp100_read, AWAITING_CONTINUE, not expired"));
       *nread = 0;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -306,8 +306,8 @@ static void h2_stream_hash_free(unsigned int id, void *stream)
 static int32_t cf_h2_get_desired_local_win(struct Curl_cfilter *cf,
                                            struct Curl_easy *data)
 {
-  curl_off_t avail =
-    Curl_rlimit_avail(&data->progress.dl.rlimit, &data->progress.now);
+  curl_off_t avail = Curl_rlimit_avail(&data->progress.dl.rlimit,
+                                       Curl_pgrs_now(data));
 
   (void)cf;
   if(avail < CURL_OFF_T_MAX) { /* limit in place */
@@ -1424,7 +1424,7 @@ static int on_data_chunk_recv(nghttp2_session *session, uint8_t flags,
   struct Curl_cfilter *cf = userp;
   struct cf_h2_ctx *ctx = cf->ctx;
   struct h2_stream_ctx *stream;
-  struct Curl_easy *data_s, *calling = CF_DATA_CURRENT(cf);
+  struct Curl_easy *data_s;
   (void)flags;
 
   DEBUGASSERT(stream_id); /* should never be a zero stream ID here */
@@ -1445,8 +1445,6 @@ static int on_data_chunk_recv(nghttp2_session *session, uint8_t flags,
   stream = H2_STREAM_CTX(ctx, data_s);
   if(!stream)
     return NGHTTP2_ERR_CALLBACK_FAILURE;
-  if(calling)
-    Curl_pgrs_now_update(data_s, calling);
 
   h2_xfer_write_resp(cf, data_s, stream, (const char *)mem, len, FALSE);
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1995,7 +1995,7 @@ static CURLcode imap_setup_connection(struct Curl_easy *data,
   Curl_sasl_init(&imapc->sasl, data, &saslimap);
 
   curlx_dyn_init(&imapc->dyn, DYN_IMAP_CMD);
-  Curl_pp_init(pp, &data->progress.now);
+  Curl_pp_init(pp, Curl_pgrs_now(data));
 
   if(Curl_conn_meta_set(conn, CURL_META_IMAP_CONN, imapc, imap_conn_dtor))
     return CURLE_OUT_OF_MEMORY;

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -186,7 +186,7 @@ static CURLcode mqtt_send(struct Curl_easy *data,
   result = Curl_xfer_send(data, buf, len, FALSE, &n);
   if(result)
     return result;
-  mq->lastTime = data->progress.now;
+  mq->lastTime = *Curl_pgrs_now(data);
   Curl_debug(data, CURLINFO_HEADER_OUT, buf, n);
   if(len != n) {
     size_t nsend = len - n;
@@ -770,7 +770,7 @@ MQTT_SUBACK_COMING:
     }
 
     /* we received something */
-    mq->lastTime = data->progress.now;
+    mq->lastTime = *Curl_pgrs_now(data);
 
     /* if QoS is set, message contains packet id */
     result = Curl_client_write(data, CLIENTWRITE_BODY, buffer, nread);
@@ -800,7 +800,7 @@ static CURLcode mqtt_do(struct Curl_easy *data, bool *done)
 
   if(!mq)
     return CURLE_FAILED_INIT;
-  mq->lastTime = data->progress.now;
+  mq->lastTime = *Curl_pgrs_now(data);
   mq->pingsent = FALSE;
 
   result = mqtt_connect(data);
@@ -839,8 +839,8 @@ static CURLcode mqtt_ping(struct Curl_easy *data)
   if(mqtt->state == MQTT_FIRST &&
      !mq->pingsent &&
      data->set.upkeep_interval_ms > 0) {
-    struct curltime t = data->progress.now;
-    timediff_t diff = curlx_timediff_ms(t, mq->lastTime);
+    struct curltime t = *Curl_pgrs_now(data);
+    timediff_t diff = curlx_ptimediff_ms(&t, &mq->lastTime);
 
     if(diff > data->set.upkeep_interval_ms) {
       /* 0xC0 is PINGREQ, and 0x00 is remaining length */
@@ -898,7 +898,7 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
     Curl_debug(data, CURLINFO_HEADER_IN, (const char *)&mq->firstbyte, 1);
 
     /* we received something */
-    mq->lastTime = data->progress.now;
+    mq->lastTime = *Curl_pgrs_now(data);
 
     /* remember the first byte */
     mq->npacket = 0;

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -538,8 +538,7 @@ CURLMcode Curl_multi_ev_assess_conn(struct Curl_multi *multi,
 }
 
 CURLMcode Curl_multi_ev_assess_xfer_bset(struct Curl_multi *multi,
-                                         struct uint32_bset *set,
-                                         struct curltime *pnow)
+                                         struct uint32_bset *set)
 {
   uint32_t mid;
   CURLMcode mresult = CURLM_OK;
@@ -548,7 +547,6 @@ CURLMcode Curl_multi_ev_assess_xfer_bset(struct Curl_multi *multi,
     do {
       struct Curl_easy *data = Curl_multi_get_easy(multi, mid);
       if(data) {
-        Curl_pgrs_now_at_least(data, pnow);
         mresult = Curl_multi_ev_assess_xfer(multi, data);
       }
     } while(!mresult && Curl_uint32_bset_next(set, mid, &mid));

--- a/lib/multi_ev.h
+++ b/lib/multi_ev.h
@@ -55,8 +55,7 @@ CURLMcode Curl_multi_ev_assess_xfer(struct Curl_multi *multi,
                                     struct Curl_easy *data);
 /* Assess all easy handles on the list */
 CURLMcode Curl_multi_ev_assess_xfer_bset(struct Curl_multi *multi,
-                                         struct uint32_bset *set,
-                                         struct curltime *pnow);
+                                         struct uint32_bset *set);
 /* Assess the connection by getting its current pollset */
 CURLMcode Curl_multi_ev_assess_conn(struct Curl_multi *multi,
                                     struct Curl_easy *data,

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -116,6 +116,8 @@ struct Curl_multi {
   struct PslCache psl;
 #endif
 
+  /* current time for transfers running in this multi handle */
+  struct curltime now;
   /* timetree points to the splay-tree of time nodes to figure out expire
      times of all currently set timers */
   struct Curl_tree *timetree;
@@ -170,6 +172,9 @@ struct Curl_multi {
   unsigned int maxconnects; /* if >0, a fixed limit of the maximum number of
                                entries we are allowed to grow the connection
                                cache to */
+#ifdef DEBUGBUILD
+  unsigned int now_access_count;
+#endif
 #define IPV6_UNKNOWN 0
 #define IPV6_DEAD    1
 #define IPV6_WORKS   2

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -33,8 +33,7 @@ void Curl_expire_ex(struct Curl_easy *data,
                     timediff_t milli, expire_id id);
 bool Curl_expire_clear(struct Curl_easy *data);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);
-CURLMcode Curl_update_timer(struct Curl_multi *multi,
-                            struct curltime *pnow) WARN_UNUSED_RESULT;
+CURLMcode Curl_update_timer(struct Curl_multi *multi) WARN_UNUSED_RESULT;
 void Curl_attach_connection(struct Curl_easy *data,
                             struct connectdata *conn);
 void Curl_detach_connection(struct Curl_easy *data);
@@ -162,5 +161,7 @@ unsigned int Curl_multi_xfers_running(struct Curl_multi *multi);
 void Curl_multi_mark_dirty(struct Curl_easy *data);
 /* Clear transfer from the dirty set. */
 void Curl_multi_clear_dirty(struct Curl_easy *data);
+
+void Curl_multi_set_now(struct Curl_multi *multi);
 
 #endif /* HEADER_CURL_MULTIIF_H */

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -87,7 +87,7 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data, struct pingpong *pp,
                            bool block, bool disconnecting);
 
 /* initialize stuff to prepare for reading a fresh new response */
-void Curl_pp_init(struct pingpong *pp, struct curltime *pnow);
+void Curl_pp_init(struct pingpong *pp, const struct curltime *pnow);
 
 /* Returns timeout in ms. 0 or negative number means the timeout has already
    triggered */

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1297,7 +1297,7 @@ static CURLcode pop3_connect(struct Curl_easy *data, bool *done)
   Curl_sasl_init(&pop3c->sasl, data, &saslpop3);
 
   /* Initialise the pingpong layer */
-  Curl_pp_init(pp, &data->progress.now);
+  Curl_pp_init(pp, Curl_pgrs_now(data));
 
   /* Parse the URL options */
   result = pop3_parse_url_options(conn);

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -102,7 +102,7 @@ static void pgrs_speedinit(struct Curl_easy *data)
  * @unittest: 1606
  */
 UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
-                                  struct curltime *pnow)
+                                  const struct curltime *pnow)
 {
   if(!data->set.low_speed_time || !data->set.low_speed_limit ||
      Curl_xfer_recv_is_paused(data) || Curl_xfer_send_is_paused(data))
@@ -116,7 +116,8 @@ UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
         data->state.keeps_speed = *pnow;
       else {
         /* how long has it been under the limit */
-        timediff_t howlong = curlx_timediff_ms(*pnow, data->state.keeps_speed);
+        timediff_t howlong =
+          curlx_ptimediff_ms(pnow, &data->state.keeps_speed);
 
         if(howlong >= data->set.low_speed_time * 1000) {
           /* too long */
@@ -141,23 +142,12 @@ UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-void Curl_pgrs_now_set(struct Curl_easy *data)
+const struct curltime *Curl_pgrs_now(struct Curl_easy *data)
 {
-  data->progress.now = curlx_now();
-}
-
-void Curl_pgrs_now_at_least(struct Curl_easy *data, struct curltime *pts)
-{
-  if((pts->tv_sec > data->progress.now.tv_sec) ||
-     ((pts->tv_sec == data->progress.now.tv_sec) &&
-      (pts->tv_usec > data->progress.now.tv_usec))) {
-    data->progress.now = *pts;
-  }
-}
-
-void Curl_pgrs_now_update(struct Curl_easy *data, struct Curl_easy *other)
-{
-  Curl_pgrs_now_at_least(data, &other->progress.now);
+  struct curltime *pnow = data->multi ?
+                          &data->multi->now : &data->progress.now;
+  curlx_pnow(pnow);
+  return pnow;
 }
 
 /*
@@ -251,7 +241,7 @@ void Curl_pgrsTimeWas(struct Curl_easy *data, timerid timer,
   case TIMER_POSTQUEUE:
     /* Queue time is accumulative from all involved redirects */
     data->progress.t_postqueue +=
-      curlx_timediff_us(timestamp, data->progress.t_startqueue);
+      curlx_ptimediff_us(&timestamp, &data->progress.t_startqueue);
     break;
   case TIMER_STARTACCEPT:
     data->progress.t_acceptdata = timestamp;
@@ -287,13 +277,14 @@ void Curl_pgrsTimeWas(struct Curl_easy *data, timerid timer,
     delta = &data->progress.t_posttransfer;
     break;
   case TIMER_REDIRECT:
-    data->progress.t_redirect = curlx_timediff_us(timestamp,
-                                                 data->progress.start);
+    data->progress.t_redirect = curlx_ptimediff_us(&timestamp,
+                                                   &data->progress.start);
     data->progress.t_startqueue = timestamp;
     break;
   }
   if(delta) {
-    timediff_t us = curlx_timediff_us(timestamp, data->progress.t_startsingle);
+    timediff_t us = curlx_ptimediff_us(&timestamp,
+                                       &data->progress.t_startsingle);
     if(us < 1)
       us = 1; /* make sure at least one microsecond passed */
     *delta += us;
@@ -309,15 +300,15 @@ void Curl_pgrsTimeWas(struct Curl_easy *data, timerid timer,
  */
 void Curl_pgrsTime(struct Curl_easy *data, timerid timer)
 {
-  Curl_pgrs_now_set(data); /* update on real progress */
-  Curl_pgrsTimeWas(data, timer, data->progress.now);
+  Curl_pgrsTimeWas(data, timer, *Curl_pgrs_now(data));
 }
 
 void Curl_pgrsStartNow(struct Curl_easy *data)
 {
   struct Progress *p = &data->progress;
+
   p->speeder_c = 0; /* reset the progress meter display */
-  p->start = data->progress.now;
+  p->start = *Curl_pgrs_now(data);
   p->is_t_startransfer_set = FALSE;
   p->dl.cur_size = 0;
   p->ul.cur_size = 0;
@@ -330,7 +321,7 @@ void Curl_pgrs_download_inc(struct Curl_easy *data, size_t delta)
 {
   if(delta) {
     data->progress.dl.cur_size += delta;
-    Curl_rlimit_drain(&data->progress.dl.rlimit, delta, &data->progress.now);
+    Curl_rlimit_drain(&data->progress.dl.rlimit, delta, Curl_pgrs_now(data));
   }
 }
 
@@ -338,7 +329,7 @@ void Curl_pgrs_upload_inc(struct Curl_easy *data, size_t delta)
 {
   if(delta) {
     data->progress.ul.cur_size += delta;
-    Curl_rlimit_drain(&data->progress.ul.rlimit, delta, &data->progress.now);
+    Curl_rlimit_drain(&data->progress.ul.rlimit, delta, Curl_pgrs_now(data));
   }
 }
 
@@ -394,7 +385,8 @@ static curl_off_t trspeed(curl_off_t size, /* number of bytes */
 }
 
 /* returns TRUE if it is time to show the progress meter */
-static bool progress_calc(struct Curl_easy *data, struct curltime *pnow)
+static bool progress_calc(struct Curl_easy *data,
+                          const struct curltime *pnow)
 {
   struct Progress * const p = &data->progress;
   int i_next, i_oldest, i_latest;
@@ -402,7 +394,7 @@ static bool progress_calc(struct Curl_easy *data, struct curltime *pnow)
   curl_off_t amount;
 
   /* The time spent so far (from the start) in microseconds */
-  p->timespent = curlx_timediff_us(*pnow, p->start);
+  p->timespent = curlx_ptimediff_us(pnow, &p->start);
   p->dl.speed = trspeed(p->dl.cur_size, p->timespent);
   p->ul.speed = trspeed(p->ul.cur_size, p->timespent);
 
@@ -422,7 +414,7 @@ static bool progress_calc(struct Curl_easy *data, struct curltime *pnow)
 
   /* Make a new record only when some time has passed.
    * Too frequent calls otherwise ruin the history. */
-  if(curlx_timediff_ms(*pnow, p->speed_time[i_latest]) >= 1000) {
+  if(curlx_ptimediff_ms(pnow, &p->speed_time[i_latest]) >= 1000) {
     p->speeder_c++;
     i_latest = i_next;
     p->speed_amount[i_latest] = p->dl.cur_size + p->ul.cur_size;
@@ -449,8 +441,8 @@ static bool progress_calc(struct Curl_easy *data, struct curltime *pnow)
   /* How much we transferred between oldest and current records */
   amount = p->speed_amount[i_latest] - p->speed_amount[i_oldest];
   /* How long this took */
-  duration_ms = curlx_timediff_ms(p->speed_time[i_latest],
-                                  p->speed_time[i_oldest]);
+  duration_ms = curlx_ptimediff_ms(&p->speed_time[i_latest],
+                                   &p->speed_time[i_oldest]);
   if(duration_ms <= 0)
     duration_ms = 1;
 
@@ -635,7 +627,8 @@ static CURLcode pgrsupdate(struct Curl_easy *data, bool showprogress)
   return CURLE_OK;
 }
 
-static CURLcode pgrs_update(struct Curl_easy *data, struct curltime *pnow)
+static CURLcode pgrs_update(struct Curl_easy *data,
+                            const struct curltime *pnow)
 {
   bool showprogress = progress_calc(data, pnow);
   return pgrsupdate(data, showprogress);
@@ -643,16 +636,16 @@ static CURLcode pgrs_update(struct Curl_easy *data, struct curltime *pnow)
 
 CURLcode Curl_pgrsUpdate(struct Curl_easy *data)
 {
-  return pgrs_update(data, &data->progress.now);
+  return pgrs_update(data, Curl_pgrs_now(data));
 }
 
 CURLcode Curl_pgrsCheck(struct Curl_easy *data)
 {
   CURLcode result;
 
-  result = pgrs_update(data, &data->progress.now);
+  result = pgrs_update(data, Curl_pgrs_now(data));
   if(!result && !data->req.done)
-    result = pgrs_speedcheck(data, &data->progress.now);
+    result = pgrs_speedcheck(data, Curl_pgrs_now(data));
   return result;
 }
 
@@ -661,5 +654,5 @@ CURLcode Curl_pgrsCheck(struct Curl_easy *data)
  */
 void Curl_pgrsUpdate_nometer(struct Curl_easy *data)
 {
-  (void)progress_calc(data, &data->progress.now);
+  (void)progress_calc(data, Curl_pgrs_now(data));
 }

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -44,16 +44,8 @@ typedef enum {
   TIMER_LAST /* must be last */
 } timerid;
 
-#define CURL_PGRS_NOW_MONOTONIC
-
-/* Set current time in data->progress.now */
-void Curl_pgrs_now_set(struct Curl_easy *data);
-/* Advance `now` timestamp at least to given timestamp.
- * No effect it data's `now` is already later than `pts`. */
-void Curl_pgrs_now_at_least(struct Curl_easy *data, struct curltime *pts);
-/* `data` progressing continues after `other` processing. Advance `data`s
- * now timestamp to at least `other's` timestamp. */
-void Curl_pgrs_now_update(struct Curl_easy *data, struct Curl_easy *other);
+/* Get the current timestamp of the transfer */
+const struct curltime *Curl_pgrs_now(struct Curl_easy *data);
 
 int Curl_pgrsDone(struct Curl_easy *data);
 void Curl_pgrsStartNow(struct Curl_easy *data);
@@ -93,7 +85,7 @@ void Curl_pgrsEarlyData(struct Curl_easy *data, curl_off_t sent);
 
 #ifdef UNITTESTS
 UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
-                                  struct curltime *pnow);
+                                  const struct curltime *pnow);
 #endif
 
 #endif /* HEADER_CURL_PROGRESS_H */

--- a/lib/psl.c
+++ b/lib/psl.c
@@ -29,6 +29,7 @@
 #ifdef USE_LIBPSL
 
 #include "psl.h"
+#include "progress.h"
 #include "curl_share.h"
 
 void Curl_psl_destroy(struct PslCache *pslcache)
@@ -41,25 +42,18 @@ void Curl_psl_destroy(struct PslCache *pslcache)
   }
 }
 
-static time_t now_seconds(void)
-{
-  struct curltime now = curlx_now();
-
-  return now.tv_sec;
-}
-
 const psl_ctx_t *Curl_psl_use(struct Curl_easy *easy)
 {
   struct PslCache *pslcache = easy->psl;
   const psl_ctx_t *psl;
-  time_t now;
+  time_t now_sec;
 
   if(!pslcache)
     return NULL;
 
   Curl_share_lock(easy, CURL_LOCK_DATA_PSL, CURL_LOCK_ACCESS_SHARED);
-  now = now_seconds();
-  if(!pslcache->psl || pslcache->expires <= now) {
+  now_sec = Curl_pgrs_now(easy)->tv_sec;
+  if(!pslcache->psl || pslcache->expires <= now_sec) {
     /* Let a chance to other threads to do the job: avoids deadlock. */
     Curl_share_unlock(easy, CURL_LOCK_DATA_PSL);
 
@@ -67,8 +61,10 @@ const psl_ctx_t *Curl_psl_use(struct Curl_easy *easy)
     Curl_share_lock(easy, CURL_LOCK_DATA_PSL, CURL_LOCK_ACCESS_SINGLE);
 
     /* Recheck in case another thread did the job. */
-    now = now_seconds();
-    if(!pslcache->psl || pslcache->expires <= now) {
+    if(pslcache->expires <= now_sec) {
+      now_sec = Curl_pgrs_now(easy)->tv_sec;
+    }
+    if(!pslcache->psl || pslcache->expires <= now_sec) {
       bool dynamic = FALSE;
       time_t expires = TIME_T_MAX;
 
@@ -76,7 +72,8 @@ const psl_ctx_t *Curl_psl_use(struct Curl_easy *easy)
       psl = psl_latest(NULL);
       dynamic = psl != NULL;
       /* Take care of possible time computation overflow. */
-      expires = now < TIME_T_MAX - PSL_TTL ? now + PSL_TTL : TIME_T_MAX;
+      expires = (now_sec < TIME_T_MAX - PSL_TTL) ?
+                (now_sec + PSL_TTL) : TIME_T_MAX;
 
       /* Only get the built-in PSL if we do not already have the "latest". */
       if(!psl && !pslcache->dynamic)

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -119,7 +119,8 @@ static CURLcode weak_random(struct Curl_easy *data,
     static bool seeded = FALSE;
     unsigned int rnd;
     if(!seeded) {
-      struct curltime now = curlx_now();
+      struct curltime now;
+      curlx_pnow(&now);
       randseed += (unsigned int)now.tv_usec + (unsigned int)now.tv_sec;
       randseed = randseed * 1103515245 + 12345;
       randseed = randseed * 1103515245 + 12345;

--- a/lib/ratelimit.h
+++ b/lib/ratelimit.h
@@ -26,6 +26,8 @@
 
 #include "curlx/timeval.h"
 
+struct Curl_easy;
+
 /* This is a rate limiter that provides "tokens" to be consumed
  * per second with a "burst" rate limitation. Example:
  * A rate limit of 1 megabyte per second with a burst rate of 1.5MB.
@@ -62,14 +64,14 @@ struct Curl_rlimit {
 void Curl_rlimit_init(struct Curl_rlimit *r,
                       curl_off_t rate_per_s,
                       curl_off_t burst_per_s,
-                      struct curltime *pts);
+                      const struct curltime *pts);
 
 /* Start ratelimiting with the given timestamp. Resets available tokens. */
-void Curl_rlimit_start(struct Curl_rlimit *r, struct curltime *pts);
+void Curl_rlimit_start(struct Curl_rlimit *r, const struct curltime *pts);
 
 /* How many milliseconds to wait until token are available again. */
 timediff_t Curl_rlimit_wait_ms(struct Curl_rlimit *r,
-                               struct curltime *pts);
+                               const struct curltime *pts);
 
 /* Return if rate limiting of tokens is active */
 bool Curl_rlimit_active(struct Curl_rlimit *r);
@@ -77,16 +79,16 @@ bool Curl_rlimit_is_blocked(struct Curl_rlimit *r);
 
 /* Return how many tokens are available to spend, may be negative */
 curl_off_t Curl_rlimit_avail(struct Curl_rlimit *r,
-                             struct curltime *pts);
+                             const struct curltime *pts);
 
 /* Drain tokens from the ratelimit, return how many are now available. */
 void Curl_rlimit_drain(struct Curl_rlimit *r,
                        size_t tokens,
-                       struct curltime *pts);
+                       const struct curltime *pts);
 
 /* Block/unblock ratelimiting. A blocked ratelimit has 0 tokens available. */
 void Curl_rlimit_block(struct Curl_rlimit *r,
                        bool activate,
-                       struct curltime *pts);
+                       const struct curltime *pts);
 
 #endif /* HEADER_Curl_rlimit_H */

--- a/lib/request.c
+++ b/lib/request.c
@@ -90,7 +90,7 @@ CURLcode Curl_req_soft_reset(struct SingleRequest *req,
 CURLcode Curl_req_start(struct SingleRequest *req,
                         struct Curl_easy *data)
 {
-  req->start = data->progress.now;
+  req->start = *Curl_pgrs_now(data);
   return Curl_req_soft_reset(req, data);
 }
 

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -230,7 +230,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
   if(!ctx->started_response &&
      !(type & (CLIENTWRITE_INFO | CLIENTWRITE_CONNECT))) {
     Curl_pgrsTime(data, TIMER_STARTTRANSFER);
-    Curl_rlimit_start(&data->progress.dl.rlimit, &data->progress.now);
+    Curl_rlimit_start(&data->progress.dl.rlimit, Curl_pgrs_now(data));
     ctx->started_response = TRUE;
   }
 
@@ -1202,13 +1202,13 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
     DEBUGASSERT(data->req.reader_stack);
   }
   if(!data->req.reader_started) {
-    Curl_rlimit_start(&data->progress.ul.rlimit, &data->progress.now);
+    Curl_rlimit_start(&data->progress.ul.rlimit, Curl_pgrs_now(data));
     data->req.reader_started = TRUE;
   }
 
   if(Curl_rlimit_active(&data->progress.ul.rlimit)) {
-    curl_off_t ul_avail =
-      Curl_rlimit_avail(&data->progress.ul.rlimit, &data->progress.now);
+    curl_off_t ul_avail = Curl_rlimit_avail(&data->progress.ul.rlimit,
+                                            Curl_pgrs_now(data));
     if(ul_avail <= 0) {
       result = CURLE_OK;
       *eos = FALSE;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2814,7 +2814,7 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
       return CURLE_BAD_FUNCTION_ARGUMENT;
     s->max_send_speed = offt;
     Curl_rlimit_init(&data->progress.ul.rlimit, offt, offt,
-                     &data->progress.now);
+                     Curl_pgrs_now(data));
     break;
   case CURLOPT_MAX_RECV_SPEED_LARGE:
     /*
@@ -2825,7 +2825,7 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
       return CURLE_BAD_FUNCTION_ARGUMENT;
     s->max_recv_speed = offt;
     Curl_rlimit_init(&data->progress.dl.rlimit, offt, offt,
-                     &data->progress.now);
+                     Curl_pgrs_now(data));
     break;
   case CURLOPT_RESUME_FROM_LARGE:
     /*

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1441,7 +1441,7 @@ static CURLcode smtp_connect(struct Curl_easy *data, bool *done)
   Curl_sasl_init(&smtpc->sasl, data, &saslsmtp);
 
   /* Initialise the pingpong layer */
-  Curl_pp_init(&smtpc->pp, &data->progress.now);
+  Curl_pp_init(&smtpc->pp, Curl_pgrs_now(data));
 
   /* Parse the URL options */
   result = smtp_parse_url_options(data->conn, smtpc);

--- a/lib/splay.h
+++ b/lib/splay.h
@@ -36,14 +36,14 @@ struct Curl_tree {
   void *ptr;                 /* data the splay code does not care about */
 };
 
-struct Curl_tree *Curl_splay(struct curltime i,
+struct Curl_tree *Curl_splay(const struct curltime *pkey,
                              struct Curl_tree *t);
 
-struct Curl_tree *Curl_splayinsert(struct curltime key,
+struct Curl_tree *Curl_splayinsert(const struct curltime *pkey,
                                    struct Curl_tree *t,
                                    struct Curl_tree *newnode);
 
-struct Curl_tree *Curl_splaygetbest(struct curltime key,
+struct Curl_tree *Curl_splaygetbest(const struct curltime *pkey,
                                     struct Curl_tree *t,
                                     struct Curl_tree **removed);
 

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1508,8 +1508,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     } /* switch */
 
     if(data->set.timeout) {
-      Curl_pgrs_now_set(data);
-      if(curlx_timediff_ms(data->progress.now, conn->created) >=
+      if(curlx_ptimediff_ms(Curl_pgrs_now(data), &conn->created) >=
          data->set.timeout) {
         failf(data, "Time-out");
         result = CURLE_OPERATION_TIMEDOUT;
@@ -1628,8 +1627,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     } /* poll switch statement */
 
     if(data->set.timeout) {
-      Curl_pgrs_now_set(data);
-      if(curlx_timediff_ms(data->progress.now, conn->created) >=
+      if(curlx_ptimediff_ms(Curl_pgrs_now(data), &conn->created) >=
          data->set.timeout) {
         failf(data, "Time-out");
         result = CURLE_OPERATION_TIMEDOUT;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -261,7 +261,7 @@ static CURLcode sendrecv_dl(struct Curl_easy *data,
 
     if(bytestoread && Curl_rlimit_active(&data->progress.dl.rlimit)) {
       curl_off_t dl_avail = Curl_rlimit_avail(&data->progress.dl.rlimit,
-                                              &data->progress.now);
+                                              Curl_pgrs_now(data));
       /* DEBUGF(infof(data, "dl_rlimit, available=%" FMT_OFF_T, dl_avail));
        */
       /* In case of rate limited downloads: if this loop already got
@@ -399,15 +399,15 @@ CURLcode Curl_sendrecv(struct Curl_easy *data)
         failf(data, "Operation timed out after %" FMT_TIMEDIFF_T
               " milliseconds with %" FMT_OFF_T " out of %"
               FMT_OFF_T " bytes received",
-              curlx_timediff_ms(data->progress.now,
-                                data->progress.t_startsingle),
+              curlx_ptimediff_ms(Curl_pgrs_now(data),
+                                 &data->progress.t_startsingle),
               k->bytecount, k->size);
       }
       else {
         failf(data, "Operation timed out after %" FMT_TIMEDIFF_T
               " milliseconds with %" FMT_OFF_T " bytes received",
-              curlx_timediff_ms(data->progress.now,
-                                data->progress.t_startsingle),
+              curlx_ptimediff_ms(Curl_pgrs_now(data),
+                                 &data->progress.t_startsingle),
               k->bytecount);
       }
       result = CURLE_OPERATION_TIMEDOUT;
@@ -903,7 +903,7 @@ bool Curl_xfer_recv_is_paused(struct Curl_easy *data)
 CURLcode Curl_xfer_pause_send(struct Curl_easy *data, bool enable)
 {
   CURLcode result = CURLE_OK;
-  Curl_rlimit_block(&data->progress.ul.rlimit, enable, &data->progress.now);
+  Curl_rlimit_block(&data->progress.ul.rlimit, enable, Curl_pgrs_now(data));
   if(!enable && Curl_creader_is_paused(data))
     result = Curl_creader_unpause(data);
   Curl_pgrsSendPause(data, enable);
@@ -913,7 +913,7 @@ CURLcode Curl_xfer_pause_send(struct Curl_easy *data, bool enable)
 CURLcode Curl_xfer_pause_recv(struct Curl_easy *data, bool enable)
 {
   CURLcode result = CURLE_OK;
-  Curl_rlimit_block(&data->progress.dl.rlimit, enable, &data->progress.now);
+  Curl_rlimit_block(&data->progress.dl.rlimit, enable, Curl_pgrs_now(data));
   if(!enable && Curl_cwriter_is_paused(data))
     result = Curl_cwriter_unpause(data);
   Curl_conn_ev_data_pause(data, enable);

--- a/lib/url.h
+++ b/lib/url.h
@@ -90,8 +90,7 @@ bool Curl_conn_seems_dead(struct connectdata *conn,
  * Perform upkeep operations on the connection.
  */
 CURLcode Curl_conn_upkeep(struct Curl_easy *data,
-                          struct connectdata *conn,
-                          struct curltime *now);
+                          struct connectdata *conn);
 
 /**
  * Always eval all arguments, return the first result != CURLE_OK.

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1650,7 +1650,7 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
     if(acked_len > 0 || (eos && !s->send_blocked)) {
       /* Since QUIC buffers the data written internally, we can tell
        * nghttp3 that it can move forward on it */
-      ctx->q.last_io = curlx_now();
+      ctx->q.last_io = *Curl_pgrs_now(data);
       rv = nghttp3_conn_add_write_offset(ctx->h3.conn, s->id, acked_len);
       if(rv && rv != NGHTTP3_ERR_STREAM_NOT_FOUND) {
         failf(data, "nghttp3_conn_add_write_offset returned error: %s",
@@ -1766,7 +1766,7 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
   CF_DATA_SAVE(save, cf, data);
 
   if(!ctx->tls.ossl.ssl) {
-    ctx->started_at = data->progress.now;
+    ctx->started_at = *Curl_pgrs_now(data);
     result = cf_osslq_ctx_start(cf, data);
     if(result)
       goto out;
@@ -1776,7 +1776,7 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
     int readable = SOCKET_READABLE(ctx->q.sockfd, 0);
     if(readable > 0 && (readable & CURL_CSELECT_IN)) {
       ctx->got_first_byte = TRUE;
-      ctx->first_byte_at = data->progress.now;
+      ctx->first_byte_at = *Curl_pgrs_now(data);
     }
   }
 
@@ -1797,14 +1797,13 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
       /* if not recorded yet, take the timestamp before we called
        * SSL_do_handshake() as the time we received the first packet. */
       ctx->got_first_byte = TRUE;
-      ctx->first_byte_at = data->progress.now;
+      ctx->first_byte_at = *Curl_pgrs_now(data);
     }
     /* Record the handshake complete with a new time stamp. */
-    Curl_pgrs_now_set(data);
-    ctx->handshake_at = data->progress.now;
-    ctx->q.last_io = data->progress.now;
+    ctx->handshake_at = *Curl_pgrs_now(data);
+    ctx->q.last_io = *Curl_pgrs_now(data);
     CURL_TRC_CF(data, cf, "handshake complete after %" FMT_TIMEDIFF_T "ms",
-                curlx_timediff_ms(data->progress.now, ctx->started_at));
+                curlx_ptimediff_ms(Curl_pgrs_now(data), &ctx->started_at));
     result = cf_osslq_verify_peer(cf, data);
     if(!result) {
       CURL_TRC_CF(data, cf, "peer verified");
@@ -1816,17 +1815,17 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
     int detail = SSL_get_error(ctx->tls.ossl.ssl, err);
     switch(detail) {
     case SSL_ERROR_WANT_READ:
-      ctx->q.last_io = data->progress.now;
+      ctx->q.last_io = *Curl_pgrs_now(data);
       CURL_TRC_CF(data, cf, "QUIC SSL_connect() -> WANT_RECV");
       goto out;
     case SSL_ERROR_WANT_WRITE:
-      ctx->q.last_io = data->progress.now;
+      ctx->q.last_io = *Curl_pgrs_now(data);
       CURL_TRC_CF(data, cf, "QUIC SSL_connect() -> WANT_SEND");
       result = CURLE_OK;
       goto out;
 #ifdef SSL_ERROR_WANT_ASYNC
     case SSL_ERROR_WANT_ASYNC:
-      ctx->q.last_io = data->progress.now;
+      ctx->q.last_io = *Curl_pgrs_now(data);
       CURL_TRC_CF(data, cf, "QUIC SSL_connect() -> WANT_ASYNC");
       result = CURLE_OK;
       goto out;
@@ -2240,7 +2239,7 @@ static bool cf_osslq_conn_is_alive(struct Curl_cfilter *cf,
       goto out;
     }
     CURL_TRC_CF(data, cf, "negotiated idle timeout: %" PRIu64 "ms", idle_ms);
-    idletime = curlx_timediff_ms(data->progress.now, ctx->q.last_io);
+    idletime = curlx_ptimediff_ms(Curl_pgrs_now(data), &ctx->q.last_io);
     if(idle_ms && idletime > 0 && (uint64_t)idletime > idle_ms)
       goto out;
   }
@@ -2330,7 +2329,8 @@ static CURLcode cf_osslq_query(struct Curl_cfilter *cf,
   }
   case CF_QUERY_CONNECT_REPLY_MS:
     if(ctx->got_first_byte) {
-      timediff_t ms = curlx_timediff_ms(ctx->first_byte_at, ctx->started_at);
+      timediff_t ms = curlx_ptimediff_ms(&ctx->first_byte_at,
+                                         &ctx->started_at);
       *pres1 = (ms < INT_MAX) ? (int)ms : INT_MAX;
     }
     else

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -96,7 +96,7 @@ CURLcode vquic_ctx_init(struct Curl_easy *data,
     }
   }
 #endif
-  vquic_ctx_set_time(data, qctx);
+  vquic_ctx_set_time(qctx, Curl_pgrs_now(data));
 
   return CURLE_OK;
 }
@@ -106,17 +106,16 @@ void vquic_ctx_free(struct cf_quic_ctx *qctx)
   Curl_bufq_free(&qctx->sendbuf);
 }
 
-void vquic_ctx_set_time(struct Curl_easy *data,
-                        struct cf_quic_ctx *qctx)
+void vquic_ctx_set_time(struct cf_quic_ctx *qctx,
+                        const struct curltime *pnow)
 {
-  qctx->last_op = data->progress.now;
+  qctx->last_op = *pnow;
 }
 
-void vquic_ctx_update_time(struct Curl_easy *data,
-                           struct cf_quic_ctx *qctx)
+void vquic_ctx_update_time(struct cf_quic_ctx *qctx,
+                           const struct curltime *pnow)
 {
-  Curl_pgrs_now_set(data);
-  qctx->last_op = data->progress.now;
+  qctx->last_op = *pnow;
 }
 
 static CURLcode send_packet_no_gso(struct Curl_cfilter *cf,

--- a/lib/vquic/vquic_int.h
+++ b/lib/vquic/vquic_int.h
@@ -58,11 +58,11 @@ CURLcode vquic_ctx_init(struct Curl_easy *data,
                         struct cf_quic_ctx *qctx);
 void vquic_ctx_free(struct cf_quic_ctx *qctx);
 
-void vquic_ctx_set_time(struct Curl_easy *data,
-                        struct cf_quic_ctx *qctx);
+void vquic_ctx_set_time(struct cf_quic_ctx *qctx,
+                        const struct curltime *pnow);
 
-void vquic_ctx_update_time(struct Curl_easy *data,
-                           struct cf_quic_ctx *qctx);
+void vquic_ctx_update_time(struct cf_quic_ctx *qctx,
+                           const struct curltime *pnow);
 
 void vquic_push_blocked_pkt(struct Curl_cfilter *cf,
                             struct cf_quic_ctx *qctx,

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3121,13 +3121,12 @@ static CURLcode ssh_block_statemach(struct Curl_easy *data,
                                     bool disconnect)
 {
   CURLcode result = CURLE_OK;
-  struct curltime start = data->progress.now;
+  struct curltime start = *Curl_pgrs_now(data);
 
   while((sshc->state != SSH_STOP) && !result) {
     bool block;
     timediff_t left_ms = 1000;
 
-    Curl_pgrs_now_set(data); /* timeout disconnect */
     result = ssh_statemachine(data, sshc, sshp, &block);
     if(result)
       break;
@@ -3143,7 +3142,7 @@ static CURLcode ssh_block_statemach(struct Curl_easy *data,
         return CURLE_OPERATION_TIMEDOUT;
       }
     }
-    else if(curlx_timediff_ms(data->progress.now, start) > 1000) {
+    else if(curlx_ptimediff_ms(Curl_pgrs_now(data), &start) > 1000) {
       /* disconnect timeout */
       failf(data, "Disconnect timed out");
       result = CURLE_OK;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -412,7 +412,7 @@ CURLcode Curl_gtls_shared_creds_create(struct Curl_easy *data,
   }
 
   shared->refcount = 1;
-  shared->time = data->progress.now;
+  shared->time = *Curl_pgrs_now(data);
   *pcreds = shared;
   return CURLE_OK;
 }
@@ -559,11 +559,11 @@ static CURLcode gtls_populate_creds(struct Curl_cfilter *cf,
 /* key to use at `multi->proto_hash` */
 #define MPROTO_GTLS_X509_KEY   "tls:gtls:x509:share"
 
-static bool gtls_shared_creds_expired(const struct Curl_easy *data,
+static bool gtls_shared_creds_expired(struct Curl_easy *data,
                                       const struct gtls_shared_creds *sc)
 {
   const struct ssl_general_config *cfg = &data->set.general_ssl;
-  timediff_t elapsed_ms = curlx_timediff_ms(data->progress.now, sc->time);
+  timediff_t elapsed_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &sc->time);
   timediff_t timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
 
   if(timeout_ms < 0)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1722,7 +1722,7 @@ schannel_recv_renegotiate(struct Curl_cfilter *cf, struct Curl_easy *data,
     connssl->connecting_state = ssl_connect_2;
     memset(rs, 0, sizeof(*rs));
     rs->io_need = CURL_SSL_IO_NEED_SEND;
-    rs->start_time = curlx_now();
+    rs->start_time = *Curl_pgrs_now(data);
     rs->started = TRUE;
   }
 
@@ -1731,7 +1731,7 @@ schannel_recv_renegotiate(struct Curl_cfilter *cf, struct Curl_easy *data,
     curl_socket_t readfd, writefd;
     timediff_t elapsed;
 
-    elapsed = curlx_timediff_ms(curlx_now(), rs->start_time);
+    elapsed = curlx_ptimediff_ms(Curl_pgrs_now(data), &rs->start_time);
     if(elapsed >= MAX_RENEG_BLOCK_TIME) {
       failf(data, "schannel: renegotiation timeout");
       result = CURLE_SSL_CONNECT_ERROR;
@@ -1797,7 +1797,7 @@ schannel_recv_renegotiate(struct Curl_cfilter *cf, struct Curl_easy *data,
       if(result)
         break;
 
-      elapsed = curlx_timediff_ms(curlx_now(), rs->start_time);
+      elapsed = curlx_ptimediff_ms(Curl_pgrs_now(data), &rs->start_time);
       if(elapsed >= MAX_RENEG_BLOCK_TIME) {
         failf(data, "schannel: renegotiation timeout");
         result = CURLE_SSL_CONNECT_ERROR;
@@ -2723,7 +2723,7 @@ static void *schannel_get_internals(struct ssl_connect_data *connssl,
 }
 
 HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
-                                               const struct Curl_easy *data)
+                                               struct Curl_easy *data)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   struct Curl_multi *multi = data->multi;
@@ -2732,7 +2732,6 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
   const struct ssl_general_config *cfg = &data->set.general_ssl;
   timediff_t timeout_ms;
   timediff_t elapsed_ms;
-  struct curltime now;
   unsigned char info_blob_digest[CURL_SHA256_DIGEST_LENGTH];
 
   DEBUGASSERT(multi);
@@ -2758,8 +2757,7 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
      negative timeout means retain forever. */
   timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
   if(timeout_ms >= 0) {
-    now = curlx_now();
-    elapsed_ms = curlx_timediff_ms(now, share->time);
+    elapsed_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &share->time);
     if(elapsed_ms >= timeout_ms) {
       return NULL;
     }
@@ -2803,7 +2801,7 @@ static void schannel_cert_share_free(void *key, size_t key_len, void *p)
 }
 
 bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
-                                         const struct Curl_easy *data,
+                                         struct Curl_easy *data,
                                          HCERTSTORE cert_store)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -158,10 +158,10 @@ struct num_ip_data {
 };
 
 HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
-                                               const struct Curl_easy *data);
+                                               struct Curl_easy *data);
 
 bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
-                                         const struct Curl_easy *data,
+                                         struct Curl_easy *data,
                                          HCERTSTORE cert_store);
 
 #endif /* USE_SCHANNEL */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1371,8 +1371,7 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
   if(!result && *done) {
     cf->connected = TRUE;
     if(connssl->state == ssl_connection_complete) {
-      Curl_pgrs_now_set(data);
-      connssl->handshake_done = data->progress.now;
+      connssl->handshake_done = *Curl_pgrs_now(data);
     }
     /* Connection can be deferred when sending early data */
     DEBUGASSERT(connssl->state == ssl_connection_complete ||

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -148,7 +148,7 @@ static CURLcode test_unit1303(const char *arg)
     NOW(run[i].now_s, run[i].now_us);
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
     easy->progress.now = now;
-    timeout = Curl_timeleft_ms(easy, run[i].connecting);
+    timeout = Curl_timeleft_now_ms(easy, &now, run[i].connecting);
     if(timeout != run[i].result)
       fail(run[i].comment);
   }

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -78,7 +78,7 @@ static CURLcode test_unit1309(const char *arg)
     key.tv_usec = (541 * i) % 1023;
     storage[i] = key.tv_usec;
     Curl_splayset(&nodes[i], &storage[i]);
-    root = Curl_splayinsert(key, root, &nodes[i]);
+    root = Curl_splayinsert(&key, root, &nodes[i]);
   }
 
   puts("Result:");
@@ -111,7 +111,7 @@ static CURLcode test_unit1309(const char *arg)
     for(j = 0; j <= i % 3; j++) {
       storage[i * 3 + j] = key.tv_usec * 10 + j;
       Curl_splayset(&nodes[i * 3 + j], &storage[i * 3 + j]);
-      root = Curl_splayinsert(key, root, &nodes[i * 3 + j]);
+      root = Curl_splayinsert(&key, root, &nodes[i * 3 + j]);
     }
   }
 
@@ -119,12 +119,12 @@ static CURLcode test_unit1309(const char *arg)
   for(i = 0; i <= 1100; i += 100) {
     curl_mprintf("Removing nodes not larger than %d\n", i);
     tv_now.tv_usec = i;
-    root = Curl_splaygetbest(tv_now, root, &removed);
+    root = Curl_splaygetbest(&tv_now, root, &removed);
     while(removed) {
       curl_mprintf("removed payload %zu[%zu]\n",
                    *(size_t *)Curl_splayget(removed) / 10,
                    *(size_t *)Curl_splayget(removed) % 10);
-      root = Curl_splaygetbest(tv_now, root, &removed);
+      root = Curl_splaygetbest(&tv_now, root, &removed);
     }
   }
 

--- a/tests/unit/unit1399.c
+++ b/tests/unit/unit1399.c
@@ -78,6 +78,7 @@ static CURLcode test_unit1399(const char *arg)
   struct Curl_easy data;
   struct curltime now = curlx_now();
 
+  data.multi = NULL;
   data.progress.now = now;
   data.progress.t_nslookup = 0;
   data.progress.t_connect = 0;

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -25,6 +25,7 @@
 
 #include "urldata.h"
 #include "connect.h"
+#include "progress.h"
 #include "curl_share.h"
 
 static CURLcode t1607_setup(void)


### PR DESCRIPTION
time-keeping: keep timestamp in multi, **always update** when calling `Curl_pgrs_now(data)`.

Tests with skipped timestamp updates showed that we can easily run into operating with very outdated timestamp, since a process might get little cpu or even become suspended for a while. This PR now refrains from doing that.

Add `curlx_nowp()` to set current time into a `struct curltime`.
Add `curlx_ptimediff_ms() and friends, passing pointer parameters.

Update documentation.
