### PR TITLE
lib: use STRCONST() when possible in curlx_strcopy() calls

### DIFF
--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -294,7 +294,7 @@ static CURLcode hsts_push(struct Curl_easy *data,
                    stamp.tm_hour, stamp.tm_min, stamp.tm_sec);
   }
   else
-    curlx_strcopy(e.expire, sizeof(e.expire), UNLIMITED, strlen(UNLIMITED));
+    curlx_strcopy(e.expire, sizeof(e.expire), STRCONST(UNLIMITED));
 
   sc = data->set.hsts_write(data, &e, i, data->set.hsts_write_userp);
   *stop = (sc != CURLSTS_OK);

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1966,7 +1966,7 @@ static CURLcode imap_connect(struct Curl_easy *data, bool *done)
   imap_state(data, imapc, IMAP_SERVERGREET);
 
   /* Start off with an response id of '*' */
-  curlx_strcopy(imapc->resptag, sizeof(imapc->resptag), "*", 1);
+  curlx_strcopy(imapc->resptag, sizeof(imapc->resptag), STRCONST("*"));
 
   result = imap_multi_statemach(data, done);
 

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -573,7 +573,7 @@ static size_t encoder_qp_read(char *buffer, size_t size, bool ateof,
         }
       }
       if(softlinebreak) {
-        curlx_strcopy(buf, sizeof(buf), "\x3D\x0D\x0A", 3);    /* "=\r\n" */
+        curlx_strcopy(buf, sizeof(buf), STRCONST("\x3D\x0D\x0A")); /* =\r\n */
         len = 3;
         consumed = 0;
       }

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -43,7 +43,7 @@ UNITTEST void time2str(char *r, size_t rsize, curl_off_t seconds)
 {
   curl_off_t h;
   if(seconds <= 0) {
-    curlx_strcopy(r, rsize, "       ", 7);
+    curlx_strcopy(r, rsize, STRCONST("       "));
     return;
   }
   h = seconds / 3600;
@@ -76,7 +76,7 @@ UNITTEST void time2str(char *r, size_t rsize, curl_off_t seconds)
         if(y <= 99999)
           curl_msnprintf(r, rsize, "%6" FMT_OFF_T "y", y);
         else
-          curlx_strcopy(r, rsize, ">99999y", 7);
+          curlx_strcopy(r, rsize, STRCONST(">99999y"));
       }
     }
   }

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -656,12 +656,12 @@ const char *Curl_sspi_strerror(SECURITY_STATUS err, char *buf, size_t buflen)
     else
       curl_msnprintf(buf, buflen, "%s (0x%08lx)", txt, err);
   }
-#else
+#else /* !CURL_DISABLE_VERBOSE_STRINGS */
+  (void)txt;
   if(err == SEC_E_OK)
-    txt = "No error";
+    curlx_strcopy(buf, buflen, STRCONST("No error"));
   else
-    txt = "Error";
-  curlx_strcopy(buf, buflen, txt, strlen(txt));
+    curlx_strcopy(buf, buflen, STRCONST("Error"));
 #endif
 
   if(errno != old_errno)


### PR DESCRIPTION
Follow-up to a535be4ea0960cfaeeaf74412