### PR TITLE
cmake: always build curlu and curltool test libs in unity mode

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ if(CURL_BUILD_TESTING)
   target_link_libraries(curlu PUBLIC ${CURL_LIBS})
   # There is plenty of parallelism when building the testdeps target.
   # Override the curlu batch size with the maximum to optimize performance.
-  set_target_properties(curlu PROPERTIES UNITY_BUILD_BATCH_SIZE 0 C_CLANG_TIDY "")
+  set_target_properties(curlu PROPERTIES UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 0 C_CLANG_TIDY "")
 
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/unitprotos.h"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,7 +116,7 @@ set_target_properties(curlinfo PROPERTIES UNITY_BUILD OFF)
 add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_lib} ${_curlx_hfiles_lib})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PUBLIC ${CURL_LIBS})
-set_target_properties(curltool PROPERTIES C_CLANG_TIDY "")
+set_target_properties(curltool PROPERTIES UNITY_BUILD ON C_CLANG_TIDY "")
 
 if(CURL_HAS_LTO)
   set_target_properties(${EXE_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)


### PR DESCRIPTION
To speed up building/running tests by default (e.g. via `testdeps` or 
`tests` targets.)

It reduces build commands to 21 (from 239) for a test build.

In CI, it affects build test step times as below:
- GHA/linux: aws-lc
  12s https://github.com/curl/curl/actions/runs/22279958343/job/64448913413 →
  6s https://github.com/curl/curl/actions/runs/22282767915/job/64455970302
- GHA/linux: Fil-C
  39s https://github.com/curl/curl/actions/runs/22279958343/job/64448913430 →
  37s https://github.com/curl/curl/actions/runs/22282767915/job/64455970352
- GHA/non-native: FreeBSD Intel
  22s https://github.com/curl/curl/actions/runs/22279958335/job/64448913514 →
  15s https://github.com/curl/curl/actions/runs/22282767899/job/64455969960
- GHA/windows: dl-mingw 6.4.0
  23s https://github.com/curl/curl/actions/runs/22279958334/job/64448917225 →
  9s https://github.com/curl/curl/actions/runs/22282767922/job/64455975006

Follow-up to fff9905bcf7c8c1da1668213d79473865461048f #20670
