### PR TITLE
config2setopts: fix for --disable-aws configuration

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -486,12 +486,14 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
 /* only called for HTTP transfers */
 static CURLcode http_setopts(struct OperationConfig *config, CURL *curl)
 {
-  CURLcode result;
+  CURLcode result = CURLE_OK;
   long postRedir = 0;
 
   my_setopt_long(curl, CURLOPT_FOLLOWLOCATION, config->followlocation);
   my_setopt_long(curl, CURLOPT_UNRESTRICTED_AUTH, config->unrestricted_auth);
+#ifndef CURL_DISABLE_AWS
   MY_SETOPT_STR(curl, CURLOPT_AWS_SIGV4, config->aws_sigv4);
+#endif
   my_setopt_long(curl, CURLOPT_AUTOREFERER, config->autoreferer);
 
   if(config->proxyheaders) {


### PR DESCRIPTION
Hello.
I noticed that curl binary does not work as intended when built with --disable-aws setting. While using curl for http queries, it kept exiting with the following error:

```
$ ./curl http://curl.se
curl: (48) An unknown option was passed in to libcurl
```

The cause of the problem is the usage of `MY_SETOPT_STR` macro for setting `CURLOPT_AWS_SIGV4` in `http_setopts()` when other AWS-related code is disabled. Adding the corresponding `#ifndef` macro fixed the problem.

Also `result` variable in `http_setopts()` should be preset to `CURLE_OK` value, because otherwise `http_setopts()` may return the value of uninitialised variable and the following error will occur:

```
$ ./curl http://curl.se
curl: (32542) Unknown error
```

My commit fixes the problem.