### PR TITLE
ws/tftp: include header file even when protocol disabled

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 #include "urldata.h"
+#include "tftp.h"
 
 #ifndef CURL_DISABLE_TFTP
 
@@ -51,7 +52,6 @@
 #include "transfer.h"
 #include "sendf.h"
 #include "curl_trc.h"
-#include "tftp.h"
 #include "progress.h"
 #include "connect.h"
 #include "sockaddr.h" /* required for Curl_sockaddr_storage */

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 #include "urldata.h"
+#include "ws.h"
 
 #ifndef CURL_DISABLE_WEBSOCKETS
 
@@ -35,7 +36,6 @@
 #include "sendf.h"
 #include "curl_trc.h"
 #include "multiif.h"
-#include "ws.h"
 #include "easyif.h"
 #include "transfer.h"
 #include "select.h"


### PR DESCRIPTION
As the scheme details are still needed. clang 21 warned for this in HTTP-only builds.

Reported-by: Marcel Raad
URL: https://curl.se/mail/lib-2026-02/0008.html