### PR TITLE
Remove no TLS (mqtts) support

### DIFF
--- a/docs/internals/MQTT.md
+++ b/docs/internals/MQTT.md
@@ -58,5 +58,4 @@ Remaining limitations:
 
 - Only QoS level 0 is implemented for publish
 - No way to set retain flag for publish
-- No TLS (mqtts) support
 - Naive EAGAIN handling does not handle split messages


### PR DESCRIPTION
As curl now supports TLS (mqtts), it is no longer necessary to list it as a limitation in the docs.