### PR TITLE
checksrc-all.pl: skip non-repository files

### DIFF
--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -11,8 +11,10 @@ use File::Find;
 use Cwd 'abs_path';
 
 my @files;
+my $is_git = 0;
 if(system('git rev-parse --is-inside-work-tree >/dev/null 2>&1') == 0) {
-    @files = `git ls-files '*.[ch]'`;
+    @files = `git ls-files \"*.[ch]\"`;
+    $is_git = 1;
 }
 else {
     find(sub { if(/\.[ch]$/) { push(@files, $File::Find::name) } }, ('.'));
@@ -30,7 +32,13 @@ my $scripts_dir = dirname(abs_path($0));
 my $anyfailed = 0;
 
 for my $dir (@dirs) {
-    @files = glob("$dir/*.[ch]");
+    if($is_git) {
+        @files = `git ls-files \"$dir/*.[ch]\"`;
+        chomp(@files);
+    }
+    else {
+        @files = glob("$dir/*.[ch]");
+    }
     if(@files && system("$scripts_dir/checksrc.pl", @files) != 0) {
         $anyfailed = 1;
     }


### PR DESCRIPTION
To avoid noise due to local C files when using automatic local checksrc
checks (e.g. via CMake `-DCURL_LINT=ON` option, or `curl-lint` target).

Also replace single-quote with double-quote in external git command, for
portability.

Follow-up to 88ff396549e12f070c65e69a0411d2e3e00be5b0 #17882
Follow-up to e785e898a6a32fc63b35615b55a147d309082f3d #17376

---

https://github.com/curl/curl/pull/20439/files?w=1
