### PR TITLE
curlx_win32_fopen: use `_fsopen()`/`_wfsopen()` with `_SH_DENYNO`

### DIFF
--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -40,7 +40,7 @@ int curlx_fseek(void *stream, curl_off_t offset, int whence)
 
 #ifdef _WIN32
 
-#include <share.h>  /* for _SH_SECURE */
+#include <share.h>  /* for _SH_DENYNO */
 
 #include "multibyte.h"
 #include "timeval.h"
@@ -316,7 +316,7 @@ int curlx_win32_open(const char *filename, int oflag, ...)
       target = fixed;
     else
       target = filename_w;
-    errno = _wsopen_s(&result, target, oflag, _SH_SECURE, pmode);
+    errno = _wsopen_s(&result, target, oflag, _SH_DENYNO, pmode);
     CURLX_FREE(filename_w);
   }
   else
@@ -327,7 +327,7 @@ int curlx_win32_open(const char *filename, int oflag, ...)
     target = fixed;
   else
     target = filename;
-  errno = _sopen_s(&result, target, oflag, _SH_SECURE, pmode);
+  errno = _sopen_s(&result, target, oflag, _SH_DENYNO, pmode);
 #endif
 
   CURLX_FREE(fixed);
@@ -348,7 +348,7 @@ FILE *curlx_win32_fopen(const char *filename, const char *mode)
       target = fixed;
     else
       target = filename_w;
-    result = _wfsopen(target, mode_w, _SH_SECURE);
+    result = _wfsopen(target, mode_w, _SH_DENYNO);
   }
   else
     /* !checksrc! disable ERRNOVAR 1 */
@@ -360,7 +360,7 @@ FILE *curlx_win32_fopen(const char *filename, const char *mode)
     target = fixed;
   else
     target = filename;
-  result = _fsopen(target, mode, _SH_SECURE);
+  result = _fsopen(target, mode, _SH_DENYNO);
 #endif
 
   CURLX_FREE(fixed);


### PR DESCRIPTION
Replacing `fopen_s()`/`_wfopen_s()`, to allow customizing share mode,
and keep the sharing mode as was with `fopen()`/`_wopen()` earlier and
as used in `_sopen_s()`/`_wsopen_s()`.

The replaced functions used `_SH_SECURE` internally. Otherwise they are
identical to the replacements.

Ref: https://learn.microsoft.com/cpp/c-runtime-library/reference/fsopen-wfsopen

Reported-by: Jay Satiro
Fixes #20155
Ref: #20156
Follow-up to 1e7d0bafc6d25d98ec72ff419df65fda3cf147a7 #19643

---

Also tried: `_SH_SECURE`. It breaks test 1490. `_SH_SECURE` is used
by the secure flavors of these functions. Other than that they are identical
internally.

Refs:
https://github.com/huangqinjin/ucrt/blob/master/stdio/fopen.cpp
https://github.com/huangqinjin/ucrt/blob/master/lowio/open.cpp
