### PR TITLE
openssl: toggling CURLSSLOPT_NO_PARTIALCHAIN makes a different CA cache

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3234,9 +3234,8 @@ static bool ossl_cached_x509_store_different(struct Curl_cfilter *cf,
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   struct ssl_config_data *ssl_config =
     Curl_ssl_cf_get_config(cf, CURL_UNCONST(data));
-  bool diff = mb->no_partialchain != ssl_config->no_partialchain;
-  if(diff)
-    return diff;
+  if(mb->no_partialchain != ssl_config->no_partialchain)
+    return TRUE;
   if(!mb->CAfile || !conn_config->CAfile)
     return mb->CAfile != conn_config->CAfile;
   return strcmp(mb->CAfile, conn_config->CAfile);


### PR DESCRIPTION
Reported-by: Stanislav Fort