### PR TITLE
thread pools

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -258,6 +258,8 @@ LIB_CFILES =         \
   system_win32.c     \
   telnet.c           \
   tftp.c             \
+  thrdpool.c         \
+  thrdqueue.c        \
   transfer.c         \
   uint-bset.c        \
   uint-hash.c        \
@@ -385,6 +387,8 @@ LIB_HFILES =         \
   system_win32.h     \
   telnet.h           \
   tftp.h             \
+  thrdpool.h         \
+  thrdqueue.h        \
   transfer.h         \
   uint-bset.h        \
   uint-hash.h        \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -703,6 +703,10 @@
 #endif
 
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
+#define USE_THREADS
+#endif
+
+#ifdef USE_THREADS
 #  define CURLRES_ASYNCH
 #  define CURLRES_THREADED
 #elif defined(USE_ARES)

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -23,11 +23,14 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+#ifdef USE_THREADS
+
 #if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
 #include <pthread.h>
 #endif
 
 #include "curl_threads.h"
+#include "curlx/timeval.h"
 
 #ifdef USE_THREADS_POSIX
 
@@ -97,6 +100,34 @@ int Curl_thread_join(curl_thread_t *hnd)
   return ret;
 }
 
+void Curl_cond_signal(pthread_cond_t *c)
+{
+  /* return code defined as always 0 */
+  (void)pthread_cond_signal(c);
+}
+
+void Curl_cond_wait(pthread_cond_t *c, pthread_mutex_t *m)
+{
+  /* return code defined as always 0 */
+  (void)pthread_cond_wait(c, m);
+}
+
+CURLcode Curl_cond_timedwait(pthread_cond_t *c, pthread_mutex_t *m,
+                             uint32_t timeout_ms)
+{
+  struct curltime now = curlx_now();
+  struct timespec ts;
+  int rc;
+
+  ts.tv_sec = now.tv_sec + (timeout_ms / 1000);
+  ts.tv_nsec = (now.tv_usec + ((timeout_ms % 1000) * 1000)) * 1000;
+
+  rc = pthread_cond_timedwait(c, m, &ts);
+  if(rc == SOCKETIMEDOUT)
+    return CURLE_OPERATION_TIMEDOUT;
+  return rc ? CURLE_UNRECOVERABLE_POLL : CURLE_OK;
+}
+
 #elif defined(USE_THREADS_WIN32)
 
 curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
@@ -131,4 +162,27 @@ int Curl_thread_join(curl_thread_t *hnd)
   return ret;
 }
 
-#endif /* USE_THREADS_* */
+void Curl_cond_signal(CONDITION_VARIABLE *c)
+{
+  WakeConditionVariable(c);
+}
+
+void Curl_cond_wait(CONDITION_VARIABLE *c, CRITICAL_SECTION *m)
+{
+  SleepConditionVariableCS(c, m, INFINITE);
+}
+
+CURLcode Curl_cond_timedwait(CONDITION_VARIABLE *c, CRITICAL_SECTION *m,
+                             uint32_t timeout_ms)
+{
+  if(!SleepConditionVariableCS(c, m, (DWORD)timeout_ms)) {
+    DWORD err = GetLastError();
+    return (err == ERROR_TIMEOUT) ?
+           CURLE_OPERATION_TIMEDOUT : CURLE_UNRECOVERABLE_POLL;
+  }
+  return CURLE_OK;
+}
+
+#endif /* USE_THREADS_WIN32 */
+
+#endif /* USE_THREADS */

--- a/lib/thrdpool.c
+++ b/lib/thrdpool.c
@@ -1,0 +1,391 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "curl_setup.h"
+
+#ifdef USE_THREADS
+
+#if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
+#include <pthread.h>
+#endif
+
+#include "llist.h"
+#include "curl_threads.h"
+#include "curlx/timeval.h"
+#include "thrdpool.h"
+
+struct thrdslot {
+  struct Curl_llist_node node;
+  struct curl_thrdpool *tpool;
+  curl_thread_t thread;
+  curl_cond_t await;
+  BIT(running);
+  BIT(idle);
+};
+
+struct curl_thrdpool {
+  char *name;
+  uint64_t refcount;
+  curl_mutex_t lock;
+  curl_cond_t await;
+  struct Curl_llist slots;
+  struct Curl_llist zombies;
+  Curl_thrdpool_take_item_cb *fn_take;
+  Curl_thrdpool_process_item_cb *fn_process;
+  Curl_thrdpool_return_item_cb *fn_return;
+  void *fn_user_data;
+  CURLcode fatal_err;
+  uint32_t min_threads;
+  uint32_t max_threads;
+  uint32_t idle_time_ms;
+  BIT(aborted);
+  BIT(detached);
+};
+
+static void thrdpool_join_zombies(struct curl_thrdpool *tpool);
+static bool thrdpool_unlink(struct curl_thrdpool *tpool, bool locked);
+
+static void thrdslot_destroy(struct thrdslot *tslot)
+{
+  DEBUGASSERT(tslot->thread == curl_thread_t_null);
+  DEBUGASSERT(!tslot->running);
+  Curl_cond_destroy(&tslot->await);
+  curlx_free(tslot);
+}
+
+static void thrdslot_done(struct thrdslot *tslot)
+{
+  struct curl_thrdpool *tpool = tslot->tpool;
+
+  DEBUGASSERT(Curl_node_llist(&tslot->node) == &tpool->slots);
+  Curl_node_remove(&tslot->node);
+  tslot->running = FALSE;
+  Curl_llist_append(&tpool->zombies, tslot, &tslot->node);
+  Curl_cond_signal(&tpool->await);
+}
+
+static CURL_THREAD_RETURN_T CURL_STDCALL thrdslot_run(void *arg)
+{
+  struct thrdslot *tslot = arg;
+  struct curl_thrdpool *tpool = tslot->tpool;
+  void *item;
+
+  Curl_mutex_acquire(&tpool->lock);
+  DEBUGASSERT(Curl_node_llist(&tslot->node) == &tpool->slots);
+  for(;;) {
+    while(!tpool->aborted) {
+      item = tpool->fn_take(tpool->fn_user_data);
+      if(!item)
+        break;
+
+      Curl_mutex_release(&tpool->lock);
+
+      tpool->fn_process(item);
+
+      Curl_mutex_acquire(&tpool->lock);
+      tpool->fn_return(item, tpool->aborted ? NULL : tpool->fn_user_data);
+    }
+
+    if(tpool->aborted)
+      goto out;
+
+    tslot->idle = TRUE;
+    thrdpool_join_zombies(tpool);
+    Curl_cond_signal(&tpool->await);
+    /* Only wait with idle timeout when we are above the minimum
+     * number of threads. Otherwise short idle timeouts will keep
+     * on activating threads that have no means to shut down. */
+    if((tpool->idle_time_ms > 0) &&
+       (Curl_llist_count(&tpool->slots) > tpool->min_threads)) {
+      CURLcode r = Curl_cond_timedwait(&tslot->await, &tpool->lock,
+                                       tpool->idle_time_ms);
+      if((r == CURLE_OPERATION_TIMEDOUT) &&
+         (Curl_llist_count(&tpool->slots) > tpool->min_threads))
+        goto out;
+    }
+    else {
+      Curl_cond_wait(&tslot->await, &tpool->lock);
+    }
+    tslot->idle = FALSE;
+  }
+
+out:
+  thrdslot_done(tslot);
+  if(!thrdpool_unlink(tslot->tpool, TRUE)) {
+    /* tpool not destroyed */
+    Curl_mutex_release(&tpool->lock);
+  }
+  return 0;
+}
+
+static CURLcode thrdslot_start(struct curl_thrdpool *tpool)
+{
+  struct thrdslot *tslot;
+  CURLcode result = CURLE_OUT_OF_MEMORY;
+
+  tslot = curlx_calloc(1, sizeof(*tslot));
+  if(!tslot)
+    goto out;
+  tslot->tpool = tpool;
+  tslot->thread = curl_thread_t_null;
+  Curl_cond_init(&tslot->await);
+
+  tpool->refcount++;
+  tslot->running = TRUE;
+  tslot->thread = Curl_thread_create(thrdslot_run, tslot);
+  if(tslot->thread == curl_thread_t_null) { /* never started */
+    tslot->running = FALSE;
+    thrdpool_unlink(tpool, TRUE);
+    result = CURLE_FAILED_INIT;
+    goto out;
+  }
+
+  Curl_llist_append(&tpool->slots, tslot, &tslot->node);
+  tslot = NULL;
+  result = CURLE_OK;
+
+out:
+  if(tslot)
+    thrdslot_destroy(tslot);
+  return result;
+}
+
+static void thrdpool_wake_all(struct curl_thrdpool *tpool)
+{
+  struct Curl_llist_node *e;
+  for(e = Curl_llist_head(&tpool->slots); e; e = Curl_node_next(e)) {
+    struct thrdslot *tslot = Curl_node_elem(e);
+    Curl_cond_signal(&tslot->await);
+  }
+}
+
+static void thrdpool_join_zombies(struct curl_thrdpool *tpool)
+{
+  struct Curl_llist_node *e;
+
+  for(e = Curl_llist_head(&tpool->zombies); e;
+      e = Curl_llist_head(&tpool->zombies)) {
+    struct thrdslot *tslot = Curl_node_elem(e);
+
+    Curl_node_remove(&tslot->node);
+    if(tslot->thread != curl_thread_t_null) {
+      Curl_mutex_release(&tpool->lock);
+      Curl_thread_join(&tslot->thread);
+      Curl_mutex_acquire(&tpool->lock);
+      tslot->thread = curl_thread_t_null;
+    }
+    thrdslot_destroy(tslot);
+  }
+}
+
+static bool thrdpool_unlink(struct curl_thrdpool *tpool, bool locked)
+{
+  DEBUGASSERT(tpool->refcount);
+  if(tpool->refcount)
+    tpool->refcount--;
+  if(tpool->refcount)
+    return FALSE;
+
+  /* no more references, free */
+  DEBUGASSERT(tpool->aborted);
+  thrdpool_join_zombies(tpool);
+  if(locked)
+    Curl_mutex_release(&tpool->lock);
+  curlx_free(tpool->name);
+  Curl_cond_destroy(&tpool->await);
+  Curl_mutex_destroy(&tpool->lock);
+  curlx_free(tpool);
+  return TRUE;
+}
+
+CURLcode Curl_thrdpool_create(struct curl_thrdpool **ptpool,
+                              const char *name,
+                              uint32_t min_threads,
+                              uint32_t max_threads,
+                              uint32_t idle_time_ms,
+                              Curl_thrdpool_take_item_cb *fn_take,
+                              Curl_thrdpool_process_item_cb *fn_process,
+                              Curl_thrdpool_return_item_cb *fn_return,
+                              void *user_data)
+{
+  struct curl_thrdpool *tpool;
+  CURLcode result = CURLE_OUT_OF_MEMORY;
+
+  tpool = curlx_calloc(1, sizeof(*tpool));
+  if(!tpool)
+    goto out;
+  tpool->refcount = 1;
+
+  tpool->name = curlx_strdup(name);
+  if(!tpool->name)
+    goto out;
+
+  Curl_mutex_init(&tpool->lock);
+  Curl_cond_init(&tpool->await);
+  Curl_llist_init(&tpool->slots, NULL);
+  Curl_llist_init(&tpool->zombies, NULL);
+  tpool->min_threads = min_threads;
+  tpool->max_threads = max_threads;
+  tpool->idle_time_ms = idle_time_ms;
+  tpool->fn_take = fn_take;
+  tpool->fn_process = fn_process;
+  tpool->fn_return = fn_return;
+  tpool->fn_user_data = user_data;
+
+  if(tpool->min_threads)
+    result = Curl_thrdpool_signal(tpool, tpool->min_threads);
+  else
+    result = CURLE_OK;
+
+out:
+  if(result && tpool) {
+    tpool->aborted = TRUE;
+    thrdpool_unlink(tpool, FALSE);
+    tpool = NULL;
+  }
+  *ptpool = tpool;
+  return result;
+}
+
+void Curl_thrdpool_destroy(struct curl_thrdpool *tpool, bool join)
+{
+  Curl_mutex_acquire(&tpool->lock);
+
+  tpool->aborted = TRUE;
+
+  while(join && Curl_llist_count(&tpool->slots)) {
+    thrdpool_wake_all(tpool);
+    Curl_cond_wait(&tpool->await, &tpool->lock);
+  }
+
+  thrdpool_join_zombies(tpool);
+
+  /* detach all still running threads */
+  if(Curl_llist_count(&tpool->slots)) {
+    struct Curl_llist_node *e;
+    for(e = Curl_llist_head(&tpool->slots); e; e = Curl_node_next(e)) {
+      struct thrdslot *tslot = Curl_node_elem(e);
+      if(tslot->thread != curl_thread_t_null)
+        Curl_thread_destroy(&tslot->thread);
+    }
+    tpool->detached = TRUE;
+  }
+
+  if(!thrdpool_unlink(tpool, TRUE)) {
+    /* tpool not destroyed */
+    Curl_mutex_release(&tpool->lock);
+  }
+}
+
+CURLcode Curl_thrdpool_signal(struct curl_thrdpool *tpool, uint32_t nthreads)
+{
+  struct Curl_llist_node *e, *n;
+  CURLcode result = CURLE_OK;
+
+  Curl_mutex_acquire(&tpool->lock);
+  DEBUGASSERT(!tpool->aborted);
+
+  thrdpool_join_zombies(tpool);
+
+  for(e = Curl_llist_head(&tpool->slots); e && nthreads; e = n) {
+    struct thrdslot *tslot = Curl_node_elem(e);
+    n = Curl_node_next(e);
+    if(tslot->idle) {
+      Curl_cond_signal(&tslot->await);
+      --nthreads;
+    }
+  }
+
+  while(nthreads && !result &&
+        Curl_llist_count(&tpool->slots) < tpool->max_threads) {
+    result = thrdslot_start(tpool);
+    if(result)
+      break;
+    --nthreads;
+  }
+
+  Curl_mutex_release(&tpool->lock);
+  return result;
+}
+
+static bool thrdpool_all_idle(struct curl_thrdpool *tpool)
+{
+  struct Curl_llist_node *e;
+  for(e = Curl_llist_head(&tpool->slots); e; e = Curl_node_next(e)) {
+    struct thrdslot *tslot = Curl_node_elem(e);
+    if(!tslot->idle)
+      return FALSE;
+  }
+  return TRUE;
+}
+
+CURLcode Curl_thrdpool_await_idle(struct curl_thrdpool *tpool,
+                                  uint32_t timeout_ms)
+{
+  CURLcode result = CURLE_OK;
+  struct curltime end = { 0 };
+
+  Curl_mutex_acquire(&tpool->lock);
+  DEBUGASSERT(!tpool->aborted);
+  if(tpool->aborted) {
+    result = CURLE_FAILED_INIT;
+    goto out;
+  }
+
+  while(!thrdpool_all_idle(tpool)) {
+    if(timeout_ms) {
+      timediff_t remain_ms;
+      CURLcode r;
+
+      if(!end.tv_sec && !end.tv_usec) {
+        end = curlx_now();
+        end.tv_sec += (time_t)(timeout_ms / 1000);
+        end.tv_usec += (int)(timeout_ms % 1000) * 1000;
+        if(end.tv_usec >= 1000000) {
+          end.tv_sec++;
+          end.tv_usec -= 1000000;
+        }
+      }
+      remain_ms = curlx_timediff_ms(curlx_now(), end);
+      if(remain_ms <= 0)
+        r = CURLE_OPERATION_TIMEDOUT;
+      else
+        r = Curl_cond_timedwait(&tpool->await, &tpool->lock,
+                                (uint32_t)remain_ms);
+      if(r == CURLE_OPERATION_TIMEDOUT) {
+        result = r;
+        break;
+      }
+    }
+    else {
+      Curl_cond_wait(&tpool->await, &tpool->lock);
+    }
+  }
+
+out:
+  thrdpool_join_zombies(tpool);
+  Curl_mutex_release(&tpool->lock);
+  return result;
+}
+
+#endif /* USE_THREADS */

--- a/lib/thrdpool.h
+++ b/lib/thrdpool.h
@@ -1,0 +1,88 @@
+#ifndef HEADER_CURL_THRDPOOL_H
+#define HEADER_CURL_THRDPOOL_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "curl_setup.h"
+
+#ifdef USE_THREADS
+
+struct curl_thrdpool;
+
+/* Invoked under thread pool lock to get an "item" to work on. Must
+ * return NULL if there is nothing to do. */
+typedef void *Curl_thrdpool_take_item_cb(void *user_data);
+
+/* Invoked outside thread pool lock to process the item taken. */
+typedef void Curl_thrdpool_process_item_cb(void *item);
+
+/* Invoked under thread pool lock to return a processed item back
+ * to the producer.
+ * If the thread pool has been destroyed, `user_data` will be NULL
+ * and the callback is responsible to release all `item` resources. */
+typedef void Curl_thrdpool_return_item_cb(void *item, void *user_data);
+
+/* Create a new thread pool.
+ * @param name         name of pool for tracing purposes
+ * @param min_threads  minimum number of threads to have always running
+ * @param max_threads  maximum umber of threads running, ever.
+ * @param idle_time_ms maximum time a thread should wait for tasks to
+ *                     process before shutting down (unless the pool is
+ *                     already at minimum thread count), use 0 for
+ *                     infinite wait.
+ * @param fn_take      take the next item to process
+ * @param fn_process   process the item taken
+ * @param fn_return    return the processed item
+ * @param user_data    parameter passed to take/return callbacks
+ */
+CURLcode Curl_thrdpool_create(struct curl_thrdpool **ptpool,
+                              const char *name,
+                              uint32_t min_threads,
+                              uint32_t max_threads,
+                              uint32_t idle_time_ms,
+                              Curl_thrdpool_take_item_cb *fn_take,
+                              Curl_thrdpool_process_item_cb *fn_process,
+                              Curl_thrdpool_return_item_cb *fn_return,
+                              void *user_data);
+
+/* Destroy the thread pool, release its resources.
+ * With `join` being TRUE, the call will wait for all threads to finish
+ * processing before returning. On FALSE, it will detach all threads
+ * running. Ongoing item processing will continue to run and
+ * `fn_return` will be invoked with NULL user_data before the thread exits.
+ */
+void Curl_thrdpool_destroy(struct curl_thrdpool *tpool, bool join);
+
+/* Signal the pool to wake up `nthreads` idle worker threads, possible
+ * creating new threads up to the max limit. The number should reflect
+ * the items that can actually be taken for processing right away, e.g.
+ * the producers "queue" length of outstanding items.
+ */
+CURLcode Curl_thrdpool_signal(struct curl_thrdpool *tpool, uint32_t nthreads);
+
+CURLcode Curl_thrdpool_await_idle(struct curl_thrdpool *tpool,
+                                  uint32_t timeout_ms);
+
+#endif /* USE_THREADS */
+
+#endif /* HEADER_CURL_THRDPOOL_H */

--- a/lib/thrdqueue.c
+++ b/lib/thrdqueue.c
@@ -1,0 +1,330 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "curl_setup.h"
+
+#ifdef USE_THREADS
+
+#if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
+#include <pthread.h>
+#endif
+
+#include "llist.h"
+#include "curl_threads.h"
+#include "thrdpool.h"
+#include "thrdqueue.h"
+
+
+struct curl_thrdq {
+  char *name;
+  curl_mutex_t lock;
+  curl_cond_t await;
+  struct Curl_llist sendq;
+  struct Curl_llist recvq;
+  struct curl_thrdpool *tpool;
+  Curl_thrdq_item_free_cb *fn_free;
+  Curl_thrdq_item_process_cb *fn_process;
+  Curl_thrdq_ev_cb *fn_event;
+  void *fn_user_data;
+  uint64_t nscheduled;
+  uint64_t nprocessed;
+  uint32_t send_max_len;
+  BIT(aborted);
+};
+
+struct thrdq_item {
+  struct Curl_llist_node node;
+  Curl_thrdq_item_free_cb *fn_free;
+  Curl_thrdq_item_process_cb *fn_process;
+  void *item;
+};
+
+static struct thrdq_item *thrdq_item_create(struct curl_thrdq *tqueue,
+                                            void *item)
+{
+  struct thrdq_item *qitem;
+
+  qitem = curlx_calloc(1, sizeof(*qitem));
+  if(!qitem)
+    return NULL;
+  qitem->item = item;
+  qitem->fn_free = tqueue->fn_free;
+  qitem->fn_process = tqueue->fn_process;
+  return qitem;
+}
+
+static void thrdq_item_destroy(struct thrdq_item *qitem)
+{
+  if(qitem->item)
+    qitem->fn_free(qitem->item);
+  curlx_free(qitem);
+}
+
+static void thrdq_item_list_dtor(void *user_data, void *elem)
+{
+  (void)user_data;
+  thrdq_item_destroy(elem);
+}
+
+static void *thrdq_tpool_take(void *user_data)
+{
+  struct curl_thrdq *tqueue = user_data;
+  struct thrdq_item *qitem = NULL;
+  struct Curl_llist_node *e;
+
+  Curl_mutex_acquire(&tqueue->lock);
+  if(!tqueue->aborted) {
+    e = Curl_llist_head(&tqueue->sendq);
+    if(e) {
+      qitem = Curl_node_take_elem(e);
+    }
+  }
+  Curl_mutex_release(&tqueue->lock);
+  return qitem;
+}
+
+static void thrdq_tpool_return(void *item, void *user_data)
+{
+  struct curl_thrdq *tqueue = user_data;
+  struct thrdq_item *qitem = item;
+  Curl_thrdq_ev_cb *fn_event = NULL;
+  void *fn_user_data = NULL;
+
+  if(!tqueue) {
+    thrdq_item_destroy(item);
+    return;
+  }
+
+  Curl_mutex_acquire(&tqueue->lock);
+  if(tqueue->aborted) {
+    thrdq_item_destroy(item);
+  }
+  else {
+    DEBUGASSERT(!Curl_node_llist(&qitem->node));
+    Curl_llist_append(&tqueue->recvq, qitem, &qitem->node);
+    tqueue->nprocessed++;
+    fn_event = tqueue->fn_event;
+    fn_user_data = tqueue->fn_user_data;
+  }
+  Curl_mutex_release(&tqueue->lock);
+  /* avoiding deadlocks */
+  if(fn_event)
+    fn_event(tqueue, CURL_THRDQ_EV_ITEM_DONE, fn_user_data);
+}
+
+static void thrdq_tpool_process(void *item)
+{
+  struct thrdq_item *qitem = item;
+  qitem->fn_process(qitem->item);
+}
+
+static void thrdq_unlink(struct curl_thrdq *tqueue, bool locked, bool join)
+{
+  DEBUGASSERT(tqueue->aborted);
+  if(tqueue->tpool) {
+    if(locked)
+      Curl_mutex_release(&tqueue->lock);
+    Curl_thrdpool_destroy(tqueue->tpool, join);
+    tqueue->tpool = NULL;
+    if(locked)
+      Curl_mutex_acquire(&tqueue->lock);
+  }
+
+  Curl_llist_destroy(&tqueue->sendq, NULL);
+  Curl_llist_destroy(&tqueue->recvq, NULL);
+  curlx_free(tqueue->name);
+  Curl_cond_destroy(&tqueue->await);
+  if(locked)
+    Curl_mutex_release(&tqueue->lock);
+  Curl_mutex_destroy(&tqueue->lock);
+  curlx_free(tqueue);
+}
+
+CURLcode Curl_thrdq_create(struct curl_thrdq **ptqueue,
+                           const char *name,
+                           uint32_t max_len,
+                           uint32_t min_threads,
+                           uint32_t max_threads,
+                           uint32_t idle_time_ms,
+                           Curl_thrdq_item_free_cb *fn_free,
+                           Curl_thrdq_item_process_cb *fn_process,
+                           Curl_thrdq_ev_cb *fn_event,
+                           void *user_data)
+{
+  struct curl_thrdq *tqueue;
+  CURLcode result = CURLE_OUT_OF_MEMORY;
+
+  tqueue = curlx_calloc(1, sizeof(*tqueue));
+  if(!tqueue)
+    goto out;
+
+  tqueue->name = curlx_strdup(name);
+  if(!tqueue->name)
+    goto out;
+
+  Curl_mutex_init(&tqueue->lock);
+  Curl_cond_init(&tqueue->await);
+  Curl_llist_init(&tqueue->sendq, thrdq_item_list_dtor);
+  Curl_llist_init(&tqueue->recvq, thrdq_item_list_dtor);
+  tqueue->fn_free = fn_free;
+  tqueue->fn_process = fn_process;
+  tqueue->fn_event = fn_event;
+  tqueue->fn_user_data = user_data;
+  tqueue->send_max_len = max_len;
+
+  result = Curl_thrdpool_create(&tqueue->tpool, name,
+                                min_threads, max_threads, idle_time_ms,
+                                thrdq_tpool_take,
+                                thrdq_tpool_process,
+                                thrdq_tpool_return,
+                                tqueue);
+
+out:
+  if(result && tqueue) {
+    tqueue->aborted = TRUE;
+    thrdq_unlink(tqueue, FALSE, TRUE);
+    tqueue = NULL;
+  }
+  *ptqueue = tqueue;
+  return result;
+}
+
+void Curl_thrdq_destroy(struct curl_thrdq *tqueue, bool join)
+{
+  Curl_mutex_acquire(&tqueue->lock);
+  DEBUGASSERT(!tqueue->aborted);
+  tqueue->aborted = TRUE;
+  thrdq_unlink(tqueue, TRUE, join);
+}
+
+void Curl_thrdq_stat(struct curl_thrdq *tqueue,
+                     uint32_t *pnsend,
+                     uint32_t *pnrecv,
+                     uint64_t *pnscheduled,
+                     uint64_t *pnprocessed)
+{
+  Curl_mutex_acquire(&tqueue->lock);
+  DEBUGASSERT(!tqueue->aborted);
+  if(pnsend)
+    *pnsend = (uint32_t)Curl_llist_count(&tqueue->sendq);
+  if(pnrecv)
+    *pnrecv = (uint32_t)Curl_llist_count(&tqueue->recvq);
+  if(pnscheduled)
+    *pnscheduled = tqueue->nscheduled;
+  if(pnprocessed)
+    *pnprocessed = tqueue->nprocessed;
+  Curl_mutex_release(&tqueue->lock);
+}
+
+CURLcode Curl_thrdq_send(struct curl_thrdq *tqueue, void *item)
+{
+  CURLcode result = CURLE_AGAIN;
+
+  Curl_mutex_acquire(&tqueue->lock);
+  if(tqueue->aborted) {
+    DEBUGASSERT(0);
+    result = CURLE_SEND_ERROR;
+    goto out;
+  }
+
+  if(!tqueue->send_max_len ||
+     (Curl_llist_count(&tqueue->sendq) < tqueue->send_max_len)) {
+    struct thrdq_item *qitem = thrdq_item_create(tqueue, item);
+    if(!qitem) {
+      result = CURLE_OUT_OF_MEMORY;
+      goto out;
+    }
+    Curl_llist_append(&tqueue->sendq, qitem, &qitem->node);
+    result = CURLE_OK;
+  }
+out:
+  Curl_mutex_release(&tqueue->lock);
+  /* Signal thread pool unlocked to void deadlocks */
+  if(!result)
+    result = Curl_thrdpool_signal(tqueue->tpool, 1);
+  return result;
+}
+
+CURLcode Curl_thrdq_recv(struct curl_thrdq *tqueue, void **pitem)
+{
+  CURLcode result = CURLE_AGAIN;
+  struct Curl_llist_node *e;
+
+  *pitem = NULL;
+  Curl_mutex_acquire(&tqueue->lock);
+  if(tqueue->aborted) {
+    DEBUGASSERT(0);
+    result = CURLE_RECV_ERROR;
+    goto out;
+  }
+
+  e = Curl_llist_head(&tqueue->recvq);
+  if(e) {
+    struct thrdq_item *qitem = Curl_node_take_elem(e);
+    *pitem = qitem->item;
+    qitem->item = NULL;
+    thrdq_item_destroy(qitem);
+    result = CURLE_OK;
+  }
+out:
+  Curl_mutex_release(&tqueue->lock);
+  return result;
+}
+
+static void thrdq_llist_clean_matches(struct Curl_llist *llist,
+                                      Curl_thrdq_item_match_cb *fn_match,
+                                      void *match_data)
+{
+  struct Curl_llist_node *e, *n;
+  struct thrdq_item *qitem;
+
+  for(e = Curl_llist_head(llist); e; e = n) {
+    n = Curl_node_next(e);
+    qitem = Curl_node_elem(e);
+    if(fn_match(qitem->item, match_data))
+      Curl_node_remove(e);
+  }
+}
+
+void Curl_thrdq_clear(struct curl_thrdq *tqueue,
+                      Curl_thrdq_item_match_cb *fn_match,
+                      void *match_data)
+{
+  Curl_mutex_acquire(&tqueue->lock);
+  if(tqueue->aborted) {
+    DEBUGASSERT(0);
+    goto out;
+  }
+  thrdq_llist_clean_matches(&tqueue->sendq, fn_match, match_data);
+  thrdq_llist_clean_matches(&tqueue->recvq, fn_match, match_data);
+out:
+  Curl_mutex_release(&tqueue->lock);
+}
+
+CURLcode Curl_thrdq_await_done(struct curl_thrdq *tqueue,
+                               uint32_t timeout_ms)
+{
+  return Curl_thrdpool_await_idle(tqueue->tpool, timeout_ms);
+}
+
+#endif /* USE_THREADS */

--- a/lib/thrdqueue.h
+++ b/lib/thrdqueue.h
@@ -1,0 +1,107 @@
+#ifndef HEADER_CURL_THRDQUEUE_H
+#define HEADER_CURL_THRDQUEUE_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "curl_setup.h"
+
+#ifdef USE_THREADS
+
+struct curl_thrdq;
+
+typedef enum {
+  CURL_THRDQ_EV_ITEM_DONE /* an item has been processed and is ready */
+} Curl_thrdq_event;
+
+/* Notification callback when "events" happen in the queue. May be
+ * call from any thread, tqueue is not locked. */
+typedef void Curl_thrdq_ev_cb(const struct curl_thrdq *tqueue,
+                              Curl_thrdq_event ev,
+                              void *user_data);
+
+/* Process a queued item. Maybe call from any thread. Queue is
+ * not locked. */
+typedef void Curl_thrdq_item_process_cb(void *item);
+
+/* Free an item. May be called from any thread at any time for an
+ * item that is in the queue (either before or after processing). */
+typedef void Curl_thrdq_item_free_cb(void *item);
+
+/* Create a new queue processing "items" by a thread pool.
+ */
+CURLcode Curl_thrdq_create(struct curl_thrdq **ptqueue,
+                           const char *name,
+                           uint32_t max_len, /* 0 for unlimited */
+                           uint32_t min_threads,
+                           uint32_t max_threads,
+                           uint32_t idle_time_ms,
+                           Curl_thrdq_item_free_cb *fn_free,
+                           Curl_thrdq_item_process_cb *fn_process,
+                           Curl_thrdq_ev_cb *fn_event, /* optional */
+                           void *user_data);
+
+/* Destroy the queue, free all queued items unprocessed and destroy
+ * the thread pool used.
+ * @param join TRUE when thread pool shall be joined. FALSE for
+ *             detaching any running threads.
+ */
+void Curl_thrdq_destroy(struct curl_thrdq *tqueue, bool join);
+
+/* Get information about the current queue state. Parameters may be
+ * passed as NULL if caller is not interested. */
+void Curl_thrdq_stat(struct curl_thrdq *tqueue,
+                     uint32_t *pnsend, /* # of items awaitting processing */
+                     uint32_t *pnrecv, /* # of items ready for recv */
+                     uint64_t *pnscheduled, /* total items added */
+                     uint64_t *pnprocessed); /* total items processed */
+
+/* Send "item" onto the queue. The caller needs to clear any reference
+ * to "item" on success, e.g. the queue takes ownership.
+ * Returns CURLE_AGAIN when the queue has already been full.
+ */
+CURLcode Curl_thrdq_send(struct curl_thrdq *tqueue, void *item);
+
+/* Receive the oldest, processed item from the queue again, if there is one.
+ * The caller takes ownership of the item received, e.g. the queue
+ * relinquishes all references to item.
+ * Returns CURLE_AGAIN when there is no processed item, setting `pitem`
+ * to NULL.
+ */
+CURLcode Curl_thrdq_recv(struct curl_thrdq *tqueue, void **pitem);
+
+/* Return TRUE if the passed "item" matches. */
+typedef bool Curl_thrdq_item_match_cb(void *item, void *match_data);
+
+/* Clear all scheduled/processed items that match from the queue. This
+ * will *not* be able to clear items that are being processed.
+ */
+void Curl_thrdq_clear(struct curl_thrdq *tqueue,
+                      Curl_thrdq_item_match_cb *fn_match,
+                      void *match_data);
+
+CURLcode Curl_thrdq_await_done(struct curl_thrdq *tqueue,
+                               uint32_t timeout_ms);
+
+#endif /* USE_THREADS */
+
+#endif /* HEADER_CURL_THRDQUEUE_H */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -280,8 +280,9 @@ test3032 test3033 test3034 test3035 \
 \
 test3100 test3101 test3102 test3103 test3104 test3105 \
 \
-test3200 test3201 test3202 test3203 test3204 test3205 test3206 test3207 test3208 \
-test3209 test3210 test3211 test3212 test3213 test3214 test3215 test3216 \
+test3200 test3201 test3202 test3203 test3204 test3205 test3206 test3207 \
+test3208 test3209 test3210 test3211 test3212 test3213 test3214 test3215 \
+test3216 test3217 test3218 \
 test4000 test4001
 
 EXTRA_DIST = $(TESTCASES) DISABLED data-xml1 data320.html \

--- a/tests/data/test3217
+++ b/tests/data/test3217
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+threads
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+unittest
+</features>
+<name>
+thrdpool unit tests
+</name>
+</client>
+</testcase>

--- a/tests/data/test3218
+++ b/tests/data/test3218
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+threads
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+unittest
+</features>
+<name>
+thrdqueue unit tests
+</name>
+</client>
+</testcase>

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -66,7 +66,7 @@ static size_t write_memory_callback(char *contents, size_t size,
   return realsize;
 }
 
-#if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
+#ifdef USE_THREADS
 static CURL_THREAD_RETURN_T CURL_STDCALL test_thread(void *ptr)
 #else
 static unsigned int test_thread(void *ptr)
@@ -111,7 +111,7 @@ test_cleanup:
   return 0;
 }
 
-#if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
+#ifdef USE_THREADS
 
 static void t3207_test_lock(CURL *curl, curl_lock_data data,
                             curl_lock_access laccess, void *useptr)

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -43,4 +43,5 @@ TESTS_C = \
   unit1979.c unit1980.c \
   unit2600.c unit2601.c unit2602.c unit2603.c unit2604.c unit2605.c \
   unit3200.c                                             unit3205.c \
-  unit3211.c unit3212.c unit3213.c unit3214.c            unit3216.c
+  unit3211.c unit3212.c unit3213.c unit3214.c            unit3216.c unit3217.c \
+  unit3218.c

--- a/tests/unit/unit3217.c
+++ b/tests/unit/unit3217.c
@@ -1,0 +1,157 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+
+#include "curlx/wait.h"
+#include "thrdpool.h"
+
+#ifdef USE_THREADS
+
+struct unit3217_ctx {
+  uint32_t total;
+  uint32_t taken;
+  uint32_t returned;
+};
+
+static uint32_t unit3217_item = 23;
+static uint32_t unit3217_delay_ms = 0;
+
+static void unit3217_ctx_init(struct unit3217_ctx *ctx,
+                              uint32_t total,
+                              uint32_t delay_ms)
+{
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->total = total;
+  unit3217_delay_ms = delay_ms;
+}
+
+static void *unit3217_take(void *user_data)
+{
+  struct unit3217_ctx *ctx = user_data;
+  if(ctx->taken < ctx->total) {
+    ctx->taken++;
+    return &unit3217_item;
+  }
+  return NULL;
+}
+
+static void unit3217_process(void *item)
+{
+  fail_unless(item == &unit3217_item, "process unexpected item");
+  if(unit3217_delay_ms) {
+    curlx_wait_ms(unit3217_delay_ms);
+  }
+}
+
+static void unit3217_return(void *item, void *user_data)
+{
+  struct unit3217_ctx *ctx = user_data;
+  (void)item;
+  if(ctx) {
+    ctx->returned++;
+    fail_unless(ctx->returned <= ctx->total, "returned too many");
+  }
+}
+
+static CURLcode test_unit3217(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+  struct curl_thrdpool *tpool;
+  struct unit3217_ctx ctx;
+  CURLcode r;
+
+  /* pool without minimum, will not start anything */
+  unit3217_ctx_init(&ctx, 10, 0);
+  r = Curl_thrdpool_create(&tpool, "unit3217a", 0, 2, 0,
+                           unit3217_take, unit3217_process, unit3217_return,
+                           &ctx);
+  fail_unless(!r, "pool-a create");
+  Curl_thrdpool_destroy(tpool, TRUE);
+  fail_unless(!ctx.returned, "pool-a unexpected items returned");
+  fail_unless(!ctx.taken, "pool-a unexpected items taken");
+
+  /* pool without minimum, signal start, consumes everything */
+  unit3217_ctx_init(&ctx, 10, 0);
+  r = Curl_thrdpool_create(&tpool, "unit3217b", 0, 2, 0,
+                           unit3217_take, unit3217_process, unit3217_return,
+                           &ctx);
+  fail_unless(!r, "pool-b create");
+  r = Curl_thrdpool_signal(tpool, 2);
+  fail_unless(!r, "pool-b signal");
+  Curl_thrdpool_await_idle(tpool, 0);
+  Curl_thrdpool_destroy(tpool, TRUE);
+  fail_unless(ctx.returned == ctx.total, "pool-b items returned missing");
+  fail_unless(ctx.taken == ctx.total, "pool-b items taken missing");
+
+  /* pool with minimum, consumes everything without signal */
+  unit3217_ctx_init(&ctx, 10, 0);
+  r = Curl_thrdpool_create(&tpool, "unit3217c", 1, 2, 0,
+                           unit3217_take, unit3217_process, unit3217_return,
+                           &ctx);
+  fail_unless(!r, "pool-c create");
+  Curl_thrdpool_await_idle(tpool, 0);
+  Curl_thrdpool_destroy(tpool, TRUE);
+  fail_unless(ctx.returned == ctx.total, "pool-c items returned missing");
+  fail_unless(ctx.taken == ctx.total, "pool-c items taken missing");
+
+  /* pool with many max, signal abundance, consumes everything */
+  unit3217_ctx_init(&ctx, 100, 0);
+  r = Curl_thrdpool_create(&tpool, "unit3217d", 0, 50, 0,
+                           unit3217_take, unit3217_process, unit3217_return,
+                           &ctx);
+  fail_unless(!r, "pool-d create");
+  r = Curl_thrdpool_signal(tpool, 100);
+  fail_unless(!r, "pool-d signal");
+  Curl_thrdpool_await_idle(tpool, 0);
+  Curl_thrdpool_destroy(tpool, TRUE);
+  fail_unless(ctx.returned == ctx.total, "pool-d items returned missing");
+  fail_unless(ctx.taken == ctx.total, "pool-d items taken missing");
+
+  /* pool with 1 max, many to take, no await, destroy without join */
+  unit3217_ctx_init(&ctx, 10000000, 1);
+  r = Curl_thrdpool_create(&tpool, "unit3217e", 0, 1, 0,
+                           unit3217_take, unit3217_process, unit3217_return,
+                           &ctx);
+  fail_unless(!r, "pool-e create");
+  r = Curl_thrdpool_signal(tpool, 100);
+  fail_unless(!r, "pool-e signal");
+  Curl_thrdpool_destroy(tpool, FALSE);
+  fail_unless(ctx.returned < ctx.total, "pool-e returned all");
+  fail_unless(ctx.taken < ctx.total, "pool-e took all");
+  /* pool thread will notice destruction and should immediately abort.
+   * No memory leak should be reported. */
+  curlx_wait_ms(1000);
+
+  UNITTEST_END_SIMPLE
+}
+
+#else
+
+static CURLcode test_unit3217(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+  (void)arg;
+  UNITTEST_END_SIMPLE
+}
+#endif /* USE_THREADS */

--- a/tests/unit/unit3218.c
+++ b/tests/unit/unit3218.c
@@ -1,0 +1,142 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+
+#include "curlx/wait.h"
+#include "thrdqueue.h"
+
+#ifdef USE_THREADS
+
+struct unit3218_item {
+  int id;
+  BIT(processed);
+};
+
+struct unit3218_ctx {
+  int ndone;
+};
+
+static struct unit3218_item *unit3218_item_create(int id)
+{
+  struct unit3218_item *uitem;
+  uitem = curlx_calloc(1, sizeof(*uitem));
+  if(uitem) {
+    uitem->id = id;
+    curl_mfprintf(stderr, "created item %d\n", uitem->id);
+  }
+  return uitem;
+}
+
+static void unit3218_item_free(void *item)
+{
+  struct unit3218_item *uitem = item;
+  curl_mfprintf(stderr, "free item %d\n", uitem->id);
+  curlx_free(uitem);
+}
+
+static void unit3218_event(const struct curl_thrdq *tqueue,
+                           Curl_thrdq_event ev,
+                           void *user_data)
+{
+  struct unit3218_ctx *ctx = user_data;
+  (void)tqueue;
+  switch(ev) {
+  case CURL_THRDQ_EV_ITEM_DONE:
+    ctx->ndone++;
+    break;
+  default:
+    break;
+  }
+}
+
+static void unit3218_process(void *item)
+{
+  struct unit3218_item *uitem = item;
+  curl_mfprintf(stderr, "start item %d\n", uitem->id);
+  curlx_wait_ms(1);
+  uitem->processed = TRUE;
+  curl_mfprintf(stderr, "end item %d\n", uitem->id);
+}
+
+static CURLcode test_unit3218(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+  struct curl_thrdq *tqueue;
+  struct unit3218_ctx ctx;
+  int i, count;
+  CURLcode r;
+
+  /* create and teardown queue */
+  memset(&ctx, 0, sizeof(ctx));
+  r = Curl_thrdq_create(&tqueue, "unit3218-a", 0, 0, 2, 1,
+                        unit3218_item_free, unit3218_process, unit3218_event,
+                        &ctx);
+  fail_unless(!r, "queue-a create");
+  Curl_thrdq_destroy(tqueue, TRUE);
+  tqueue = NULL;
+  fail_unless(!ctx.ndone, "queue-a unexpected done count");
+
+  /* create queue, have it process `count` items */
+  count = 10;
+  memset(&ctx, 0, sizeof(ctx));
+  r = Curl_thrdq_create(&tqueue, "unit3218-b", 0, 0, 2, 1,
+                        unit3218_item_free, unit3218_process, unit3218_event,
+                        &ctx);
+  fail_unless(!r, "queue-b create");
+  for(i = 0; i < count; ++i) {
+    struct unit3218_item *uitem = unit3218_item_create(i);
+    fail_unless(uitem, "queue-b item create");
+    r = Curl_thrdq_send(tqueue, uitem);
+    fail_unless(!r, "queue-b send");
+  }
+
+  r = Curl_thrdq_await_done(tqueue, 0);
+  fail_unless(!r, "queue-b await done");
+
+  for(i = 0; i < count; ++i) {
+    void *item;
+    r = Curl_thrdq_recv(tqueue, &item);
+    fail_unless(!r, "queue-b recv");
+    if(item) {
+      struct unit3218_item *uitem = item;
+      fail_unless(uitem->processed, "queue-b recv unprocessed item");
+      unit3218_item_free(item);
+    }
+  }
+  Curl_thrdq_destroy(tqueue, TRUE);
+  tqueue = NULL;
+  fail_unless(ctx.ndone == count, "queue-b unexpected done count");
+
+  UNITTEST_END_SIMPLE
+}
+
+#else
+
+static CURLcode test_unit3218(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+  (void)arg;
+  UNITTEST_END_SIMPLE
+}
+#endif /* USE_THREADS */


### PR DESCRIPTION
## thread pools

Add curl_thrdpool and associated methods for managing a pool of threads that can resize between min/max number of threads waiting for "work" to "process".

Threads above the min number will exit after an idle timeout. A pool can be waited for to become idle, e.g. having processed everything. A pool can be destroyed either by joining all threads or detaching them. In the later case the pool's memory will be released when the last thread exits.

Add unit3217 test to verify thread pools operation.

Other adjustments:
* curl_setup.h: define `USE_THREADS` when either POSIX or WINDOWS threads are configured for simpler ifdefs
* memdebug.c: in atexit handle, inspect global var under lock. Otherwise thread sanitizer will report unsynchronized data access

## thread queue

Add curl_thrdq and associated methods for a "processing queue" where one can send "items" for processing and receiving them afterwards. The thread queue uses a thread pool to perform the processing.

Add unit3218 test to verify the thread queue operation.