### PR TITLE
lib547, 555: fix off-by-one null-terminator in read callback

### DIFF
--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -44,7 +44,7 @@ static size_t t547_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
 
   if(size * nmemb >= T547_DATALEN) {
     curl_mfprintf(stderr, "READ!\n");
-    curlx_strcopy(ptr, size * nmemb, t547_uploadthis, T547_DATALEN);
+    memcpy(ptr, t547_uploadthis, T547_DATALEN);
     return T547_DATALEN;
   }
   curl_mfprintf(stderr, "READ NOT FINE!\n");

--- a/tests/libtest/lib555.c
+++ b/tests/libtest/lib555.c
@@ -48,7 +48,7 @@ static size_t t555_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
 
   if(size * nmemb >= T555_DATALEN) {
     curl_mfprintf(stderr, "READ!\n");
-    curlx_strcopy(ptr, size * nmemb, t555_uploadthis, T555_DATALEN);
+    memcpy(ptr, t555_uploadthis, T555_DATALEN);
     return T555_DATALEN;
   }
   curl_mfprintf(stderr, "READ NOT FINE!\n");


### PR DESCRIPTION
`strcpy()` wrote an unnecessary null-terminator past the available read
buffer.

test551 was also affected because it reuses lib547.

Cherry-picked from #20076
