### PR TITLE
GHA/windows: set `lookup-only` in build-cache jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           path: C:\my-stunnel
           key: ${{ runner.os }}-stunnel-${{ env.STUNNEL_VERSION }}-amd64
+          lookup-only: true
 
       - name: 'install test prereqs (stunnel)'
         if: ${{ steps.cache-stunnel.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
To save a few seconds by not actually restoring the cache, just checking
if there is cache hit.

Follow-up to fb44e44d929f4e8eb140e5e1c7bd3a7f4d0e7d58 #20456
