### PR TITLE
tool_doswin: add debug envs to test filename sanitization failure modes

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -207,10 +207,10 @@ SANITIZEcode sanitize_file_name(char ** const sanitized, const char *file_name,
   }
 
 #ifdef DEBUGBUILD
-  if(getenv("CURL_FN_SANITIZE_OOM"))
-    return SANITIZE_ERR_OUT_OF_MEMORY;
   if(getenv("CURL_FN_SANITIZE_BAD"))
     return SANITIZE_ERR_INVALID_PATH;
+  if(getenv("CURL_FN_SANITIZE_OOM"))
+    return SANITIZE_ERR_OUT_OF_MEMORY;
 #endif
 
   *sanitized = target;


### PR DESCRIPTION
- `CURL_FN_SANITIZE_BAD=<any-value>` to simulate
  `SANITIZE_ERR_INVALID_PATH`.

- `CURL_FN_SANITIZE_OOM=<any-value>` to simulate
  `SANITIZE_ERR_OUT_OF_MEMORY`.

Both are Windows/MS-DOS-specific and require debug-enabled curl build.

Cherry-picked from #20116
