### PR TITLE
docs: add a note about --compressed to note about binary output

### DIFF
--- a/docs/cmdline-opts/output.md
+++ b/docs/cmdline-opts/output.md
@@ -68,4 +68,4 @@ override curl's internal binary output in terminal prevention:
     curl https://example.com/jpeg -o -
 
 Note that the binary output may be caused by the response being compressed, in
-which case you may want to use the --compressed option instead.
+which case you may want to use the --compressed option.


### PR DESCRIPTION
Follow-up from https://github.com/curl/curl/pull/19867

Instead of modifying the binary output warning directly, this just adds a note to the docs as requested.