### PR TITLE
rtsp: fix missing variable declaration

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 #include "urldata.h"
+#include "rtsp.h"
 
 #ifndef CURL_DISABLE_RTSP
 
@@ -33,7 +34,6 @@
 #include "http.h"
 #include "url.h"
 #include "progress.h"
-#include "rtsp.h"
 #include "strcase.h"
 #include "select.h"
 #include "connect.h"


### PR DESCRIPTION
```
lib/rtsp.c:1073:26: error: no previous extern declaration for non-static variable 'Curl_scheme_rtsp' [-Werror,-Wmissing-variable-declarations]
 1073 | const struct Curl_scheme Curl_scheme_rtsp = {
      |                          ^
lib/rtsp.c:1073:7: note: declare 'static' if the variable is not intended to be used outside of this translation unit
 1073 | const struct Curl_scheme Curl_scheme_rtsp = {
      |       ^
```
Ref: https://github.com/curl/trurl/actions/runs/21157411659/job/60844860592?pr=425#step:3:3036

Follow-up to 8edc0338f30f458f812f9ea355de1240771fa343 #20351
