### PR TITLE
clang-tidy: swap `fwrite()` size/items args where necessary

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -16,4 +16,5 @@ Checks: >-
   misc-const-correctness,
   portability-*,
   readability-named-parameter,
-  readability-redundant-control-flow
+  readability-redundant-control-flow,
+  readability-suspicious-call-argument

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -108,7 +108,7 @@ static size_t my_write_d_cb(char *buf, size_t nitems, size_t buflen,
     return CURL_WRITEFUNC_PAUSE;
   }
 
-  nwritten = fwrite(buf, nitems, buflen, t->out);
+  nwritten = fwrite(buf, buflen, nitems, t->out);
   if(nwritten < blen) {
     curl_mfprintf(stderr, "[t-%zu] write failure\n", t->idx);
     return 0;

--- a/tests/libtest/cli_hx_upload.c
+++ b/tests/libtest/cli_hx_upload.c
@@ -79,7 +79,7 @@ static size_t my_write_u_cb(char *buf, size_t nitems, size_t buflen,
       return 0;
   }
 
-  nwritten = fwrite(buf, nitems, buflen, t->out);
+  nwritten = fwrite(buf, buflen, nitems, t->out);
   if(nwritten < blen) {
     curl_mfprintf(stderr, "[t-%zu] write failure\n", t->idx);
     return 0;


### PR DESCRIPTION
It did not cause an actual issue. Reported by check:
`readability-suspicious-call-argument`

Ref: https://clang.llvm.org/extra/clang-tidy/checks/readability/suspicious-call-argument.html
