### PR TITLE
servers.pm: say the protocol when http server failed to start

### DIFF
--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2485,7 +2485,7 @@ sub startservers {
                 ($serr, $pid, $pid2, $PORT{'http'}) =
                     runhttpserver("http", $verbose, 0);
                 if($pid <= 0) {
-                    return ("failed starting HTTP server (http)", $serr);
+                    return ("failed starting HTTP server (for http)", $serr);
                 }
                 logmsg sprintf ("* pid http => %d %d\n", $pid, $pid2)
                     if($verbose);
@@ -2642,7 +2642,7 @@ sub startservers {
                 ($serr, $pid, $pid2, $PORT{'http'}) =
                     runhttpserver("http", $verbose, 0);
                 if($pid <= 0) {
-                    return ("failed starting HTTP server (https/https-mtls)", $serr);
+                    return ("failed starting HTTP server (for https/https-mtls)", $serr);
                 }
                 logmsg sprintf("* pid http => %d %d\n", $pid, $pid2) if($verbose);
                 $run{'http'}="$pid $pid2";
@@ -2683,7 +2683,7 @@ sub startservers {
                 ($serr, $pid, $pid2, $PORT{'http'}) =
                     runhttpserver("http", $verbose, 0);
                 if($pid <= 0) {
-                    return ("failed starting HTTP server (http/2)", $serr);
+                    return ("failed starting HTTP server (for http/2)", $serr);
                 }
                 logmsg sprintf("* pid http => %d %d\n", $pid, $pid2) if($verbose);
                 $run{'http'}="$pid $pid2";
@@ -2724,7 +2724,7 @@ sub startservers {
                 ($serr, $pid, $pid2, $PORT{'http'}) =
                     runhttpserver("http", $verbose, 0);
                 if($pid <= 0) {
-                    return ("failed starting HTTP server (http/3)", $serr);
+                    return ("failed starting HTTP server (for http/3)", $serr);
                 }
                 logmsg sprintf("* pid http => %d %d\n", $pid, $pid2) if($verbose);
                 $run{'http'}="$pid $pid2";


### PR DESCRIPTION
To serve as possibly more signal to see when/why the http server fails
to start in some random cases (on Windows).

Seen it happen in the 'mingw, CM clang-x86_64 gnutls libss' CI job:
https://github.com/curl/curl/pull/20163#issuecomment-3705572750
https://github.com/curl/curl/pull/20163#issuecomment-3707231458
