### PR TITLE
ldap: silence potential unused variable warning (OS400)

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -970,23 +970,20 @@ void Curl_ldap_version(char *buf, size_t bufsz)
     unsigned int minor =
       (((unsigned int)api.ldapai_vendor_version - major * 10000)
        - patch) / 100;
-
 #ifdef __OS400__
-    curl_msnprintf(buf, bufsz, "IBMLDAP/%u.%u.%u",
-                   major, minor, patch);
-
+    curl_msnprintf(buf, bufsz, "IBMLDAP/%u.%u.%u", major, minor, patch);
     ldap_value_free(api.ldapai_extensions);
+    (void)flavor;
 #else
     curl_msnprintf(buf, bufsz, "%s/%u.%u.%u%s",
                    api.ldapai_vendor_name, major, minor, patch, flavor);
-
     ldap_memfree(api.ldapai_vendor_name);
     ber_memvfree((void **)api.ldapai_extensions);
 #endif
   }
   else
     curl_msnprintf(buf, bufsz, "LDAP/1");
-#endif
+#endif /* USE_WIN32_LDAP */
 }
 
 /*


### PR DESCRIPTION
Also:
- add `endif` comment.
- unfold a line.

Follow-up to 64350280d3b9aca54856f73d109aab8f49615de3 #20197
