### PR TITLE
build: move curl stat struct type to the curlx namespace

### DIFF
--- a/lib/curl_fopen.c
+++ b/lib/curl_fopen.c
@@ -89,7 +89,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   unsigned char randbuf[41];
   char *tempstore = NULL;
 #ifndef _WIN32
-  curl_struct_stat sb;
+  curlx_struct_stat sb;
 #endif
   int fd = -1;
   char *dir = NULL;

--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -405,7 +405,7 @@ FILE *curlx_win32_freopen(const char *filename, const char *mode, FILE *fp)
   return result;
 }
 
-int curlx_win32_stat(const char *path, curl_struct_stat *buffer)
+int curlx_win32_stat(const char *path, curlx_struct_stat *buffer)
 {
   int result = -1;
   TCHAR *fixed = NULL;

--- a/lib/curlx/fopen.h
+++ b/lib/curlx/fopen.h
@@ -45,10 +45,10 @@ HANDLE curlx_CreateFile(const char *filename,
                         HANDLE hTemplateFile);
 #endif /* !CURL_WINDOWS_UWP */
 #define curlx_fstat             _fstati64
-#define curl_struct_stat        struct _stati64
+#define curlx_struct_stat       struct _stati64
 FILE *curlx_win32_fopen(const char *filename, const char *mode);
 FILE *curlx_win32_freopen(const char *filename, const char *mode, FILE *fh);
-int curlx_win32_stat(const char *path, curl_struct_stat *buffer);
+int curlx_win32_stat(const char *path, curlx_struct_stat *buffer);
 int curlx_win32_open(const char *filename, int oflag, ...);
 int curlx_win32_rename(const char *oldpath, const char *newpath);
 #define CURLX_FOPEN_LOW         curlx_win32_fopen
@@ -60,7 +60,7 @@ int curlx_win32_rename(const char *oldpath, const char *newpath);
 #define curlx_rename            curlx_win32_rename
 #else
 #define curlx_fstat             fstat
-#define curl_struct_stat        struct stat
+#define curlx_struct_stat       struct stat
 #define CURLX_FOPEN_LOW         fopen
 #define CURLX_FREOPEN_LOW       freopen
 #define CURLX_FDOPEN_LOW        fdopen

--- a/lib/file.c
+++ b/lib/file.c
@@ -270,7 +270,7 @@ static CURLcode file_upload(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   char *xfer_ulbuf;
   size_t xfer_ulblen;
-  curl_struct_stat file_stat;
+  curlx_struct_stat file_stat;
   const char *sendbuf;
   bool eos = FALSE;
 
@@ -390,7 +390,7 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
   */
   struct FILEPROTO *file = Curl_meta_get(data, CURL_META_FILE_EASY);
   CURLcode result = CURLE_OK;
-  curl_struct_stat statbuf;
+  curlx_struct_stat statbuf;
   curl_off_t expected_size = -1;
   bool size_known;
   bool fstated = FALSE;

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -107,7 +107,7 @@ static const char aschex[] =
  * and CD/DVD images should be either a STREAM_LF format or a fixed format.
  *
  */
-curl_off_t VmsRealFileSize(const char *name, const curl_struct_stat *stat_buf)
+curl_off_t VmsRealFileSize(const char *name, const curlx_struct_stat *stat_buf)
 {
   char buffer[8192];
   curl_off_t count;
@@ -137,7 +137,7 @@ curl_off_t VmsRealFileSize(const char *name, const curl_struct_stat *stat_buf)
  *
  */
 static curl_off_t VmsSpecialSize(const char *name,
-                                 const curl_struct_stat *stat_buf)
+                                 const curlx_struct_stat *stat_buf)
 {
   switch(stat_buf->st_fab_rfm) {
   case FAB$C_VAR:
@@ -161,7 +161,7 @@ static curl_off_t VmsSpecialSize(const char *name,
  */
 static FILE *vmsfopenread(const char *file, const char *mode)
 {
-  curl_struct_stat statbuf;
+  curlx_struct_stat statbuf;
   int result;
 
   result = curlx_stat(file, &statbuf);
@@ -1308,7 +1308,7 @@ CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
 
   if(filename) {
     char *base;
-    curl_struct_stat sbuf;
+    curlx_struct_stat sbuf;
 
     if(curlx_stat(filename, &sbuf))
       result = CURLE_READ_ERROR;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1089,7 +1089,7 @@ static CURLcode ssh_state_pkey_init(struct Curl_easy *data,
       /* To ponder about: should really the lib be messing about with the
          HOME environment variable etc? */
       char *home = curl_getenv("HOME");
-      curl_struct_stat sbuf;
+      curlx_struct_stat sbuf;
 
       /* If no private key file is specified, try some common paths. */
       if(home) {

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -291,7 +291,7 @@ static SANITIZEcode rename_if_reserved_dos(char ** const sanitized,
    * to rename such files. */
   char *p, *base, *buffer;
 #ifdef MSDOS
-  curl_struct_stat st_buf;
+  curlx_struct_stat st_buf;
 #endif
   size_t len, bufsize;
 

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -68,7 +68,7 @@ int getfiletime(const char *filename, curl_off_t *stamp)
           GetLastError());
   }
 #else
-  curl_struct_stat statbuf;
+  curlx_struct_stat statbuf;
   if(curlx_stat(filename, &statbuf) != -1) {
     *stamp = (curl_off_t)statbuf.st_mtime;
     rc = 0;

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -122,7 +122,7 @@ static struct tool_mime *tool_mime_new_filedata(struct tool_mime *parent,
     char *data = NULL;
     curl_off_t size;
     curl_off_t origin;
-    curl_struct_stat sbuf;
+    curlx_struct_stat sbuf;
 
     CURLX_SET_BINMODE(stdin);
     origin = ftell(stdin);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2208,7 +2208,7 @@ static ParameterError existingfile(char **store,
                                    const struct LongShort *a,
                                    const char *filename)
 {
-  curl_struct_stat info;
+  curlx_struct_stat info;
   if(curlx_stat(filename, &info)) {
     errorf("The file '%s' provided to --%s does not exist",
            filename, a->lname);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -146,7 +146,7 @@ static bool is_pkcs11_uri(const char *string)
  *
  */
 static curl_off_t vms_realfilesize(const char *name,
-                                   const curl_struct_stat *stat_buf)
+                                   const curlx_struct_stat *stat_buf)
 {
   char buffer[8192];
   curl_off_t count;
@@ -177,7 +177,7 @@ static curl_off_t vms_realfilesize(const char *name,
  *
  */
 static curl_off_t VmsSpecialSize(const char *name,
-                                 const curl_struct_stat *stat_buf)
+                                 const curlx_struct_stat *stat_buf)
 {
   switch(stat_buf->st_fab_rfm) {
   case FAB$C_VAR:
@@ -248,7 +248,7 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
 static CURLcode pre_transfer(struct per_transfer *per)
 {
   curl_off_t uploadfilesize = -1;
-  curl_struct_stat fileinfo;
+  curlx_struct_stat fileinfo;
   CURLcode result = CURLE_OK;
 
   if(per->uploadfile && !stdin_upload(per->uploadfile)) {
@@ -548,7 +548,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
     }
 
     if(truncate && outs->bytes && outs->filename && outs->stream) {
-      curl_struct_stat fileinfo;
+      curlx_struct_stat fileinfo;
 
       /* The output can be a named pipe or a character device etc that
          cannot be truncated. Only truncate regular files. */
@@ -718,7 +718,7 @@ static CURLcode post_per_transfer(struct per_transfer *per,
       errorf("curl: (%d) Failed writing body", result);
     }
     if(result && config->rm_partial) {
-      curl_struct_stat st;
+      curlx_struct_stat st;
       if(!curlx_stat(outs->filename, &st) && S_ISREG(st.st_mode)) {
         if(!unlink(outs->filename))
           notef("Removed output file: %s", outs->filename);
@@ -1040,7 +1040,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
   }
 
   if(config->skip_existing) {
-    curl_struct_stat fileinfo;
+    curlx_struct_stat fileinfo;
     if(!curlx_stat(per->outfile, &fileinfo)) {
       /* file is present */
       notef("skips transfer, \"%s\" exists locally", per->outfile);
@@ -1052,7 +1052,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
   if(config->resume_from_current) {
     /* We are told to continue from where we are now. Get the size
        of the file as it is now and open it for append instead */
-    curl_struct_stat fileinfo;
+    curlx_struct_stat fileinfo;
     /* VMS -- Danger, the filesize is only valid for stream files */
     if(curlx_stat(per->outfile, &fileinfo) == 0)
       /* set offset to current file size: */

--- a/tests/libtest/lib505.c
+++ b/tests/libtest/lib505.c
@@ -37,7 +37,7 @@ static CURLcode test_lib505(const char *URL)
   char errbuf[STRERROR_LEN];
   FILE *hd_src;
   int hd;
-  curl_struct_stat file_info;
+  curlx_struct_stat file_info;
   struct curl_slist *hl;
 
   struct curl_slist *headerlist = NULL;

--- a/tests/libtest/lib525.c
+++ b/tests/libtest/lib525.c
@@ -30,7 +30,7 @@ static CURLcode test_lib525(const char *URL)
   char errbuf[STRERROR_LEN];
   FILE *hd_src = NULL;
   int hd;
-  curl_struct_stat file_info;
+  curlx_struct_stat file_info;
   CURLM *multi = NULL;
   int running;
 

--- a/tests/libtest/lib541.c
+++ b/tests/libtest/lib541.c
@@ -34,7 +34,7 @@ static CURLcode test_lib541(const char *URL)
   char errbuf[STRERROR_LEN];
   FILE *hd_src;
   int hd;
-  curl_struct_stat file_info;
+  curlx_struct_stat file_info;
 
   if(!libtest_arg2) {
     curl_mfprintf(stderr, "Usage: <url> <file-to-upload>\n");

--- a/tests/libtest/lib568.c
+++ b/tests/libtest/lib568.c
@@ -35,7 +35,7 @@ static CURLcode test_lib568(const char *URL)
   char errbuf[STRERROR_LEN];
   int sdp;
   FILE *sdpf = NULL;
-  curl_struct_stat file_info;
+  curlx_struct_stat file_info;
   char *stream_uri = NULL;
   int request = 1;
   struct curl_slist *custom_headers = NULL;

--- a/tests/libtest/lib572.c
+++ b/tests/libtest/lib572.c
@@ -35,7 +35,7 @@ static CURLcode test_lib572(const char *URL)
   char errbuf[STRERROR_LEN];
   int params;
   FILE *paramsf = NULL;
-  curl_struct_stat file_info;
+  curlx_struct_stat file_info;
   char *stream_uri = NULL;
   int request = 1;
   struct curl_slist *custom_headers = NULL;

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -220,7 +220,7 @@ static CURLcode test_lib582(const char *URL)
   char errbuf[STRERROR_LEN];
   FILE *hd_src = NULL;
   int hd;
-  curl_struct_stat file_info;
+  curlx_struct_stat file_info;
   CURLM *multi = NULL;
   struct t582_ReadWriteSockets sockets = { { NULL, 0, 0 }, { NULL, 0, 0 } };
   int success = 0;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -670,7 +670,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
   curlx_strcopy(sau->sun_path, sizeof(sau->sun_path), unix_socket, len);
   rc = bind(sock, (struct sockaddr *)sau, sizeof(struct sockaddr_un));
   if(rc && SOCKERRNO == SOCKEADDRINUSE) {
-    curl_struct_stat statbuf;
+    curlx_struct_stat statbuf;
     /* socket already exists. Perhaps it is stale? */
     curl_socket_t unixfd = socket(AF_UNIX, SOCK_STREAM, 0);
     if(CURL_SOCKET_BAD == unixfd) {


### PR DESCRIPTION
To match surrounding curlx symbols and functions.

Follow-up to a84b041281463315d3f8723febc97be1147964f4 #20496
