### PR TITLE
tool_dirhie: drop superfluous `F_OK` fallback (Windows)

### DIFF
--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -32,9 +32,6 @@
 
 #if defined(_WIN32) || (defined(MSDOS) && !defined(__DJGPP__))
 #  define mkdir(x, y) (mkdir)(x)
-#  ifndef F_OK
-#  define F_OK 0
-#  endif
 #endif
 
 static void show_dir_errno(const char *name)


### PR DESCRIPTION
Follow-up to cb5ba675a73e7ef9e8ea0ce913bf15ba63f87d1f