### PR TITLE
pytest 03_02, remove

### DIFF
--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -75,7 +75,7 @@ class TestGoAway:
     # nghttpx during transfers. This proved to be unreliable. The nature of
     # UDP makes QUIC streams error (ERR_DRAINGIN, e.g. connection closes)
     # at possibly any point. We do not retry on requests in all such
-    # situations which made the test fail in CI ocasionally. Not good enough.
+    # situations which made the test fail in CI occasionally. Not good enough.
     # def test_03_02_h3_goaway(self, env: Env, httpd, nghttpx):
 
     # download files sequentially with delay, reload server for GOAWAY


### PR DESCRIPTION
The test for restarting the server during ongoing transfers does not work reliably for HTTP/3. This seems due to the nature of UDP/QUIC where the client may learn about a closed connection at any time, not only when starting a new request.

Remove the test.