### PR TITLE
verbose.md: explain the { and } prefixes

### DIFF
--- a/docs/cmdline-opts/verbose.md
+++ b/docs/cmdline-opts/verbose.md
@@ -42,8 +42,8 @@ data received by curl
 
 ## *
 
-additional info provided by curl. Text that adds explanations of what goes on
-and about choices curl does.
+additional info provided by curl. Text that adds explanations what goes on and
+about choices curl does.
 
 ##
 


### PR DESCRIPTION
The prefixes are now made as subtitles

Reported-by: Thibault de Villèle
Fixes #20386