### PR TITLE
REUSE: drop broken reference to `MAIL-ETIQUETTE`

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -15,7 +15,6 @@ SPDX-PackageDownloadLocation = "https://curl.se/"
 path = [
   "docs/INSTALL",
   "docs/libcurl/symbols-in-versions",
-  "docs/MAIL-ETIQUETTE",
   "docs/options-in-versions",
   "docs/THANKS",
   "lib/libcurl.vers.in",


### PR DESCRIPTION
It has been renamed and converted to Markdown.

Follow-up to 271896ab337cf9ea1c7a386306df3728eff7c661 #13247
