### PR TITLE
multi: remove useless assignment

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2853,7 +2853,7 @@ CURLMcode curl_multi_perform(CURLM *m, int *running_handles)
 
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;
-  multi = m;
+
   return multi_perform(multi, &now, running_handles);
 }
 


### PR DESCRIPTION
Pointed out by CodeSonar