### PR TITLE
setopt: free the previous STRING_ENCODING before storing the new

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1725,8 +1725,10 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      */
     if(ptr && !*ptr) {
       ptr = Curl_get_content_encodings();
-      if(ptr)
+      if(ptr) {
+        curlx_free(s->str[STRING_ENCODING]);
         s->str[STRING_ENCODING] = ptr;
+      }
       else
         result = CURLE_OUT_OF_MEMORY;
       return result;


### PR DESCRIPTION
Fixes #20179
Reported-by: correctmost on github