### PR TITLE
pytest: enable OCSP test 17_08 for LibreSSL

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -293,8 +293,9 @@ class TestSSLUse:
     @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_08_cert_status(self, env: Env, proto, httpd, nghttpx):
         if not env.curl_uses_lib('openssl') and \
-           not env.curl_uses_lib('gnutls') and \
-           not env.curl_uses_lib('quictls'):
+           not env.curl_uses_lib('quictls') and \
+           not env.curl_uses_lib('libressl') and \
+           not env.curl_uses_lib('gnutls'):
             pytest.skip("TLS library does not support --cert-status")
         curl = CurlClient(env=env)
         domain = 'localhost'


### PR DESCRIPTION
Before: 735 passed, 115 skipped
After: 738 passed, 112 skipped
