### PR TITLE
curl_quiche: refuse headers with CR, LF or null bytes

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -373,7 +373,7 @@ static int cb_each_header(uint8_t *name, size_t name_len,
   struct Curl_easy *data = x->data;
   struct h3_stream_ctx *stream = x->stream;
   struct cf_quiche_ctx *ctx = cf->ctx;
-  CURLcode result;
+  CURLcode result = CURLE_OK;
 
   if(!stream || stream->xfer_result)
     return 1; /* abort iteration */


### PR DESCRIPTION
Also renamed the struct field to 'h1hdr' from 'scratch' to better say what its purpose is.