### PR TITLE
GHA/windows: mark test 3001 flaky in native Windows jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -420,6 +420,7 @@ jobs:
           TFLAGS="-j8 ${TFLAGS}"
           if [ "${MATRIX_SYS}" != 'msys' ]; then
             TFLAGS+=' !498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
+            TFLAGS+=' ~3100'  # 'HTTPS localhost, last subject alt name matches, CN does not match' HTTPS, HTTP GET, PEM certificate (returning 56)
             if [[ "${MATRIX_INSTALL}" = *'libssh2-wincng'* ]]; then
               TFLAGS+=' ~SCP ~SFTP'  # Flaky: `-8, Unable to exchange encryption keys`. https://github.com/libssh2/libssh2/issues/804
             fi
@@ -634,6 +635,7 @@ jobs:
           PATH="/d/my-cache/${MATRIX_DIR}/bin:$PATH"
           TFLAGS="-j8 ${TFLAGS}"
           TFLAGS+=' !498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
+          TFLAGS+=' ~3100'  # 'HTTPS localhost, last subject alt name matches, CN does not match' HTTPS, HTTP GET, PEM certificate (returning 56)
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -1023,6 +1025,7 @@ jobs:
         run: |
           TFLAGS="-j8 ${TFLAGS}"
           TFLAGS+=' !498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
+          TFLAGS+=' ~3100'  # 'HTTPS localhost, last subject alt name matches, CN does not match' HTTPS, HTTP GET, PEM certificate (returning 56)
           if [[ "${MATRIX_INSTALL_MSYS2}" = *'libssh2-wincng'* || \
                 "${MATRIX_INSTALL_VCPKG}" = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SCP ~SFTP'  # Flaky: `-8, Unable to exchange encryption keys`. https://github.com/libssh2/libssh2/issues/804


### PR DESCRIPTION
It has been happening for a long time.

Example:
```
test 3001...[HTTPS localhost, last subject alt name matches, CN does not match]

 3001: protocol FAILED!
 There was no content at all in the file log/7/server.input.
 Server glitch? Total curl failure? Returned: 56
== Contents of files in the log/7/ directory after test 3001
=== Start of file commands.log
 ../src/curl.exe -q --output log/7/curl3001.out  --include --trace-ascii log/7/trace3001 --trace-time -4 --cacert ./certs/test-ca.crt https://localhost:64259/3001 > log/7/stdout3001 2> log/7/stderr3001
=== End of file commands.log
=== Start of file http_server.log
 13:57:47.951283 Running HTTP IPv4 version on port 64256
=== End of file http_server.log
=== Start of file https_stunnel.log
 2026.01.28 13:57:48 LOG5[ui]: stunnel 5.76 on x64-pc-mingw32-gnu platform
 2026.01.28 13:57:48 LOG5[ui]: Compiled/running with OpenSSL 3.5.4 30 Sep 2025
 [...]
 2026.01.28 13:57:49 LOG5[0]: Service [curltest] accepted connection from 127.0.0.1:64281
 2026.01.28 13:57:51 LOG3[0]: s_connect: connect 127.0.0.1:64256: Connection refused (WSAECONNREFUSED) (10061)
 2026.01.28 13:57:51 LOG3[0]: No more addresses to connect
 2026.01.28 13:57:51 LOG5[0]: Connection reset: 0 byte(s) sent to TLS, 0 byte(s) sent to socket
=== End of file https_stunnel.log
=== Start of file server.cmd
 Testnum 3001
=== End of file server.cmd
=== Start of file stderr3001
 curl: (56) Recv failure: Connection was reset
=== End of file stderr3001
[...]
RUN: Unknown server on our https port: 64259 (56)
```

Ref: https://github.com/curl/curl/actions/runs/21440845836/job/61743268798?pr=20461