### PR TITLE
docs/libcurl: unify WARNING use

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
@@ -76,7 +76,7 @@ option.
 Using this option multiple times makes the last set string override the
 previous ones.
 
-**WARNING**: when decompressing data, even tiny transfers might be expanded
+**WARNING:** when decompressing data, even tiny transfers might be expanded
 and generate a huge amount of bytes.
 
 # HISTORY

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
@@ -56,7 +56,7 @@ specified in the *type* argument. This function must return 0. The *data*
 pointed to by the char * passed to this function is not null-terminated, but
 is exactly of the *size* as told by the *size* argument.
 
-**WARNING** this callback may receive sensitive contents from headers and
+**WARNING:** this callback may receive sensitive contents from headers and
 data, including information sent as **CURLINFO_TEXT**.
 
 The *clientp* argument is the pointer set with CURLOPT_DEBUGDATA(3).
@@ -96,8 +96,8 @@ The data is SSL/TLS (binary) data received from the peer.
 
 ##
 
-WARNING: This callback may be called with the curl *handle* set to an internal
-handle. (Added in 8.4.0)
+**WARNING:** This callback may be called with the curl *handle* set to an
+internal handle. (Added in 8.4.0)
 
 If you need to distinguish your curl *handle* from internal handles then set
 CURLOPT_PRIVATE(3) on your handle.

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
@@ -62,7 +62,7 @@ talking to. Use CURLOPT_DOH_SSL_VERIFYHOST(3) for that. The check that the
 hostname in the certificate is valid for the hostname you are connecting to
 is done independently of the CURLOPT_DOH_SSL_VERIFYPEER(3) option.
 
-WARNING: disabling verification of the certificate allows bad guys to
+**WARNING:** disabling verification of the certificate allows bad guys to
 man-in-the-middle the communication without you knowing it. Disabling
 verification makes the communication insecure. Just having encryption on a
 transfer is not enough as you cannot be sure that you are communicating with

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -40,9 +40,10 @@ Tells libcurl to not attempt to use any workarounds for a security flaw in the
 SSL3 and TLS1.0 protocols. If this option is not used or this bit is set to 0,
 the SSL layer libcurl uses may use a work-around for this flaw although it
 might cause interoperability problems with some (older) SSL implementations.
-WARNING: avoiding this work-around lessens the security, and by setting this
-option to 1 you ask for exactly that. This option is only supported for Secure
-Transport and OpenSSL.
+
+**WARNING:** avoiding this work-around lessens the security, and by setting
+this option to 1 you ask for exactly that. This option is only supported for
+Secure Transport and OpenSSL.
 
 ## CURLSSLOPT_NO_REVOKE
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
@@ -57,7 +57,7 @@ talking to. Use CURLOPT_PROXY_SSL_VERIFYHOST(3) for that. The check that the
 hostname in the certificate is valid for the hostname you are connecting to is
 done independently of the CURLOPT_PROXY_SSL_VERIFYPEER(3) option.
 
-WARNING: disabling verification of the certificate allows bad guys to
+**WARNING:** disabling verification of the certificate allows bad guys to
 man-in-the-middle the communication without you knowing it. Disabling
 verification makes the communication insecure. Just having encryption on a
 transfer is not enough as you cannot be sure that you are communicating with

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -38,9 +38,10 @@ Tells libcurl to not attempt to use any workarounds for a security flaw in the
 SSL3 and TLS1.0 protocols. If this option is not used or this bit is set to 0,
 the SSL layer libcurl uses may use a work-around for this flaw although it
 might cause interoperability problems with some (older) SSL implementations.
-WARNING: avoiding this work-around lessens the security, and by setting this
-option to 1 you ask for exactly that. This option is only supported for Secure
-Transport and OpenSSL.
+
+**WARNING:** avoiding this work-around lessens the security, and by setting
+this option to 1 you ask for exactly that. This option is only supported for
+Secure Transport and OpenSSL.
 
 ## CURLSSLOPT_NO_REVOKE
 

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -53,7 +53,7 @@ This option controls checking the server's certificate's claimed identity. The
 separate CURLOPT_SSL_VERIFYPEER(3) options enables/disables verification that
 the certificate is signed by a trusted Certificate Authority.
 
-WARNING: disabling verification of the certificate allows bad guys to
+**WARNING:** disabling verification of the certificate allows bad guys to
 man-in-the-middle the communication without you knowing it. Disabling
 verification makes the communication insecure. Just having encryption on a
 transfer is not enough as you cannot be sure that you are communicating with

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
@@ -58,7 +58,7 @@ talking to. Use CURLOPT_SSL_VERIFYHOST(3) for that. The check that the host
 name in the certificate is valid for the hostname you are connecting to is
 done independently of the CURLOPT_SSL_VERIFYPEER(3) option.
 
-WARNING: disabling verification of the certificate allows bad guys to
+**WARNING:** disabling verification of the certificate allows bad guys to
 man-in-the-middle the communication without you knowing it. Disabling
 verification makes the communication insecure. Just having encryption on a
 transfer is not enough as you cannot be sure that you are communicating with

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.md
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.md
@@ -39,7 +39,7 @@ this used when you debug/report problems.
 To also get all the protocol data sent and received, consider using the
 CURLOPT_DEBUGFUNCTION(3).
 
-**WARNING** this may show sensitive contents from headers and data.
+**WARNING:** this may show sensitive contents from headers and data.
 
 # DEFAULT
 


### PR DESCRIPTION
Consistently use bold and colon.