### PR TITLE
GHA/linux: move mbedTLS and wolfSSL valgrind jobs to arm64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -250,20 +250,6 @@ jobs:
             torture: true
             generate: -DCURL_USE_OPENSSL=ON -DENABLE_DEBUG=ON -DENABLE_ARES=ON
 
-          - name: 'openssl torture 1'
-            image: ubuntu-24.04-arm
-            install_packages: libnghttp2-dev libssh2-1-dev libc-ares-dev
-            tflags: '-t --shallow=25 --min=920 1 to 950'
-            torture: true
-            generate: -DCURL_USE_OPENSSL=ON -DENABLE_DEBUG=ON -DENABLE_ARES=ON
-
-          - name: 'openssl torture 2'
-            image: ubuntu-24.04-arm
-            install_packages: libnghttp2-dev libssh2-1-dev libc-ares-dev
-            tflags: '-t --shallow=25 --min=900 951 to 9999'
-            torture: true
-            generate: -DCURL_USE_OPENSSL=ON -DENABLE_DEBUG=ON -DENABLE_ARES=ON
-
           - name: 'openssl i686'
             install_packages: gcc-14-i686-linux-gnu libssl-dev:i386 librtmp-dev:i386 libssh2-1-dev:i386 libidn2-dev:i386 libc-ares-dev:i386 zlib1g-dev:i386
             configure: >-


### PR DESCRIPTION
For significantly better performance.

AM wolfssl-opensslextra valgrind 1:  6m53s -> 4m15s
AM wolfssl-opensslextra valgrind 2:  6m47s -> 4m25s
CM mbedtls gss valgrind 1:           8m33s -> 4m31s
CM mbedtls gss valgrind 2:           8m39s -> 4m34s
('after' times corrected for 'install prereq' differences)

before: https://github.com/curl/curl/actions/runs/21255607562
after: https://github.com/curl/curl/actions/runs/21257368016

Also tried rustls, but that'd require linux arm64 release binaries at:
https://github.com/rustls/rustls-ffi/releases
