### PR TITLE
unit1654: fix clang-tidy `bugprone-redundant-branch-condition`

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -10,6 +10,7 @@ Checks:
   - -clang-analyzer-security.insecureAPI.bzero  # for FD_ZERO() (seen on macOS)
   - -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
   - -clang-diagnostic-nullability-extension
+  - bugprone-redundant-branch-condition
   - bugprone-suspicious-realloc-usage
   - misc-const-correctness
   - portability-*

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -37,16 +37,14 @@ static CURLcode test_unit1654(const char *arg)
   struct altsvcinfo *asi = Curl_altsvc_init();
   abort_if(!asi, "Curl_altsvc_i");
   result = Curl_altsvc_load(asi, arg);
-  if(result) {
-    fail_if(result, "Curl_altsvc_load");
+  fail_if(result, "Curl_altsvc_load");
+  if(result)
     goto fail;
-  }
   curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
-  if(!curl) {
-    fail_if(!curl, "curl_easy_init");
+  fail_if(!curl, "curl_easy_init");
+  if(!curl)
     goto fail;
-  }
   fail_unless(Curl_llist_count(&asi->list) == 4, "wrong number of entries");
   curl_msnprintf(outname, sizeof(outname), "%s-out", arg);
 


### PR DESCRIPTION
```
tests/unit/unit1654.c:41:5: warning: redundant condition 'result' [bugprone-redundant-branch-condition]
   41 |     fail_if(result, "Curl_altsvc_load");
      |     ^
tests/libtest/unitcheck.h:29:5: note: expanded from macro 'fail_if'
   29 |     if(expr) {                                                         \
      |     ^
```

Ref: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/redundant-branch-condition.html