### PR TITLE
tool_urlglob: fix propagating OOM error from `sanitize_file_name()`

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -704,8 +704,11 @@ CURLcode glob_match_url(char **output, const char *filename,
                                          (SANITIZE_ALLOW_PATH |
                                           SANITIZE_ALLOW_RESERVED));
     curlx_dyn_free(&dyn);
-    if(sc)
+    if(sc) {
+      if(sc == SANITIZE_ERR_OUT_OF_MEMORY)
+        return CURLE_OUT_OF_MEMORY;
       return CURLE_URL_MALFORMAT;
+    }
     *output = sanitized;
     return CURLE_OK;
   }


### PR DESCRIPTION
Make sure to convert a low-level OOM error code a libcurl one, to make
the curl tool to display an accurate error code and messages. On Windows
and MS-DOS.

Improving:
```
$ CURL_FN_SANITIZE_OOM=1 wine curl.exe https://curl.se/ --output out.txt
[...]
curl: (3) URL using bad/illegal format or missing URL
```
to:
```
[...]
curl: (27) Out of memory
```

Cherry-picked from #20116
