### PR TITLE
binmode: delete extra nop instruction from fallback macro

### DIFF
--- a/lib/curlx/binmode.h
+++ b/lib/curlx/binmode.h
@@ -33,7 +33,7 @@
 #  define CURLX_SET_BINMODE(stream)  (void)setmode(fileno(stream), O_BINARY)
 #endif
 #else
-#  define CURLX_SET_BINMODE(stream)  (void)stream; Curl_nop_stmt
+#  define CURLX_SET_BINMODE(stream)  (void)stream
 #endif
 
 #endif /* HEADER_CURL_TOOL_BINMODE_H */


### PR DESCRIPTION
Follow-up to 250d613763dfc29f73010696ee7948f19d07dba9 #15787