### PR TITLE
tests/server/sockfilt: avoid possible endless loop on Windows

### DIFF
--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -530,6 +530,8 @@ static DWORD WINAPI select_ws_wait_thread(void *lpParameter)
           curlx_winapi_strerror(ret, buffer, sizeof(buffer));
           logmsg("[select_ws_wait_thread] PeekNamedPipe error: (0x%08lx) - %s",
                  ret, buffer);
+          if(ret == ERROR_NOT_SUPPORTED)  /* avoid endless loop */
+             break;
           SleepEx(0, FALSE);
           continue;
         }


### PR DESCRIPTION
Seen to happen when run under WINE v10.0 on macOS.
```
$ CURL_TEST_EXE_EXT_SRV=.exe CURL_TEST_EXE_EXT_TOOL=.exe \
CURL_TEST_EXE_RUNNER=wine TFLAGS='951 -t' ninja tests
[...]
16:02:18.607002 [select_ws_wait_thread] PeekNamedPipe error: (0x00000032) - Request not supported.
[...endless repeat...]
```
