### PR TITLE
build: opt-in MSVC to C99-style verbose logging logic

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1217,12 +1217,14 @@ typedef struct sockaddr_un {
 #  define CURL_INLINE /* empty */
 #endif
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#define CURL_HAVE_C99
+/* Detect if compiler supports C99 variadic macros */
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
+  defined(_MSC_VER)
+#define CURL_HAVE_MACRO_VARARG
 #endif
 
-#if (defined(CURL_HAVE_C99) && !defined(CURL_DISABLE_VERBOSE_STRINGS)) || \
-  !defined(CURL_HAVE_C99)
+#if !defined(CURL_HAVE_MACRO_VARARG) || \
+  (defined(CURL_HAVE_MACRO_VARARG) && !defined(CURL_DISABLE_VERBOSE_STRINGS))
 #define CURLVERBOSE
 #define VERBOSE(x) x
 #define NOVERBOSE(x) Curl_nop_stmt

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -129,7 +129,7 @@ void Curl_trc_ws(struct Curl_easy *data,
 #define CURL_TRC_TIMER_is_verbose(data) \
   Curl_trc_ft_is_verbose(data, &Curl_trc_feat_timer)
 
-#if defined(CURL_HAVE_C99) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#if defined(CURL_HAVE_MACRO_VARARG) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
 #define infof(data, ...)             \
   do {                               \
     if(Curl_trc_is_verbose(data))    \
@@ -202,7 +202,7 @@ void Curl_trc_ws(struct Curl_easy *data,
   } while(0)
 #endif /* !CURL_DISABLE_WEBSOCKETS && !CURL_DISABLE_HTTP */
 
-#elif defined(CURL_HAVE_C99) && defined(CURL_DISABLE_VERBOSE_STRINGS)
+#elif defined(CURL_HAVE_MACRO_VARARG) && defined(CURL_DISABLE_VERBOSE_STRINGS)
 
 #define infof(data, ...) \
   do {                   \
@@ -265,7 +265,7 @@ void Curl_trc_ws(struct Curl_easy *data,
   } while(0)
 #endif
 
-#else /* !CURL_HAVE_C99 */
+#else /* !CURL_HAVE_MACRO_VARARG */
 
 #define infof          Curl_infof
 #define CURL_TRC_M     Curl_trc_multi
@@ -291,7 +291,7 @@ void Curl_trc_ws(struct Curl_easy *data,
 #define CURL_TRC_WS    Curl_trc_ws
 #endif
 
-#endif /* !CURL_HAVE_C99 */
+#endif /* CURL_HAVE_MACRO_VARARG */
 
 #ifdef CURLVERBOSE
 extern struct curl_trc_feat Curl_trc_feat_multi;


### PR DESCRIPTION
MSVC does not advertise itself as C99 via `__STDC_VERSION__`, but
supports variadic macros in all curl-supported versions. Fix by
explicitly enabling C99 verbose string logic for MSVC.

With verbose logging enabled (default), this makes logging perform
better, on par with clang/gcc (and other C99) builds. (With the cost
of extra binary size.) With verbose logging disabled, it excludes all
verbose logging related strings and code from the binary. Before this
patch, MSVC used the C89 fallback code in both configs, which used
a fixed function call, with the called function deciding to actually
log or not, while also retaining the verbose log string in both configs.

Size comparison (bytes), schannel, static, debug, VS2022, local build:
curl-before-verbose.exe    4,024,832
curl-before-noverbose.exe  4,013,056
curl-after-verbose.exe     4,117,504
curl-after-noverbose.exe   3,928,064

In CI with non-verbose:
Before:
```
3274240 bytes: ./_bld/lib/Debug/libcurl-d.dll
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/53408629/job/htj7ps88q83ew9ww#L224

After:
```
3155968 bytes: ./_bld/lib/Debug/libcurl-d.dll
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/53408771/job/tp9epgjpef098vsr#L224

Idea-by: Arnav Purushotam
Ref: #20367
Ref: #20341
Follow-up to 61093e2a819d26b7ddf309baef264b9e50c6c56f #20353
