### PR TITLE
GHA/windows: install stunnel manually, enable for Cygwin

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,6 +45,7 @@ jobs:
       run:
         shell: D:\cygwin\bin\bash.exe '{0}'  # zizmor: ignore[misfeature]
     env:
+      CURL_TEST_MIN: 1800
       LDFLAGS: -s
       MAKEFLAGS: -j 5
       SHELLOPTS: 'igncr'


### PR DESCRIPTION
Replace Chocolatey install with direct download and unpack. To reduce
CI dependencies (Chocolatey, NuGet), improve install performance
(10s → 1s) and hopefully reliability. Last but not least to enable it
for the Cygwin CI job.

Caveats:
- Need to bump stunnel versions manually (2-3 times a year).
  Renovate could likely do it, but I failed to understand its
  documentation and miss tooling/interface to make tests.
- FIPS not enabled. (can be done if necessary)
- Possibly losing checksum verification (not sure if Chocolatey did it
  automatically for this package.)

Also:
- Increase minimum tests by 100 for the Cygwin job.

Ref: #16819 (earlier attempt)
Ref: https://www.stunnel.org/archive/
Ref: https://www.githubstatus.com/incidents/cqb5hcy0gx18
Follow-up to d176f58a2003e4231c75f09813125c5a5bb26913 #20413
Follow-up to 19b1e44660d68d38a2f48f24740a3aac1d46b9a0 #20409

---

- [x] figure out why runtests does not detect it in the Cygwin job.
   (this PR enabled it in this CI job.)
- [x] fix runtests to pass stunnel config path to stunnel in native Windows format.
- [x] rebase on #20413
