### PR TITLE
openssl: disable local keylog feature if built-in upstream

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -682,7 +682,7 @@ static void ossl_bio_cf_method_free(BIO_METHOD *m)
     BIO_meth_free(m);
 }
 
-#ifndef HAVE_KEYLOG_BUILTIN
+#ifndef HAVE_KEYLOG_UPSTREAM
 #ifdef HAVE_KEYLOG_CALLBACK
 static void ossl_keylog_callback(const SSL *ssl, const char *line)
 {
@@ -728,7 +728,7 @@ static void ossl_log_tls12_secret(const SSL *ssl, bool *keylog_done)
                         master_key, master_key_length);
 }
 #endif /* !HAVE_KEYLOG_CALLBACK */
-#endif /* HAVE_KEYLOG_BUILTIN */
+#endif /* HAVE_KEYLOG_UPSTREAM */
 
 static const char *SSL_ERROR_to_str(int err)
 {
@@ -1663,7 +1663,7 @@ static int ossl_init(void)
     0;
   OPENSSL_init_ssl(flags, NULL);
 
-#ifndef HAVE_KEYLOG_BUILTIN
+#ifndef HAVE_KEYLOG_UPSTREAM
   Curl_tls_keylog_open();
 #endif
 
@@ -1673,7 +1673,7 @@ static int ossl_init(void)
 /* Global cleanup */
 static void ossl_cleanup(void)
 {
-#ifndef HAVE_KEYLOG_BUILTIN
+#ifndef HAVE_KEYLOG_UPSTREAM
   Curl_tls_keylog_close();
 #endif
 }
@@ -3947,7 +3947,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   SSL_CTX_set_verify(octx->ssl_ctx, SSL_VERIFY_NONE, NULL);
 
   /* Enable logging of secrets to the file specified in env SSLKEYLOGFILE. */
-#if !defined(HAVE_KEYLOG_BUILTIN) && defined(HAVE_KEYLOG_CALLBACK)
+#if !defined(HAVE_KEYLOG_UPSTREAM) && defined(HAVE_KEYLOG_CALLBACK)
   if(Curl_tls_keylog_enabled()) {
     SSL_CTX_set_keylog_callback(octx->ssl_ctx, ossl_keylog_callback);
   }
@@ -4169,7 +4169,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
     octx->x509_store_setup = TRUE;
   }
 
-#if !defined(HAVE_KEYLOG_BUILTIN) && !defined(HAVE_KEYLOG_CALLBACK)
+#if !defined(HAVE_KEYLOG_UPSTREAM) && !defined(HAVE_KEYLOG_CALLBACK)
   /* If key logging is enabled, wait for the handshake to complete and then
    * proceed with logging secrets (for TLS 1.2 or older).
    */

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -47,7 +47,7 @@
 /* OpenSSL 3.5.0+ has built-in `SSLKEYLOGFILE` support if built with
    `enable-sslkeylog` */
 #if OPENSSL_VERSION_NUMBER >= 0x30500000L && !defined(OPENSSL_NO_SSLKEYLOG)
-#define HAVE_KEYLOG_BUILTIN
+#define HAVE_KEYLOG_UPSTREAM
 #endif
 
 /*
@@ -79,7 +79,7 @@ struct ossl_ctx {
   CURLcode io_result;       /* result of last BIO cfilter operation */
   /* blocked writes need to retry with same length, remember it */
   int      blocked_ssl_write_len;
-#if !defined(HAVE_KEYLOG_BUILTIN) && !defined(HAVE_KEYLOG_CALLBACK)
+#if !defined(HAVE_KEYLOG_UPSTREAM) && !defined(HAVE_KEYLOG_CALLBACK)
   /* Set to true once a valid keylog entry has been created to avoid dupes.
      This is a bool and not a bitfield because it is passed by address. */
   bool keylog_done;


### PR DESCRIPTION
Reported-by: Paul Howarth
Fixes #20611
