### PR TITLE
curl_setup.h: drop extra header guard for internal include

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -793,9 +793,7 @@
 /*
  * Include macros and defines that should only be processed once.
  */
-#ifndef HEADER_CURL_SETUP_ONCE_H
 #include "curl_setup_once.h"
-#endif
 
 /*
  * Macros and functions to safely suppress warnings


### PR DESCRIPTION
The included local header starts with this same guard. The original 
commit added it for fixing VMS builds along with many other changes, but
without mention of this specific one in the commit message.

`curl_setup.h` is included once, which includes `curl_setup_once.h`
once, even if the latter wouldn't have it's own guard.

Ref: 25f351424b353884bfe36f5e1c7a787b04b46932
