### PR TITLE
GHA/windows: bump cygwin/cygwin-install-action to v6.1

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,7 +84,7 @@ jobs:
           - { build: 'cmake'    , platform: 'x86_64', tflags: ''       , config: '-DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DENABLE_THREADED_RESOLVER=OFF', install: 'libssl-devel libssh2-devel', name: 'openssl' }
       fail-fast: false
     steps:
-      - uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d # v6
+      - uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6.1
         with:
           platform: ${{ matrix.platform }}
           work-vol: 'D:'


### PR DESCRIPTION
Previous tag v6 changed upstream and points to a different commit. This
made zizmor unhappy. Previous commit is now tagged v6.0 in case we need
it.
