### PR TITLE
test96: fix to accept non-unity memdump content with MSVC

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -769,7 +769,6 @@ jobs:
               -DNGTCP2_INCLUDE_DIR=/ucrt64/include
               -DNGTCP2_LIBRARY=/ucrt64/lib/libngtcp2.dll.a
               -DNGTCP2_CRYPTO_OSSL_LIBRARY=/ucrt64/lib/libngtcp2_crypto_ossl.dll.a
-              -DCMAKE_UNITY_BUILD=OFF
 
           - name: 'schannel U'
             install-vcpkg: 'zlib libssh2[core,zlib]'


### PR DESCRIPTION
In unity builds the source filename (via `__FILE__`) has no path (or
uses slashes?), while in non-unity ones it does contain backslashes
on Windows, with MSVC. Fix the test to recognize backslashes in the
`stripfile` regexp.

Seen in MSVC jobs in CI:
```diff
-MEM tool_cfgable.c[LF]
-MEM tool_paramhlp.c[LF]
-MEM tool_cfgable.c[LF]
-MEM tool_cfgable.c[LF]
-MEM tool_cfgable.c[LF]
-MEM tool_cfgable.c[LF]
+MEM D:\a\curl\curl\src\tool_cfgable.c[LF]
+MEM D:\a\curl\curl\src\tool_paramhlp.c[LF]
+MEM D:\a\curl\curl\src\tool_cfgable.c[LF]
+MEM D:\a\curl\curl\src\tool_cfgable.c[LF]
+MEM D:\a\curl\curl\src\tool_cfgable.c[LF]
+MEM D:\a\curl\curl\src\tool_cfgable.c[LF]
```
Ref: https://github.com/curl/curl/actions/runs/20408366058/job/58641468316?pr=20061#step:13:303
Ref: https://github.com/curl/curl/actions/runs/20408522070/job/58641826216?pr=20064#step:13:298

---

- [x] triggered OK in this PR by enabling non-unity for MSVC x64 job.
- [x] check if fix works with the trigger in place: https://github.com/curl/curl/actions/runs/20408618880/job/58642058721?pr=20064
- [x] revert trigger.
