### PR TITLE
tests/server: silence clang-tidy warning

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -659,7 +659,14 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
   int error;
   char errbuf[STRERROR_LEN];
   int rc;
-  size_t len = strlen(unix_socket);
+  size_t len;
+
+  if(!unix_socket) {
+    logmsg("Unix socket domain path not specified.");
+    return -1;
+  }
+
+  len = strlen(unix_socket);
 
   memset(sau, 0, sizeof(struct sockaddr_un));
   sau->sun_family = AF_UNIX;


### PR DESCRIPTION
It looks like a case that can never happen in practice.

Seen on mingw-w64 with experimental concatenated (vs. #included) test
sources:
```
tests/server/util.c:662:16: error: Null pointer passed as 1st
 argument to string length function [clang-analyzer-unix.cstring.NullArg]
  662 |   size_t len = strlen(unix_socket);
      |                ^
```
Ref: https://github.com/curl/curl/actions/runs/22267482855/job/64416261156#step:10:273
