### PR TITLE
lib: drop `#undef` workaround no longer necessary

### DIFF
--- a/lib/curl_share.c
+++ b/lib/curl_share.c
@@ -55,7 +55,6 @@ CURLSH *curl_share_init(void)
   return share;
 }
 
-#undef curl_share_setopt
 CURLSHcode curl_share_setopt(CURLSH *sh, CURLSHoption option, ...)
 {
   va_list param;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -849,7 +849,6 @@ void curl_easy_cleanup(CURL *ptr)
  * curl_easy_getinfo() is an external interface that allows an app to retrieve
  * information from a performed transfer and similar.
  */
-#undef curl_easy_getinfo
 CURLcode curl_easy_getinfo(CURL *easy, CURLINFO info, ...)
 {
   struct Curl_easy *data = easy;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3182,7 +3182,6 @@ out:
   return mresult;
 }
 
-#undef curl_multi_setopt
 CURLMcode curl_multi_setopt(CURLM *m, CURLMoption option, ...)
 {
   CURLMcode mresult = CURLM_OK;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2951,8 +2951,6 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
  * NOTE: This is one of few API functions that are allowed to be called from
  * within a callback.
  */
-
-#undef curl_easy_setopt
 CURLcode curl_easy_setopt(CURL *d, CURLoption tag, ...)
 {
   va_list arg;


### PR DESCRIPTION
Follow-up to daa6b27b4d998d62c8198b4fe167199cc7bf0064 #20597