### PR TITLE
clang-tidy: add arg names to prototypes where missing

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -3218,7 +3218,7 @@ typedef struct curl_version_info_data curl_version_info_data;
  * This function returns a pointer to a static copy of the version info
  * struct. See above.
  */
-CURL_EXTERN curl_version_info_data *curl_version_info(CURLversion);
+CURL_EXTERN curl_version_info_data *curl_version_info(CURLversion stamp);
 
 /*
  * NAME curl_easy_strerror()
@@ -3229,7 +3229,7 @@ CURL_EXTERN curl_version_info_data *curl_version_info(CURLversion);
  * into the equivalent human readable error string. This is useful
  * for printing meaningful error messages.
  */
-CURL_EXTERN const char *curl_easy_strerror(CURLcode);
+CURL_EXTERN const char *curl_easy_strerror(CURLcode error);
 
 /*
  * NAME curl_share_strerror()
@@ -3240,7 +3240,7 @@ CURL_EXTERN const char *curl_easy_strerror(CURLcode);
  * into the equivalent human readable error string. This is useful
  * for printing meaningful error messages.
  */
-CURL_EXTERN const char *curl_share_strerror(CURLSHcode);
+CURL_EXTERN const char *curl_share_strerror(CURLSHcode error);
 
 /*
  * NAME curl_easy_pause()

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -269,7 +269,7 @@ CURL_EXTERN CURLMsg *curl_multi_info_read(CURLM *multi_handle,
  *
  * Returns: A pointer to a null-terminated error message.
  */
-CURL_EXTERN const char *curl_multi_strerror(CURLMcode);
+CURL_EXTERN const char *curl_multi_strerror(CURLMcode error);
 
 /*
  * Name:    curl_multi_socket() and

--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -146,7 +146,7 @@ CURL_EXTERN CURLUcode curl_url_set(CURLU *handle, CURLUPart what,
  * readable error string. This is useful for printing meaningful error
  * messages.
  */
-CURL_EXTERN const char *curl_url_strerror(CURLUcode);
+CURL_EXTERN const char *curl_url_strerror(CURLUcode error);
 
 #ifdef __cplusplus
 } /* end of extern "C" */

--- a/lib/curl_addrinfo.h
+++ b/lib/curl_addrinfo.h
@@ -72,7 +72,8 @@ struct Curl_addrinfo *Curl_he2ai(const struct hostent *he, int port);
 #endif
 
 bool Curl_is_ipaddr(const char *address);
-CURLcode Curl_str2addr(const char *dotted, int port, struct Curl_addrinfo **);
+CURLcode Curl_str2addr(const char *dotted, int port,
+                       struct Curl_addrinfo **addrp);
 
 #ifdef USE_UNIX_SOCKETS
 struct Curl_addrinfo *Curl_unix2addr(const char *path, bool *longpath,

--- a/lib/curl_share.h
+++ b/lib/curl_share.h
@@ -65,9 +65,9 @@ struct Curl_share {
 #endif
 };
 
-CURLSHcode Curl_share_lock(struct Curl_easy *, curl_lock_data,
-                           curl_lock_access);
-CURLSHcode Curl_share_unlock(struct Curl_easy *, curl_lock_data);
+CURLSHcode Curl_share_lock(struct Curl_easy *data, curl_lock_data type,
+                           curl_lock_access accesstype);
+CURLSHcode Curl_share_unlock(struct Curl_easy *data, curl_lock_data type);
 
 /* convenience macro to check if this handle is using a shared SSL spool */
 #define CURL_SHARE_ssl_scache(data) ((data)->share &&                    \

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -47,7 +47,7 @@ struct FormInfo {
 };
 
 CURLcode Curl_getformdata(CURL *data,
-                          curl_mimepart *,
+                          curl_mimepart *finalform,
                           struct curl_httppost *post,
                           curl_read_callback fread_func);
 #endif /* CURL_DISABLE_FORM_API */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -85,7 +85,7 @@ void *Curl_hash_add(struct Curl_hash *h, void *key, size_t key_len, void *p);
 void *Curl_hash_add2(struct Curl_hash *h, void *key, size_t key_len, void *p,
                      Curl_hash_elem_dtor dtor);
 int Curl_hash_delete(struct Curl_hash *h, void *key, size_t key_len);
-void *Curl_hash_pick(struct Curl_hash *, void *key, size_t key_len);
+void *Curl_hash_pick(struct Curl_hash *h, void *key, size_t key_len);
 
 void Curl_hash_destroy(struct Curl_hash *h);
 size_t Curl_hash_count(struct Curl_hash *h);

--- a/lib/http.h
+++ b/lib/http.h
@@ -100,13 +100,14 @@ CURLcode Curl_dynhds_add_custom(struct Curl_easy *data, bool is_connect,
 void Curl_http_to_fold(struct dynbuf *bf);
 
 void Curl_http_method(struct Curl_easy *data,
-                      const char **method, Curl_HttpReq *);
+                      const char **method, Curl_HttpReq *reqp);
 
 /* protocol-specific functions set up to be called by the main engine */
 CURLcode Curl_http_setup_conn(struct Curl_easy *data,
                               struct connectdata *conn);
 CURLcode Curl_http(struct Curl_easy *data, bool *done);
-CURLcode Curl_http_done(struct Curl_easy *data, CURLcode, bool premature);
+CURLcode Curl_http_done(struct Curl_easy *data,
+                        CURLcode status, bool premature);
 CURLcode Curl_http_doing_pollset(struct Curl_easy *data,
                                  struct easy_pollset *ps);
 CURLcode Curl_http_perform_pollset(struct Curl_easy *data,

--- a/lib/llist.h
+++ b/lib/llist.h
@@ -50,13 +50,13 @@ struct Curl_llist_node {
 #endif
 };
 
-void Curl_llist_init(struct Curl_llist *, Curl_llist_dtor);
-void Curl_llist_insert_next(struct Curl_llist *, struct Curl_llist_node *,
-                            const void *, struct Curl_llist_node *ne);
-void Curl_llist_append(struct Curl_llist *, const void *,
+void Curl_llist_init(struct Curl_llist *l, Curl_llist_dtor dtor);
+void Curl_llist_insert_next(struct Curl_llist *list, struct Curl_llist_node *e,
+                            const void *p, struct Curl_llist_node *ne);
+void Curl_llist_append(struct Curl_llist *list, const void *p,
                        struct Curl_llist_node *ne);
-void Curl_node_remove(struct Curl_llist_node *);
-void Curl_llist_destroy(struct Curl_llist *, void *);
+void Curl_node_remove(struct Curl_llist_node *e);
+void Curl_llist_destroy(struct Curl_llist *list, void *user);
 
 /* Curl_llist_head() returns the first 'struct Curl_llist_node *', which
    might be NULL */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -27,7 +27,7 @@
  * Prototypes for library-wide functions provided by multi.c
  */
 
-void Curl_expire(struct Curl_easy *data, timediff_t milli, expire_id);
+void Curl_expire(struct Curl_easy *data, timediff_t milli, expire_id id);
 void Curl_expire_ex(struct Curl_easy *data,
                     timediff_t milli, expire_id id);
 void Curl_expire_clear(struct Curl_easy *data);

--- a/src/slist_wc.h
+++ b/src/slist_wc.h
@@ -41,7 +41,7 @@ struct slist_wc {
  * Appends a string to a linked list. If no list exists, it will be created
  * first. Returns the new list, after appending.
  */
-struct slist_wc *slist_wc_append(struct slist_wc *, const char *);
+struct slist_wc *slist_wc_append(struct slist_wc *list, const char *data);
 
 /*
  * NAME curl_slist_free_all()
@@ -50,7 +50,7 @@ struct slist_wc *slist_wc_append(struct slist_wc *, const char *);
  *
  * free a previously built curl_slist_wc.
  */
-void slist_wc_free_all(struct slist_wc *);
+void slist_wc_free_all(struct slist_wc *list);
 
 #endif /* CURL_DISABLE_LIBCURL_OPTION */
 


### PR DESCRIPTION
Detected by `readability-named-parameter` with `HeaderFilterRegex: '.*'`,
or `CURL_CLANG_TIDYFLAGS='--header-filter=.*'`.

Follow-up to c878160e9c1f7366e64299aa02540d5495c3df9c #20624

---

- [x] one change (I could spot) in `lib/curl_addrinfo.h` conflicts with the stacked set of PRs by Stefan. → acked.
