### PR TITLE
GHA/windows: fix shell, fix GHA fail to share cache between arm and intel Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:
-        image: [windows-11-arm, windows-2022]
+        image: [windows-11-arm, windows-2022]  # Cannot share cache between arm and intel: https://github.com/actions/cache/issues/1622
     steps:
       - name: 'cache test prereqs (stunnel)'
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1


### PR DESCRIPTION
A cache entry created by windows-2022 is not picked up by 
windows-11-arm. Also a cache created by windows-11-arm is not picked up
by windows-2022. Possibly related to this filed in 2025 June:
https://github.com/actions/cache/issues/1622. Also tried
`enableCrossOsArchive` to no avail. Unclear if these two runners count
as distinct operating systems, I'd guess not. Cache entries are
identical on the web UI. Via GH API they show up with the same cache key
bot different "version" (hash) and different sizes, possibly due to the
zstd vs. gzip bug above.

Fixing (identical error text on either runner):
```
Error: Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: Windows-stunnel-5.76-amd64
```

Also fix a silly typo in the shell value.

Follow-up to 0f54ca6150f5bff5e8eb8b165de86262e98f5e69 #20454
