### PR TITLE
src: simplify declaring `curl_ca_embed`

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -222,13 +222,6 @@ static CURLcode ssh_setopts(struct OperationConfig *config, CURL *curl)
   return CURLE_OK; /* ignore if SHA256 did not work */
 }
 
-#ifdef CURL_CA_EMBED
-#ifndef CURL_DECLARED_CURL_CA_EMBED
-#define CURL_DECLARED_CURL_CA_EMBED
-extern const unsigned char curl_ca_embed[];
-#endif
-#endif
-
 static long tlsversion(unsigned char mintls,
                        unsigned char maxtls)
 {

--- a/src/mk-file-embed.pl
+++ b/src/mk-file-embed.pl
@@ -39,10 +39,8 @@ print <<HEAD
  * NEVER EVER edit this manually, fix the mk-file-embed.pl script instead!
  */
 /* !checksrc! disable COPYRIGHT all */
-#ifndef CURL_DECLARED_${varname_upper}
-#define CURL_DECLARED_${varname_upper}
-extern const unsigned char ${varname}[];
-#endif
+#include "tool_setup.h"
+
 const unsigned char ${varname}[] = {
 HEAD
     ;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -86,13 +86,6 @@
 CURL_EXTERN CURLcode curl_easy_perform_ev(CURL *easy);
 #endif
 
-#ifdef CURL_CA_EMBED
-#ifndef CURL_DECLARED_CURL_CA_EMBED
-#define CURL_DECLARED_CURL_CA_EMBED
-extern const unsigned char curl_ca_embed[];
-#endif
-#endif
-
 #define CURL_CA_CERT_ERRORMSG                                              \
   "More details here: https://curl.se/docs/sslcerts.html\n\n"              \
   "curl failed to verify the legitimacy of the server and therefore "      \

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -98,4 +98,8 @@ int tool_ftruncate64(int fd, curl_off_t where);
 #endif /* !HAVE_FTRUNCATE */
 #endif /* _WIN32 */
 
+#ifdef CURL_CA_EMBED
+extern const unsigned char curl_ca_embed[];
+#endif
+
 #endif /* HEADER_CURL_TOOL_SETUP_H */


### PR DESCRIPTION
Also to avoid `-Wunused-macros` warnings.

Follow-up to 8a3740bc8e558b9a9d4a652b74cf27a0961d7010 #14059
Cherry-picked from #20593
