### PR TITLE
winapi: simplify curlx_get_winapi_error() function

### DIFF
--- a/lib/curlx/winapi.c
+++ b/lib/curlx/winapi.c
@@ -39,30 +39,31 @@
 const char *curlx_get_winapi_error(DWORD err, char *buf, size_t buflen)
 {
   char *p;
-  wchar_t wbuf[256];
-  DWORD wlen;
 
   if(!buflen)
     return NULL;
 
-  *buf = '\0';
-  *wbuf = L'\0';
+  /* FormatMessageA() fails if size >= 32768
+   * https://github.com/wine-mirror/wine/blob/b3319fa671a1f9f7b7aa09e9d9016b250cb848cb/dlls/kernelbase/locale.c#L5404 */
+  DEBUGASSERT(buflen <= 0x7FFF);
 
   /* We return the local codepage version of the error string because if it is
      output to the user's terminal it will likely be with functions which
      expect the local codepage (eg fprintf, failf, infof). */
-  wlen = FormatMessageW((FORMAT_MESSAGE_FROM_SYSTEM |
-                         FORMAT_MESSAGE_IGNORE_INSERTS), NULL, err,
-                        LANG_NEUTRAL, wbuf, CURL_ARRAYSIZE(wbuf), NULL);
-  if(wlen && !wcstombs_s(NULL, buf, buflen, wbuf, wlen)) {
-    /* Truncate multiple lines */
-    p = strchr(buf, '\n');
-    if(p) {
-      if(p > buf && *(p - 1) == '\r')
-        *(p - 1) = '\0';
-      else
-        *p = '\0';
-    }
+  if(!FormatMessageA((FORMAT_MESSAGE_FROM_SYSTEM |
+                      FORMAT_MESSAGE_IGNORE_INSERTS), NULL, err,
+                     LANG_NEUTRAL, buf, (DWORD)buflen, NULL)) {
+    *buf = '\0';
+    return NULL;
+  }
+
+  /* Truncate multiple lines */
+  p = strchr(buf, '\n');
+  if(p) {
+    if(p > buf && *(p - 1) == '\r')
+      *(p - 1) = '\0';
+    else
+      *p = '\0';
   }
 
   return *buf ? buf : NULL;


### PR DESCRIPTION
Use `FormatMessageA()` to get the error message as multibyte-character string (local codepage) right away, instead of using `FormatMessageW()` and then converting from Unicode (UTF-16) string to multibyte-character string (local codepage) manually via `wcstombs()` function.

Ref: a32687798122fd9d4263caaf3ea844462bd69f50 #6065
