### PR TITLE
cf-socket: enable Win10 `TCP_KEEP*` options with old SDKs

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -189,8 +189,7 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
                     "%" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
       }
     }
-    else
-    {
+    else {
 /* Offered by mingw-w64 and MS SDK. Latter only when targeting Win7+. */
 #ifndef SIO_KEEPALIVE_VALS
 #define SIO_KEEPALIVE_VALS  _WSAIOW(IOC_VENDOR, 4)


### PR DESCRIPTION
Define `TCP_KEEP*` macros if they are missing in Windows builds.
To allow using these runtime `setsockopt()` options regardless of
build-time SDK version, when running on Windows 10.0.16299+.

In practice in enables them for builds using mingw-w64 <12, and
MSVC with Windows SDK <10.

Before this patch these runtime options required building curl with
a recent toolchain.

Follow-up to f0de14168a4d1c3a4ed43a04af92c5755c84b9fc #19559
