### PR TITLE
ftp: replace a `curlx_free()` with `curlx_dyn_free()`

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2976,7 +2976,7 @@ static CURLcode ftp_pwd_resp(struct Curl_easy *data,
          The method used here is to check the server OS: we do it only
          if the path name looks strange to minimize overhead on other
          systems. */
-      const char *dir = curlx_dyn_ptr(&out);
+      char *dir = curlx_dyn_ptr(&out);
 
       if(!ftpc->server_os && dir[0] != '/') {
         result = Curl_pp_sendf(data, &ftpc->pp, "%s", "SYST");


### PR DESCRIPTION
On an error path.

Follow-up to f4beef524a53e1951c102fdb2ab96dd7a5e01077 #12638