### PR TITLE
GHA/codeql: improve perf on Windows, enable `CURL_WERROR=ON`, and more

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -91,7 +91,6 @@ jobs:
         with:
           languages: cpp
           build-mode: manual
-          queries: security-and-quality
           trap-caching: false
 
       - name: 'build'


### PR DESCRIPTION
- set `CURL_DROP_UNUSED=ON` for Windows (MSVC) to make the analysis step
  faster: 1m30s -> 1m15s

- enable `CURL_WERROR=ON` in all builds, to catch potential build issues
  in addition to running CodeQL. To make these builds useful as regular
  build tests too.

- add links to CodeQL Actions documentation.

- delete test data C files after checkout in an attempt to remove them
  from CodeQL code coverage stats.
