### PR TITLE
cmake: replace deprecated `OPENSSL_FOUND` with `OpenSSL_FOUND`

### DIFF
--- a/CMake/FindLibrtmp.cmake
+++ b/CMake/FindLibrtmp.cmake
@@ -90,7 +90,7 @@ else()
 
   # Necessary when linking a static librtmp
   find_package(OpenSSL)
-  if(OPENSSL_FOUND)
+  if(OpenSSL_FOUND)
     list(APPEND _librtmp_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
   endif()
 endif()


### PR DESCRIPTION
Used in `CMake/FindLibrtmp.cmake`.

`OpenSSL_FOUND` available since CMake v3.3.
`OPENSSL_FOUND` deprecated since v4.2.

Ref: https://cmake.org/cmake/help/v4.2/module/FindOpenSSL.html
