### PR TITLE
tool: avoid misleading top-level --config error summary

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2250,6 +2250,17 @@ static ParameterError opt_file(struct OperationConfig *config,
     }
     else {
       err = parseconfig(nextarg, max_recursive, NULL);
+      if(err &&
+         err != PARAM_HELP_REQUESTED &&
+         err != PARAM_MANUAL_REQUESTED &&
+         err != PARAM_VERSION_INFO_REQUESTED &&
+         err != PARAM_ENGINES_REQUESTED &&
+         err != PARAM_CA_EMBED_REQUESTED &&
+         err != PARAM_READ_ERROR)
+        /* parseconfig() already reports file and line details.
+           Return a dedicated code so the top-level error summary
+           is not misleading (for example, saying --config is unknown). */
+        err = PARAM_CONFIG_PARSE;
     }
     break;
   case C_CRLFILE: /* --crlfile */

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -357,6 +357,7 @@ typedef enum {
   PARAM_EXPAND_ERROR, /* --expand problem */
   PARAM_BLANK_STRING,
   PARAM_VAR_SYNTAX, /* --variable syntax error */
+  PARAM_CONFIG_PARSE, /* specific error while parsing --config content */
   PARAM_RECURSION,
   PARAM_LAST
 } ParameterError;

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -67,6 +67,8 @@ const char *param2text(ParameterError error)
     return "blank argument where content is expected";
   case PARAM_VAR_SYNTAX:
     return "syntax error in --variable argument";
+  case PARAM_CONFIG_PARSE:
+    return "has a parse error in the config file";
   default:
     return "unknown error";
   }


### PR DESCRIPTION
When parsing --config content fails, parseconfig() already prints precise file/line diagnostics.

Before this change, the top-level summary could still say things like `option --config: is unknown`, which is misleading because the unknown token is in the config file, not the command line option itself.

This patch introduces PARAM_CONFIG_PARSE and maps parseconfig content errors to it (while keeping PARAM_READ_ERROR unchanged), so the final summary becomes clearer.

Fixes #20598