### PR TITLE
setup-os400.h: drop no longer used custom type `u_int32_t`

### DIFF
--- a/lib/setup-os400.h
+++ b/lib/setup-os400.h
@@ -30,9 +30,6 @@
 /* OS/400 netdb.h does not define NI_MAXSERV. */
 #define NI_MAXSERV      32
 
-/* No OS/400 header file defines u_int32_t. */
-typedef unsigned long   u_int32_t;
-
 /* OS/400 has no idea of a tty! */
 #define isatty(fd)      0
 


### PR DESCRIPTION
Unused since bb5529331334e1e1c79ff3320220bba12fc8457d.
