### PR TITLE
multi-notify: add check macro

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2798,7 +2798,7 @@ static CURLMcode multi_perform(struct Curl_multi *multi,
   if(multi_ischanged(multi, TRUE))
     process_pending_handles(multi);
 
-  if(!returncode)
+  if(!returncode && CURL_MNTFY_HAS_ENTRIES(multi))
     returncode = Curl_mntfy_dispatch_all(multi);
 
   /*
@@ -3195,7 +3195,7 @@ out:
   if(multi_ischanged(multi, TRUE))
     process_pending_handles(multi);
 
-  if(!mresult)
+  if(!mresult && CURL_MNTFY_HAS_ENTRIES(multi))
     mresult = Curl_mntfy_dispatch_all(multi);
 
   if(running_handles) {

--- a/lib/multi_ntfy.c
+++ b/lib/multi_ntfy.c
@@ -174,6 +174,7 @@ void Curl_mntfy_add(struct Curl_easy *data, unsigned int type)
       mntfy_chunk_append(tail, data, (uint32_t)type);
     else
       multi->ntfy.failure = CURLM_OUT_OF_MEMORY;
+    multi->ntfy.has_entries = TRUE;
   }
 }
 
@@ -201,5 +202,7 @@ CURLMcode Curl_mntfy_dispatch_all(struct Curl_multi *multi)
     multi->ntfy.failure = CURLM_OK; /* reset, once delivered */
     return mresult;
   }
+  else
+    multi->ntfy.has_entries = FALSE;
   return CURLM_OK;
 }

--- a/lib/multi_ntfy.h
+++ b/lib/multi_ntfy.h
@@ -33,9 +33,10 @@ struct curl_multi_ntfy {
   curl_notify_callback ntfy_cb;
   void *ntfy_cb_data;
   struct uint32_bset enabled;
-  CURLMcode failure;
   struct mntfy_chunk *head;
   struct mntfy_chunk *tail;
+  CURLMcode failure;
+  BIT(has_entries);
 };
 
 void Curl_mntfy_init(struct Curl_multi *multi);
@@ -52,6 +53,8 @@ void Curl_mntfy_add(struct Curl_easy *data, unsigned int type);
     if((d) && (d)->multi && (d)->multi->ntfy.ntfy_cb) \
       Curl_mntfy_add((d), (t));                       \
   } while(0)
+
+#define CURL_MNTFY_HAS_ENTRIES(m)       ((m)->ntfy.has_entries)
 
 CURLMcode Curl_mntfy_dispatch_all(struct Curl_multi *multi);
 


### PR DESCRIPTION
Since Curl_mntfy_dispatch_all() is called with high frequency and mostly unnecessary, add a check macro to avoid the call when not needed.