### PR TITLE
url.c: code/comment cleanup around conn creation

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3289,18 +3289,18 @@ static CURLcode url_create_needle(struct Curl_easy *data,
   if(needle->bits.httpproxy) {
     result = Curl_idnconvert_hostname(&needle->http_proxy.host);
     if(result)
-      return result;
+      goto out;
   }
   if(needle->bits.socksproxy) {
     result = Curl_idnconvert_hostname(&needle->socks_proxy.host);
     if(result)
-      return result;
+      goto out;
   }
 #endif
   if(needle->bits.conn_to_host) {
     result = Curl_idnconvert_hostname(&needle->conn_to_host);
     if(result)
-      return result;
+      goto out;
   }
 
   /*************************************************************


### PR DESCRIPTION
Several comments were outdated and parameters to create_conn() and ConnectionExists() were not needed. Give functions better names and consistently use terms `needle` and `conn`.

No functional change.