### PR TITLE
rtspd: fix to check `realloc()` result

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -12,5 +12,6 @@ Checks: >-
   -clang-analyzer-security.ArrayBound,
   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
   -clang-diagnostic-nullability-extension,
+  bugprone-suspicious-realloc-usage,
   misc-const-correctness,
   portability-*

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -325,12 +325,17 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
                   req->rtp_buffersize = rtp_size + 4;
                 }
                 else {
-                  req->rtp_buffer = realloc(req->rtp_buffer,
-                                            req->rtp_buffersize +
-                                            rtp_size + 4);
-                  memcpy(req->rtp_buffer + req->rtp_buffersize, rtp_scratch,
-                         rtp_size + 4);
-                  req->rtp_buffersize += rtp_size + 4;
+                  char *rtp_buffer = realloc(req->rtp_buffer,
+                                             req->rtp_buffersize +
+                                             rtp_size + 4);
+                  if(rtp_buffer) {
+                    req->rtp_buffer = rtp_buffer;
+                    memcpy(req->rtp_buffer + req->rtp_buffersize, rtp_scratch,
+                           rtp_size + 4);
+                    req->rtp_buffersize += rtp_size + 4;
+                  }
+                  else
+                    logmsg("failed resizing buffer.");
                   free(rtp_scratch);
                 }
                 logmsg("rtp_buffersize is %zu, rtp_size is %d.",


### PR DESCRIPTION
Also enable `bugprone-suspicious-realloc-usage` clang-tidy option
to verify.

Fixing:
```
tests/server/rtspd.c:328:37: error: 'req->rtp_buffer' may be set to null if 'realloc' fails,
 which may result in a leak of the original buffer
 [bugprone-suspicious-realloc-usage,-warnings-as-errors]
  328 |                   req->rtp_buffer = realloc(req->rtp_buffer,
      |                   ~~~~~~~~~~~~~~~   ^       ~~~~~~~~~~~~~~~
```

Ref: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-realloc-usage.html
