### PR TITLE
GHA/linux: fix 'mbedtls' internal name confusion

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -119,7 +119,7 @@ jobs:
 
           - name: 'mbedtls gss valgrind 1'
             install_packages: libnghttp2-dev libidn2-dev libldap-dev libgss-dev valgrind
-            install_steps: mbedtls-latest
+            install_steps: mbedtls-latest-intel
             tflags: '--min=830 1 to 950'
             LDFLAGS: -Wl,-rpath,/home/runner/mbedtls/lib
             PKG_CONFIG_PATH: /home/runner/mbedtls/lib/pkgconfig
@@ -127,7 +127,7 @@ jobs:
 
           - name: 'mbedtls gss valgrind 2'
             install_packages: libnghttp2-dev libidn2-dev libldap-dev libgss-dev valgrind
-            install_steps: mbedtls-latest
+            install_steps: mbedtls-latest-intel
             tflags: '--min=800 951 to 9999'
             LDFLAGS: -Wl,-rpath,/home/runner/mbedtls/lib
             PKG_CONFIG_PATH: /home/runner/mbedtls/lib/pkgconfig
@@ -147,7 +147,7 @@ jobs:
 
           - name: 'mbedtls-pkg MultiSSL !pc'
             install_packages: libnghttp2-dev libmbedtls-dev
-            install_steps: mbedtls-latest skipall
+            install_steps: mbedtls-latest-intel skipall
             generate: >-
               -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls
               -DMBEDTLS_INCLUDE_DIR=/home/runner/mbedtls/include
@@ -276,7 +276,7 @@ jobs:
 
           - name: 'clang-tidy'
             install_packages: clang-tidy libssl-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev libkrb5-dev librtmp-dev libgnutls28-dev
-            install_steps: skipall mbedtls-latest rustls wolfssl-opensslextra
+            install_steps: skipall mbedtls-latest-intel rustls wolfssl-opensslextra
             install_steps_brew: gsasl
             make-custom-target: tidy
             LDFLAGS: -Wl,-rpath,/home/runner/wolfssl-opensslextra/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/gsasl/lib
@@ -288,7 +288,7 @@ jobs:
 
           - name: 'scan-build'
             install_packages: clang-tools clang libssl-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev libgss-dev librtmp-dev libgnutls28-dev
-            install_steps: skipall mbedtls-latest rustls wolfssl-opensslextra
+            install_steps: skipall mbedtls-latest-intel rustls wolfssl-opensslextra
             install_steps_brew: gsasl
             CC: clang
             configure-prefix: scan-build
@@ -563,18 +563,18 @@ jobs:
             --disable-benchmark --disable-crypttests --disable-examples --prefix=/home/runner/wolfssl-opensslextra
           make install
 
-      - name: 'cache mbedtls (latest)'
-        if: ${{ contains(matrix.build.install_steps, 'mbedtls-latest') }}
+      - name: 'cache mbedtls (latest-intel)'
+        if: ${{ contains(matrix.build.install_steps, 'mbedtls-latest-intel') }}
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        id: cache-mbedtls-latest
+        id: cache-mbedtls-latest-intel
         env:
-          cache-name: cache-mbedtls-latest
+          cache-name: cache-mbedtls-latest-intel
         with:
           path: ~/mbedtls
           key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}-${{ env.MBEDTLS_VERSION }}
 
-      - name: 'build mbedtls (latest)'
-        if: ${{ contains(matrix.build.install_steps, 'mbedtls-latest') && steps.cache-mbedtls-latest.outputs.cache-hit != 'true' }}
+      - name: 'build mbedtls (latest-intel)'
+        if: ${{ contains(matrix.build.install_steps, 'mbedtls-latest-intel') && steps.cache-mbedtls-latest-intel.outputs.cache-hit != 'true' }}
         run: |
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj


### PR DESCRIPTION
`mbedtls-arm` and `mbedtls-prev` were matching `contains()` expressions
looking for `mbedtls`. It caused an unnecessary cache restore and an
redundant mbedtls build on bumps, and made the build flavors require
different local directory names to avoid this accidental collision.

Also drop `-threadsafe` from internal names. All local builds are.

Follow-up to 88060353440df4e1b7167c180b39074fd2ab457a #20240
Follow-up to 3a305831d1a9d10b2bfd4fa3939ed41275fee7f7 #19077

---

- [x] revert ff78af5752fdf580e5beef743f932cc1625228c3 after this, or automate it somehow, because now the arch is seen twice (in two different forms) in arm and dual-arch entries. → #20249
- [ ] it's also safe now to use the same `path:` for different build flavors of the same locally built dep. E.g. mbedtls-prev can now use mbedtls to simplify things.