### PR TITLE
INSTALL.md: suggest `-Wl,-dead_strip` for Apple targets

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -563,7 +563,7 @@ may be relevant in some environments: `-march=X`, `-mthumb`, `-m32`,
 `-mdynamic-no-pic`, `-flto`, `-fdata-sections`, `-ffunction-sections`,
 `-fno-unwind-tables`, `-fno-asynchronous-unwind-tables`,
 `-fno-record-gcc-switches`, `-fsection-anchors`, `-fno-plt`,
-`-Wl,--gc-sections`, `-Wl,-Bsymbolic`, `-Wl,-dead_strip` (Apple), `-Wl,-s`
+`-Wl,--gc-sections`, `-Wl,-dead_strip` (Apple), `-Wl,-Bsymbolic`, `-Wl,-s`
 
 For example, this is how to combine a few of these options:
 


### PR DESCRIPTION
For reducing binary size. Also to remove (or greatly mitigate)
the side-effect of using "unity" builds. Similar to `-Wl,--gc-sections`
on non-Apple platforms.

For example with curl-for-win builds, macOS arm+intel:

curl (unity):                      7.7MB -> 6.8MB
libcurl.dylib (unity):             7.2MB -> 6.4MB
trurl /w static libcurl (!unity):  535KB -> 251KB (same size with unity)

Ref: https://github.com/curl/curl-for-win/commit/c4008d658ad82aed7d70e410a91f6d14273ebb0f
