### PR TITLE
build: fix unused variables/values/code in non-verbose builds

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -436,6 +436,7 @@ void Curl_gss_log_error(struct Curl_easy *data, const char *prefix,
 
   display_gss_error(minor, GSS_C_MECH_CODE, buf, len);
 
+  NOVERBOSE((void)prefix);
   infof(data, "%s%s", prefix, buf);
 }
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -181,7 +181,7 @@ static size_t doh_probe_write_cb(char *contents, size_t size, size_t nmemb,
   return realsize;
 }
 
-#if defined(USE_HTTPSRR) && defined(DEBUGBUILD)
+#if defined(USE_HTTPSRR) && defined(DEBUGBUILD) && defined(CURLVERBOSE)
 
 /* doh_print_buf truncates if the hex string will be more than this */
 #define LOCAL_PB_HEXMAX 400
@@ -884,7 +884,7 @@ static void doh_show(struct Curl_easy *data,
   }
 #ifdef USE_HTTPSRR
   for(i = 0; i < d->numhttps_rrs; i++) {
-# ifdef DEBUGBUILD
+# if defined(DEBUGBUILD) && defined(CURLVERBOSE)
     doh_print_buf(data, "DoH HTTPS", d->https_rrs[i].val, d->https_rrs[i].len);
 # else
     infof(data, "DoH HTTPS RR: length %d", d->https_rrs[i].len);
@@ -1155,7 +1155,7 @@ err:
   return result;
 }
 
-#ifdef DEBUGBUILD
+#if defined(DEBUGBUILD) && defined(CURLVERBOSE)
 UNITTEST void doh_print_httpsrr(struct Curl_easy *data,
                                 struct Curl_https_rrinfo *hrr);
 
@@ -1267,7 +1267,7 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
             goto error;
           }
           infof(data, "Some HTTPS RR to process");
-# ifdef DEBUGBUILD
+# if defined(DEBUGBUILD) && defined(CURLVERBOSE)
           doh_print_httpsrr(data, hrr);
 # endif
           dns->hinfo = hrr;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -488,7 +488,6 @@ static CURLcode mbed_connect_step1(struct Curl_cfilter *cf,
   const char * const ssl_cert_type = ssl_config->cert_type;
 #endif
   const char * const ssl_crlfile = ssl_config->primary.CRLfile;
-  const char *hostname = connssl->peer.hostname;
   int ret = -1;
   char errorbuf[128];
 
@@ -747,7 +746,8 @@ static CURLcode mbed_connect_step1(struct Curl_cfilter *cf,
   }
 #endif
 
-  infof(data, "mbedTLS: Connecting to %s:%d", hostname, connssl->peer.port);
+  infof(data, "mbedTLS: Connecting to %s:%d",
+        connssl->peer.hostname, connssl->peer.port);
 
   mbedtls_ssl_config_init(&backend->config);
   ret = mbedtls_ssl_config_defaults(&backend->config,

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1172,6 +1172,7 @@ static CURLcode cr_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
       }
       /* REALLY Done with the handshake. */
       {
+#ifdef CURLVERBOSE
         const uint16_t proto = rustls_connection_get_protocol_version(rconn);
         const rustls_str ciphersuite_name =
           rustls_connection_get_negotiated_ciphersuite_name(rconn);
@@ -1182,6 +1183,7 @@ static CURLcode cr_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
           ver = "TLSv1.3";
         if(proto == RUSTLS_TLS_VERSION_TLSV1_2)
           ver = "TLSv1.2";
+#endif
         infof(data,
               "rustls: handshake complete, %s, ciphersuite: %.*s, "
               "key exchange group: %.*s",

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1885,9 +1885,9 @@ static CURLcode wssl_shutdown(struct Curl_cfilter *cf,
   struct wssl_ctx *wctx = (struct wssl_ctx *)connssl->backend;
   CURLcode result = CURLE_OK;
   char buf[1024];
-  char error_buffer[256];
   int nread = -1, err;
   size_t i;
+  VERBOSE(char error_buffer[256]);
 
   DEBUGASSERT(wctx);
   if(!wctx->ssl || cf->shutdown) {
@@ -2109,6 +2109,7 @@ static bool wssl_data_pending(struct Curl_cfilter *cf,
 
 void Curl_wssl_report_handshake(struct Curl_easy *data, struct wssl_ctx *wssl)
 {
+  (void)wssl;
 #if (LIBWOLFSSL_VERSION_HEX >= 0x03009010)
   infof(data, "SSL connection using %s / %s",
         wolfSSL_get_version(wssl->ssl),


### PR DESCRIPTION
Seen in GHA/codeql builds.

One of them also affected wolfSSL < 3.9.10 builds.

61093e2a819d26b7ddf309baef264b9e50c6c56f #20353
Cherry-picked from #20404
