### PR TITLE
GHA/linux: switch scan-build jobs to cmake (for 2x perf)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -274,21 +274,6 @@ jobs:
               -DCMAKE_UNITY_BUILD=OFF -DCURL_DISABLE_TYPECHECK=ON
               -DCURL_DISABLE_VERBOSE_STRINGS=ON
 
-          - name: 'scan-build H3 c-ares !examples'
-            install_packages: clang-tools clang libidn2-dev libssh-dev libnghttp2-dev
-            install_steps: skipall
-            install_steps_brew: openssl libngtcp2 libnghttp3 c-ares
-            CC: clang
-            configure-prefix: scan-build
-            make-prefix: scan-build --status-bugs
-            LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib
-            PKG_CONFIG_PATH: /home/linuxbrew/.linuxbrew/opt/libngtcp2/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig
-            configure: >-
-              --with-openssl=/home/linuxbrew/.linuxbrew/opt/openssl --with-ngtcp2 --with-nghttp3=
-              --with-libidn2 --with-libssh --enable-httpsrr --enable-ares
-              --disable-debug --disable-unity --disable-typecheck
-              --disable-verbose --disable-static
-
           - name: 'address-sanitizer'
             install_packages: clang libssl-dev libssh-dev libidn2-dev libnghttp2-dev libubsan1 libasan8 libtsan2
             install_steps: pytest randcurl


### PR DESCRIPTION
Somewhat unexpectedly, switching autotools jobs to identical (non-unity,
non-debug, same options) cmake ones, makes them complete 2x faster.
Most of it comes from cmake building shared libcurl only, while autotools
was using defaults and building both, in two separate passes. Thers is
about a minute (per job) of gain due to other reasons.

Before:
MultiSSL: 10m30: https://github.com/curl/curl/actions/runs/20656775456/job/59311070197
H3: 9m14s: https://github.com/curl/curl/actions/runs/20656775456/job/59311070204

After:
MultiSSL: 4m52s: https://github.com/curl/curl/actions/runs/20658343323/job/59315501903
H3: 4m7s: https://github.com/curl/curl/actions/runs/20658343323/job/59315501918
H3: 5m4s: https://github.com/curl/curl/actions/runs/20659294959/job/59318215987 (autotools shared only, for comparison, not merged)

Also:
- drop building examples with scan-build in the second (shorter) job.
  This offers no extra coverage over the long job that has both GnuTLS
  and OpenSSL. Saving an extra ~30s.
