### PR TITLE
tests/server/sockfilt: check for NULL `tv` to silence clang-tidy

### DIFF
--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -717,8 +717,10 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
             data[nws].wsasock = wsasock;
             data[nws].wsaevent = wsaevent;
             data[nfd].wsastate = 0;
-            tv->tv_sec = 0;
-            tv->tv_usec = 0;
+            if(tv) {
+              tv->tv_sec = 0;
+              tv->tv_usec = 0;
+            }
             /* check if the socket is already ready */
             if(select(fd + 1, &readsock, &writesock, &exceptsock, tv) == 1) {
               logmsg("[select_ws] socket %d is ready", fd);


### PR DESCRIPTION
A NULL dereference cannot happen with existing use of this code.

linux-mingw, CM clang-tidy:
```
/home/runner/work/curl/curl/tests/server/sockfilt.c:720:24: error: Access
 to field 'tv_sec' results in a dereference of a null pointer (loaded from
 variable 'tv') [clang-analyzer-core.NullDereference,-warnings-as-errors]
  720 |             tv->tv_sec = 0;
      |             ~~         ^
```
Ref: https://github.com/curl/curl/actions/runs/22191200093/job/64179197235?pr=20631#step:10:283

Cherry-picked from #20631
