### PR TITLE
curl_ntlm_core: drop unused OpenSSL/wolfSSL headers

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -69,7 +69,6 @@
 
 #ifdef USE_OPENSSL
 #  include <openssl/des.h>
-#  include <openssl/ssl.h>
 #  ifdef OPENSSL_IS_AWSLC  /* for versions 1.2.0 to 1.30.1 */
 #    define DES_set_key_unchecked (void)DES_set_key
 #  endif
@@ -77,7 +76,6 @@
 #else
 #  include <wolfssl/options.h>
 #  include <wolfssl/openssl/des.h>
-#  include <wolfssl/openssl/ssl.h>
 #  ifdef OPENSSL_COEXIST
 #    define DES_key_schedule      WOLFSSL_DES_key_schedule
 #    define DES_cblock            WOLFSSL_DES_cblock


### PR DESCRIPTION
`openssl/rand.h` and `openssl/ssl.h`.
