### PR TITLE
tool_operate: improve the error message for bad output file name

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -997,7 +997,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
     tool_safefree(storefile);
     if(result) {
       /* bad globbing */
-      warnf("bad output glob");
+      warnf("bad output filename");
       return result;
     }
     if(!*per->outfile) {


### PR DESCRIPTION
if for example sanitize_file_name deems it bad, saying `bad output filename` seems much better than `bad output glob`.

Reported-by: Viktor Szakats
Ref: #20044