### PR TITLE
openssl: fix building against no-ocsp openssl with Apple SecTrust

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4744,7 +4744,8 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
   long ossl_verify;
   X509 *server_cert;
   bool verified = FALSE;
-#ifdef USE_APPLE_SECTRUST
+#if !defined(OPENSSL_NO_TLSEXT) && !defined(OPENSSL_NO_OCSP) && \
+  defined(USE_APPLE_SECTRUST)
   bool sectrust_verified = FALSE;
 #endif
 
@@ -4799,7 +4800,9 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
     if(verified) {
       infof(data, "SSL certificate verified via Apple SecTrust.");
       ssl_config->certverifyresult = X509_V_OK;
+#if !defined(OPENSSL_NO_TLSEXT) && !defined(OPENSSL_NO_OCSP)
       sectrust_verified = TRUE;
+#endif
     }
   }
 #endif


### PR DESCRIPTION
(Not tested in CI. Regression in 8.17.0.)

Fixing:
```
lib/vtls/openssl.c:4750:8: error: variable 'sectrust_verified' set but not used [-Werror,-Wunused-but-set-variable]
 4750 |   bool sectrust_verified = FALSE;
      |        ^
1 error generated.
```

Follow-up to b4630ed8faef1834e2b64f30acc24e5101d4d2fb #19308
