### PR TITLE
CI: move individual binary sizes to the 'disk space used' step

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -684,7 +684,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . -type f \( -name curl -o -name '*.so.*' -o -name '*.a' \) -print0 | xargs -0 du --
+          find . -type f \( -name curl -o -name '*.so.*' -o -name '*.a' \) -print0 | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
       - name: 'install test prereqs'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -905,5 +905,5 @@ jobs:
       - name: 'disk space used'
         if: ${{ !startsWith(matrix.build.container, 'alpine') }}  # has BusyBox 'du' without '-t' option
         run: |
-          find . -type f \( -name curl -o -name '*.so.*' -o -name '*.a' \) -print0 | xargs -0 du --
+          find . -type f \( -name curl -o -name '*.so.*' -o -name '*.a' \) -print0 | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . -type f \( -name curl -o -name '*.dylib' -o -name '*.a' \) -print0 | xargs -0 du --
+          find . -type f \( -name curl -o -name '*.dylib' -o -name '*.a' \) -print0 | xargs -0 stat -f '%10z bytes: %N' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   macos:
@@ -547,7 +547,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . -type f \( -name curl -o -name '*.dylib' -o -name '*.a' \) -print0 | xargs -0 du --
+          find . -type f \( -name curl -o -name '*.dylib' -o -name '*.a' \) -print0 | xargs -0 stat -f '%10z bytes: %N' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   combinations:  # Test buildability with host OS, Xcode / SDK, compiler, target-OS, built tool, combinations
@@ -710,5 +710,5 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . -type f \( -name curl -o -name '*.dylib' -o -name '*.a' \) -print0 | xargs -0 du --
+          find . -type f \( -name curl -o -name '*.dylib' -o -name '*.a' \) -print0 | xargs -0 stat -f '%10z bytes: %N' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -328,7 +328,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . -type f \( -name curl -o -name '*.so' -o -name '*.a' \) -print0 | xargs -0 du --
+          find . -type f \( -name curl -o -name '*.so' -o -name '*.a' \) -print0 | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   msdos:
@@ -439,5 +439,5 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . \( -name '*.exe' -o -name '*.a' \) -print0 | xargs -0 du --
+          find . \( -name '*.exe' -o -name '*.a' \) -print0 | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 du --
+          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   msys2:  # both msys and mingw-w64
@@ -407,7 +407,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 du --
+          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   mingw-w64-standalone-downloads:
@@ -596,7 +596,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 du --
+          /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   linux-cross-mingw-w64:
@@ -695,7 +695,7 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 du --
+          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld
 
   msvc:
@@ -984,5 +984,5 @@ jobs:
 
       - name: 'disk space used'
         run: |
-          /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 du --
+          /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
           du -sh .; echo; du -sh -t 250KB ./*; echo; du -h -t 250KB bld

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -159,7 +159,7 @@ fi
 
 # disk space used
 
-find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 du --
+find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
 du -sh .; echo; du -sh -t 250KB ./*
 if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   echo; du -h -t 250KB _bld


### PR DESCRIPTION
To get information about test binaries, and to unclutter the `curl -V`
step. Slight downside: size data only appears after test runs, and
building examples.

Also:
- Linux, macOS: add 'disk space used' step.
- Linux, macOS: remove `file` info from `curl -V` steps.
  Revert 4cf43508e8e60d0d8acef1beecb0f76040609543 #20355

Follow-up to 4cf43508e8e60d0d8acef1beecb0f76040609543 #20355
