### PR TITLE
GHA: strip Windows/MS-DOS/Android binaries to see their real size

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -240,6 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
+      LDFLAGS: -s
       MAKEFLAGS: -j 5
       MATRIX_BUILD: '${{ matrix.build }}'
     strategy:
@@ -333,6 +334,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
+      LDFLAGS: -s
       MAKEFLAGS: -j 5
       MATRIX_BUILD: '${{ matrix.build }}'
       # renovate: datasource=github-releases depName=andrewwutw/build-djgpp versioning=semver-coerced registryUrl=https://github.com

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,6 +44,7 @@ jobs:
       run:
         shell: D:\cygwin\bin\bash.exe '{0}'  # zizmor: ignore[misfeature]
     env:
+      LDFLAGS: -s
       MAKEFLAGS: -j 5
       SHELLOPTS: 'igncr'
       MATRIX_BUILD: '${{ matrix.build }}'
@@ -187,6 +188,7 @@ jobs:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
     env:
+      LDFLAGS: -s
       MAKEFLAGS: -j 5
       MATRIX_BUILD: '${{ matrix.build }}'
       MATRIX_SYS: '${{ matrix.sys }}'
@@ -417,6 +419,7 @@ jobs:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
     env:
       CURL_TEST_MIN: 1550
+      LDFLAGS: -s
       MAKEFLAGS: -j 5
       MATRIX_DIR: '${{ matrix.dir }}'
     strategy:
@@ -601,6 +604,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
+      LDFLAGS: -s
       MAKEFLAGS: -j 5
       TRIPLET: 'x86_64-w64-mingw32'
       MATRIX_BUILD: '${{ matrix.build }}'


### PR DESCRIPTION
Unstripped size hides effective binary sizes due to the added debug
information. E.g. `--gc-sections` may inflate unstripped binaries, while
their unstripped size decreases. To see if binary size optimization
options work, it's more useful to observe unstripped size.

Ref: #20357
Follow-up to 4cf43508e8e60d0d8acef1beecb0f76040609543 #20355
