### PR TITLE
vquic: handle too large udp datagram

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -168,7 +168,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
       return CURLE_AGAIN;
     case SOCKEMSGSIZE:
       /* UDP datagram is too large; caused by PMTUD. Just let it be lost. */
-      break;
+      return CURLE_SEND_ERROR;
     case EIO:
       if(pktlen > gsolen) {
         /* GSO failure */


### PR DESCRIPTION
If interface MTU is too small this code looped in `vquic_flush()`. Let's return a send error on too large udp datagram to handle this.

Fixes: https://github.com/curl/curl/issues/20440
Downstream: https://gitlab.archlinux.org/archlinux/packaging/packages/curl/-/issues/14