### PR TITLE
docs: Fix grammar nitpicks

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,7 +21,7 @@ document](https://curl.se/docs/knownbugs.html) are subject for fixing.
 
 ## Consult `%APPDATA%` also for `.netrc`
 
-`%APPDATA%\.netrc` is not considered when running on Windows. Should not it?
+`%APPDATA%\.netrc` is not considered when running on Windows. Should it not?
 
 See [curl issue 4016](https://github.com/curl/curl/issues/4016)
 

--- a/docs/cmdline-opts/_URL.md
+++ b/docs/cmdline-opts/_URL.md
@@ -1,7 +1,7 @@
 <!-- Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al. -->
 <!-- SPDX-License-Identifier: curl -->
 # URL
-The URL syntax is protocol-dependent. You find a detailed description in
+The URL syntax is protocol-dependent. You can find a detailed description in
 RFC 3986.
 
 If you provide a URL without a leading **protocol://** scheme, curl guesses


### PR DESCRIPTION
I hope small, nitpick-y PRs like this aren't too annoying. The wording just sounded a little off in a couple of places.

I bisected to a28464ae77c201ae29afc9dc9dc756b80a960d4c after stumbling on `should not it`, then checked its word diff. Besides `should not it`, the only other thing that stood out to me was when `You'll find` changed to `You find`, which didn't sound right.