### PR TITLE
cmake: improve clang-tidy invocation for tests in cross-builds

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -187,15 +187,26 @@ macro(curl_add_clang_tidy_test_target _target_clang_tidy _target)
       list(APPEND _sources "${_source}")
     endforeach()
 
+    set(_cc "${CMAKE_C_COMPILER}")
+    if(CMAKE_C_COMPILER_TARGET AND CMAKE_C_COMPILE_OPTIONS_TARGET)
+      list(APPEND _cc "${CMAKE_C_COMPILE_OPTIONS_TARGET}${CMAKE_C_COMPILER_TARGET}")
+    endif()
+    if(APPLE AND CMAKE_OSX_SYSROOT)
+      list(APPEND _cc "-isysroot" "${CMAKE_OSX_SYSROOT}")
+    elseif(CMAKE_SYSROOT AND CMAKE_C_COMPILE_OPTIONS_SYSROOT)
+      list(APPEND _cc "${CMAKE_C_COMPILE_OPTIONS_SYSROOT}${CMAKE_SYSROOT}")
+    endif()
+
     # Pass -clang-diagnostic-unused-function to disable -Wunused-function implied by -Wunused
     add_custom_target(${_target_clang_tidy} USES_TERMINAL
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMAND ${CMAKE_C_CLANG_TIDY}
         "--checks=-clang-diagnostic-unused-function"
-        ${_sources} -- ${_definitions} ${_includes} ${_options}
+        ${_sources} -- ${_cc} ${_definitions} ${_includes} ${_options}
       DEPENDS ${_sources})
     add_dependencies(tests-clang-tidy ${_target_clang_tidy})
 
+    unset(_cc)
     unset(_definitions)
     unset(_includes)
     unset(_options)

--- a/scripts/cmakelint.sh
+++ b/scripts/cmakelint.sh
@@ -75,5 +75,5 @@ cd "$(dirname "$0")"/..
     --max-branches 12 \
     --max-arguments 5 \
     --max-localvars 15 \
-    --max-statements 50 \
+    --max-statements 65 \
     --


### PR DESCRIPTION
By passing to clang-tidy the C compiler with `--target` and sysroot
options, if any.

Fixing (GHA-windows, linux-mingw, CM clang-tidy):
```
lib/curl_setup.h:841:10: error: 'io.h' file not found [clang-diagnostic-error]
  841 | #include <io.h>
      |          ^~~~~~
Found compiler error(s).
FAILED: [code=1] tests/server/CMakeFiles/servers-clang-tidy bld/tests/server/CMakeFiles/servers-clang-tidy
cd tests/server && /usr/bin/clang-tidy --config-file=.clang-tidy.yml
--warnings-as-errors=* --checks=-clang-diagnostic-unused-function first.c getpart.c util.c dnsd.c [...]
-- <-D-options> <-I-options> <cflags>
```

For reference, this is CMake's built-in clang-tidy invocation:
```
/usr/local/bin/cmake -E __run_co_compile --tidy="/usr/bin/clang-tidy;--config-file=.clang-tidy.yml;
--warnings-as-errors=*;--extra-arg-before=--driver-mode=gcc" --source=lib/curl_fopen.c
-- /usr/bin/clang --target=x86_64-w64-mingw32 <-D-options> <-I-options> <cflags>
```

Also:
- bump cmakelint `--max-statements`. Need 59 after this patch.
- use undocumented CMake variables:
  - `CMAKE_C_COMPILE_OPTIONS_TARGET` for `--target=`
  - `CMAKE_C_COMPILE_OPTIONS_SYSROOT` for `--sysroot=`

Cherry-picked from #20631
