### PR TITLE
vtls: keep ssl_primary_config in filter context

### DIFF
--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -115,16 +115,22 @@ typedef CURLcode Curl_cft_conn_keep_alive(struct Curl_cfilter *cf,
  * "ignored" meaning return values are ignored and the event is distributed
  *           to all filters in the chain. Overall result is always CURLE_OK.
  */
-/*      data event                            arg1       arg2     return */
-#define CF_CTRL_DATA_SETUP              4  /* 0          NULL     first fail */
+/*      data event                            arg1       arg2   return */
+#define CF_CTRL_DATA_SETUP              4  /* 0          NULL   first fail */
 /* unused now                           5  */
-#define CF_CTRL_DATA_PAUSE              6  /* on/off     NULL     first fail */
-#define CF_CTRL_DATA_DONE               7  /* premature  NULL     ignored */
-#define CF_CTRL_DATA_DONE_SEND          8  /* 0          NULL     ignored */
+#define CF_CTRL_DATA_PAUSE              6  /* on/off     NULL   first fail */
+#define CF_CTRL_DATA_DONE               7  /* premature  NULL   ignored */
+#define CF_CTRL_DATA_DONE_SEND          8  /* 0          NULL   ignored */
 /* update conn info at connection and data */
-#define CF_CTRL_CONN_INFO_UPDATE (256 + 0) /* 0          NULL     ignored */
-#define CF_CTRL_FORGET_SOCKET    (256 + 1) /* 0          NULL     ignored */
-#define CF_CTRL_FLUSH            (256 + 2) /* 0          NULL     first fail */
+#define CF_CTRL_CONN_INFO_UPDATE (256 + 0) /* 0          NULL   ignored */
+#define CF_CTRL_FORGET_SOCKET    (256 + 1) /* 0          NULL   ignored */
+#define CF_CTRL_FLUSH            (256 + 2) /* 0          NULL   first fail */
+
+#define CF_CTRL_SSL_UPDATE       (256 + 3) /* flags      NULL   ignored */
+/* flag bits for CF_CTRL_SSL_UPDATE */
+#define CF_CTRL_SSL_VERIFYPEER    (1 << 0)
+#define CF_CTRL_SSL_VERIFYHOST    (1 << 1)
+#define CF_CTRL_SSL_VERIFYSTATUS   (1 << 2)
 
 /**
  * Handle event/control for the filter.
@@ -388,14 +394,15 @@ bool Curl_conn_is_ip_connected(struct Curl_easy *data, int sockindex);
  */
 bool Curl_conn_is_ssl(struct connectdata *conn, int sockindex);
 
-/*
- * Fill `info` with information about the TLS instance securing
- * the connection when available, otherwise e.g. when
- * Curl_conn_is_ssl() is FALSE, return FALSE.
- */
-bool Curl_conn_get_ssl_info(struct Curl_easy *data,
-                            struct connectdata *conn, int sockindex,
-                            struct curl_tlssessioninfo *info);
+/* Get the SSL filter on the transfer's connection. Returns NULL
+ * when there is none. */
+struct Curl_cfilter *Curl_conn_get_cf_ssl(struct connectdata *conn,
+                                          int sockindex);
+
+#ifndef CURL_DISABLE_PROXY
+struct Curl_cfilter *Curl_conn_get_cf_proxy_ssl(struct connectdata *conn,
+                                                int sockindex);
+#endif /* !CURL_DISABLE_PROXY */
 
 CURLcode Curl_conn_get_ip_info(struct Curl_easy *data,
                                struct connectdata *conn, int sockindex,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -315,7 +315,7 @@ void Curl_conncontrol(struct connectdata *conn,
             ((ctrl == CONNCTRL_STREAM) && !is_multiplex);
   if((ctrl == CONNCTRL_STREAM) && is_multiplex)
     ;  /* stream signal on multiplex conn never affects close state */
-  else if((curl_bit)closeit != conn->bits.close) {
+  else if(conn && ((curl_bit)closeit != conn->bits.close)) {
     conn->bits.close = closeit; /* the only place in the source code that
                                    should assign this bit */
   }
@@ -385,7 +385,8 @@ connect_sub_chain:
 #ifdef USE_SSL
     if(IS_HTTPS_PROXY(cf->conn->http_proxy.proxytype) &&
        !Curl_conn_is_ssl(cf->conn, cf->sockindex)) {
-      result = Curl_cf_ssl_proxy_insert_after(cf, data);
+      result = Curl_cf_ssl_proxy_insert_after(
+        cf, data, &cf->conn->proxy_ssl_config);
       if(result)
         return result;
     }

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -589,7 +589,7 @@ static CURLcode getinfo_slist(struct Curl_easy *data, CURLINFO info,
     /* we are exposing a pointer to internal memory with unknown
      * lifetime here. */
     *tsip = tsi;
-    if(!Curl_conn_get_ssl_info(data, data->conn, FIRSTSOCKET, tsi)) {
+    if(!Curl_ssl_conn_get_info(data, data->conn, FIRSTSOCKET, tsi)) {
       tsi->backend = Curl_ssl_backend();
       tsi->internals = NULL;
     }

--- a/lib/http.c
+++ b/lib/http.c
@@ -83,6 +83,7 @@
 #include "rtsp.h"
 #include "ws.h"
 #include "bufref.h"
+#include "vtls/vtls.h"
 #include "curlx/strparse.h"
 
 void Curl_http_neg_init(struct Curl_easy *data, struct http_negotiation *neg)

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -589,7 +589,9 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     s->proxy_ssl.primary.verifypeer = enabled;
 
     /* Update the current connection proxy_ssl_config. */
-    Curl_ssl_conn_config_update(data, TRUE);
+    Curl_ssl_proxy_conn_update(data, !!s->proxy_ssl.primary.verifypeer,
+                               !!s->proxy_ssl.primary.verifyhost,
+                               !!s->proxy_ssl.primary.verifystatus);
     break;
   case CURLOPT_PROXY_SSL_VERIFYHOST:
     /*
@@ -598,7 +600,9 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     s->proxy_ssl.primary.verifyhost = enabled;
     ok = 2;
     /* Update the current connection proxy_ssl_config. */
-    Curl_ssl_conn_config_update(data, TRUE);
+    Curl_ssl_proxy_conn_update(data, !!s->proxy_ssl.primary.verifypeer,
+                               !!s->proxy_ssl.primary.verifyhost,
+                               !!s->proxy_ssl.primary.verifystatus);
     break;
   case CURLOPT_PROXY_TRANSFER_MODE:
     /*
@@ -683,7 +687,9 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     s->ssl.primary.verifypeer = enabled;
 
     /* Update the current connection ssl_config. */
-    Curl_ssl_conn_config_update(data, FALSE);
+    Curl_ssl_conn_update(data, !!s->ssl.primary.verifypeer,
+                         !!s->ssl.primary.verifyhost,
+                         !!s->ssl.primary.verifystatus);
     break;
 #ifndef CURL_DISABLE_DOH
   case CURLOPT_DOH_SSL_VERIFYPEER:
@@ -722,7 +728,9 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     ok = 2;
 
     /* Update the current connection ssl_config. */
-    Curl_ssl_conn_config_update(data, FALSE);
+    Curl_ssl_conn_update(data, !!s->ssl.primary.verifypeer,
+                         !!s->ssl.primary.verifyhost,
+                         !!s->ssl.primary.verifystatus);
     break;
   case CURLOPT_SSL_VERIFYSTATUS:
     /*
@@ -734,7 +742,9 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     s->ssl.primary.verifystatus = enabled;
 
     /* Update the current connection ssl_config. */
-    Curl_ssl_conn_config_update(data, FALSE);
+    Curl_ssl_conn_update(data, !!s->ssl.primary.verifypeer,
+                         !!s->ssl.primary.verifyhost,
+                         !!s->ssl.primary.verifystatus);
     break;
   case CURLOPT_CERTINFO:
 #ifdef USE_SSL

--- a/lib/vquic/curl_ngtcp2.h
+++ b/lib/vquic/curl_ngtcp2.h
@@ -53,7 +53,8 @@ void Curl_ngtcp2_ver(char *p, size_t len);
 CURLcode Curl_cf_ngtcp2_create(struct Curl_cfilter **pcf,
                                struct Curl_easy *data,
                                struct connectdata *conn,
-                               const struct Curl_addrinfo *ai);
+                               const struct Curl_addrinfo *ai,
+                               struct ssl_primary_config *config);
 #endif
 
 #endif /* HEADER_CURL_VQUIC_CURL_NGTCP2_H */

--- a/lib/vquic/curl_quiche.h
+++ b/lib/vquic/curl_quiche.h
@@ -38,7 +38,8 @@ void Curl_quiche_ver(char *p, size_t len);
 CURLcode Curl_cf_quiche_create(struct Curl_cfilter **pcf,
                                struct Curl_easy *data,
                                struct connectdata *conn,
-                               const struct Curl_addrinfo *ai);
+                               const struct Curl_addrinfo *ai,
+                               struct ssl_primary_config *config);
 
 #endif
 

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -47,6 +47,7 @@ struct curl_tls_ctx {
 #elif defined(USE_WOLFSSL)
   struct wssl_ctx wssl;
 #endif
+  struct ssl_primary_config *config;
 };
 
 /**
@@ -72,6 +73,7 @@ typedef CURLcode Curl_vquic_session_reuse_cb(struct Curl_cfilter *cf,
  * @param ctx              the TLS context to initialize
  * @param cf               the connection filter involved
  * @param data             the transfer involved
+ * @param config           the relevant ssl configuration
  * @param peer             the peer that will be connected to
  * @param alpns            the ALPN specifications to negotiate, may be NULL
  * @param cb_setup         optional callback for early TLS config
@@ -82,6 +84,7 @@ typedef CURLcode Curl_vquic_session_reuse_cb(struct Curl_cfilter *cf,
 CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                              struct Curl_cfilter *cf,
                              struct Curl_easy *data,
+                             struct ssl_primary_config *config,
                              struct ssl_peer *peer,
                              const struct alpn_spec *alpns,
                              Curl_vquic_tls_ctx_setup *cb_setup,

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -697,12 +697,13 @@ CURLcode Curl_cf_quic_create(struct Curl_cfilter **pcf,
                              const struct Curl_addrinfo *ai,
                              uint8_t transport)
 {
+  struct ssl_primary_config *config = &conn->ssl_config;
   (void)transport;
   DEBUGASSERT(transport == TRNSPRT_QUIC);
 #if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
-  return Curl_cf_ngtcp2_create(pcf, data, conn, ai);
+  return Curl_cf_ngtcp2_create(pcf, data, conn, ai, config);
 #elif defined(USE_QUICHE)
-  return Curl_cf_quiche_create(pcf, data, conn, ai);
+  return Curl_cf_quiche_create(pcf, data, conn, ai, config);
 #else
   *pcf = NULL;
   (void)data;

--- a/lib/vtls/apple.c
+++ b/lib/vtls/apple.c
@@ -85,13 +85,13 @@
 CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
                                 struct ssl_peer *peer,
+                                struct ssl_primary_config *config,
                                 size_t num_certs,
                                 Curl_vtls_get_cert_der *der_cb,
                                 void *cb_user_data,
                                 const unsigned char *ocsp_buf,
                                 size_t ocsp_len)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   CURLcode result = CURLE_OK;
   SecTrustRef trust = NULL;
   SecPolicyRef policy = NULL;
@@ -104,7 +104,7 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
   char *err_desc = NULL;
   size_t i;
 
-  if(conn_config->verifyhost) {
+  if(config->verifyhost) {
     host_str = CFStringCreateWithCString(NULL,
       peer->sni ? peer->sni : peer->hostname, kCFStringEncodingUTF8);
     if(!host_str) {

--- a/lib/vtls/apple.h
+++ b/lib/vtls/apple.h
@@ -29,6 +29,7 @@
 struct Curl_cfilter;
 struct Curl_easy;
 struct ssl_peer;
+struct ssl_primary_config;
 
 /* Get the DER encoded i-th certificate in the server handshake */
 typedef CURLcode Curl_vtls_get_cert_der(struct Curl_cfilter *cf,
@@ -44,6 +45,7 @@ typedef CURLcode Curl_vtls_get_cert_der(struct Curl_cfilter *cf,
 CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
                                 struct ssl_peer *peer,
+                                struct ssl_primary_config *config,
                                 size_t num_certs,
                                 Curl_vtls_get_cert_der *der_cb,
                                 void *cb_user_data,

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -64,6 +64,7 @@ void Curl_gtls_shared_creds_free(struct gtls_shared_creds **pcreds);
 
 struct gtls_ctx {
   gnutls_session_t session;
+  struct ssl_primary_config *config;
   struct gtls_shared_creds *shared_creds;
 #ifdef USE_GNUTLS_SRP
   gnutls_srp_client_credentials_t srp_client_cred;
@@ -89,6 +90,7 @@ CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
                             struct Curl_easy *data,
                             struct ssl_peer *peer,
                             const struct alpn_spec *alpns,
+                            struct ssl_primary_config *config,
                             Curl_gtls_ctx_setup_cb *cb_setup,
                             void *cb_user_data,
                             void *ssl_user_data,
@@ -100,8 +102,7 @@ CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
 
 CURLcode Curl_gtls_verifyserver(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
-                                gnutls_session_t session,
-                                struct ssl_primary_config *config,
+                                struct gtls_ctx *gctx,
                                 struct ssl_config_data *ssl_config,
                                 struct ssl_peer *peer,
                                 const char *pinned_key);
@@ -109,6 +110,7 @@ CURLcode Curl_gtls_verifyserver(struct Curl_cfilter *cf,
 /* Extract TLS session and place in cache, if configured. */
 CURLcode Curl_gtls_cache_session(struct Curl_cfilter *cf,
                                  struct Curl_easy *data,
+                                 struct gtls_ctx *gctx,
                                  const char *ssl_peer_key,
                                  gnutls_session_t session,
                                  curl_off_t valid_until,

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -70,6 +70,7 @@ struct ossl_ctx {
   SSL_CTX* ssl_ctx;
   SSL*     ssl;
   BIO_METHOD *bio_method;
+  struct ssl_primary_config *config; /* relevant SSL config */
   CURLcode io_result;       /* result of last BIO cfilter operation */
   /* blocked writes need to retry with same length, remember it */
   int      blocked_ssl_write_len;
@@ -101,6 +102,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
                             struct Curl_easy *data,
                             struct ssl_peer *peer,
                             const struct alpn_spec *alpns,
+                            struct ssl_primary_config *config,
                             Curl_ossl_ctx_setup_cb *cb_setup,
                             void *cb_user_data,
                             Curl_ossl_new_session_cb *cb_new_session,
@@ -131,6 +133,7 @@ CURLcode Curl_ossl_ctx_configure(struct Curl_cfilter *cf,
  */
 CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
                                struct Curl_easy *data,
+                               struct ssl_primary_config *config,
                                const char *ssl_peer_key,
                                SSL_SESSION *ssl_sessionid,
                                int ietf_tls_id,

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -663,7 +663,6 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
                                  struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   SECURITY_STATUS sspi_status;
   CURLcode result = CURLE_OK;
@@ -688,7 +687,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
   }
 
   if(result == CURLE_OK &&
-     (conn_config->CAfile || conn_config->ca_info_blob) &&
+     (connssl->config->CAfile || connssl->config->ca_info_blob) &&
      BACKEND->use_manual_cred_validation) {
     /*
      * Create a chain engine that uses the certificates in the CA file as
@@ -722,7 +721,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
           result = CURLE_SSL_CACERT_BADFILE;
         }
         else {
-          const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
+          const struct curl_blob *ca_info_blob = connssl->config->ca_info_blob;
           own_trust_store = trust_store;
 
           if(ca_info_blob) {
@@ -734,7 +733,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
           }
           else {
             result = add_certs_file_to_store(trust_store,
-                                              conn_config->CAfile,
+                                              connssl->config->CAfile,
                                               data);
           }
           if(result == CURLE_OK) {
@@ -838,7 +837,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
   }
 
   if(result == CURLE_OK) {
-    if(conn_config->verifyhost) {
+    if(connssl->config->verifyhost) {
       result = Curl_verify_host(cf, data);
     }
   }

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -112,6 +112,7 @@ struct ssl_connect_data {
   const struct Curl_ssl *ssl_impl;  /* TLS backend for this filter */
   struct ssl_peer peer;             /* peer the filter talks to */
   const struct alpn_spec *alpn;     /* ALPN to use or NULL for none */
+  struct ssl_primary_config *config; /* relevant SSL config */
   void *backend;                    /* vtls backend specific props */
   struct cf_call_data call_data;    /* data handle used in current call */
   struct curltime handshake_done;   /* time when handshake finished */

--- a/lib/vtls/vtls_scache.h
+++ b/lib/vtls/vtls_scache.h
@@ -56,6 +56,7 @@ void Curl_ssl_scache_destroy(struct Curl_ssl_scache *scache);
  * information.
  * @param cf      the connection filter wanting to use it
  * @param peer    the peer the filter wants to talk to
+ * @param config  the relevant SSL configuration
  * @param tls_id  identifier of TLS implementation for sessions. Should
  *                include full version if session data from other versions
  *                is to be avoided.
@@ -63,6 +64,7 @@ void Curl_ssl_scache_destroy(struct Curl_ssl_scache *scache);
  */
 CURLcode Curl_ssl_peer_key_make(struct Curl_cfilter *cf,
                                 const struct ssl_peer *peer,
+                                struct ssl_primary_config *config,
                                 const char *tls_id,
                                 char **ppeer_key);
 
@@ -96,6 +98,7 @@ void Curl_ssl_scache_unlock(struct Curl_easy *data);
  */
 void *Curl_ssl_scache_get_obj(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
+                              struct ssl_primary_config *config,
                               const char *ssl_peer_key);
 
 typedef void Curl_ssl_scache_obj_dtor(void *sobj);
@@ -110,12 +113,14 @@ typedef void Curl_ssl_scache_obj_dtor(void *sobj);
  * with cache (e.g. incrementing refcount on success)
  * @param cf      the connection filter wanting to use it
  * @param data    the transfer involved
+ * @param config  the relevant ssl configuration
  * @param ssl_peer_key the key for lookup
  * @param sobj    the TLS session object
  * @param sobj_free_cb callback to free the session objectt
  */
 CURLcode Curl_ssl_scache_add_obj(struct Curl_cfilter *cf,
                                  struct Curl_easy *data,
+                                 struct ssl_primary_config *config,
                                  const char *ssl_peer_key,
                                  void *sobj,
                                  Curl_ssl_scache_obj_dtor *sobj_dtor_cb);
@@ -164,22 +169,26 @@ void Curl_ssl_session_destroy(struct Curl_ssl_session *s);
  * Call takes ownership of `s` in all outcomes.
  * @param cf      the connection filter wanting to use it
  * @param data    the transfer involved
+ * @param config  the relevant ssl configuration
  * @param ssl_peer_key the key for lookup
  * @param s       the scache session object
  */
 CURLcode Curl_ssl_scache_put(struct Curl_cfilter *cf,
                              struct Curl_easy *data,
+                             struct ssl_primary_config *config,
                              const char *ssl_peer_key,
                              struct Curl_ssl_session *s);
 
 /* Take a matching scache session from the cache. Does NOT need locking.
  * @param cf      the connection filter wanting to use it
  * @param data    the transfer involved
+ * @param config  the relevant ssl configuration
  * @param ssl_peer_key the key for lookup
  * @param s       on return, the scache session object or NULL
  */
 CURLcode Curl_ssl_scache_take(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
+                              struct ssl_primary_config *config,
                               const char *ssl_peer_key,
                               struct Curl_ssl_session **ps);
 
@@ -189,12 +198,14 @@ CURLcode Curl_ssl_scache_take(struct Curl_cfilter *cf,
  */
 void Curl_ssl_scache_return(struct Curl_cfilter *cf,
                             struct Curl_easy *data,
+                            struct ssl_primary_config *config,
                             const char *ssl_peer_key,
                             struct Curl_ssl_session *s);
 
 /* Remove all sessions and obj for the peer_key. Does NOT need locking. */
 void Curl_ssl_scache_remove_all(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
+                                struct ssl_primary_config *config,
                                 const char *ssl_peer_key);
 
 #ifdef USE_SSLS_EXPORT

--- a/lib/vtls/wolfssl.h
+++ b/lib/vtls/wolfssl.h
@@ -42,6 +42,7 @@ extern const struct Curl_ssl Curl_ssl_wolfssl;
 struct wssl_ctx {
   struct WOLFSSL_CTX *ssl_ctx;
   struct WOLFSSL *ssl;
+  struct ssl_primary_config *config;
   CURLcode io_result;      /* result of last BIO cfilter operation */
   CURLcode hs_result;      /* result of handshake */
   int io_send_blocked_len; /* length of last BIO write that EAGAIN-ed */
@@ -66,6 +67,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
                             struct Curl_easy *data,
                             struct ssl_peer *peer,
                             const struct alpn_spec *alpns,
+                            struct ssl_primary_config *config,
                             Curl_wssl_ctx_setup_cb *cb_setup,
                             void *cb_user_data,
                             void *ssl_user_data,
@@ -78,6 +80,7 @@ CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
 #ifdef HAVE_EX_DATA
 CURLcode Curl_wssl_cache_session(struct Curl_cfilter *cf,
                                  struct Curl_easy *data,
+                                 struct ssl_primary_config *config,
                                  const char *ssl_peer_key,
                                  struct WOLFSSL_SESSION *session,
                                  int ietf_tls_id,


### PR DESCRIPTION
Keep the pointer to the relevant ssl_primary_config in the filter context. The idea is to eventually have the connection filter own it and use a new `CF_QUERY_MATCH` to check for config matches. 

That way, `connectdata` would no longer need to have those structs, saving memory when no ssl or ssl proxy is used.

wip, needs #20464 merge to continue 