### PR TITLE
GHA/macos: reduce number of combination jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -605,13 +605,15 @@ jobs:
           # Reduce build combinations, by dropping less interesting ones
           - { image: macos-26, compiler: 'gcc-13' }
           - { compiler: 'gcc-14' , build: cmake }
+          # Reduce autotools to just one job that is also build with cmake
           - { compiler: 'gcc-13' , build: autotools }
           - { compiler: 'gcc-14' , build: autotools }
-          - { compiler: 'gcc-26' , build: autotools }
+          - { compiler: 'gcc-15' , build: autotools }
           - { compiler: 'llvm@15', build: autotools }
           - { compiler: 'llvm@18', build: autotools }
           - { compiler: 'llvm@20', build: autotools }
-          - { compiler: 'clang'  , build: autotools }
+          - { image: macos-14,     build: autotools }
+          - { image: macos-15,     build: autotools }
     steps:
       - name: 'install autotools'
         if: ${{ matrix.build == 'autotools' }}


### PR DESCRIPTION
- drop autotools (except one) from combination jobs.
  They seem to add little value over cmake ones, yet take a lot of time
  even after restricting them to shared libs.

  20-25s to install autotools via Homebrew, for each 11 jobs. autoreconf
  taking 10s, configure 25s, build 30-35s. A total of 1m30s to 1m45s per
  job. Sometimes jumping up to 2-4 minutes.

  Compare this to 20-25s total job times with cmake.

  Keep one job with an indentical cmake pair to help detecting
  build-tool-specific fallouts.

- drop more combination jobs.
  To avoid overlap with main build jobs.

Reducing number of jobs to 9, from 22 (-13),
total job time to 5.5 minutes, from 25 (-20m).

Before: https://github.com/curl/curl/actions/runs/20637652089
After: https://github.com/curl/curl/actions/runs/20686390641?pr=20178

Considering the small amount of Apple-specific code in curl since
dropping Secure Transport, and that most combination issue were in
the toolchains, not curl, there is likely more room to avoid wasting
cycles (at 41 macOS + 3 iOS jobs after this patch).

Follow-up to d057b705fdb44b2df99ce6fc6ffb8f2a3530755a #20167
