### PR TITLE
openssl: fix potential NULL dereference when loading certs (Windows)

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2918,7 +2918,7 @@ static CURLcode ossl_win_load_store(struct Curl_easy *data,
        * CertGetEnhancedKeyUsage doc.
        */
       if(CertGetEnhancedKeyUsage(pContext, 0, NULL, &req_size) && req_size) {
-        if(req_size && req_size > enhkey_usage_size) {
+        if(req_size > enhkey_usage_size) {
           void *tmp = curlx_realloc(enhkey_usage, req_size);
 
           if(!tmp) {


### PR DESCRIPTION
This could happen if the first cert to be loaded missed EKU (Enhanced
Key Usage) data, when using native CA on Windows.

Fix by skipping certs without Enhanced Key Usage data.

Detected by clang-tidy:
```
lib/vtls/openssl.c:2922:15: warning: Access to field 'cUsageIdentifier'
 results in a dereference of a null pointer (loaded from variable
 'enhkey_usage') [clang-analyzer-core.NullDereference]
 2922 |           if(!enhkey_usage->cUsageIdentifier) {
      |               ^
```

Refs:
https://learn.microsoft.com/windows/win32/secgloss/e-gly
https://learn.microsoft.com/windows/win32/api/wincrypt/nf-wincrypt-certgetenhancedkeyusage
https://gitlab.winehq.org/wine/wine/-/blob/wine-11.2/dlls/crypt32/cert.c?ref_type=tags#L3061-3164

Assisted-by: Stefan Eissing

---

https://github.com/curl/curl/pull/20634/files?w=1
