### PR TITLE
socks.h: delete obsolete, unused, macros

### DIFF
--- a/lib/socks.h
+++ b/lib/socks.h
@@ -26,11 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifdef CURL_DISABLE_PROXY
-#define Curl_SOCKS4(a, b, c, d, e)    CURLE_NOT_BUILT_IN
-#define Curl_SOCKS5(a, b, c, d, e, f) CURLE_NOT_BUILT_IN
-#define Curl_SOCKS_getsock(x, y, z)   0
-#else
+#ifndef CURL_DISABLE_PROXY
 /*
  * Helper read-from-socket functions. Does the same as Curl_read() but it
  * blocks until all bytes amount of buffersize will be read. No more, no less.
@@ -56,6 +52,6 @@ CURLcode Curl_cf_socks_proxy_insert_after(struct Curl_cfilter *cf_at,
 
 extern struct Curl_cftype Curl_cft_socks_proxy;
 
-#endif /* CURL_DISABLE_PROXY */
+#endif /* !CURL_DISABLE_PROXY */
 
 #endif  /* HEADER_CURL_SOCKS_H */


### PR DESCRIPTION
Unused since dafdb20a26d0c890e83dea61a104b75408481ebd #9855

Cherry-picked from #20051
