### PR TITLE
curl_setup.h: update/expand `OPENSSL_SUPPRESS_DEPRECATED` comment

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1548,8 +1548,11 @@ typedef struct sockaddr_un {
 #endif
 
 #ifdef USE_OPENSSL
-/* OpenSSLv3 marks DES, MD5 and ENGINE functions deprecated but we have no
-   replacements (yet) so tell the compiler to not warn for them. */
+/* OpenSSL 3 marks these functions deprecated but we have no replacements (yet)
+   so tell the compiler to not warn for them:
+   - DES_* (for NTLM), SSL_CTX_set_srp_* (for TLS-SRP)
+   - EVP_PKEY_get1_RSA, MD5_*, RSA_flags, RSA_free (auto-skipped for OpenSSL
+     built with no-deprecated) */
 #  define OPENSSL_SUPPRESS_DEPRECATED
 #  ifdef _WIN32
 /* Silence LibreSSL warnings about wincrypt.h collision. Works in 3.8.2+ */


### PR DESCRIPTION
Document functions/features requiring it.

Follow-up to cab040248d3fba3600825d77d56383019066b447 #10543
Cherry-picked from #20593