### PR TITLE
schannel: use Win8 `CERT_NAME_SEARCH_ALL_NAMES_FLAG` with old SDKs

### DIFF
--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -371,10 +371,12 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
   LPTSTR current_pos = NULL;
   DWORD i;
 
-/* Offered by mingw-w64 v4+. MS SDK ~10+/~VS2017+. */
-#ifdef CERT_NAME_SEARCH_ALL_NAMES_FLAG
   /* CERT_NAME_SEARCH_ALL_NAMES_FLAG is available from Windows 8 onwards. */
   if(Win8_compat) {
+/* Offered by mingw-w64 v4+. MS SDK ~10+/~VS2017+. */
+#ifndef CERT_NAME_SEARCH_ALL_NAMES_FLAG
+#define CERT_NAME_SEARCH_ALL_NAMES_FLAG 0x2
+#endif
     /* CertGetNameString will provide the 8-bit character string without
      * any decoding */
     DWORD name_flags =
@@ -387,10 +389,6 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
                                       length);
     return actual_length;
   }
-#else
-  (void)cert_context;
-  (void)Win8_compat;
-#endif
 
   if(!alt_name_info)
     return 0;


### PR DESCRIPTION
Define `CERT_NAME_SEARCH_ALL_NAMES_FLAG` macro if missing.
To allow using a runtime branch regardless of build-time SDK version,
when running on Windows 8+.

In practice it enables this branch for builds using mingw-w64 v3, and
MSVC with Windows SDK <8.

Also reducing build variations.

Follow-up to 29e40a6d8a70630dd8eaa15beded205792342d08 #4761 #3711
Follow-up to 899630021153b2a26a43008cccc6620b6c3f9bbf #1325
Follow-up to 172b2beba6b89b632c09be7a88645e3a0607cfe9 #264 (comment)
