### PR TITLE
pytest-16_01 stabilize

### DIFF
--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -8,4 +8,3 @@ psutil==7.2.0
 pytest==9.0.2
 pytest-xdist==3.8.0
 websockets==15.0.1
-functools

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -568,8 +568,8 @@ class ExecResult:
             # assert all events not in reference timeline are 0
             for key in [key for key in all_keys if key not in ref_tl and key not in somewhere_keys]:
                 self.check_stat_zero(s, key)
-        # calculate the timeline that did happen
 
+        # calculate the timeline that did happen
         def cmp_ts(t1, t2):
             n = s[t1] - s[t2]
             if not n:  # same timestamp, order to expected occurrence


### PR DESCRIPTION
When checking the reported times of a transfer, do not exptect
the 'queue' time to be in any relation to others. 'queue' uses its own
start timestamp and the reported duration is thereofore independant.

refs #20112