### PR TITLE
GHA/non-native: stop building examples in a cross-job

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -139,7 +139,7 @@ jobs:
         include:
           - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
           - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
-          - { build: 'autotools', arch: 'arm64' , compiler: 'clang' }
+          - { build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
           - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
       fail-fast: false
     steps:


### PR DESCRIPTION
To make the longest running FreeBSD job finish 1.5 minutes faster
(9.5m -> 8m).

Examples are still built with both autotools and cmake, one on Intel and
one on ARM.
