### PR TITLE
docs: clarify --ipv4 and --ipv6

### DIFF
--- a/docs/cmdline-opts/ipv4.md
+++ b/docs/cmdline-opts/ipv4.md
@@ -20,5 +20,5 @@ Example:
 
 # `--ipv4`
 
-Use IPv4 addresses only when resolving hostnames, and not for example try
+Request only IPv4 addresses when resolving hostnames, and not for example any
 IPv6.

--- a/docs/cmdline-opts/ipv6.md
+++ b/docs/cmdline-opts/ipv6.md
@@ -20,9 +20,9 @@ Example:
 
 # `--ipv6`
 
-Use IPv6 addresses only when resolving hostnames, and not for example try
+Request only IPv6 addresses when resolving hostnames, and not for example any
 IPv4.
 
-Your resolver may respond to an IPv6-only resolve request by returning IPv6
-addresses that contain "mapped" IPv4 addresses for compatibility purposes.
+Your resolver may still respond to an IPv6-only resolve request by returning
+IPv6 addresses that contain "mapped" IPv4 addresses for compatibility purposes.
 macOS is known to do this.


### PR DESCRIPTION
Try to make the wording more clear. It is the addresses in the resolver result that are affected, not anything regarding *how* resolving is done.