### PR TITLE
checksrc: ban `strcpy`

### DIFF
--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -711,6 +711,7 @@ char *Curl_ldap_get_dn_a(void *ld, LDAPMessage *entry)
      ldap_memfree() and ldap_memalloc() does not exist. The solution is to
      overwrite the EBCDIC buffer with ASCII to return it. */
 
+  /* !checksrc! disable BANNEDFUNC 1 */
   strcpy(cp, cp2);
   free(cp2);
   return cp;
@@ -741,6 +742,7 @@ char *Curl_ldap_first_attribute_a(void *ld, LDAPMessage *entry,
      ldap_memfree() and ldap_memalloc() does not exist. The solution is to
      overwrite the EBCDIC buffer with ASCII to return it. */
 
+  /* !checksrc! disable BANNEDFUNC 1 */
   strcpy(cp, cp2);
   free(cp2);
   return cp;
@@ -771,6 +773,7 @@ char *Curl_ldap_next_attribute_a(void *ld, LDAPMessage *entry,
      ldap_memfree() and ldap_memalloc() does not exist. The solution is to
      overwrite the EBCDIC buffer with ASCII to return it. */
 
+  /* !checksrc! disable BANNEDFUNC 1 */
   strcpy(cp, cp2);
   free(cp2);
   return cp;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -110,6 +110,7 @@ my %banfunc = (
     "sscanf" => 1,
     "stat" => 1,
     "strcat" => 1,
+    "strcpy" => 1,
     "strdup" => 1,
     "strerror" => 1,
     "strncat" => 1,


### PR DESCRIPTION
No longer used in the codebase. Replacement is `curlx_strcopy()`, possibly
`memcpy()` or dynbuf.

Also:
- OS400: allow three calls.
