### PR TITLE
curlx: drop unused `curlx_saferealloc()`

### DIFF
--- a/lib/curlx/dynbuf.c
+++ b/lib/curlx/dynbuf.c
@@ -102,8 +102,6 @@ static CURLcode dyn_nappend(struct dynbuf *s,
   }
 
   if(a != s->allc) {
-    /* this logic is not using curlx_saferealloc() to make the tool not have to
-       include that as well when it uses this code */
     void *p = curlx_realloc(s->bufr, a);
     if(!p) {
       curlx_dyn_free(s);

--- a/lib/curlx/strdup.c
+++ b/lib/curlx/strdup.c
@@ -112,26 +112,3 @@ void *curlx_memdup0(const char *src, size_t length)
   buf[length] = 0;
   return buf;
 }
-
-/***************************************************************************
- *
- * curlx_saferealloc(ptr, size)
- *
- * Does a normal curlx_realloc(), but will free the data pointer if the realloc
- * fails. If 'size' is non-zero, it will free the data and return a failure.
- *
- * This convenience function is provided and used to help us avoid a common
- * mistake pattern when we could pass in a zero, catch the NULL return and end
- * up free'ing the memory twice.
- *
- * Returns the new pointer or NULL on failure.
- *
- ***************************************************************************/
-void *curlx_saferealloc(void *ptr, size_t size)
-{
-  void *datap = curlx_realloc(ptr, size);
-  if(size && !datap)
-    /* only free 'ptr' if size was non-zero */
-    curlx_free(ptr);
-  return datap;
-}

--- a/lib/curlx/strdup.h
+++ b/lib/curlx/strdup.h
@@ -32,5 +32,4 @@ char *curlx_strdup_low(const char *str);
 #endif
 void *curlx_memdup(const void *src, size_t buffer_length);
 void *curlx_memdup0(const char *src, size_t length);
-void *curlx_saferealloc(void *ptr, size_t size);
 #endif /* HEADER_CURLX_STRDUP_H */


### PR DESCRIPTION
Unused since 67ae101666f1023263c475b88b266bc9b5e658c0 #19949