### PR TITLE
cmake: fix `CURL_DROP_UNUSED` accidental left always-enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ endif()
 set(CURL_CFLAGS "")  # C flags set for libcurl and curl tool (aka public binaries) only
 
 option(CURL_DROP_UNUSED "Drop unused code and data from built binaries" OFF)
-if(CURL_DROP_UNUSED OR TRUE)
+if(CURL_DROP_UNUSED)
   if(APPLE)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
       set_property(DIRECTORY APPEND PROPERTY LINK_OPTIONS "-Wl,-dead_strip")


### PR DESCRIPTION
Follow-up to 66ad54e46b934e17e786e10e0292fa6f1f3fa816 #20357