### PR TITLE
openssl: stop checking for `OPENSSL_NO_TLSEXT` macro

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2591,9 +2591,6 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
   (void)ssl;
 }
 
-/* Check for ALPN support. */
-#define HAS_ALPN_OPENSSL
-
 static CURLcode
 ossl_set_ssl_version_min_max(struct Curl_cfilter *cf, SSL_CTX *ctx,
                              unsigned int ssl_version_min)
@@ -3422,7 +3419,6 @@ ossl_init_session_and_alpns(struct ossl_ctx *octx,
     Curl_ssl_scache_return(cf, data, peer->scache_key, scs);
   }
 
-#ifdef HAS_ALPN_OPENSSL
   if(alpns.count) {
     struct alpn_proto_buf proto;
     memset(&proto, 0, sizeof(proto));
@@ -3436,7 +3432,6 @@ ossl_init_session_and_alpns(struct ossl_ctx *octx,
       return CURLE_SSL_CONNECT_ERROR;
     }
   }
-#endif
 
   return CURLE_OK;
 }
@@ -4072,14 +4067,13 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
   SSL_set_bio(octx->ssl, bio, bio);
 #endif
 
-#ifdef HAS_ALPN_OPENSSL
   if(connssl->alpn && (connssl->state != ssl_connection_deferred)) {
     struct alpn_proto_buf proto;
     memset(&proto, 0, sizeof(proto));
     Curl_alpn_to_proto_str(&proto, connssl->alpn);
     infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
   }
-#endif
+
   connssl->connecting_state = ssl_connect_2;
   return CURLE_OK;
 }
@@ -4362,7 +4356,6 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
     }
 #endif /* HAVE_SSL_SET1_ECH_CONFIG_LIST && !HAVE_BORINGSSL_LIKE */
 
-#ifdef HAS_ALPN_OPENSSL
     /* Sets data and len to negotiated protocol, len is 0 if no protocol was
      * negotiated
      */
@@ -4373,7 +4366,6 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
 
       return Curl_alpn_set_negotiated(cf, data, connssl, neg_protocol, len);
     }
-#endif
 
     return CURLE_OK;
   }


### PR DESCRIPTION
The macro has been deleted upstream and never defined in OpenSSL 1.1.0+:
https://github.com/openssl/openssl/commit/e481f9b90b164fd1053015d1c4e0a0d92076d7a8

BoringSSL and LibreSSL deleted the last uses in 2014:
https://github.com/google/boringssl/commit/6dbd73db5d58ec44304266012d23ff8d297eca55
https://github.com/libressl/openbsd/commit/7b2f3298f7eb7ce5cfd1c3eb55b1ecc89118f52c

Also:
- drop internal guard `HAS_ALPN_OPENSSL`. It's always set.

Follow-up to 69c89bf3d3137fcbb2b8bc57233182adcf1e2817 #18330

---

- [x] verify its status in forks.
  - LibreSSL: last internal reference removed in 2014: https://github.com/libressl/openbsd/commit/7b2f3298f7eb7ce5cfd1c3eb55b1ecc89118f52c.
  - BoringSSL: last internal reference removed in 2014 (thus inherited by AWS-LC too): https://github.com/google/boringssl/commit/6dbd73db5d58ec44304266012d23ff8d297eca55
- [x] rebase on #20128.
