### PR TITLE
tests: fix to use `uint32_t` where necessary

### DIFF
--- a/tests/unit/unit1616.c
+++ b/tests/unit/unit1616.c
@@ -25,7 +25,7 @@
 
 #include "uint-hash.h"
 
-static void t1616_mydtor(unsigned int id, void *elem)
+static void t1616_mydtor(uint32_t id, void *elem)
 {
   int *ptr = (int *)elem;
   (void)id;
@@ -53,8 +53,8 @@ static CURLcode test_unit1616(const char *arg)
   int *value2;
   bool ok;
 
-  unsigned int key = 20;
-  unsigned int key2 = 25;
+  uint32_t key = 20;
+  uint32_t key2 = 25;
 
   value = curlx_malloc(sizeof(int));
   abort_unless(value != NULL, "Out of memory");

--- a/tests/unit/unit3211.c
+++ b/tests/unit/unit3211.c
@@ -27,14 +27,14 @@
 #include "uint-bset.h"
 #include "curl_trc.h"
 
-static void check_set(const char *name, unsigned int capacity,
-                      const unsigned int *s, size_t slen)
+static void check_set(const char *name, uint32_t capacity,
+                      const uint32_t *s, size_t slen)
 {
   struct uint32_bset bset;
   size_t i, j;
-  unsigned int n, c;
+  uint32_t n, c;
 
-  curl_mfprintf(stderr, "test %s, capacity=%u, %zu numbers\n",
+  curl_mfprintf(stderr, "test %s, capacity=%" PRIu32 ", %zu numbers\n",
                 name, capacity, slen);
   Curl_uint32_bset_init(&bset);
   fail_unless(!Curl_uint32_bset_resize(&bset, capacity), "bset resize failed");
@@ -63,7 +63,8 @@ static void check_set(const char *name, unsigned int capacity,
   for(i = 1; i < slen; ++i) {
     fail_unless(Curl_uint32_bset_next(&bset, n, &n), "next failed");
     if(n != s[i]) {
-      curl_mfprintf(stderr, "expected next to be %u, not %u\n", s[i], n);
+      curl_mfprintf(stderr, "expected next to be %" PRIu32
+                    ", not %" PRIu32 "\n", s[i], n);
       fail_unless(n == s[i], "next not correct number");
     }
   }
@@ -127,11 +128,11 @@ static CURLcode test_unit3211(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
 
-  static const unsigned int s1[] = {
+  static const uint32_t s1[] = {
     /* spread numbers, some at slot edges */
     0, 1, 4, 17, 63, 64, 65, 66, 90, 99,
   };
-  static const unsigned int s2[] = {
+  static const uint32_t s2[] = {
     /* set with all bits in slot1 set */
     64, 65, 66, 67, 68, 69, 70, 71,
     72, 73, 74, 75, 76, 77, 78, 79,

--- a/tests/unit/unit3212.c
+++ b/tests/unit/unit3212.c
@@ -48,7 +48,7 @@ static CURLcode test_unit3212(const char *arg)
 
   UNITTEST_BEGIN(t3212_setup(&tbl))
 
-  unsigned int i, key, n;
+  uint32_t i, key, n;
   void *entry;
 
   fail_unless(Curl_uint32_tbl_capacity(&tbl) == TBL_SIZE, "wrong capacity");

--- a/tests/unit/unit3213.c
+++ b/tests/unit/unit3213.c
@@ -28,11 +28,11 @@
 #include "curl_trc.h"
 #include "unitprotos.h"
 
-static void check_spbset(const char *name, const unsigned int *s, size_t slen)
+static void check_spbset(const char *name, const uint32_t *s, size_t slen)
 {
   struct uint32_spbset bset;
   size_t i, j;
-  unsigned int n, c;
+  uint32_t c, n;
 
   curl_mfprintf(stderr, "test %s, %zu numbers\n", name, slen);
 
@@ -60,7 +60,8 @@ static void check_spbset(const char *name, const unsigned int *s, size_t slen)
   for(i = 1; i < slen; ++i) {
     fail_unless(Curl_uint32_spbset_next(&bset, n, &n), "next failed");
     if(n != s[i]) {
-      curl_mfprintf(stderr, "expected next to be %u, not %u\n", s[i], n);
+      curl_mfprintf(stderr, "expected next to be %" PRIu32
+                    ", not %" PRIu32 "\n", s[i], n);
       fail_unless(n == s[i], "next not correct number");
     }
   }
@@ -96,11 +97,11 @@ static CURLcode test_unit3213(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
 
-  static const unsigned int s1[] = {
+  static const uint32_t s1[] = {
     /* spread numbers, some at slot edges */
     0, 1, 4, 17, 63, 64, 65, 66, 90, 99,
   };
-  static const unsigned int s2[] = {
+  static const uint32_t s2[] = {
     /* set with all bits in slot1 set */
     64, 65, 66, 67, 68, 69, 70, 71,
     72, 73, 74, 75, 76, 77, 78, 79,
@@ -111,7 +112,7 @@ static CURLcode test_unit3213(const char *arg)
     112, 113, 114, 115, 116, 117, 118, 119,
     120, 121, 122, 123, 124, 125, 126, 127,
   };
-  static const unsigned int s3[] = {
+  static const uint32_t s3[] = {
     /* very spread numbers */
     2232, 5167, 8204, 8526, 8641, 10056, 10140, 10611,
     10998, 11626, 13735, 15539, 17947, 24295, 27833, 30318,


### PR DESCRIPTION
Fixes MS-DOS DJGPP buidls, possibly others.

Follow-up to e70436a88a7ba16f6a49237054dde41f181fd9c4 #20200
Follow-up to 4701a6d2ae9f0b66a0feac4061868e944353449b #19695
