### PR TITLE
docs: document the need for a 64-bit type and stdint.h

### DIFF
--- a/.github/scripts/pyspelling.words
+++ b/.github/scripts/pyspelling.words
@@ -394,6 +394,7 @@ inlined
 interop
 interoperable
 interoperates
+inttypes
 IoT
 ipadOS
 IPCXN
@@ -827,6 +828,7 @@ stateful
 statvfs
 stderr
 stdin
+stdint
 stdout
 Steinar
 Stenberg
@@ -905,6 +907,7 @@ UDP
 UI
 UID
 UIDL
+uint
 Ultrix
 umask
 Unary

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -14,7 +14,9 @@ versions of libs and build tools.
 
 We write curl and libcurl to compile with C89 compilers on 32-bit and up
 machines. Most of libcurl assumes more or less POSIX compliance but that is
-not a requirement.
+not a requirement. The compiler must support a 64-bit integer type as well as
+supply a stdint.h (or inttypes.h) header file that defines C99-style
+fixed-width integer types like uint32_t.
 
 We write libcurl to build and work with lots of third party tools, and we
 want it to remain functional and buildable with these and later versions


### PR DESCRIPTION
These are requirements above and above C89.

Closes #20384