### PR TITLE
GHA/windows: try enabling clang-tidy for tests

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -664,7 +664,7 @@ jobs:
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       LDFLAGS: -s
       MAKEFLAGS: -j 5


### PR DESCRIPTION
Downside: it's slow. So slow, it makes this job the longest in CI.

5 and a half minutes. Total job time 10m30.

Follow-up to aa1854a8fffbcd1144b64fc25485ae71a6e6f4cf #20639
Follow-up to 4042e7d9d8341e059dfe26276797e7296cc66518 #20638
Follow-up to c927b18d6bd79109f8f8c47343aa157c15d28101 #20637
Follow-up to 6dc5f2948cbd7ad420242faafa9e5b23cc4f409e #20631
