### PR TITLE
checksrc: do not apply `BANNEDFUNC` to struct member functions

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -970,7 +970,7 @@ sub scanfile {
             my $bad = $2;
             my $prefix = $1;
             my $suff = $3;
-            if($prefix !~ /->$/) {
+            if($prefix !~ /(->|\.)$/) {
                 checkwarn("BANNEDFUNC",
                           $line, length($prefix), $file, $ol,
                           "use of $bad is banned");

--- a/tests/data/test1185
+++ b/tests/data/test1185
@@ -88,7 +88,8 @@ void startfunc(int a, int b) {
 
  // CPP comment ?
 
- int d = impl->magicbad(buffer, "%d", 99); /* member function shall pass */
+ int d = impl->magicbad(1); /* member function always allowed */
+ int e = impl.magicbad(); /* member function always allowed */
 
  /* comment does not end
 


### PR DESCRIPTION
Omit this warning, when `close()` is banned:
```
./lib/vtls/vtls.c:947:13: warning: use of close is banned (BANNEDFUNC)
   Curl_ssl->close(cf, data);
             ^
```
Ref: https://github.com/curl/curl/actions/runs/21012427938/job/60410334312?pr=20212#step:3:6

Ref: #20212

---

https://github.com/curl/curl/pull/20323/files?w=1
