### PR TITLE
badwords: Add fist -> first, fix fallout

### DIFF
--- a/.github/scripts/badwords.txt
+++ b/.github/scripts/badwords.txt
@@ -73,6 +73,7 @@ host name\b:hostname
 host names\b:hostnames
 [^;<]file name\b:filename
 file names\b:filenames
+\bfist\b:first
 \buser name\b:username
 \buser names\b:usernames
 \bpass phrase:passphrase

--- a/docs/internals/MID.md
+++ b/docs/internals/MID.md
@@ -36,7 +36,7 @@ writing that is `16` for "multi_easy" handles (used in `curl_easy_perform()`
 and `512` for multi handles created with `curl_multi_init()`.
 
 The first added easy handle gets `mid == 1` assigned. The second one receives `2`,
-even when the fist one has been removed already. Every added handle gets an
+even when the first one has been removed already. Every added handle gets an
 `mid` one larger than the previously assigned one. Until the capacity of
 the table is reached and it starts looking for a free id at `1` again (`0`
 is always in the table).

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -447,7 +447,7 @@ static CURLcode proxy_h2_progress_ingress(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OK;
   size_t nread;
 
-  /* Process network input buffer fist */
+  /* Process network input buffer first */
   if(!Curl_bufq_is_empty(&ctx->inbufq)) {
     CURL_TRC_CF(data, cf, "[0] process %zu bytes in connection buffer",
                 Curl_bufq_len(&ctx->inbufq));

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2043,7 +2043,7 @@ static CURLcode h2_progress_ingress(struct Curl_cfilter *cf,
     return CURLE_HTTP2;
   }
 
-  /* Process network input buffer fist */
+  /* Process network input buffer first */
   if(!Curl_bufq_is_empty(&ctx->inbufq)) {
     CURL_TRC_CF(data, cf, "Process %zu bytes in connection buffer",
                 Curl_bufq_len(&ctx->inbufq));

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1496,7 +1496,7 @@ static ParameterError parse_verbose(bool toggle)
     return err;
   }
   else if(!verbose_nopts) {
-    /* fist `-v` in an argument resets to base verbosity */
+    /* first `-v` in an argument resets to base verbosity */
     global->verbosity = 0;
     if(!global->trace_set && set_trace_config("-all"))
       return PARAM_NO_MEM;


### PR DESCRIPTION
There are still `curl_fistrgs` in packages/OS400/curl.inc.in but I'm not sure what that's supposed to be exactly