### PR TITLE
fix: Suppress unsigned-integer-overflow sanitizer report in curl_easy_escape()

### DIFF
--- a/lib/escape.c
+++ b/lib/escape.c
@@ -64,7 +64,7 @@ char *curl_easy_escape(CURL *data, const char *string, int inlength)
 
   curlx_dyn_init(&d, length * 3 + 1);
 
-  while(length--) {
+  while(length) {
     /* treat the characters unsigned */
     unsigned char in = (unsigned char)*string++;
 
@@ -80,6 +80,7 @@ char *curl_easy_escape(CURL *data, const char *string, int inlength)
       if(curlx_dyn_addn(&d, out, 3))
         return NULL;
     }
+    length--;
   }
 
   return curlx_dyn_ptr(&d);


### PR DESCRIPTION
Hi, here are my environment settings:

Reproduced on
* curl 8.16.0
* current master: d92e264ff0c15294ded048f33d8cf34b1b7846c3

Issue
When building with Clang sanitizers including `unsigned-integer-overflow`, `curl_easy_escape()` in `lib/escape.c` triggers a runtime report:

`runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t'`

This is caused by the loop condition `while(length--)`, which performs a post-decrement even on the final iteration check when `length` is 0 (the loop body is not entered, but the decrement still occurs), resulting in an unsigned wraparound that the sanitizer reports.

Build / Reproduction (CMake)

```bash
cmake -S . -B build-asan-ubsan -G Ninja \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_C_FLAGS="-O1 -g -fno-omit-frame-pointer -fsanitize=address,undefined,unsigned-integer-overflow -fno-sanitize-recover=undefined" \
  -DCMAKE_CXX_FLAGS="-O1 -g -fno-omit-frame-pointer -fsanitize=address,undefined,unsigned-integer-overflow -fno-sanitize-recover=undefined" \
  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
  -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF \
  -DUSE_BROTLI=ON -DUSE_ZSTD=ON \
  -DENABLE_THREADED_RESOLVER=OFF \
  -DENABLE_ARES=OFF -DCURL_USE_ARES=OFF \
  -DCMAKE_DISABLE_FIND_PACKAGE_Threads=ON \
  -DCMAKE_FIND_LIBRARY_SUFFIXES=.a \
  -DCMAKE_DISABLE_FIND_PACKAGE_LibSSH2=ON \
  -DCMAKE_DISABLE_FIND_PACKAGE_libssh=ON \
  -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=OFF \
  -DCURL_DISABLE_SCP=ON -DCURL_DISABLE_SFTP=ON \
  -DCMAKE_PREFIX_PATH="$STATIC_PREFIX" \
  -DCURL_ZLIB=OFF \
  -DCURL_USE_OPENSSL=OFF \
  -DCURL_CA_BUNDLE=none -DCURL_CA_PATH=none \
  -DCURL_USE_LIBPSL=OFF \
  -DUSE_NGHTTP2=OFF -DUSE_LIBIDN2=OFF \
  -DCURL_DISABLE_LDAP=ON \
&& cmake --build build-asan-ubsan --parallel \
&& ./build-asan-ubsan/src/curl -V
```

Reproduction command

```bash
./curl "-qT" " ���" "--" " ���" " �����������������"
```

> **Note:** If copying the Unicode arguments risks corruption, the exact command line is provided in base64: `Li9jdXJsICItcVQiICLigIDvv73vv73vv70iICItLSIgIuKAgO+/ve+/ve+/vSIgIuKAgO+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/ve+/vSI=`


Observed output (before fix)

```
Warning: The argument ' ���' starts with a Unicode character. Maybe ASCII was intended?
Warning: The argument ' ���' starts with a Unicode character. Maybe ASCII was intended?
Warning: The argument ' �����������������' starts with a Unicode character.
Warning: Maybe ASCII was intended?
/data/curl/lib/escape.c:67:15: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /data/curl/lib/escape.c:67:15
curl: cannot open ' ���'
curl: try 'curl --help' or 'curl --manual' for more information
curl: (26) Failed to open/read local data from file/application
```

Fix
change in `lib/escape.c`:

* From:
`while(length--) { ... }`
* To:
`while(length) { ...; length--; }`

Expected output (after fix)
The sanitizer report is gone; curl still errors out normally for the invalid local file argument:

```
Warning: The argument ' ���' starts with a Unicode character. Maybe ASCII was intended?
Warning: The argument ' ���' starts with a Unicode character. Maybe ASCII was intended?
Warning: The argument ' �����������������' starts with a Unicode character.
Warning: Maybe ASCII was intended?
curl: cannot open ' ���'
curl: try 'curl --help' or 'curl --manual' for more information
curl: (26) Failed to open/read local data from file/application
```
