### PR TITLE
curl_ntlm_core: fix DES_* symbols for some wolfSSL builds

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -76,6 +76,7 @@
 #else
 #  include <wolfssl/options.h>
 #  include <wolfssl/openssl/des.h>
+#  include <wolfssl/version.h>
 #  ifdef OPENSSL_COEXIST
 #    define DES_key_schedule      WOLFSSL_DES_key_schedule
 #    define DES_cblock            WOLFSSL_DES_cblock
@@ -84,6 +85,13 @@
 #    define DES_set_key_unchecked wolfSSL_DES_set_key_unchecked
 #    define DES_ecb_encrypt       wolfSSL_DES_ecb_encrypt
 #    define DESKEY(x)             ((WOLFSSL_DES_key_schedule *)(x))
+
+#    if defined(LIBWOLFSSL_VERSION_HEX) &&      \
+  (LIBWOLFSSL_VERSION_HEX >= 0x05007006)
+#      define DES_ENCRYPT WC_DES_ENCRYPT
+#      define DES_DECRYPT WC_DES_DECRYPT
+#    endif
+
 #  else
 #    define DESKEY(x) &x
 #  endif


### PR DESCRIPTION
Recent wolfSSL with OPENSSL_COEXIST enabled does not provide the DES_* symbols, so we do.

Reported-by: Daniel Pouzzner