### PR TITLE
setopt: fix checking range for CURLOPT_MAXCONNECTS

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -851,9 +851,9 @@ static CURLcode setopt_long_net(struct Curl_easy *data, CURLoption option,
     s->dns_cache_timeout_ms = -1;
     break;
   case CURLOPT_MAXCONNECTS:
-    result = value_range(&arg, 1, 1, UINT_MAX);
+    result = value_range(&arg, 1, 1, INT_MAX);
     if(!result)
-      s->maxconnects = (unsigned int)arg;
+      s->maxconnects = (uint32_t)arg;
     break;
   case CURLOPT_SERVER_RESPONSE_TIMEOUT:
     return setopt_set_timeout_sec(&s->server_response_timeout, arg);


### PR DESCRIPTION
UINT_MAX can be converted to -1L. In this case, the value_range function will return an incorrect value of 0xFFFFFFFF, because 1 is greater than -1.

Using the upper limit as INT_MAX instead of UINT_MAX.