### PR TITLE
src: drop redundant definition of `BIT()`

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -29,15 +29,6 @@
 #include "tool_urlglob.h"
 #include "var.h"
 
-/* the type we use for storing a single boolean bit */
-#ifndef BIT
-#ifdef _MSC_VER
-#define BIT(x) bool x
-#else
-#define BIT(x) unsigned int x:1
-#endif
-#endif
-
 #define MAX_CONFIG_LINE_LENGTH (10 * 1024 * 1024)
 
 #define checkprefix(a, b) curl_strnequal(b, STRCONST(a))


### PR DESCRIPTION
It's defined in `lib/curl_setup_once.h` which is always included before
the duplicate definition in `src/tool_cfgable.h`. Delete the latter.

Follow-up to 06bb1587373dcc42ffbe104b214c900936acfb3c #16211