### PR TITLE
altsvc: move logic from setopt into Curl_altsvc_ctrl()

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -310,10 +310,18 @@ CURLcode Curl_altsvc_load(struct altsvcinfo *asi, const char *file)
 /*
  * Curl_altsvc_ctrl() passes on the external bitmask.
  */
-CURLcode Curl_altsvc_ctrl(struct altsvcinfo *asi, const long ctrl)
+CURLcode Curl_altsvc_ctrl(struct Curl_easy *data, const long ctrl)
 {
-  DEBUGASSERT(asi);
-  asi->flags = ctrl;
+  DEBUGASSERT(data);
+  if(!ctrl)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+
+  if(!data->asi) {
+    data->asi = Curl_altsvc_init();
+    if(!data->asi)
+      return CURLE_OUT_OF_MEMORY;
+  }
+  data->asi->flags = ctrl;
   return CURLE_OK;
 }
 

--- a/lib/altsvc.h
+++ b/lib/altsvc.h
@@ -54,7 +54,7 @@ struct altsvcinfo *Curl_altsvc_init(void);
 CURLcode Curl_altsvc_load(struct altsvcinfo *asi, const char *file);
 CURLcode Curl_altsvc_save(struct Curl_easy *data,
                           struct altsvcinfo *asi, const char *file);
-CURLcode Curl_altsvc_ctrl(struct altsvcinfo *asi, const long ctrl);
+CURLcode Curl_altsvc_ctrl(struct Curl_easy *data, const long ctrl);
 void Curl_altsvc_cleanup(struct altsvcinfo **altsvc);
 CURLcode Curl_altsvc_parse(struct Curl_easy *data,
                            struct altsvcinfo *altsvc, const char *value,

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1261,16 +1261,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
 #endif /* !CURL_DISABLE_HSTS */
 #ifndef CURL_DISABLE_ALTSVC
   case CURLOPT_ALTSVC_CTRL:
-    if(!arg) {
-      DEBUGF(infof(data, "bad CURLOPT_ALTSVC_CTRL input"));
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    }
-    if(!data->asi) {
-      data->asi = Curl_altsvc_init();
-      if(!data->asi)
-        return CURLE_OUT_OF_MEMORY;
-    }
-    return Curl_altsvc_ctrl(data->asi, arg);
+    return Curl_altsvc_ctrl(data, arg);
 #endif /* !CURL_DISABLE_ALTSVC */
 #ifndef CURL_DISABLE_WEBSOCKETS
   case CURLOPT_WS_OPTIONS:


### PR DESCRIPTION
To keep it all in one place.