### PR TITLE
Makefile.am: delete RPM targets referencing non-existent files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,24 +140,6 @@ examples:
 check-docs:
 	@(cd docs/libcurl; $(MAKE) check)
 
-# Build source and binary rpms. For rpm-3.0 and above, the ~/.rpmmacros
-# must contain the following line:
-# %_topdir /home/loic/local/rpm
-# and that /home/loic/local/rpm contains the directory SOURCES, BUILD etc.
-#
-# cd /home/loic/local/rpm ; mkdir -p SOURCES BUILD RPMS/i386 SPECS SRPMS
-#
-# If additional configure flags are needed to build the package, add the
-# following in ~/.rpmmacros
-# %configure CFLAGS="%{optflags}" ./configure %{_target_platform} --prefix=%{_prefix} ${AM_CONFIGFLAGS}
-# and run make rpm in the following way:
-# AM_CONFIGFLAGS='--with-uri=/home/users/loic/local/RedHat-6.2' make rpm
-#
-
-rpms:
-	$(MAKE) RPMDIST=curl rpm
-	$(MAKE) RPMDIST=curl-ssl rpm
-
 # We extend the standard install with a custom hook:
 if BUILD_DOCS
 install-data-hook:


### PR DESCRIPTION
Follow-up to bae0d473f5912d38fc8da1f9850a70b015b53c9e #3331
