### PR TITLE
mk-ca-bundle.pl: make generated timestamps deterministic

### DIFF
--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -312,7 +312,7 @@ if(!$opt_n) {
 
         my $out = '';
         # https://raw.githubusercontent.com/mozilla-firefox/firefox/refs/heads/autoland/security/nss/lib/ckfw/builtins/certdata.txt
-        if($url =~ /^https:\/\/raw.githubusercontent.com\/([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+)\/(refs\/heads\/[a-z]+)(\/.+)$/) {
+        if($url =~ /^https:\/\/raw.githubusercontent.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/(refs\/heads\/[a-z]+)(\/.+)$/) {
             my $slug = $1;
             my $refs = "&sha=$2";
             my $path = $3;


### PR DESCRIPTION
With default invocation, make generated file timestamps deterministic
by looking up (via the GitHub API) the last commit that modified 
`certdata.txt`, along with  its commit timestamp.

Also:
- show the URL used to download `certdata.txt` from.
- make `ca-bundle.crt` timestamp match `certdata.txt`'s.

---

- [x] fail if the stable timestamp could not be determined, and therefore the output is not reproducible. [another time]
- [x] maybe just omit the timestamp from the comment when using `-r`? [NO, but also skip adding `-r` for now]
- [x] make the timestamp of the output the same as the input's?
