### PR TITLE
Clarify Binary Packages

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: curl
 
 ## Installing Binary Packages
 
-Lots of people download binary distributions of curl and libcurl. This
+Lots of people download binary distributions of curl and libcurl. These binary packages                                                 can usually be installed using your operating system's package manager. This
 document does not describe how to install curl or libcurl using such a binary
 package. This document describes how to compile, build and install curl and
 libcurl from [source code](https://curl.se/download.html).


### PR DESCRIPTION
Adds a short clarification explaining that binary packages are installed using the system package manager.