### PR TITLE
vquic: handle SOCKEMSGSIZE correctly

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -207,8 +207,8 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
       goto out;
     }
     else {
-      failf(data, "send() returned %zd (errno %d)", rv, SOCKERRNO);
       if(SOCKERRNO != SOCKEMSGSIZE) {
+        failf(data, "send() returned %zd (errno %d)", rv, SOCKERRNO);
         result = CURLE_SEND_ERROR;
         goto out;
       }


### PR DESCRIPTION
Report UDP packets with SOCKEMSGSIZE as being "sent" to progress the send buffer properly on PMTUD probes.

refs #20440