### PR TITLE
TODO: remove item about signals

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1039,11 +1039,3 @@ See [curl issue 12655](https://github.com/curl/curl/issues/12655)
 
 Running test suite with `CURL_DBG_SOCK_WBLOCK=90 ./runtests.pl -a 1200 to
 1300` makes several Gopher test cases fail where they should not.
-
-# Signals
-
-## SIGPIPE
-
-Since we control the IO functions for most protocols and disable
-SIGPIPE on sends, libcurl could skip the special SIGPIPE ignore
-handling for those transfers.


### PR DESCRIPTION
With SIGPIPE handling now automatic on most platforms, remove the TODO item again.