### PR TITLE
ngtcp2: stabilize recv

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1425,7 +1425,7 @@ static CURLcode cf_ngtcp2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   /* first check for results/closed already known without touching
    * the connection. For an already failed/closed stream, errors on
-   * the connetion do not count.
+   * the connection do not count.
    * Then handle incoming data and check for failed/closed again.
    */
   for(i = 0; i < 2; ++i) {


### PR DESCRIPTION
When receiving on a stream that already failed or has already been closed, return the matching error code without touching the connection. In case the connection shows errors, e.g. the server closed, those errors should not have impact on an already failed/closed stream.

This might mitigate flakiness in pytest 07_13 where unexpected errors occur after a successful upload.