### PR TITLE
cmake: silence useless compiler warnings triggered by the FASTBuild generator

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -226,6 +226,14 @@ if(PICKY_COMPILER)
             -Wno-reserved-macro-identifier # clang 13.0            appleclang 13.1  # External macros have to be set sometimes
         )
       endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3))
+        if(CMAKE_GENERATOR STREQUAL "FASTBuild")
+          list(APPEND _picky_enable
+            -Wno-gnu-line-marker           # clang 15.0            appleclang 14.0.3
+          )
+        endif()
+      endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0))
         list(APPEND _picky_enable


### PR DESCRIPTION
Silencing all of these:
```
11>/tmp/_fbuild.tmp/0x0752c383/core_2/70816E19/krb5_sspi.c:1:5: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
    1 | # 1 "<built-in>"
      |     ^
/path/to/curl/lib/vauth/krb5_sspi.c:29:6: error: this style of line directive is a GNU extension [-Werror,-Wgnu-line-marker]
   29 | # 26 "/path/to/curl/lib/vauth/krb5_sspi.c"
      |      ^
[...]
```

FASTBuild is slightly faster than Ninja in basic (single-machine, build
from scratch) cases (and can be more faster in other build cases). It
doesn't support unity builds. Maybe it can bring slightly better
performance to non-unity cmake CI jobs, in jobs having an 'install
prereq' phase already, and installing the fastbuild package being faster
than this gain. It overall seems marginal if any in curl CI. At least
for now. But it doesn't hurt if it works, and may be useful for some.

Requires CMake 4.2+.

That said this workaround may have a better place within CMake.

Refs:
https://www.kitware.com/cmake-fastbuild-distributed-cached-and-fast/
https://cmake.org/cmake/help/latest/generator/FASTBuild.html
https://github.com/fastbuild/fastbuild
https://fastbuild.org/docs/home.html
