### PR TITLE
Fixed LDAP version display on IBMi

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -1030,11 +1030,16 @@ void Curl_ldap_version(char *buf, size_t bufsz)
     unsigned int minor =
       (((unsigned int)api.ldapai_vendor_version - major * 10000)
        - patch) / 100;
-    curl_msnprintf(buf, bufsz, "%s/%u.%u.%u%s",
-                   api.ldapai_vendor_name, major, minor, patch, flavor);
+
 #ifdef __OS400__
+    curl_msnprintf(buf, bufsz, "IBMLDAP/%u.%u.%u",
+                   major, minor, patch);
+
     ldap_value_free(api.ldapai_extensions);
 #else
+    curl_msnprintf(buf, bufsz, "%s/%u.%u.%u%s",
+                   api.ldapai_vendor_name, major, minor, patch, flavor);
+
     ldap_memfree(api.ldapai_vendor_name);
     ber_memvfree((void **)api.ldapai_extensions);
 #endif


### PR DESCRIPTION
Fixes #20196

Now it looks like this:
```
> curl --version                                                   
  curl 8.18.0.10 (OS/400) libcurl/8.18.0.10 mit-krb5 IBMLDAP/0.6.10
```