### PR TITLE
hostip6: remove debug-only code

### DIFF
--- a/lib/hostip6.c
+++ b/lib/hostip6.c
@@ -52,23 +52,6 @@
 
 #ifdef CURLRES_SYNCH
 
-#ifdef DEBUG_ADDRINFO
-static void dump_addrinfo(const struct Curl_addrinfo *ai)
-{
-  curl_mprintf("dump_addrinfo:\n");
-  for(; ai; ai = ai->ai_next) {
-    char buf[INET6_ADDRSTRLEN];
-    curl_mprintf("    fam %2d, CNAME %s, ",
-                 ai->ai_family,
-                 ai->ai_canonname ? ai->ai_canonname : "<none>");
-    Curl_printable_address(ai, buf, sizeof(buf));
-    curl_mprintf("%s\n", buf);
-  }
-}
-#else
-#define dump_addrinfo(x) Curl_nop_stmt
-#endif
-
 /*
  * Curl_sync_getaddrinfo() when built IPv6-enabled (non-threading and
  * non-ares version).
@@ -129,8 +112,6 @@ struct Curl_addrinfo *Curl_sync_getaddrinfo(struct Curl_easy *data,
   if(port) {
     Curl_addrinfo_set_port(res, port);
   }
-
-  dump_addrinfo(res);
 
   return res;
 }


### PR DESCRIPTION
Introduced in 021e786c7108bc60. Not used these days.