### PR TITLE
hostip: fix unreachable code in rare build configuration

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -935,10 +935,12 @@ out:
     return CURLE_OK;
   }
   else if(respwait) {
+#ifdef USE_CURL_ASYNC
     if(!Curl_resolv_check(data, &dns)) {
       *entry = dns;
       return dns ? CURLE_OK : CURLE_AGAIN;
     }
+#endif
     result = CURLE_COULDNT_RESOLVE_HOST;
   }
 error:


### PR DESCRIPTION
with cmake options:
```
-DCMAKE_UNITY_BUILD=OFF -DCURL_DISABLE_HTTP=ON -DENABLE_THREADED_RESOLVER=OFF
```

Fixing (seen with Apple clang 17):
```
lib/hostip.c:939:16: error: code will never be executed [-Werror,-Wunreachable-code]
  940 |       *entry = dns;
      |                ^~~
```
