### PR TITLE
Resolve inconsistency between curl_multi_perform and curl_multi_wait/poll documentation

### DIFF
--- a/docs/libcurl/curl_multi_perform.md
+++ b/docs/libcurl/curl_multi_perform.md
@@ -76,8 +76,8 @@ int main(void)
     for(;;) {
       CURLMcode mresult = curl_multi_perform(multi, &still_running);
       if(mresult != CURLM_OK) {
-        fprintf(stderr,
-          "curl_multi_perform() failed, code %d.\n", (int)mresult);
+        fprintf(stderr, "curl_multi_perform() failed, code %d.\n",
+                (int)mresult);
         break;
       }
 


### PR DESCRIPTION
The `curl_multi_perform` documentation (https://curl.se/libcurl/c/curl_multi_perform.html) uses integer contextual conversion to `bool` to test the resulting `CURLMcode`, while other functions like `curl_multi_wait` and `curl_multi_poll` test against `CURLM_OK` ( for example https://curl.se/libcurl/c/curl_multi_wait.html ). (I was initially confused by this as it looked like some docs call curl_multi_wait/poll on error, while some called only on success. I think it would be clearer to always test against `CURLM_OK`)

Also fixed the example to print which function call failed; previously an error reported by `curl_multi_perform` was printed as a failure of `curl_multi_wait`. It may be better to fix that by removing the function name entirely as https://curl.se/libcurl/c/curl_multi_wait.html seems to do instead...