### PR TITLE
tool: fix error/warning messages when output filename sanitization fails

### DIFF
--- a/.github/scripts/pyspelling.words
+++ b/.github/scripts/pyspelling.words
@@ -749,6 +749,7 @@ rustls
 rustup
 Sagula
 SanDisk
+sanitization
 SAS
 SASL
 Satiro

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -52,6 +52,7 @@ struct OperationConfig *config_alloc(void)
   config->ftp_skip_ip = TRUE;
   config->file_clobber_mode = CLOBBER_DEFAULT;
   config->upload_flags = CURLULFLAG_SEEN;
+  config->tresult = CURLTE_OK;
   curlx_dyn_init(&config->postdata, MAX_FILE2MEMORY);
   return config;
 }

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -218,6 +218,7 @@ struct OperationConfig {
     CLOBBER_NEVER, /* If the file exists, always fail */
     CLOBBER_ALWAYS /* If the file exists, always overwrite it */
   } file_clobber_mode;
+  CURLTcode tresult;
   unsigned char upload_flags; /* Bitmask for --upload-flags */
   unsigned short porttouse;
   unsigned char ssl_version;     /* 0 - 4, 0 being default */

--- a/src/tool_operhlp.h
+++ b/src/tool_operhlp.h
@@ -31,7 +31,8 @@ void clean_getout(struct OperationConfig *config);
 bool output_expected(const char *url, const char *uploadfile);
 bool stdin_upload(const char *uploadfile);
 CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename);
-CURLcode get_url_file_name(char **filename, const char *url);
+CURLcode get_url_file_name(char **filename, const char *url,
+                           CURLTcode *sanitize);
 CURLcode urlerr_cvt(CURLUcode ucode);
 
 #endif /* HEADER_CURL_TOOL_OPERHLP_H */

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -98,6 +98,7 @@ struct getout {
   BIT(noglob);    /* disable globbing for this URL */
   BIT(out_null);  /* discard output for this URL */
 };
+
 /*
  * 'trace' enumeration represents curl's output look'n feel possibilities.
  */
@@ -121,6 +122,14 @@ typedef enum {
   TOOL_HTTPREQ_SIMPLEPOST,
   TOOL_HTTPREQ_PUT
 } HttpReq;
+
+/* CURLTcode errors specific to tool */
+typedef enum {
+  CURLTE_OK,                  /* 0 */
+  CURLTE_ERROR,               /* 1 */
+  CURLTE_BAD_FILENAME = 900,
+  CURLTE_LAST                 /* never use! */
+} CURLTcode;
 
 /*
  * Complete struct declarations which have OperationConfig struct members,

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -637,10 +637,11 @@ CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
 #define MAX_OUTPUT_GLOB_LENGTH (1024 * 1024)
 
 CURLcode glob_match_url(char **output, const char *filename,
-                        struct URLGlob *glob)
+                        struct URLGlob *glob, CURLTcode *sanitize)
 {
   struct dynbuf dyn;
   *output = NULL;
+  *sanitize = CURLTE_OK;
 
   curlx_dyn_init(&dyn, MAX_OUTPUT_GLOB_LENGTH);
 
@@ -705,9 +706,12 @@ CURLcode glob_match_url(char **output, const char *filename,
                                           SANITIZE_ALLOW_RESERVED));
     curlx_dyn_free(&dyn);
     if(sc) {
-      if(sc == SANITIZE_ERR_OUT_OF_MEMORY)
+      if(sc == SANITIZE_ERR_OUT_OF_MEMORY) {
+        *sanitize = CURLTE_ERROR;
         return CURLE_OUT_OF_MEMORY;
-      return CURLE_URL_MALFORMAT;
+      }
+      *sanitize = CURLTE_BAD_FILENAME;
+      return CURLE_BAD_FUNCTION_ARGUMENT;
     }
     *output = sanitized;
     return CURLE_OK;

--- a/src/tool_urlglob.h
+++ b/src/tool_urlglob.h
@@ -75,7 +75,7 @@ CURLcode glob_url(struct URLGlob *glob, const char *url, curl_off_t *urlnum,
                   FILE *error);
 CURLcode glob_next_url(char **globbed, struct URLGlob *glob);
 CURLcode glob_match_url(char **output, const char *filename,
-                        struct URLGlob *glob);
+                        struct URLGlob *glob, CURLTcode *sanitize);
 void glob_cleanup(struct URLGlob *glob);
 bool glob_inuse(struct URLGlob *glob);
 


### PR DESCRIPTION
Add support for curl-tool-specific error codes, and allow to show them
for errors that have no libcurl `CURLE_*` code.

Use this capability to show an accurate message when the output filename
fails sanitization on MS-DOS.

Also:
- tidy up messages when filename sanitization runs OOM.
- tidy up low-level messages when the output filename fails sanitization
  on MS-DOS.

Before:
```
$ CURL_FN_SANITIZE_OOM=1 wine curl.exe https://curl.se/ --output out.txt
Warning: bad output glob
curl: (27) Out of memory

$ CURL_FN_SANITIZE_BAD=1 wine curl.exe https://curl.se/ --output out.txt
Warning: bad output glob
curl: (3) URL using bad/illegal format or missing URL

$ CURL_FN_SANITIZE_OOM=1 wine curl.exe https://curl.se/index.html --globoff -O
curl: Failed to extract a filename from the URL to use for storage
curl: (27) Out of memory

$ CURL_FN_SANITIZE_BAD=1 wine curl.exe https://curl.se/index.html --globoff -O
curl: Failed to extract a filename from the URL to use for storage
curl: (3) URL using bad/illegal format or missing URL
```

After:
```
$ CURL_FN_SANITIZE_OOM=1 wine curl.exe https://curl.se/ --output out.txt
curl: (27) Out of memory

$ CURL_FN_SANITIZE_BAD=1 wine curl.exe https://curl.se/ --output out.txt
Warning: bad output filename
curl: (900) Filename failed sanitization

$ CURL_FN_SANITIZE_OOM=1 wine curl.exe https://curl.se/index.html --globoff -O
curl: (27) Out of memory

$ CURL_FN_SANITIZE_BAD=1 wine curl.exe https://curl.se/index.html --globoff -O
curl: bad output filename
curl: (900) Filename failed sanitization
```

Ref: #20113 #20121
Ref: 40c1748af503cf54443e17db5f537b548faa9328 #20198
Ref: eb7f5b71e5b3fe1e73f6065c78ad0143ff580916 #20143
Ref: 8c02407bef55baaee8d721a7e5f7f0ba8d91dd47 #20125
Fixes #20044

---

- [x] avoid spilling the output stdout in case of a sanitization failure. (to keep existing behavior)
- [x] fixme one remaining `output glob` OOM case.