### PR TITLE
GHA/macos: switch one H3 pytest job to cmake

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -263,7 +263,7 @@ jobs:
             compiler: clang
             install: libnghttp3 libngtcp2
             install_steps: pytest
-            generate: -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON
+            generate: -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=OFF
             macos-version-min: '10.15'
           - name: 'OpenSSL SecTrust'
             compiler: clang


### PR DESCRIPTION
To:
- see if build tool makes a difference for flaky 8x pytest slowdowns.
- to make this job finished faster.

`curl -V`, number of runtests (1793) and pytests (568/159) verified
to remain the same.
