### PR TITLE
clang-tidy: work around clang-tidy <=20 false positive (Windows)

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1105,7 +1105,9 @@ typedef unsigned int curl_bit;
 #define SOCKEINVAL        WSAEINVAL
 #define SOCKEISCONN       WSAEISCONN
 #define SOCKEMSGSIZE      WSAEMSGSIZE
-#define SOCKENOMEM        WSA_NOT_ENOUGH_MEMORY
+/* Use literal value to work around clang-tidy <=20 misreporting
+  'readability-uppercase-literal-suffix' with mingw-w64 headers */
+#define SOCKENOMEM        8L  /* WSA_NOT_ENOUGH_MEMORY */
 #define SOCKETIMEDOUT     WSAETIMEDOUT
 #define SOCKEWOULDBLOCK   WSAEWOULDBLOCK
 #else


### PR DESCRIPTION
clang-tidy <= v20 (as seen between 18.1.3 and 20.1.2) report
`readability-uppercase-literal-suffix` originating from mingw-w64 system
header `_mingw_mac.h` via `define __MSABI_LONG(x) x ## l`

Triggered by `SOCKENOMEM` (e.g. in tests/server/sockfilt.c):
```
warning: integer literal has suffix 'l', which is not uppercase [readability-uppercase-literal-suffix]
```

Work around by replacing Windows macro `WSA_NOT_ENOUGH_MEMORY`
with its literal value.

Bug: https://github.com/curl/curl/pull/20631#issuecomment-3930619868
Follow-up to c07c3cac746bb899e8014200aad02e5f4bb507de #20629
Cherry-picked from #20631
