### PR TITLE
lib: fix two `CURLDEBUG` guards to be `DEBUGBUILD`

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -836,7 +836,7 @@ static CURLcode async_ares_set_dns_servers(struct Curl_easy *data,
   const char *servers = data->set.str[STRING_DNS_SERVERS];
   int ares_result = ARES_SUCCESS;
 
-#if defined(CURLDEBUG) && defined(HAVE_CARES_SERVERS_CSV)
+#if defined(DEBUGBUILD) && defined(HAVE_CARES_SERVERS_CSV)
   if(getenv("CURL_DNS_SERVER"))
     servers = getenv("CURL_DNS_SERVER");
 #endif

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -372,7 +372,7 @@ static CURLcode async_rr_start(struct Curl_easy *data, int port)
     curlx_free(rrname);
     return CURLE_FAILED_INIT;
   }
-#ifdef CURLDEBUG
+#ifdef DEBUGBUILD
   if(getenv("CURL_DNS_SERVER")) {
     const char *servers = getenv("CURL_DNS_SERVER");
     status = ares_set_servers_ports_csv(thrdd->rr.channel, servers);


### PR DESCRIPTION
Both guard the use of `CURL_DNS_SERVER` debug env.

Follow-up to df2b4ccc229c9de61dd798e4b3a7cf74a073144e #18157
Follow-up to 02e9690c3ee2feb7c78c93c1c544c898df733383 #17015
Follow-up to 59dc9f7e69c399102e9ebe3670360ef52706ff23 #13718
