### PR TITLE
Fix CXX mingw cmake usage

### DIFF
--- a/CMake/curl-config.in.cmake
+++ b/CMake/curl-config.in.cmake
@@ -138,7 +138,7 @@ endif()
 
 set(CMAKE_MODULE_PATH ${_curl_cmake_module_path_save})
 
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND WIN32 AND NOT TARGET CURL::win32_winsock)
+if(WIN32 AND NOT TARGET CURL::win32_winsock)
   add_library(CURL::win32_winsock INTERFACE IMPORTED)
   set_target_properties(CURL::win32_winsock PROPERTIES INTERFACE_LINK_LIBRARIES "ws2_32")
 endif()


### PR DESCRIPTION
The CMake config can be consumed by project which enable only language `CXX`. `CMAKE_C_COMPILER_ID` isn't defined in this case, and the target definition would be missing.
But the check for compiler id isn't really needed: The target is namespaced and valid, regardless of actual compiler.

Noticed in https://github.com/microsoft/vcpkg/issues/49518, building cpr.