### PR TITLE
clang-tidy: enable more checks

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -11,10 +11,22 @@ Checks:
   - -clang-analyzer-security.insecureAPI.bzero  # for FD_ZERO() (seen on macOS)
   - -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
   - -clang-diagnostic-nullability-extension
+  - bugprone-assert-side-effect
+  - bugprone-chained-comparison
+  - bugprone-dynamic-static-initializers
   - bugprone-macro-parentheses
+  - bugprone-macro-repeated-side-effects
+  - bugprone-misplaced-operator-in-strlen-in-alloc
+  - bugprone-misplaced-pointer-arithmetic-in-alloc
+  - bugprone-not-null-terminated-result
+  - bugprone-posix-return
   - bugprone-redundant-branch-condition
   - bugprone-signed-char-misuse
+  - bugprone-suspicious-enum-usage
+  - bugprone-suspicious-memset-usage
+  - bugprone-suspicious-missing-comma
   - bugprone-suspicious-realloc-usage
+  - bugprone-suspicious-semicolon
   - misc-const-correctness
   - misc-header-include-cycle
   - portability-*
@@ -22,6 +34,9 @@ Checks:
   - readability-math-missing-parentheses
   - readability-named-parameter
   - readability-redundant-control-flow
+  - readability-redundant-declaration
+  - readability-redundant-function-ptr-dereference
+  - readability-redundant-parentheses
   - readability-redundant-preprocessor
   - readability-uppercase-literal-suffix
 


### PR DESCRIPTION
Refs:
https://clang.llvm.org/extra/clang-tidy/checks/list.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/assert-side-effect.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/chained-comparison.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/dynamic-static-initializers.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/macro-repeated-side-effects.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/misplaced-operator-in-strlen-in-alloc.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/misplaced-pointer-arithmetic-in-alloc.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/not-null-terminated-result.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/posix-return.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-enum-usage.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-memset-usage.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-missing-comma.html
https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-semicolon.html
https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-declaration.html
https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-function-ptr-dereference.html
https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-parentheses.html

---

I've found these checkers potentially useful, though they do not find
any hits in current code.
