### PR TITLE
renovate: merge two custom regex rules, escape dots

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,8 +83,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^\\.github/workflows/linux\\.yml$/",
-        "/^\\.github/workflows/http3-linux\\.yml$/"
+        "/^\\.github/workflows/http3-linux\\.yml$/",
+        "/^\\.github/workflows/linux\\.yml$/"
       ],
       "matchStrings": [
         "OPENSSL_VERSION: (?<currentValue>.*)\\s"


### PR DESCRIPTION
There are no longer envs ending with `_VER` in Circle CI config.

Follow-up to 17a669426f36b467dfd945b4b35f6211598b7977 #17537
