### PR TITLE
pytest-07_22 stabilize

### DIFF
--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -225,7 +225,7 @@ class TestUpload:
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}'\
-            f'/curltest/tweak?status=400&delay=5ms&chunks=1&body_error=reset&id=[0-{count-1}]'
+            f'/curltest/tweak?status=200&delay=5ms&chunks=1&body_error=reset&id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto,
                              extra_args=['--parallel'])
         # depending on timing and protocol, we might get CURLE_PARTIAL_FILE or


### PR DESCRIPTION
Do not generate a 400 response code, but use a 200 one. The upload needs to fail on sending, not on seeing a 400 response. Seeing a 400 before the sending fails (when CI timings shift) will expose the wrong error code.

refs #20112