### PR TITLE
GHA/non-native: enable FreeBSD on arm again

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -135,8 +135,8 @@ jobs:
         include:
           - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
           - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
-          # - { build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
-          # - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
+          - { build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
+          - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Upstream package install is working again.

Follow-up to 41a6eeadf6de719caf414c3520e912db989a6d43 #20267
