### PR TITLE
cmake: include `curl/curl.h` as system header in integration tests

### DIFF
--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -21,7 +21,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#include "curl/curl.h"
+#include <curl/curl.h>
 #include <stdio.h>
 
 int main(int argc, const char **argv)


### PR DESCRIPTION
Follow-up to fb70812437ad28b74dbdc1031e46c1d86bc9db3c #16126
