### PR TITLE
pytest-03_02 stabilize

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2694,7 +2694,8 @@ static CURLcode cf_ngtcp2_connect(struct Curl_cfilter *cf,
   }
 
 out:
-  if(result == CURLE_RECV_ERROR && ctx->qconn &&
+  if(ctx->qconn &&
+     ((result == CURLE_RECV_ERROR) || (result == CURLE_SEND_ERROR)) &&
      ngtcp2_conn_in_draining_period(ctx->qconn)) {
     const ngtcp2_ccerr *cerr = ngtcp2_conn_get_ccerr(ctx->qconn);
 


### PR DESCRIPTION
The special handling for draining server connections during a connect attempt was only done on CURLE_RECV_ERROR. But it may also happen when ngtcp2 errors on writing data. Check for CURLE_SEND_ERROR also.

refs #20112