### PR TITLE
tool_getparam: avoid `-Wcomma` with Apple clang in C89 mode

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -3059,7 +3059,8 @@ ParameterError parse_args(int argc, argv_item_t argv[])
   ParameterError result = PARAM_OK;
   struct OperationConfig *config = global->first;
 
-  for(i = 1, stillflags = TRUE; i < argc && !result; i++) {
+  stillflags = TRUE;
+  for(i = 1; i < argc && !result; i++) {
     orig_opt = convert_tchar_to_UTF8(argv[i]);
     if(!orig_opt)
       return PARAM_NO_MEM;


### PR DESCRIPTION
Seen with Apple clang 17:
```
curl/src/tool_getparam.c:3062:12: warning: possible misuse of comma operator here [-Wcomma]
 3062 |   for(i = 1, stillflags = TRUE; i < argc && !result; i++) {
      |            ^
curl/src/tool_getparam.c:3062:7: note: cast expression to void to silence warning
 3062 |   for(i = 1, stillflags = TRUE; i < argc && !result; i++) {
      |       ^~~~~
      |       (void)( )
```
