### PR TITLE
cli_hx_download: add Schannel support

### DIFF
--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -43,8 +43,6 @@
 #include <rustls.h>
 #endif
 #ifdef USE_SCHANNEL
-#include <subauth.h>  /* for [P]UNICODE_STRING */
-#define SECURITY_WIN32  /* for sspi.h */
 #include <sspi.h>  /* for CtxtHandle, QueryContextAttributes() */
 #include <schannel.h>  /* SecPkgContext_ConnectionInfo,
                           SECPKG_ATTR_CONNECTION_INFO */


### PR DESCRIPTION
Fixes:
```
$ wine libtests.exe cli_hx_download https://curl.se/
[...]
Assertion failed: t->checked_ssl, file .../curl/tests/libtest/cli_hx_download.c, line 563
```

into:
```
[t-0] info Schannel TLS version 0x00000800
```

Refs:
https://learn.microsoft.com/windows/win32/secauthn/querycontextattributes--general
https://learn.microsoft.com/windows/win32/api/schannel/ns-schannel-secpkgcontext_connectioninfo

Ref: c220674ac451231e05df1686bd3da473e5c37252 #20564
Follow-up to ba9ddb935794a9fdd6906f043102a0d3e5795113 #18066
