### PR TITLE
pytest: enable OCSP test 17_08 for aws-lc, boringssl, quiche

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -295,6 +295,8 @@ class TestSSLUse:
         if not env.curl_uses_lib('openssl') and \
            not env.curl_uses_lib('quictls') and \
            not env.curl_uses_lib('libressl') and \
+           not env.curl_uses_lib('boringssl') and \
+           not env.curl_uses_lib('aws-lc') and \
            not env.curl_uses_lib('quiche') and \
            not env.curl_uses_lib('gnutls'):
             pytest.skip("TLS library does not support --cert-status")


### PR DESCRIPTION
Follow-up to f2c765028fcf91c4f7bf15eeb0249d525e13ac8f #20149
