### PR TITLE
docs: document idle connection behavior for socket callbacks

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -103,7 +103,7 @@ active transfer. It might soon be added again. After libcurl signals
 CURL_POLL_REMOVE, the application must stop monitoring that socket on
 libcurl's behalf. libcurl does not track idle connections. The pointer
 previously assigned to the socket with curl_multi_assign(3) is forgotten by
-libcurl. Applications must not rely on *socketp* to track idle connections.
+libcurl.
 
 When a socket is given a CURL_POLL_REMOVE value, it might be because libcurl
 is going to close it, but it might also mean that it does not need any more

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -7,6 +7,7 @@ Source: libcurl
 See-also:
   - CURLMOPT_SOCKETDATA (3)
   - CURLMOPT_TIMERFUNCTION (3)
+  - CURLOPT_CLOSESOCKETFUNCTION (3)
   - curl_multi_socket_action (3)
 Protocol:
   - All
@@ -98,7 +99,11 @@ writable.
 ## CURL_POLL_REMOVE
 
 The specified socket/file descriptor is no longer used by libcurl for any
-active transfer. It might soon be added again.
+active transfer. It might soon be added again. When a connection enters
+the idle pool, libcurl invokes the callback with CURL_POLL_REMOVE.
+Subsequent callbacks for that socket may have *socketp* set to NULL; do
+not rely on *socketp* to track idle connections. For more on idle
+connection behavior, see CURLOPT_CLOSESOCKETFUNCTION(3).
 
 When a socket is given a CURL_POLL_REMOVE value, it might be because libcurl
 is going to close it, but it might also mean that it does not need any more

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -98,7 +98,7 @@ writable.
 
 ## CURL_POLL_REMOVE
 
-The specified socket/file descriptor is no longer used by libcurl for any
+The specified socket or file descriptor is no longer used by libcurl for any
 active transfer. It might soon be added again. When a connection enters
 the idle pool, libcurl invokes the callback with CURL_POLL_REMOVE.
 Subsequent callbacks for that socket may have *socketp* set to NULL; do

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -99,11 +99,12 @@ writable.
 ## CURL_POLL_REMOVE
 
 The specified socket or file descriptor is no longer used by libcurl for any
-active transfer. It might soon be added again. When a connection enters
-the idle pool, libcurl invokes the callback with CURL_POLL_REMOVE.
-Subsequent callbacks for that socket may have *socketp* set to NULL; do
-not rely on *socketp* to track idle connections. For more on idle
-connection behavior, see CURLOPT_CLOSESOCKETFUNCTION(3).
+active transfer. It might soon be added again. After libcurl signals
+CURL_POLL_REMOVE, the application must stop monitoring that socket for
+read and write events on libcurl's behalf. The pointer previously assigned
+to the socket with curl_multi_assign(3) is forgotten by libcurl.
+Applications must not rely on *socketp* to track idle connections. For
+more on idle connection behavior, see CURLOPT_CLOSESOCKETFUNCTION(3).
 
 When a socket is given a CURL_POLL_REMOVE value, it might be because libcurl
 is going to close it, but it might also mean that it does not need any more

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -101,9 +101,7 @@ writable.
 The specified socket or file descriptor is no longer used by libcurl for any
 active transfer. It might soon be added again. After libcurl signals
 CURL_POLL_REMOVE, the application must stop monitoring that socket on
-libcurl's behalf. libcurl does not track idle connections. The pointer
-previously assigned to the socket with curl_multi_assign(3) is forgotten by
-libcurl.
+libcurl's behalf. libcurl does not track idle connections.
 
 When a socket is given a CURL_POLL_REMOVE value, it might be because libcurl
 is going to close it, but it might also mean that it does not need any more

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -100,11 +100,10 @@ writable.
 
 The specified socket or file descriptor is no longer used by libcurl for any
 active transfer. It might soon be added again. After libcurl signals
-CURL_POLL_REMOVE, the application must stop monitoring that socket for
-read and write events on libcurl's behalf. The pointer previously assigned
-to the socket with curl_multi_assign(3) is forgotten by libcurl.
-Applications must not rely on *socketp* to track idle connections. For
-more on idle connection behavior, see CURLOPT_CLOSESOCKETFUNCTION(3).
+CURL_POLL_REMOVE, the application must stop monitoring that socket on
+libcurl's behalf. libcurl does not track idle connections. The pointer
+previously assigned to the socket with curl_multi_assign(3) is forgotten by
+libcurl. Applications must not rely on *socketp* to track idle connections.
 
 When a socket is given a CURL_POLL_REMOVE value, it might be because libcurl
 is going to close it, but it might also mean that it does not need any more

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -99,9 +99,7 @@ writable.
 ## CURL_POLL_REMOVE
 
 The specified socket or file descriptor is no longer used by libcurl for any
-active transfer. It might soon be added again. After libcurl signals
-CURL_POLL_REMOVE, the application must stop monitoring that socket on
-libcurl's behalf. libcurl does not track idle connections.
+active transfer. It might soon be added again.
 
 When a socket is given a CURL_POLL_REMOVE value, it might be because libcurl
 is going to close it, but it might also mean that it does not need any more

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -68,13 +68,13 @@ callback to be called for every socket that leaves use.
 
 Idle connections are not expected to receive application data. Read or
 error events may still occur when the peer closes the connection, or as
-zero-length reads, or for HTTPS when encrypted data decrypts to
+zero-length reads, or for HTTPS when encrypted data `decrypts` to
 zero-length. libcurl cannot safely interpret or act on such events
 once the socket has been removed from polling (CURL_POLL_REMOVE), and
 applications cannot forward them to libcurl for idle connections.
-Applications must handle fd reuse and spurious readiness events
+Applications must handle `fd` reuse and spurious readiness events
 defensively; the underlying risk is the kernel closing or reusing the
-fd after libcurl has stopped monitoring it.
+`fd` after libcurl has stopped monitoring it.
 
 ## Socket callback and idle sockets
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -66,13 +66,15 @@ callback to be called for every socket that leaves use.
 
 ## Idle connection polling
 
-Connections in the idle pool may still receive read or error events
-from the kernel. Polling backends (kqueue, epoll, etc.) can deliver
-events even after libcurl has removed read or write interest for that
-socket. This can surface as zero-length reads or spurious data when
-the connection is later closed or reused. Applications using
-CURLMOPT_SOCKETFUNCTION(3) should handle such events without assuming
-the socket is still actively used by libcurl.
+Idle connections are not expected to receive application data. Read or
+error events may still occur when the peer closes the connection, or as
+zero-length reads, or for HTTPS when encrypted data decrypts to
+zero-length. libcurl cannot safely interpret or act on such events
+once the socket has been removed from polling (CURL_POLL_REMOVE), and
+applications cannot forward them to libcurl for idle connections.
+Applications must handle fd reuse and spurious readiness events
+defensively; the underlying risk is the kernel closing or reusing the
+fd after libcurl has stopped monitoring it.
 
 ## Socket callback and idle sockets
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -54,7 +54,7 @@ When using the multi interface with a connection cache, the following
 observed behavior applies. It is relevant for applications that manage
 large numbers of sockets and custom polling loops (e.g. kqueue or epoll).
 
-**CURLOPT_CLOSESOCKETFUNCTION lifecycle**
+## Callback lifecycle
 
 The callback and CURLOPT_CLOSESOCKETDATA(3) are copied from the *first* easy
 handle that creates the connection. Changing this option on a subsequent
@@ -64,17 +64,17 @@ closed after CURL_CSELECT_ERR (e.g. when the socket has already been
 reported as in error state). Applications should not rely on the close
 callback to be called for every socket that leaves use.
 
-**Idle connection polling**
+## Idle connection polling
 
-Connections in the idle pool may still receive read (or error) events
+Connections in the idle pool may still receive read or error events
 from the kernel. Polling backends (kqueue, epoll, etc.) can deliver
-events even after libcurl has removed read/write interest for that
+events even after libcurl has removed read or write interest for that
 socket. This can surface as zero-length reads or spurious data when
 the connection is later closed or reused. Applications using
 CURLMOPT_SOCKETFUNCTION(3) should handle such events without assuming
 the socket is still actively used by libcurl.
 
-**CURLMOPT_SOCKETFUNCTION and idle sockets**
+## Socket callback and idle sockets
 
 When a connection enters the idle pool, libcurl invokes the socket
 callback with CURL_POLL_REMOVE. Subsequent callbacks for that socket

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -79,8 +79,7 @@ After libcurl signals CURL_POLL_REMOVE for a socket, the application must
 stop monitoring that socket on libcurl's behalf.
 libcurl may still retain the connection internally for reuse. When the
 socket has been removed, the pointer previously assigned to it with
-curl_multi_assign(3) is forgotten by libcurl. Applications must not rely
-on *socketp* to track idle connections.
+curl_multi_assign(3) is forgotten by libcurl. libcurl does not track idle connections.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -76,7 +76,7 @@ unexpected readiness events.
 ## Socket callback and idle sockets
 
 After libcurl signals CURL_POLL_REMOVE for a socket, the application must
-stop monitoring that socket for read and write events on libcurl's behalf.
+stop monitoring that socket on libcurl's behalf.
 libcurl may still retain the connection internally for reuse. When the
 socket has been removed, the pointer previously assigned to it with
 curl_multi_assign(3) is forgotten by libcurl. Applications must not rely

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -50,14 +50,11 @@ than the transfer itself in the multi/share handle's connection cache.
 
 # NOTES ON IDLE CONNECTIONS
 
-The close socket callback is invoked when libcurl closes a socket it owns.
-The callback and CURLOPT_CLOSESOCKETDATA(3) are copied from the *first* easy
-handle that creates the connection; changing this option on a subsequent
-easy handle that reuses the same connection has no effect for that
-connection. The callback is not guaranteed to be called for every socket
-that leaves use, for example when connections are kept alive in the
-connection cache and reused. Applications must not assume the callback is
-called for every socket lifecycle.
+When using the multi interface, the close socket callback is invoked when
+libcurl closes a socket it owns. The callback and CURLOPT_CLOSESOCKETDATA(3)
+are copied from the *first* easy handle that creates the connection;
+changing this option on a subsequent easy handle that reuses the same
+connection has no effect for that connection.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -50,36 +50,14 @@ than the transfer itself in the multi/share handle's connection cache.
 
 # NOTES ON IDLE CONNECTIONS
 
-When using the multi interface with a connection cache, applications must
-not assume that sockets associated with idle connections behave the same
-as active connections.
-
-## Callback life cycle
-
+The close socket callback is invoked when libcurl closes a socket it owns.
 The callback and CURLOPT_CLOSESOCKETDATA(3) are copied from the *first* easy
-handle that creates the connection. Changing this option on a subsequent
+handle that creates the connection; changing this option on a subsequent
 easy handle that reuses the same connection has no effect for that
-connection. The callback is not invoked when an idle connection is
-closed after CURL_CSELECT_ERR. Applications should not rely on the close
-callback to be called for every socket that leaves use.
-
-## Readiness events after CURL_POLL_REMOVE
-
-Applications must not assume that receiving readiness events for a socket
-implies that libcurl still expects the socket to be reported back via
-curl_multi_socket_action(3). Readiness events may occur for reasons
-outside libcurl's control, but libcurl provides no API for reporting such
-events once a socket has been removed from polling. Applications
-integrating with external polling systems must defensively handle
-unexpected readiness events.
-
-## Socket callback and idle sockets
-
-After libcurl signals CURL_POLL_REMOVE for a socket, the application must
-stop monitoring that socket on libcurl's behalf.
-libcurl may still retain the connection internally for reuse. When the
-socket has been removed, the pointer previously assigned to it with
-curl_multi_assign(3) is forgotten by libcurl. libcurl does not track idle connections.
+connection. The callback is not guaranteed to be called for every socket
+that leaves use, for example when connections are kept alive in the
+connection cache and reused. Applications must not assume the callback is
+called for every socket lifecycle.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -54,7 +54,10 @@ When using the multi interface, the close socket callback is invoked when
 libcurl closes a socket it owns. The callback and CURLOPT_CLOSESOCKETDATA(3)
 are copied from the *first* easy handle that creates the connection;
 changing this option on a subsequent easy handle that reuses the same
-connection has no effect for that connection.
+connection has no effect for that connection. The callback is stored with
+the connection because the connection may outlive the easy handle that
+created it, so that libcurl can still invoke it when the connection is
+closed even after that handle has been cleaned up.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -54,7 +54,7 @@ When using the multi interface with a connection cache, the following
 observed behavior applies. It is relevant for applications that manage
 large numbers of sockets and custom polling loops (e.g. kqueue or epoll).
 
-## Callback lifecycle
+## Callback life cycle
 
 The callback and CURLOPT_CLOSESOCKETDATA(3) are copied from the *first* easy
 handle that creates the connection. Changing this option on a subsequent

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -48,16 +48,16 @@ after the easy handle has been cleaned up. The callback and data is
 inherited by a new connection and that connection may live longer
 than the transfer itself in the multi/share handle's connection cache.
 
-# NOTES ON IDLE CONNECTIONS
+# NOTES ON CONNECTION REUSE
 
 When using the multi interface, the close socket callback is invoked when
 libcurl closes a socket it owns. The callback and CURLOPT_CLOSESOCKETDATA(3)
-are copied from the *first* easy handle that creates the connection;
-changing this option on a subsequent easy handle that reuses the same
-connection has no effect for that connection. The callback is stored with
-the connection because the connection may outlive the easy handle that
-created it, so that libcurl can still invoke it when the connection is
-closed even after that handle has been cleaned up.
+are copied from the *first* easy handle that creates the socket used for a
+connection; changing this option on a subsequent easy handle that reuses the
+same connection has no effect for that connection. The callback is stored with
+the connection because the connection and its associated socket may outlive the
+easy handle that created it, so that libcurl can still invoke it when the
+socket is closed even after that handle has been cleaned up.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -50,14 +50,15 @@ than the transfer itself in the multi/share handle's connection cache.
 
 # NOTES ON CONNECTION REUSE
 
-When using the multi interface, the close socket callback is invoked when
-libcurl closes a socket it owns. The callback and CURLOPT_CLOSESOCKETDATA(3)
-are copied from the *first* easy handle that creates the socket used for a
-connection; changing this option on a subsequent easy handle that reuses the
-same connection has no effect for that connection. The callback is stored with
-the connection because the connection and its associated socket may outlive the
-easy handle that created it, so that libcurl can still invoke it when the
-socket is closed even after that handle has been cleaned up.
+The close socket callback is invoked when libcurl closes a socket it owns.
+When using the multi interface, the callback and
+CURLOPT_CLOSESOCKETDATA(3) are copied from the *first* easy handle that
+creates the socket used for a connection; changing this option on a subsequent
+easy handle that reuses the same connection has no effect for that connection.
+The callback is stored with the connection because the connection and its
+associated socket may outlive the easy handle that created it, so that libcurl
+can still invoke it when the socket is closed even after that handle has been
+cleaned up.
 
 # DEFAULT
 


### PR DESCRIPTION
This PR documents observed behavior around idle connections and socket callbacks that is not currently described in the documentation.

Specifically:
- When CURLOPT_CLOSESOCKETFUNCTION is copied and when it is invoked
- How idle connections interact with CURLMOPT_SOCKETFUNCTION
- Why read/error events may still occur on sockets that have been removed from polling

This behavior is relevant for applications managing large numbers of sockets and custom polling loops (e.g. kqueue/epoll-based integrations).

No functional changes are introduced.

Addresses #20377
