### PR TITLE
setopt: drop duplicate check

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -223,7 +223,7 @@ static CURLcode protocol2num(const char *str, curl_prot_t *val)
 
       *val |= h->protocol;
     }
-  } while(str && str++);
+  } while(str++);
 
   if(!*val)
     /* no protocol listed */


### PR DESCRIPTION
Reported by clang-tidy `bugprone-inc-dec-in-conditions`.

Ref: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/inc-dec-in-conditions.html
