### PR TITLE
GHA/distcheck: bump old cmake, switch to arm64 for performance

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -262,7 +262,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-latest, macos-latest, windows-2022]
+        image: [ubuntu-24.04-arm, macos-latest, windows-2022]
     steps:
       - uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
         if: ${{ contains(matrix.image, 'windows') }}
@@ -289,8 +289,8 @@ jobs:
             sudo apt-get -o Dpkg::Use-Pty=0 install libpsl-dev libssl-dev
             cd ~
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              --location "https://github.com/Kitware/CMake/releases/download/v${OLD_CMAKE_VERSION}/cmake-${OLD_CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar -xz
-            printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-Linux-x86_64/bin/cmake > ~/old-cmake-path.txt
+              --location "https://github.com/Kitware/CMake/releases/download/v${OLD_CMAKE_VERSION}/cmake-${OLD_CMAKE_VERSION}-Linux-aarch64.tar.gz" | tar -xz
+            printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-Linux-aarch64/bin/cmake > ~/old-cmake-path.txt
           else
             brew install libpsl openssl
             cd ~


### PR DESCRIPTION
Bump CMake version in CMake integration tests for better performance
(8x on macOS, 2-3x on Windows) and native arm64 binaries.

- bump old CMake in integration tests to v3.19.8 (was: v3.11.4)
- switch to native arm64 CMake binaries on macOS.
- switch Linux CMake integration job to arm64.

Speed gains:
- Linux: 2m → 1m30s
- macOS: 9-10m → 1m15s
- Windows: 6-7m → 2m43s

Before:
https://github.com/curl/curl/actions/runs/21255697172
https://github.com/curl/curl/actions/runs/21255020621

After:
https://github.com/curl/curl/actions/runs/21272021446

With this, CI is:
- no longer testing deprecated CMake versions.
  Follow-up to a7c974e038572bd1d4a653afbd6de5fad5a10215 #19902
- not testing the next (from 2026 April) minimum 3.18, but going for
  3.19 instead. For arm64 binaries on both macOS and Linux. There is
  no 3.18-specific CMake code in curl.

Cherry-picked from #20407
