### PR TITLE
GHA/non-native: bump to FreeBSD 15

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           environment_variables: CC CURL_CI CURL_TEST_MIN MATRIX_ARCH MATRIX_BUILD MATRIX_DESC MATRIX_OPTIONS
           operating_system: 'freebsd'
-          version: '14.3'
+          version: '15.0'
           architecture: ${{ matrix.arch }}
           run: |
             export CURL_CI=github


### PR DESCRIPTION
Follow-up to 34683b552c7254d7195108953d49149052f9c04d #20140
