### PR TITLE
GHA/checkdocs: drop duplicate spacecheck job

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -12,17 +12,21 @@ name: 'Docs'
     branches:
       - master
       - '*/ci'
-    paths-ignore:
-      - '.circleci/**'
-      - 'appveyor.*'
-      - 'Dockerfile'
+    paths:
+      - '.github/workflows/checkdocs.yml'
+      - '.github/scripts/**'
+      - 'scripts/**'
+      - '**.md'
+      - 'docs/*'
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '.circleci/**'
-      - 'appveyor.*'
-      - 'Dockerfile'
+    paths:
+      - '.github/workflows/checkdocs.yml'
+      - '.github/scripts/**'
+      - 'scripts/**'
+      - '**.md'
+      - 'docs/*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
No longer necessary after making GHA/checksrc also run on `*.md` file
changes.

Reported-by: Daniel Stenberg
Bug: https://github.com/curl/curl/pull/20266#issuecomment-3738955165
Follow-up to 3800a26582af8b355e96cf80135ba7642e816ed6 #18935
Follow-up to 9acecc923df9ea8675f026ab173e8f2a6051822e #15423
