### PR TITLE
noproxy: fix /0 CIDR notation to match all addresses

### DIFF
--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -57,6 +57,9 @@ UNITTEST bool Curl_cidr4_match(const char *ipv4,    /* 1.2.3.4 address */
   if(curlx_inet_pton(AF_INET, network, &check) != 1)
     return FALSE;
 
+  if(!bits)
+    return TRUE; /* /0 means all addresses match */
+
   if(bits && (bits != 32)) {
     unsigned int mask = 0xffffffff << (32 - bits);
     unsigned int haddr = htonl(address);


### PR DESCRIPTION
When using CIDR notation 0.0.0.0/0 in NO_PROXY, the current implementation falls through to exact IP matching instead of correctly matching all IPv4 addresses.

The issue is in Curl_cidr4_match() where bits=0 is not explicitly handled. When bits=0, the condition `if(bits && (bits != 32))` evaluates to FALSE, causing the function to fall through to the final `return (address == check)` which performs exact IP matching.

According to CIDR notation semantics, /0 represents all addresses in the address space (0.0.0.0/0 for IPv4, ::/0 for IPv6).

This patch adds an explicit check: when bits=0, immediately return TRUE to match all addresses.

Example usage:
  NO_PROXY=0.0.0.0/0 curl http://example.com

Expected: Bypass proxy for all IPv4 addresses
Before: Only bypasses if target is exactly 0.0.0.0
After: Correctly bypasses proxy for any IPv4 address

Reported-by: Jacek Migacz <jmigacz@redhat.com>