### PR TITLE
multi_remove_handle: update timer unconditionally

### DIFF
--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -30,7 +30,7 @@
 void Curl_expire(struct Curl_easy *data, timediff_t milli, expire_id);
 void Curl_expire_ex(struct Curl_easy *data,
                     timediff_t milli, expire_id id);
-bool Curl_expire_clear(struct Curl_easy *data);
+void Curl_expire_clear(struct Curl_easy *data);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);
 CURLMcode Curl_update_timer(struct Curl_multi *multi) WARN_UNUSED_RESULT;
 void Curl_attach_connection(struct Curl_easy *data,


### PR DESCRIPTION
When removing an easy handle from a multi, there was an optimization to update the timer only when the removed handle had any timers.

With the introduction of the "dirty" bitset, easy handles can now cause a timeout of 0 to be set without having anything in their timer list. Removing such a handle needs to update the timer now always, so that it may get cleared when there is nothing more to wait for.

The previous "not clearing a 0 timer" should not have any effect on application's logic. Without clearing, the timer will fire and then adjust itself to the proper value. But it would cause one more timer fire than necessary.

refs #20498