### PR TITLE
clang-tidy: replace comma-separated string with list in config

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -4,18 +4,16 @@
 ---
 # https://clang.llvm.org/extra/clang-tidy/checks/list.html
 
-# -clang-analyzer-security.insecureAPI.bzero: for FD_ZERO() (seen on macOS)
-# -clang-analyzer-security.ArrayBound: due to false positives with clang-tidy v21.1.0
-Checks: >-
-  -clang-analyzer-security.insecureAPI.bzero,
-  -clang-analyzer-optin.performance.Padding,
-  -clang-analyzer-security.ArrayBound,
-  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
-  -clang-diagnostic-nullability-extension,
-  bugprone-suspicious-realloc-usage,
-  misc-const-correctness,
-  portability-*,
-  readability-named-parameter,
-  readability-redundant-control-flow,
-  readability-redundant-preprocessor,
-  readability-uppercase-literal-suffix
+Checks:
+  - -clang-analyzer-security.insecureAPI.bzero  # for FD_ZERO() (seen on macOS)
+  - -clang-analyzer-optin.performance.Padding
+  - -clang-analyzer-security.ArrayBound  # due to false positives with clang-tidy v21.1.0
+  - -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+  - -clang-diagnostic-nullability-extension
+  - bugprone-suspicious-realloc-usage
+  - misc-const-correctness
+  - portability-*
+  - readability-named-parameter
+  - readability-redundant-control-flow
+  - readability-redundant-preprocessor
+  - readability-uppercase-literal-suffix

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -49,7 +49,7 @@ When writing code (mostly for generating stuff included in release tarballs)
 we use a few "build tools" and we make sure that we remain functional with
 these versions:
 
-- clang-tidy     14.0.0 (2022-03-23), recommended: 19.1.0 or later (2024-09-17)
+- clang-tidy     17.0.0 (2023-09-19), recommended: 19.1.0 or later (2024-09-17)
 - cmake          3.7 (2016-11-11)
 - GNU autoconf   2.59 (2003-11-06)
 - GNU automake   1.7 (2002-09-25)


### PR DESCRIPTION
Bump required clang-tidy version to v17.0.0 for this.

Ref: https://releases.llvm.org/17.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
Follow-up to 4497dbd9ac4a31b0056a9179d500676ebe091de5 #20605
