### PR TITLE
vtls_scache: simplify sanity check in `cf_ssl_scache_get()`

### DIFF
--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -312,7 +312,7 @@ static struct Curl_ssl_scache *cf_ssl_scache_get(struct Curl_easy *data)
     scache = data->share->ssl_scache;
   else if(data->multi && data->multi->ssl_scache)
     scache = data->multi->ssl_scache;
-  if(scache && !GOOD_SCACHE(scache)) {
+  if(scache && (scache->magic != CURL_SCACHE_MAGIC)) {
     failf(data, "transfer would use an invalid scache at %p, denied",
           (void *)scache);
     DEBUGASSERT(0);


### PR DESCRIPTION
Previously the check always failed, because of conditions `scache` and
`&& !scache` as part of the `GOOD_SCACHE()` macro.
