### PR TITLE
ratelimit blocking: fix busy loop

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1080,10 +1080,9 @@ static CURLcode mstate_perform_pollset(struct Curl_easy *data,
     result = conn->handler->perform_pollset(data, ps);
   else {
     /* Default is to obey the data->req.keepon flags for send/recv */
-    if(CURL_WANT_RECV(data) && CONN_SOCK_IDX_VALID(conn->recv_idx)) {
+    if(Curl_req_want_recv(data) && CONN_SOCK_IDX_VALID(conn->recv_idx)) {
       result = Curl_pollset_add_in(data, ps, conn->sock[conn->recv_idx]);
     }
-
     if(!result && Curl_req_want_send(data) &&
        CONN_SOCK_IDX_VALID(conn->send_idx)) {
       result = Curl_pollset_add_out(data, ps, conn->sock[conn->send_idx]);

--- a/lib/request.c
+++ b/lib/request.c
@@ -415,14 +415,23 @@ bool Curl_req_sendbuf_empty(struct Curl_easy *data)
 
 bool Curl_req_want_send(struct Curl_easy *data)
 {
-  /* Not done and
-   * - KEEP_SEND and not PAUSEd.
-   * - or request has buffered data to send
-   * - or transfer connection has pending data to send */
+  /* Not done and upload not blocked and either one of
+   * - KEEP_SEND
+   * - request has buffered data to send
+   * - connection has pending data to send */
   return !data->req.done &&
+         !Curl_rlimit_is_blocked(&data->progress.ul.rlimit) &&
          ((data->req.keepon & KEEP_SEND) ||
           !Curl_req_sendbuf_empty(data) ||
           Curl_xfer_needs_flush(data));
+}
+
+bool Curl_req_want_recv(struct Curl_easy *data)
+{
+  /* Not done and download not blocked and KEEP_RECV */
+  return !data->req.done &&
+         !Curl_rlimit_is_blocked(&data->progress.dl.rlimit) &&
+         (data->req.keepon & KEEP_RECV);
 }
 
 bool Curl_req_done_sending(struct Curl_easy *data)

--- a/lib/request.h
+++ b/lib/request.h
@@ -193,10 +193,12 @@ bool Curl_req_done_sending(struct Curl_easy *data);
  */
 CURLcode Curl_req_send_more(struct Curl_easy *data);
 
-/**
- * TRUE iff the request wants to send, e.g. has buffered bytes.
- */
+/* TRUE if the request wants to send, e.g. is not done sending
+ * and is not blocked. */
 bool Curl_req_want_send(struct Curl_easy *data);
+
+/* TRUE if the request wants to receive and is not blocked. */
+bool Curl_req_want_recv(struct Curl_easy *data);
 
 /**
  * TRUE iff the request has no buffered bytes yet to send.


### PR DESCRIPTION
Fix the pollset in perform state to not add sockets for directions that are blocked. This otherwise will lead to busy loops for a transfer that cannot be progressed.

refs #20091