### PR TITLE
GHA/non-native: restore MS-DOS jobs

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -337,6 +337,7 @@ jobs:
     env:
       MAKEFLAGS: -j 5
       MATRIX_BUILD: '${{ matrix.build }}'
+      # renovate: datasource=github-releases depName=andrewwutw/build-djgpp versioning=semver-coerced registryUrl=https://github.com
       TOOLCHAIN_VERSION: '3.4'
     strategy:
       matrix:


### PR DESCRIPTION
In `!ssl` variant.

It's useful to catch `uint32_t` mismatches with `unsigned int` or its
printf mask.

Also add Renovate version bump rule.

It takes about 1m (autotools) + 30s (cmake) in CI.

Bug: https://github.com/curl/curl/pull/20199#discussion_r2666363334
Follow-up to 8881a52ab0bc7f8cdaad3161e189570d69f0cd3c #20210
Follow-up to e70436a88a7ba16f6a49237054dde41f181fd9c4 #20200
Follow-up to 0630e66cb4044892ec137c3357852fe025746f35 #18338

---

- [x] rebase on #20210 to fix building tests.
- [x] rebase on #20200 to fix the builds.
- [x] perhaps move to GHA/non-native, where it was before?
