### PR TITLE
lib: remove uses of PRIu32 for *printf()

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -610,7 +610,7 @@ static void cpool_discard_conn(struct cpool *cpool,
    */
   if(CONN_INUSE(conn) && !aborted) {
     CURL_TRC_M(data, "[CPOOL] not discarding #%" FMT_OFF_T
-               " still in use by %" PRIu32 " transfers", conn->connection_id,
+               " still in use by %u transfers", conn->connection_id,
                conn->attached_xfers);
     return;
   }

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -462,13 +462,17 @@
 #include <stdint.h>
 #endif
 
+#ifdef __DJGPP__
+/* By default, DJGPP provides this type as a version of 'unsigned long' which
+   forces us to use a define use it in printf() format strings without
+   warnings. long and int are both 32 bits for this platform. */
+#define uint32_t unsigned int
+#endif
+
 #include <limits.h>
 
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
-#else
-#define PRIu32 "u"
-#define PRIx32 "x"
 #endif
 
 #ifdef _WIN32

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -391,7 +391,7 @@ static CURLMcode multi_xfers_add(struct Curl_multi *multi,
      * to downsize the already resized ones. The sets continue
      * to work properly when larger than the table, but not
      * the other way around. */
-    CURL_TRC_M(data, "increasing xfer table size to %" PRIu32, new_size);
+    CURL_TRC_M(data, "increasing xfer table size to %u", new_size);
     if(Curl_uint32_bset_resize(&multi->process, new_size) ||
        Curl_uint32_bset_resize(&multi->dirty, new_size) ||
        Curl_uint32_bset_resize(&multi->pending, new_size) ||
@@ -517,8 +517,8 @@ CURLMcode curl_multi_add_handle(CURLM *m, CURL *d)
     data->set.server_response_timeout;
   multi->admin->set.no_signal = data->set.no_signal;
 
-  CURL_TRC_M(data, "added to multi, mid=%" PRIu32 ", running=%u"
-             ", total=%" PRIu32, data->mid, Curl_multi_xfers_running(multi),
+  CURL_TRC_M(data, "added to multi, mid=%u, running=%u"
+             ", total=%u", data->mid, Curl_multi_xfers_running(multi),
              Curl_uint32_tbl_count(&multi->xfers));
   return CURLM_OK;
 }
@@ -608,11 +608,11 @@ static void multi_done_locked(struct connectdata *conn,
 
   Curl_detach_connection(data);
 
-  CURL_TRC_M(data, "multi_done_locked, in use=%" PRIu32, conn->attached_xfers);
+  CURL_TRC_M(data, "multi_done_locked, in use=%u", conn->attached_xfers);
   if(CONN_INUSE(conn)) {
     /* Stop if still used. */
     CURL_TRC_M(data,
-               "Connection still in use %" PRIu32 ", no more multi_done now!",
+               "Connection still in use %u, no more multi_done now!",
                conn->attached_xfers);
     return;
   }
@@ -885,8 +885,8 @@ CURLMcode curl_multi_remove_handle(CURLM *m, CURL *d)
       return mresult;
   }
 
-  CURL_TRC_M(data, "removed from multi, mid=%" PRIu32 ", running=%u"
-             ", total=%" PRIu32, mid, Curl_multi_xfers_running(multi),
+  CURL_TRC_M(data, "removed from multi, mid=%u, running=%u"
+             ", total=%u", mid, Curl_multi_xfers_running(multi),
              Curl_uint32_tbl_count(&multi->xfers));
   return CURLM_OK;
 }
@@ -2717,18 +2717,18 @@ statemachine_end:
         /* A sub transfer, not for msgsent to application */
         struct Curl_easy *mdata;
 
-        CURL_TRC_M(data, "sub xfer done for master %" PRIu32,
+        CURL_TRC_M(data, "sub xfer done for master %u",
                    data->master_mid);
         mdata = Curl_multi_get_easy(multi, data->master_mid);
         if(mdata) {
           if(mdata->sub_xfer_done)
             mdata->sub_xfer_done(mdata, data, result);
           else
-            CURL_TRC_M(data, "master easy %" PRIu32
+            CURL_TRC_M(data, "master easy %u"
                        " without sub_xfer_done callback.", data->master_mid);
         }
         else {
-          CURL_TRC_M(data, "master easy %" PRIu32 " already gone.",
+          CURL_TRC_M(data, "master easy %u already gone.",
                      data->master_mid);
         }
       }
@@ -3127,7 +3127,7 @@ static CURLMcode multi_run_dirty(struct multi_run_ctx *mrc)
       }
       else {
         CURL_TRC_M(multi->admin,
-                   "multi_run_dirty, %" PRIu32 " no longer found", mid);
+                   "multi_run_dirty, %u no longer found", mid);
         Curl_uint32_bset_remove(&multi->dirty, mid);
       }
     } while(Curl_uint32_bset_next(&multi->dirty, mid, &mid));
@@ -3349,7 +3349,7 @@ static bool multi_has_dirties(struct Curl_multi *multi)
         Curl_uint32_bset_remove(&multi->dirty, mid);
       }
       else {
-        CURL_TRC_M(multi->admin, "dirty transfer %" PRIu32 " no longer found",
+        CURL_TRC_M(multi->admin, "dirty transfer %u no longer found",
                    mid);
         Curl_uint32_bset_remove(&multi->dirty, mid);
       }
@@ -3994,7 +3994,7 @@ struct Curl_easy *Curl_multi_get_easy(struct Curl_multi *multi,
   if(data && GOOD_EASY_HANDLE(data))
     return data;
   CURL_TRC_M(multi->admin,
-             "invalid easy handle in xfer table for mid=%" PRIu32, mid);
+             "invalid easy handle in xfer table for mid=%u", mid);
   Curl_uint32_tbl_remove(&multi->xfers, mid);
   return NULL;
 }

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -341,7 +341,7 @@ static CURLMcode mev_pollset_diff(struct Curl_multi *multi,
           return CURLM_OUT_OF_MEMORY;
       }
       CURL_TRC_M(data, "ev entry fd=%" FMT_SOCKET_T ", added %s #%" FMT_OFF_T
-                 ", total=%" PRIu32 "/%d (xfer/conn)", s,
+                 ", total=%u/%d (xfer/conn)", s,
                  conn ? "connection" : "transfer",
                  conn ? conn->connection_id : data->mid,
                  Curl_uint32_spbset_count(&entry->xfers),
@@ -411,7 +411,7 @@ static CURLMcode mev_pollset_diff(struct Curl_multi *multi,
       if(mresult)
         return mresult;
       CURL_TRC_M(data, "ev entry fd=%" FMT_SOCKET_T ", removed transfer, "
-                 "total=%" PRIu32 "/%d (xfer/conn)", s,
+                 "total=%u/%d (xfer/conn)", s,
                  Curl_uint32_spbset_count(&entry->xfers),
                  entry->conn ? 1 : 0);
     }
@@ -582,7 +582,7 @@ void Curl_multi_ev_dirty_xfers(struct Curl_multi *multi,
         }
         else {
           CURL_TRC_M(multi->admin,
-                     "socket transfer %" PRIu32 " no longer found", mid);
+                     "socket transfer %u no longer found", mid);
           Curl_uint32_spbset_remove(&entry->xfers, mid);
         }
       } while(Curl_uint32_spbset_next(&entry->xfers, mid, &mid));

--- a/lib/multi_ntfy.c
+++ b/lib/multi_ntfy.c
@@ -111,7 +111,7 @@ static void mntfy_chunk_dispatch_all(struct Curl_multi *multi,
       if(data && Curl_uint32_bset_contains(&multi->ntfy.enabled, e->type)) {
         /* this may cause new notifications to be added! */
         CURL_TRC_M(multi->admin,
-                   "[NTFY] dispatch %" PRIu32 " to xfer %" PRIu32,
+                   "[NTFY] dispatch %u to xfer %u",
                    e->type, e->mid);
         multi->ntfy.ntfy_cb(multi, e->type, data, multi->ntfy.ntfy_cb_data);
       }
@@ -169,7 +169,7 @@ void Curl_mntfy_add(struct Curl_easy *data, unsigned int type)
      Curl_uint32_bset_contains(&multi->ntfy.enabled, (uint32_t)type)) {
     /* append to list of outstanding notifications */
     struct mntfy_chunk *tail = mntfy_non_full_tail(&multi->ntfy);
-    CURL_TRC_M(data, "[NTFY] add %u for xfer %" PRIu32, type, data->mid);
+    CURL_TRC_M(data, "[NTFY] add %u for xfer %u", type, data->mid);
     if(tail)
       mntfy_chunk_append(tail, data, (uint32_t)type);
     else

--- a/lib/url.c
+++ b/lib/url.c
@@ -881,12 +881,12 @@ static bool url_match_multiplex_limits(struct connectdata *conn,
     if(conn->attached_xfers >=
             Curl_multi_max_concurrent_streams(m->data->multi)) {
       infof(m->data, "client side MAX_CONCURRENT_STREAMS reached"
-            ", skip (%" PRIu32 ")", conn->attached_xfers);
+            ", skip (%u)", conn->attached_xfers);
       return FALSE;
     }
     if(conn->attached_xfers >=
        Curl_conn_get_max_concurrent(m->data, conn, FIRSTSOCKET)) {
-      infof(m->data, "MAX_CONCURRENT_STREAMS reached, skip (%" PRIu32 ")",
+      infof(m->data, "MAX_CONCURRENT_STREAMS reached, skip (%u)",
             conn->attached_xfers);
       return FALSE;
     }

--- a/tests/unit/unit3211.c
+++ b/tests/unit/unit3211.c
@@ -34,7 +34,7 @@ static void check_set(const char *name, uint32_t capacity,
   size_t i, j;
   uint32_t n, c;
 
-  curl_mfprintf(stderr, "test %s, capacity=%" PRIu32 ", %zu numbers\n",
+  curl_mfprintf(stderr, "test %s, capacity=%u, %zu numbers\n",
                 name, capacity, slen);
   Curl_uint32_bset_init(&bset);
   fail_unless(!Curl_uint32_bset_resize(&bset, capacity), "bset resize failed");
@@ -63,8 +63,8 @@ static void check_set(const char *name, uint32_t capacity,
   for(i = 1; i < slen; ++i) {
     fail_unless(Curl_uint32_bset_next(&bset, n, &n), "next failed");
     if(n != s[i]) {
-      curl_mfprintf(stderr, "expected next to be %" PRIu32
-                    ", not %" PRIu32 "\n", s[i], n);
+      curl_mfprintf(stderr, "expected next to be %u"
+                    ", not %u\n", s[i], n);
       fail_unless(n == s[i], "next not correct number");
     }
   }

--- a/tests/unit/unit3213.c
+++ b/tests/unit/unit3213.c
@@ -60,8 +60,8 @@ static void check_spbset(const char *name, const uint32_t *s, size_t slen)
   for(i = 1; i < slen; ++i) {
     fail_unless(Curl_uint32_spbset_next(&bset, n, &n), "next failed");
     if(n != s[i]) {
-      curl_mfprintf(stderr, "expected next to be %" PRIu32
-                    ", not %" PRIu32 "\n", s[i], n);
+      curl_mfprintf(stderr, "expected next to be %u"
+                    ", not %u\n", s[i], n);
       fail_unless(n == s[i], "next not correct number");
     }
   }


### PR DESCRIPTION
Avoid using PRIu32 and PRId32 in product source code. We don't need it.
It reduces readability. It is also inconsistent since unsigned int has
the same size and does not require the define.

DJGPP warns about using %u for uint32_t by default because it seems to
typedef it to unsigned long instead of unsigned int. Which even that is
annoying since long and int are both 32 bit on this platform.

We use our own *printf() implementation and we know this is safe.

This work-around defines uint32_t for DJGPP into unsigned int to avoid
the warnings and thus the need to use PRIu32 and PRId32.
