### PR TITLE
GHA/macos: merge an autotools job into a cmake one, drop an iOS job

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -178,6 +178,7 @@ jobs:
           find . -type f \( -name curl -o -name '*.dylib' -o -name '*.a' \) -print0 | xargs -0 stat -f '%10z bytes: %N' --
 
       - name: 'build tests'
+        if: ${{ matrix.build.generate }}  # skip for autotools to save time
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld ${MATRIX_OPTIONS} --parallel 4 --target testdeps --verbose
@@ -186,6 +187,7 @@ jobs:
           fi
 
       - name: 'build examples'
+        if: ${{ matrix.build.generate }}  # skip for autotools to save time
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld ${MATRIX_OPTIONS} --parallel 4 --target curl-examples-build --verbose


### PR DESCRIPTION
Merging the two macOS jobs saves 4-5 minutes. The dropped iOS Ninja job
saves 0.5-1 minute. (Keep the two slow iOS jobs to maintain variation.)

Number of Apple jobs is 32 after this patch.

Also:
- skip building tests and example in iOS autotools to save 30-40s.
