### PR TITLE
lib: disable websockets early if no http

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -286,6 +286,9 @@
 #  define CURL_DISABLE_HEADERS_API 1
 #  define CURL_DISABLE_HSTS 1
 #  define CURL_DISABLE_HTTP_AUTH 1
+#  ifndef CURL_DISABLE_WEBSOCKETS
+#  define CURL_DISABLE_WEBSOCKETS /* no WebSockets without HTTP present */
+#  endif
 #endif
 
 /* ================================================================ */

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -24,12 +24,6 @@
 #include "curl_setup.h"
 #include "urldata.h"
 
-#ifdef CURL_DISABLE_HTTP
-/* no WebSockets without HTTP present */
-#undef CURL_DISABLE_WEBSOCKETS
-#define CURL_DISABLE_WEBSOCKETS 1
-#endif
-
 #ifndef CURL_DISABLE_WEBSOCKETS
 
 #include "url.h"


### PR DESCRIPTION
To prevent inconsistent `CURL_DISABLE_WEBSOCKETS` states between source
files.

Follow-up to 8edc0338f30f458f812f9ea355de1240771fa343 #20351
