### PR TITLE
GHA/windows: fail CI early on stunnel install failure

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -366,7 +366,7 @@ jobs:
         timeout-minutes: 5
         run: |
           /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
-          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
+          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -572,7 +572,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
+          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/requirements.txt
 
       - name: 'run tests'
@@ -951,7 +951,7 @@ jobs:
             unzip bin.zip
             rm -f bin.zip
           fi
-          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
+          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel
           if [ "${MATRIX_IMAGE}" != 'windows-11-arm' ]; then  # save 30-60 seconds, to counteract the slower test run step
             python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/requirements.txt
           fi


### PR DESCRIPTION
Before this patch CI silently ignored stunnel install failures. This
pushed the failure to the test run step due to not meeting the minimum
number of tests.

Make the root cause obvious by failing early in this case.

Reported-by: Stefan Eissing
Follow-up to 3f1cd809eeae05f39fec72fe780f3a69d21972fb #19942
Ref: https://github.com/curl/curl/actions/runs/21245626382/job/61134101176?pr=20397
Ref: #16819
