### PR TITLE
GHA/windows: reduce workflow timeouts

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -185,7 +185,7 @@ jobs:
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
     runs-on: ${{ matrix.image || 'windows-2022' }}
-    timeout-minutes: ${{ contains(matrix.tflags, '-t') && 15 || 10 }}
+    timeout-minutes: ${{ contains(matrix.tflags, '-t') && 14 || 10 }}
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
From 15 to 10 minutes.

To reduce the idle wait for hung jobs from 20 to 15 minutes (hopefully),
so that the failed just can be restarted manually eariler. It appears
that GitHub Actions notices a hung job 5 minutes past the workflow
timeout (reason undiscovered).

Also: Leave extra time for torture and arm64 jobs.
