### PR TITLE
scorecard: more upload options

### DIFF
--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -422,7 +422,7 @@ class ScoreRunner:
             curl = self.mk_curl_client()
             r = curl.http_put(urls=[url], fdata=fpath, alpn_proto=self.protocol,
                               with_headers=False, with_profile=True,
-                              supress_cl=self.suppress_cl)
+                              suppress_cl=self.suppress_cl)
             err = self._check_uploads(r, 1)
             if err:
                 errors.append(err)
@@ -442,7 +442,7 @@ class ScoreRunner:
             curl = self.mk_curl_client()
             r = curl.http_put(urls=[url], fdata=fpath, alpn_proto=self.protocol,
                               with_headers=False, with_profile=True,
-                              supress_cl=self.suppress_cl)
+                              suppress_cl=self.suppress_cl)
             err = self._check_uploads(r, count)
             if err:
                 errors.append(err)
@@ -463,7 +463,7 @@ class ScoreRunner:
             curl = self.mk_curl_client()
             r = curl.http_put(urls=[url], fdata=fpath, alpn_proto=self.protocol,
                               with_headers=False, with_profile=True,
-                              supress_cl=self.suppress_cl,
+                              suppress_cl=self.suppress_cl,
                               extra_args=[
                                    '--parallel',
                                    '--parallel-max', str(max_parallel),

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -784,7 +784,7 @@ class CurlClient:
                  with_stats: bool = True,
                  with_headers: bool = False,
                  with_profile: bool = False,
-                 supress_cl: bool = False,
+                 suppress_cl: bool = False,
                  extra_args: Optional[List[str]] = None):
         if extra_args is None:
             extra_args = []
@@ -799,7 +799,7 @@ class CurlClient:
             extra_args.extend([
                 '-w', '%{json}\\n'
             ])
-        if supress_cl:
+        if suppress_cl:
             extra_args.extend([
                 '-H', 'Content-Length:',
                 '-H', 'Transfer-Encoding: chunked',


### PR DESCRIPTION
`--upload-no-cl` for uploads without "Content-Length:" `--upload-parallel=1` for testing only serial uploads