### PR TITLE
url.h: fix `-Wdocumentation`

### DIFF
--- a/lib/url.h
+++ b/lib/url.h
@@ -81,7 +81,6 @@ const struct Curl_handler *Curl_getn_scheme_handler(const char *scheme,
 
 /**
  * Return TRUE iff the given connection is considered dead.
- * @param nowp      NULL or pointer to time being checked against.
  */
 bool Curl_conn_seems_dead(struct connectdata *conn,
                           struct Curl_easy *data);


### PR DESCRIPTION
Seen when testing `-Weverything`:
```
lib/url.h:84:11: warning: parameter 'nowp' not found in the function declaration [-Wdocumentation]
   84 |  * @param nowp      NULL or pointer to time being checked against.
      |           ^~~~
```

Follow-up to 2de22a00c7adb81b4e5cbc90785e29b4b083c1ed #19961
