### PR TITLE
vquic: initialize new callback in nghttp3 1.14.0+

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -877,7 +877,7 @@ static ngtcp2_callbacks ng_callbacks = {
   cb_recv_rx_key,
   NULL, /* recv_tx_key */
   NULL, /* early_data_rejected */
-#ifdef NGTCP2_CALLBACKS_V2
+#ifdef NGTCP2_CALLBACKS_V2  /* ngtcp2 v1.14.0+ */
   NULL, /* begin_path_validation */
 #endif
 };
@@ -1292,12 +1292,12 @@ static nghttp3_callbacks ngh3_callbacks = {
   cb_h3_reset_stream,
   NULL, /* shutdown */
   NULL, /* recv_settings (deprecated) */
-#ifdef NGHTTP3_CALLBACKS_V2
+#ifdef NGHTTP3_CALLBACKS_V2  /* nghttp3 v1.11.0+ */
   NULL, /* recv_origin */
   NULL, /* end_origin */
   NULL, /* rand */
 #endif
-#ifdef NGHTTP3_CALLBACKS_V3
+#ifdef NGHTTP3_CALLBACKS_V3  /* nghttp3 v1.14.0+ */
   NULL, /* recv_settings2 */
 #endif
 };

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1075,12 +1075,12 @@ static nghttp3_callbacks ngh3_callbacks = {
   cb_h3_reset_stream,
   NULL, /* shutdown */
   NULL, /* recv_settings (deprecated) */
-#ifdef NGHTTP3_CALLBACKS_V2
+#ifdef NGHTTP3_CALLBACKS_V2  /* nghttp3 v1.11.0+ */
   NULL, /* recv_origin */
   NULL, /* end_origin */
   NULL, /* rand */
 #endif
-#ifdef NGHTTP3_CALLBACKS_V3
+#ifdef NGHTTP3_CALLBACKS_V3  /* nghttp3 v1.14.0+ */
   NULL, /* recv_settings2 */
 #endif
 };


### PR DESCRIPTION
Fixing (seen in curl-for-win production build):
```
lib/vquic/curl_ngtcp2.c:1257:1: error: missing field 'recv_settings2' initializer [-Werror,-Wmissing-field-initializers]
 1257 | };
      | ^
1 error generated.
```
Ref: https://ci.appveyor.com/project/curlorg/curl-for-win/builds/53281785#L6752
Ref: https://github.com/curl/curl/actions/runs/20459295003/job/58788229134#step:3:5513

Also:
- Mark previous callback deprecated.
- Document ngtcp2, nghttp3 versions for callback entry feature guards.

Refs:
https://github.com/ngtcp2/nghttp3/releases/tag/v1.14.0
https://github.com/ngtcp2/nghttp3/pull/432
https://github.com/ngtcp2/nghttp3/commit/1616ab835061d7cdd2ef114bc3ddb917ce269611
