### PR TITLE
examples/usercertinmem: use modern OpenSSL API, drop mentions of RSA

### DIFF
--- a/docs/examples/usercertinmem.c
+++ b/docs/examples/usercertinmem.c
@@ -43,7 +43,7 @@
 #pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
 
-static size_t writefunction(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   fwrite(ptr, size, nmemb, (FILE *)stream);
   return nmemb * size;
@@ -150,9 +150,9 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunction);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
-    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, writefunction);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, write_cb);
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, stderr);
     curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
 


### PR DESCRIPTION
Replacing API calls deprecated by OpenSSL 3, and also missing
from OpenSSL 3 no-deprecated builds, fixing builds with the latter:
`PEM_read_bio_RSAPrivateKey()`, `RSA_free()`,
`SSL_CTX_use_RSAPrivateKey()`

Also: rename callback to match its `cacertinmem.c` sibling.

Fixes #20595
