### PR TITLE
GHA/linux: rename `intel` to `intelc` to avoid mixup with `<pkg>-intel`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -383,7 +383,7 @@ jobs:
 
           - name: 'IntelC openssl'
             install_packages: libssl-dev
-            install_steps: intel
+            install_steps: intelc
             configure: CC=icc --enable-debug --with-openssl
 
           - name: 'Slackware !ssl gssapi gcc'
@@ -757,7 +757,7 @@ jobs:
         run: sudo dpkg -i ~/rustls/"librustls_${RUSTLS_VERSION}_amd64.deb"
 
       - name: 'install Intel compilers'
-        if: ${{ contains(matrix.build.install_steps, 'intel') }}
+        if: ${{ contains(matrix.build.install_steps, 'intelc') }}
         run: |
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \


### PR DESCRIPTION
To avoid unnecessarily installing Intel C for any `<pkg>-intel` locally built dependency.

Follow-up to ab8ccaed2479bf7d019b3aa25f22299546e23828 #20392
Follow-up to d9fe60d4572bf82e407ae33277f81def896d06f2 #20248
