### PR TITLE
easy: reset pausing when resetting request

### DIFF
--- a/lib/request.c
+++ b/lib/request.c
@@ -158,6 +158,9 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->no_body = data->set.opt_no_body;
   req->authneg = FALSE;
   req->shutdown = FALSE;
+  /* Unpause all directions */
+  Curl_rlimit_block(&data->progress.dl.rlimit, FALSE, &t0);
+  Curl_rlimit_block(&data->progress.ul.rlimit, FALSE, &t0);
 }
 
 void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)


### PR DESCRIPTION
When the easy handle's request is reset, this needs to also reset any pausing/ratelimit state.

Fixes #20641