### PR TITLE
multi: split multi_runsingle into sub functions

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2323,7 +2323,7 @@ static CURLMcode state_connect(struct Curl_multi *multi,
   return mresult;
 }
 
-/* returns error if it changed state */
+/* returns the possibly updated result */
 static CURLcode is_finished(struct Curl_multi *multi,
                             struct Curl_easy *data,
                             bool stream_error,


### PR DESCRIPTION
To reduce complexity.

- is_finished() checks if the individual transfer is done

- handle_completed() is the logic that runs for a completed transfer