### PR TITLE
GHA/windows: replace Cygwin distro server

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,7 +91,7 @@ jobs:
           # https://cygwin.com/mirrors.html
           # Main mirror status: https://archlinux.org/mirrors/kernel.org/
           # site: https://mirrors.kernel.org/sourceware/cygwin/
-          site: https://cygwin.osuosl.org/
+          site: https://cygwin.mirror.gtcomm.net/
           # https://cygwin.com/cgi-bin2/package-grep.cgi
           packages: >-
             ${{ matrix.build == 'autotools' && 'autoconf automake libtool make' || 'cmake ninja' }}


### PR DESCRIPTION
`mirrors.kernel.org` is down.

Also:
- link to `mirrors.kernel.org` status page.
- link to list of mirrors.

Ref: https://archlinux.org/mirrors/kernel.org/

---

Another backup option: https://mirrors.edge.kernel.org/ (Amsterdam)
