### PR TITLE
telnet: abort on bad suboption sequence

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1124,7 +1124,6 @@ static CURLcode telrcv(struct Curl_easy *data,
       break;
 
     case CURL_TS_IAC:
-process_iac:
       DEBUGASSERT(startwrite < 0);
       switch(c) {
       case CURL_WILL:
@@ -1197,24 +1196,12 @@ process_iac:
         if(c != CURL_IAC) {
           /*
            * This is an error. We only expect to get "IAC IAC" or "IAC SE".
-           * Several things may have happened. An IAC was not doubled, the
-           * IAC SE was left off, or another option got inserted into the
-           * suboption are all possibilities. If we assume that the IAC was
-           * not doubled, and really the IAC SE was left off, we could get
-           * into an infinite loop here. So, instead, we terminate the
-           * suboption, and process the partial suboption if we can.
+           * Several things may have happened. An IAC was not doubled, the IAC
+           * SE was left off, or another option got inserted into the
+           * suboption are all possibilities.
            */
-          CURL_SB_ACCUM(tn, CURL_IAC);
-          CURL_SB_ACCUM(tn, c);
-          tn->subpointer -= 2;
-          CURL_SB_TERM(tn);
-
-          printoption(data, "In SUBOPTION processing, RCVD", CURL_IAC, c);
-          result = suboption(data, tn);   /* handle sub-option */
-          if(result)
-            return result;
-          tn->telrcv_state = CURL_TS_IAC;
-          goto process_iac;
+          failf(data, "telnet: suboption error");
+          return CURLE_RECV_ERROR;
         }
         CURL_SB_ACCUM(tn, c);
         tn->telrcv_state = CURL_TS_SB;


### PR DESCRIPTION
Instead of trying to repair.

Reported-by: Huseyin Tintas