### PR TITLE
curl_ntlm_core: move `vauth/vauth.h` include from header to source

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -116,6 +116,7 @@
 #include "curl_hmac.h"
 #include "curlx/warnless.h"
 #include "curl_md4.h"
+#include "vauth/vauth.h"
 
 #ifdef USE_CURL_DES_SET_ODD_PARITY
 /*

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -28,8 +28,6 @@
 
 #ifdef USE_CURL_NTLM_CORE
 
-#include "vauth/vauth.h"
-
 struct ntlmdata;
 
 /* Helpers to generate function byte arguments in little endian order */


### PR DESCRIPTION
To not include it implicitly for all `curl_ntlm_core.h` users.
