### PR TITLE
Improved integration with the lwip library

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -86,8 +86,8 @@ static void tcpnodelay(struct Curl_cfilter *cf,
   int level = IPPROTO_TCP;
   VERBOSE(char buffer[STRERROR_LEN]);
 
-  if(setsockopt(sockfd, level, TCP_NODELAY,
-                (void *)&onoff, sizeof(onoff)) < 0)
+  if(CURL_SETSOCKOPT(sockfd, level, TCP_NODELAY,
+                     (void *)&onoff, sizeof(onoff)) < 0)
     CURL_TRC_CF(data, cf, "Could not set TCP_NODELAY: %s",
                 curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));
 #else
@@ -115,8 +115,8 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
   int optval = data->set.tcp_keepalive ? 1 : 0;
 
   /* only set IDLE and INTVL if setting KEEPALIVE is successful */
-  if(setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE,
-                (void *)&optval, sizeof(optval)) < 0) {
+  if(CURL_SETSOCKOPT(sockfd, SOL_SOCKET, SO_KEEPALIVE,
+                     (void *)&optval, sizeof(optval)) < 0) {
     CURL_TRC_CF(data, cf, "Failed to set SO_KEEPALIVE on fd "
                 "%" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
   }
@@ -189,8 +189,8 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
 #ifdef TCP_KEEPIDLE
     optval = curlx_sltosi(data->set.tcp_keepidle);
     KEEPALIVE_FACTOR(optval);
-    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,
-                  (void *)&optval, sizeof(optval)) < 0) {
+    if(CURL_SETSOCKOPT(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,
+                       (void *)&optval, sizeof(optval)) < 0) {
       CURL_TRC_CF(data, cf, "Failed to set TCP_KEEPIDLE on fd "
                   "%" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
     }
@@ -198,8 +198,8 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
     /* macOS style */
     optval = curlx_sltosi(data->set.tcp_keepidle);
     KEEPALIVE_FACTOR(optval);
-    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPALIVE,
-                  (void *)&optval, sizeof(optval)) < 0) {
+    if(CURL_SETSOCKOPT(sockfd, IPPROTO_TCP, TCP_KEEPALIVE,
+                       (void *)&optval, sizeof(optval)) < 0) {
       CURL_TRC_CF(data, cf, "Failed to set TCP_KEEPALIVE on fd "
                   "%" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
     }
@@ -207,8 +207,8 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
     /* Solaris <11.4 style */
     optval = curlx_sltosi(data->set.tcp_keepidle);
     KEEPALIVE_FACTOR(optval);
-    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPALIVE_THRESHOLD,
-                  (void *)&optval, sizeof(optval)) < 0) {
+    if(CURL_SETSOCKOPT(sockfd, IPPROTO_TCP, TCP_KEEPALIVE_THRESHOLD,
+                       (void *)&optval, sizeof(optval)) < 0) {
       CURL_TRC_CF(data, cf, "Failed to set TCP_KEEPALIVE_THRESHOLD on fd "
                   "%" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
     }
@@ -216,8 +216,8 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
 #ifdef TCP_KEEPINTVL
     optval = curlx_sltosi(data->set.tcp_keepintvl);
     KEEPALIVE_FACTOR(optval);
-    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL,
-                  (void *)&optval, sizeof(optval)) < 0) {
+    if(CURL_SETSOCKOPT(sockfd, IPPROTO_TCP, TCP_KEEPINTVL,
+                       (void *)&optval, sizeof(optval)) < 0) {
       CURL_TRC_CF(data, cf, "Failed to set TCP_KEEPINTVL on fd "
                   "%" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
     }
@@ -236,16 +236,16 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
     optval = curlx_sltosi(data->set.tcp_keepcnt) *
              curlx_sltosi(data->set.tcp_keepintvl);
     KEEPALIVE_FACTOR(optval);
-    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPALIVE_ABORT_THRESHOLD,
-                  (void *)&optval, sizeof(optval)) < 0) {
+    if(CURL_SETSOCKOPT(sockfd, IPPROTO_TCP, TCP_KEEPALIVE_ABORT_THRESHOLD,
+                       (void *)&optval, sizeof(optval)) < 0) {
       CURL_TRC_CF(data, cf, "Failed to set TCP_KEEPALIVE_ABORT_THRESHOLD"
                   " on fd %" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
     }
 #endif
 #ifdef TCP_KEEPCNT
     optval = curlx_sltosi(data->set.tcp_keepcnt);
-    if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPCNT,
-                  (void *)&optval, sizeof(optval)) < 0) {
+    if(CURL_SETSOCKOPT(sockfd, IPPROTO_TCP, TCP_KEEPCNT,
+                       (void *)&optval, sizeof(optval)) < 0) {
       CURL_TRC_CF(data, cf, "Failed to set TCP_KEEPCNT on fd "
                   "%" FMT_SOCKET_T ": errno %d", sockfd, SOCKERRNO);
     }
@@ -298,8 +298,8 @@ static CURLcode sock_assign_addr(struct Curl_sockaddr_ex *dest,
 int Curl_sock_nosigpipe(curl_socket_t sockfd)
 {
   int onoff = 1;
-  return setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE,
-                    (void *)&onoff, sizeof(onoff));
+  return CURL_SETSOCKOPT(sockfd, SOL_SOCKET, SO_NOSIGPIPE,
+                         (void *)&onoff, sizeof(onoff));
 }
 #endif /* USE_SO_NOSIGPIPE */
 
@@ -352,7 +352,7 @@ static CURLcode socket_open(struct Curl_easy *data,
 #endif /* USE_SO_NOSIGPIPE */
 
 #ifdef HAVE_FCNTL
-  if(fcntl(*sockfd, F_SETFD, FD_CLOEXEC) < 0) {
+  if(sfcntl(*sockfd, F_SETFD, FD_CLOEXEC) < 0) {
     failf(data, "fcntl set CLOEXEC: %s",
           curlx_strerror(SOCKERRNO, errbuf, sizeof(errbuf)));
     sclose(*sockfd);
@@ -573,8 +573,8 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
        * converted to an IP address and would fail Curl_if2ip. Simply try to
        * use it straight away.
        */
-      if(setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
-                    iface, (curl_socklen_t)strlen(iface) + 1) == 0) {
+      if(CURL_SETSOCKOPT(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
+                         iface, (curl_socklen_t)strlen(iface) + 1) == 0) {
         /* This is often "errno 1, error: Operation not permitted" if you are
          * not running as root or another suitable privileged user. If it
          * succeeds it means the parameter was a valid interface and not an IP
@@ -727,10 +727,11 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
     }
   }
 #ifdef IP_BIND_ADDRESS_NO_PORT
-  (void)setsockopt(sockfd, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &on, sizeof(on));
+  (void)CURL_SETSOCKOPT(sockfd, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &on,
+                        sizeof(on));
 #endif
   for(;;) {
-    if(bind(sockfd, sock, sizeof_sa) >= 0) {
+    if(CURL_BIND(sockfd, sock, sizeof_sa) >= 0) {
       /* we succeeded to bind */
       infof(data, "Local port: %hu", port);
       conn->bits.bound = TRUE;
@@ -793,7 +794,7 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
   SleepEx(0, FALSE);
 #endif
 
-  if(getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (void *)&err, &errSize))
+  if(CURL_GETSOCKOPT(sockfd, SOL_SOCKET, SO_ERROR, (void *)&err, &errSize))
     err = SOCKERRNO;
 #if defined(EBADIOCTL) && defined(__minix)
   /* Minix 3.1.x does not support getsockopt on UDP sockets */
@@ -990,7 +991,7 @@ static void set_local_ip(struct Curl_cfilter *cf,
     VERBOSE(char buffer[STRERROR_LEN]);
 
     memset(&ssloc, 0, sizeof(ssloc));
-    if(getsockname(ctx->sock, (struct sockaddr *)&ssloc, &slen)) {
+    if(CURL_GETSOCKNAME(ctx->sock, (struct sockaddr *)&ssloc, &slen)) {
       VERBOSE(int error = SOCKERRNO);
       infof(data, "getsockname() failed with errno %d: %s",
             error, curlx_strerror(error, buffer, sizeof(buffer)));
@@ -1197,28 +1198,28 @@ static int do_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
                     NULL, 0, NULL, NULL);
     }
     else {
-      rc = connect(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
+      rc = CURL_CONNECT(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
     }
 #  else
-    rc = connect(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
+    rc = CURL_CONNECT(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
 #  endif /* HAVE_BUILTIN_AVAILABLE */
 #elif defined(TCP_FASTOPEN_CONNECT) /* Linux >= 4.11 */
-    if(setsockopt(ctx->sock, IPPROTO_TCP, TCP_FASTOPEN_CONNECT,
-                  (void *)&optval, sizeof(optval)) < 0)
+    if(CURL_SETSOCKOPT(ctx->sock, IPPROTO_TCP, TCP_FASTOPEN_CONNECT,
+                       (void *)&optval, sizeof(optval)) < 0)
       CURL_TRC_CF(data, cf, "Failed to enable TCP Fast Open on fd %"
                   FMT_SOCKET_T, ctx->sock);
 
-    rc = connect(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
+    rc = CURL_CONNECT(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
 #elif defined(MSG_FASTOPEN) /* old Linux */
     if(Curl_conn_is_ssl(cf->conn, cf->sockindex))
-      rc = connect(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
+      rc = CURL_CONNECT(ctx->sock, &ctx->addr.curl_sa_addr, ctx->addr.addrlen);
     else
       rc = 0; /* Do nothing */
 #endif
   }
   else {
-    rc = connect(ctx->sock, &ctx->addr.curl_sa_addr,
-                 (curl_socklen_t)ctx->addr.addrlen);
+    rc = CURL_CONNECT(ctx->sock, &ctx->addr.curl_sa_addr,
+                      (curl_socklen_t)ctx->addr.addrlen);
   }
   return rc;
 }
@@ -1773,8 +1774,8 @@ static CURLcode cf_udp_setup_quic(struct Curl_cfilter *cf,
 
   /* error: The 1st argument to 'connect' is -1 but should be >= 0
      NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions) */
-  rc = connect(ctx->sock, &ctx->addr.curl_sa_addr,
-               (curl_socklen_t)ctx->addr.addrlen);
+  rc = CURL_CONNECT(ctx->sock, &ctx->addr.curl_sa_addr,
+                    (curl_socklen_t)ctx->addr.addrlen);
   if(-1 == rc) {
     return socket_connect_result(data, ctx->ip.remote_ip, SOCKERRNO);
   }
@@ -1980,7 +1981,7 @@ static void cf_tcp_set_accepted_remote_ip(struct Curl_cfilter *cf,
   ctx->ip.remote_port = 0;
   plen = sizeof(ssrem);
   memset(&ssrem, 0, plen);
-  if(getpeername(ctx->sock, (struct sockaddr *)&ssrem, &plen)) {
+  if(CURL_GETPEERNAME(ctx->sock, (struct sockaddr *)&ssrem, &plen)) {
     int error = SOCKERRNO;
     failf(data, "getpeername() failed with errno %d: %s",
           error, curlx_strerror(error, buffer, sizeof(buffer)));
@@ -2068,7 +2069,7 @@ static CURLcode cf_tcp_accept_connect(struct Curl_cfilter *cf,
   }
 #ifndef HAVE_ACCEPT4
 #ifdef HAVE_FCNTL
-  if(fcntl(s_accepted, F_SETFD, FD_CLOEXEC) < 0) {
+  if(sfcntl(s_accepted, F_SETFD, FD_CLOEXEC) < 0) {
     failf(data, "fcntl set CLOEXEC: %s",
           curlx_strerror(SOCKERRNO, errbuf, sizeof(errbuf)));
     Curl_socket_close(data, cf->conn, s_accepted);

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -104,8 +104,8 @@ static CURLcode rtmp_connect(struct Curl_easy *data, bool *done)
     r->Link.lFlags |= RTMP_LF_BUFX;
 
   (void)curlx_nonblock(r->m_sb.sb_socket, FALSE);
-  setsockopt(r->m_sb.sb_socket, SOL_SOCKET, SO_RCVTIMEO,
-             (char *)&tv, sizeof(tv));
+  CURL_SETSOCKOPT(r->m_sb.sb_socket, SOL_SOCKET, SO_RCVTIMEO,
+                  (char *)&tv, sizeof(tv));
 
   if(!RTMP_Connect1(r, NULL))
     return CURLE_FAILED_INIT;

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1065,18 +1065,60 @@ CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
 #define sclose(x) CURL_SCLOSE(x)
 #define fake_sclose(x) Curl_nop_stmt
 
-#define CURL_GETADDRINFO getaddrinfo
+#ifdef USE_LWIPSOCK
+#define CURL_ACCEPT lwip_accept
+#define CURL_FREEADDRINFO lwip_freeaddrinfo
+#define CURL_GETADDRINFO lwip_getaddrinfo
+#define CURL_SOCKET lwip_socket
+#else
+#define CURL_ACCEPT accept
 #define CURL_FREEADDRINFO freeaddrinfo
+#define CURL_GETADDRINFO getaddrinfo
 #define CURL_SOCKET socket
+#endif
+
 #ifdef HAVE_SOCKETPAIR
 #define CURL_SOCKETPAIR socketpair
 #endif
-#define CURL_ACCEPT accept
 #ifdef HAVE_ACCEPT4
 #define CURL_ACCEPT4 accept4
 #endif
 
 #endif /* CURL_MEMDEBUG */
+
+#ifdef USE_LWIPSOCK
+#define CURL_BIND lwip_bind
+#define CURL_CONNECT lwip_connect
+#ifdef HAVE_GETHOSTBYNAME_R_6
+#define CURL_GETHOSTBYNAME_R lwip_gethostbyname_r
+#endif
+#ifdef HAVE_GETPEERNAME
+#define CURL_GETPEERNAME lwip_getpeername
+#endif
+#ifdef HAVE_GETSOCKNAME
+#define CURL_GETSOCKNAME lwip_getsockname
+#endif
+#define CURL_GETSOCKOPT lwip_getsockopt
+#define CURL_LISTEN lwip_listen
+#define CURL_SELECT lwip_select
+#define CURL_SETSOCKOPT lwip_setsockopt
+#else
+#define CURL_BIND bind
+#define CURL_CONNECT connect
+#ifdef HAVE_GETHOSTBYNAME_R_6
+#define CURL_GETHOSTBYNAME_R gethostbyname_r
+#endif
+#ifdef HAVE_GETPEERNAME
+#define CURL_GETPEERNAME getpeername
+#endif
+#ifdef HAVE_GETSOCKNAME
+#define CURL_GETSOCKNAME getsockname
+#endif
+#define CURL_GETSOCKOPT getsockopt
+#define CURL_LISTEN listen
+#define CURL_SELECT select
+#define CURL_SETSOCKOPT setsockopt
+#endif
 
 /* Allocator macros */
 

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -149,10 +149,18 @@ struct timeval {
  * SEND_TYPE_RETV must also be defined.
  */
 
+#ifdef USE_LWIPSOCK
+#define sread(x, y, z) (ssize_t)lwip_recv((RECV_TYPE_ARG1)(x), \
+                                          (RECV_TYPE_ARG2)(y), \
+                                          (RECV_TYPE_ARG3)(z), \
+                                          (RECV_TYPE_ARG4)(0))
+#else /* USE_LWIPSOCK */
 #define sread(x, y, z) (ssize_t)recv((RECV_TYPE_ARG1)(x), \
                                      (RECV_TYPE_ARG2)(y), \
                                      (RECV_TYPE_ARG3)(z), \
                                      (RECV_TYPE_ARG4)(0))
+#endif /* USE_LWIPSOCK */
+
 #else /* HAVE_RECV */
 #ifndef sread
 #error "Missing definition of macro sread!"
@@ -165,10 +173,18 @@ struct timeval {
                                        (SEND_TYPE_ARG2)CURL_UNCONST(y), \
                                        (SEND_TYPE_ARG3)(z))
 #elif defined(HAVE_SEND)
+#ifdef USE_LWIPSOCK
+#define swrite(x, y, z) (ssize_t)lwip_send((RECV_TYPE_ARG1)(x), \
+                              (SEND_QUAL_ARG2 SEND_TYPE_ARG2)CURL_UNCONST(y), \
+                                           (RECV_TYPE_ARG3)(z), \
+                                           (RECV_TYPE_ARG4)(SEND_4TH_ARG))
+#else /* USE_LWIPSOCK */
 #define swrite(x, y, z) (ssize_t)send((SEND_TYPE_ARG1)(x), \
                               (SEND_QUAL_ARG2 SEND_TYPE_ARG2)CURL_UNCONST(y), \
                                       (SEND_TYPE_ARG3)(z), \
                                       (SEND_TYPE_ARG4)(SEND_4TH_ARG))
+#endif /* USE_LWIPSOCK */
+
 #else /* HAVE_SEND */
 #ifndef swrite
 #error "Missing definition of macro swrite!"

--- a/lib/curlx/inet_ntop.h
+++ b/lib/curlx/inet_ntop.h
@@ -35,10 +35,14 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+
 #ifdef __AMIGA__
 #define curlx_inet_ntop(af, addr, buf, size)                            \
   (char *)inet_ntop(af, CURL_UNCONST(addr), (unsigned char *)buf,       \
                     (curl_socklen_t)(size))
+#elif defined(USE_LWIPSOCK)
+#define curlx_inet_ntop(af,addr,buf,size)                               \
+        lwip_inet_ntop(af, addr, buf, (curl_socklen_t)(size))
 #else
 #define curlx_inet_ntop(af, addr, buf, size)                            \
   inet_ntop(af, addr, buf, (curl_socklen_t)(size))

--- a/lib/curlx/inet_pton.h
+++ b/lib/curlx/inet_pton.h
@@ -35,9 +35,13 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+
 #ifdef __AMIGA__
 #define curlx_inet_pton(x, y, z) \
   inet_pton(x, (unsigned char *)CURL_UNCONST(y), z)
+#elif defined(USE_LWIPSOCK)
+#define curlx_inet_pton(x, y, z) \
+  lwip_inet_pton(x, y, z)
 #else
 #define curlx_inet_pton(x, y, z) \
   inet_pton(x, y, z)

--- a/lib/curlx/nonblock.c
+++ b/lib/curlx/nonblock.c
@@ -84,7 +84,7 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
 
   /* Orbis OS */
   long b = nonblock ? 1L : 0L;
-  return setsockopt(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
+  return CURL_SETSOCKOPT(sockfd, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
 
 #else
 #error "no non-blocking method was found/used/set"

--- a/lib/curlx/wait.c
+++ b/lib/curlx/wait.c
@@ -80,7 +80,8 @@ int curlx_wait_ms(timediff_t timeout_ms)
      on Apple operating systems */
   {
     struct timeval pending_tv;
-    r = select(0, NULL, NULL, NULL, curlx_mstotv(&pending_tv, timeout_ms));
+    r = CURL_SELECT(0, NULL, NULL, NULL,
+                    curlx_mstotv(&pending_tv, timeout_ms));
   }
 #endif /* _WIN32 */
   if(r) {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1044,7 +1044,7 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
     /* not an interface and not a hostname, get default by extracting
        the IP from the control connection */
     sslen = sizeof(ss);
-    if(getsockname(conn->sock[FIRSTSOCKET], sa, &sslen)) {
+    if(CURL_GETSOCKNAME(conn->sock[FIRSTSOCKET], sa, &sslen)) {
       failf(data, "getsockname() failed: %s",
             curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));
       goto out;
@@ -1116,7 +1116,7 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
       sa6->sin6_port = htons(port);
 #endif
     /* Try binding the given address. */
-    if(bind(portsock, sa, sslen)) {
+    if(CURL_BIND(portsock, sa, sslen)) {
       /* It failed. */
       error = SOCKERRNO;
       if(possibly_non_local && (error == SOCKEADDRNOTAVAIL)) {
@@ -1127,7 +1127,7 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
               curlx_strerror(error, buffer, sizeof(buffer)));
 
         sslen = sizeof(ss);
-        if(getsockname(conn->sock[FIRSTSOCKET], sa, &sslen)) {
+        if(CURL_GETSOCKNAME(conn->sock[FIRSTSOCKET], sa, &sslen)) {
           failf(data, "getsockname() failed: %s",
                 curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));
           goto out;
@@ -1158,7 +1158,7 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
   /* get the name again after the bind() so that we can extract the
      port number it uses now */
   sslen = sizeof(ss);
-  if(getsockname(portsock, sa, &sslen)) {
+  if(CURL_GETSOCKNAME(portsock, sa, &sslen)) {
     failf(data, "getsockname() failed: %s",
           curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));
     goto out;
@@ -1168,7 +1168,7 @@ static CURLcode ftp_state_use_port(struct Curl_easy *data,
 
   /* step 4, listen on the socket */
 
-  if(listen(portsock, 1)) {
+  if(CURL_LISTEN(portsock, 1)) {
     failf(data, "socket failure: %s",
           curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));
     goto out;

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -160,12 +160,12 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
 #elif defined(HAVE_GETHOSTBYNAME_R_6)
   /* Linux */
 
-  (void)gethostbyname_r(hostname,
-                        (struct hostent *)buf,
-                        (char *)buf + sizeof(struct hostent),
-                        CURL_HOSTENT_SIZE - sizeof(struct hostent),
-                        &h, /* DIFFERENCE */
-                        &h_errnop);
+  (void)CURL_GETHOSTBYNAME_R(hostname,
+                             (struct hostent *)buf,
+                             (char *)buf + sizeof(struct hostent),
+                             CURL_HOSTENT_SIZE - sizeof(struct hostent),
+                             &h, /* DIFFERENCE */
+                             &h_errnop);
   /* Redhat 8, using glibc 2.2.93 changed the behavior. Now all of a
    * sudden this function returns EAGAIN if the given buffer size is too
    * small. Previous versions are known to return ERANGE for the same

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -392,8 +392,12 @@ curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
   if(countcheck("socket", line, source))
     return CURL_SOCKET_BAD;
 
+#ifdef USE_LWIPSOCK
+  sockfd = lwip_socket(domain, type, protocol);
+#else
   /* !checksrc! disable BANNEDFUNC 1 */
   sockfd = socket(domain, type, protocol);
+#endif
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d socket() = %" FMT_SOCKET_T "\n",
@@ -425,8 +429,12 @@ curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
   struct sockaddr *addr = (struct sockaddr *)saddr;
   curl_socklen_t *addrlen = (curl_socklen_t *)saddrlen;
 
+#ifdef USE_LWIPSOCK
+  curl_socket_t sockfd = lwip_accept(s, addr, addrlen);
+#else
   /* !checksrc! disable BANNEDFUNC 1 */
   curl_socket_t sockfd = accept(s, addr, addrlen);
+#endif
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d accept() = %" FMT_SOCKET_T "\n",

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1326,7 +1326,8 @@ static void reset_socket_fdwrite(curl_socket_t s)
 {
   int t;
   int l = (int)sizeof(t);
-  if(!getsockopt(s, SOL_SOCKET, SO_TYPE, (char *)&t, &l) && t == SOCK_STREAM)
+  if(!CURL_GETSOCKOPT(s, SOL_SOCKET, SO_TYPE, (char *)&t, &l) &&
+     t == SOCK_STREAM)
     send(s, NULL, 0, 0);
 }
 #endif

--- a/lib/select.c
+++ b/lib/select.c
@@ -91,7 +91,7 @@ static int our_select(curl_socket_t maxfd,   /* highest socket number */
                 fds_write && fds_write->fd_count ? fds_write : NULL,
                 fds_err && fds_err->fd_count ? fds_err : NULL, ptimeout);
 #else
-  return select((int)maxfd + 1, fds_read, fds_write, fds_err, ptimeout);
+  return CURL_SELECT((int)maxfd + 1, fds_read, fds_write, fds_err, ptimeout);
 #endif
 }
 

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -62,8 +62,8 @@ static int wakeup_pipe(curl_socket_t socks[2], bool nonblocking)
   if(pipe(socks))
     return -1;
 #ifdef HAVE_FCNTL
-  if(fcntl(socks[0], F_SETFD, FD_CLOEXEC) ||
-     fcntl(socks[1], F_SETFD, FD_CLOEXEC)) {
+  if(sfcntl(socks[0], F_SETFD, FD_CLOEXEC) ||
+     sfcntl(socks[1], F_SETFD, FD_CLOEXEC)) {
     sclose(socks[0]);
     sclose(socks[1]);
     socks[0] = socks[1] = CURL_SOCKET_BAD;
@@ -172,27 +172,28 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
 #ifdef SO_EXCLUSIVEADDRUSE
   {
     int exclusive = 1;
-    if(setsockopt(listener, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
-                  (char *)&exclusive, (curl_socklen_t)sizeof(exclusive)) == -1)
+    if(CURL_SETSOCKOPT(listener, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+                       (char *)&exclusive,
+                       (curl_socklen_t)sizeof(exclusive)) == -1)
       goto error;
   }
 #endif
 #else
-  if(setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
-                (char *)&reuse, (curl_socklen_t)sizeof(reuse)) == -1)
+  if(CURL_SETSOCKOPT(listener, SOL_SOCKET, SO_REUSEADDR,
+                     (char *)&reuse, (curl_socklen_t)sizeof(reuse)) == -1)
     goto error;
 #endif
-  if(bind(listener, &a.addr, sizeof(a.inaddr)) == -1)
+  if(CURL_BIND(listener, &a.addr, sizeof(a.inaddr)) == -1)
     goto error;
-  if(getsockname(listener, &a.addr, &addrlen) == -1 ||
+  if(CURL_GETSOCKNAME(listener, &a.addr, &addrlen) == -1 ||
      addrlen < (int)sizeof(a.inaddr))
     goto error;
-  if(listen(listener, 1) == -1)
+  if(CURL_LISTEN(listener, 1) == -1)
     goto error;
   socks[0] = CURL_SOCKET(AF_INET, SOCK_STREAM, 0);
   if(socks[0] == CURL_SOCKET_BAD)
     goto error;
-  if(connect(socks[0], &a.addr, sizeof(a.inaddr)) == -1)
+  if(CURL_CONNECT(socks[0], &a.addr, sizeof(a.inaddr)) == -1)
     goto error;
 
   /* use non-blocking accept to make sure we do not block forever */

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -972,8 +972,8 @@ static CURLcode tftp_connect(struct Curl_easy *data, bool *done)
      * assume uses the same IP version and thus hopefully this works for both
      * IPv4 and IPv6...
      */
-    int rc = bind(state->sockfd, (struct sockaddr *)&state->local_addr,
-                  (curl_socklen_t)remote_addr->addrlen);
+    int rc = CURL_BIND(state->sockfd, (struct sockaddr *)&state->local_addr,
+                       (curl_socklen_t)remote_addr->addrlen);
     if(rc) {
       char buffer[STRERROR_LEN];
       failf(data, "bind() failed; %s",

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2594,8 +2594,8 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   if(Curl_cf_socket_peek(cf->next, data, &ctx->q.sockfd, &sockaddr, NULL))
     return CURLE_QUIC_CONNECT_ERROR;
   ctx->q.local_addrlen = sizeof(ctx->q.local_addr);
-  rv = getsockname(ctx->q.sockfd, (struct sockaddr *)&ctx->q.local_addr,
-                   &ctx->q.local_addrlen);
+  rv = CURL_GETSOCKNAME(ctx->q.sockfd, (struct sockaddr *)&ctx->q.local_addr,
+                        &ctx->q.local_addrlen);
   if(rv == -1)
     return CURLE_QUIC_CONNECT_ERROR;
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1292,8 +1292,8 @@ static CURLcode cf_quiche_ctx_open(struct Curl_cfilter *cf,
     return CURLE_QUIC_CONNECT_ERROR;
 
   ctx->q.local_addrlen = sizeof(ctx->q.local_addr);
-  rv = getsockname(ctx->q.sockfd, (struct sockaddr *)&ctx->q.local_addr,
-                   &ctx->q.local_addrlen);
+  rv = CURL_GETSOCKNAME(ctx->q.sockfd, (struct sockaddr *)&ctx->q.local_addr,
+                        &ctx->q.local_addrlen);
   if(rv == -1)
     return CURLE_QUIC_CONNECT_ERROR;
 

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -195,8 +195,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
 
   *psent = 0;
 
-  while((rv = send(qctx->sockfd, (const char *)pkt,
-                   (SEND_TYPE_ARG3)pktlen, 0)) == -1 &&
+  while((rv = swrite(qctx->sockfd, pkt, pktlen)) == -1 &&
         SOCKERRNO == SOCKEINTR)
     ;
 


### PR DESCRIPTION
Using the lwip_* function family.
Use of the inet_ntop and lwip_inet_pton functions.
I did not change references to functions if they appeared inside the linux or USE_WINSOCK definitions.