### PR TITLE
tool: enable header separation when using a proxy

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -496,7 +496,6 @@ static CURLcode http_setopts(struct OperationConfig *config, CURL *curl)
 
   if(config->proxyheaders) {
     my_setopt_slist(curl, CURLOPT_PROXYHEADER, config->proxyheaders);
-    my_setopt_long(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
   }
 
   my_setopt_long(curl, CURLOPT_MAXREDIRS, config->maxredirs);
@@ -880,6 +879,11 @@ CURLcode config2setopts(struct OperationConfig *config,
       result = cookie_setopts(config, curl);
     if(result)
       return result;
+    /* Enable header separation when using a proxy with HTTPS or proxytunnel
+     * to prevent --header content from leaking into CONNECT requests */
+    if((config->proxy || config->proxyheaders) &&
+       (use_proto == proto_https || config->proxytunnel))
+      my_setopt_long(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
   }
 
   if(use_proto == proto_ftp || use_proto == proto_ftps) {


### PR DESCRIPTION
CURLHEADER_SEPARATE was only set when --proxy-header was used, causing --header content to leak into CONNECT requests. This breaks some corporate proxies when custom User-Agent headers are specified.

Enable CURLHEADER_SEPARATE whenever --proxy is configured to ensure proper header separation:
- --header affects only HTTP requests (not CONNECT)
- --proxy-header affects only CONNECT requests
- --user-agent affects both consistently

Before:
$ curl --proxy proxy:3128 --header "User-Agent: custom" https://example.com
> CONNECT: User-Agent: curl/8.x
> CONNECT: User-Agent: custom  (leaked from --header)

After:
$ curl --proxy proxy:3128 --header "User-Agent: custom" https://example.com
> CONNECT: User-Agent: curl/8.x
> GET: User-Agent: custom