### PR TITLE
curl/curl.h: revert to recursive macros to keep supporting C++ use-case

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -161,7 +161,7 @@ if(PICKY_COMPILER)
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 3.1)
         list(APPEND _picky_enable
           -Wno-covered-switch-default      # clang  3.1            appleclang  3.1  # Annoying to fix or silence
-          -Wno-disabled-macro-expansion    # clang  3.1            appleclang  3.1  # Triggered by standard headers
+          -Wno-disabled-macro-expansion    # clang  3.1            appleclang  3.1  # Triggered by curl/curl.h, standard headers
         )
         if(MSVC)
           list(APPEND _picky_enable

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -3329,15 +3329,16 @@ CURL_EXTERN CURLcode curl_easy_ssls_export(CURL *handle,
 #if defined(__STDC__) && (__STDC__ >= 1)
 /* This preprocessor magic that replaces a call with the exact same call is
    only done to make sure application authors pass exactly three arguments
-   to these functions. */
+   to these functions. Use recursive macros to allow reusing these symbols
+   as C++ method names. */
 #define curl_easy_setopt(handle, opt, param) \
-  (curl_easy_setopt)(handle, opt, param)
+  curl_easy_setopt(handle, opt, param)
 #define curl_easy_getinfo(handle, info, arg) \
-  (curl_easy_getinfo)(handle, info, arg)
+  curl_easy_getinfo(handle, info, arg)
 #define curl_share_setopt(share, opt, param) \
-  (curl_share_setopt)(share, opt, param)
-#define curl_multi_setopt(handle,opt,param) \
-  (curl_multi_setopt)(handle, opt, param)
+  curl_share_setopt(share, opt, param)
+#define curl_multi_setopt(handle, opt, param) \
+  curl_multi_setopt(handle, opt, param)
 #endif /* __STDC__ >= 1 */
 #endif /* gcc >= 4.3 && !__cplusplus && !CURL_DISABLE_TYPECHECK */
 

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -868,7 +868,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           if test "$compiler_num" -ge "301"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [format-non-iso])
             tmp_CFLAGS="$tmp_CFLAGS -Wno-covered-switch-default"    # Annoying to fix or silence
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-disabled-macro-expansion"  # Triggered by standard headers
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-disabled-macro-expansion"  # Triggered by curl/curl.h, standard headers
           fi
           #
           dnl Only clang 3.2 or later


### PR DESCRIPTION
To avoid breaking 3rd-party code reusing these symbols as C++ methods,
e.g. in CMake sources:
```
cmake/src/v4.0.0-b30653ae0c.clean/Source/cmCurl.cxx:119:24: error: expected unqualified-id
  119 |     ::CURLcode res = ::curl_easy_setopt(curl, CURLOPT_CAINFO, cafile.c_str());
      |                        ^
```

Also expand comment to highlight the case.

Reported-by: Kai Pastor
Bug: https://github.com/curl/curl/commit/daa6b27b4d998d62c8198b4fe167199cc7bf0064#r177869049
Reported-by: Marcel Raad
Bug: https://curl.se/mail/lib-2026-02/0020.html
Fixes #20682
Follow-up to daa6b27b4d998d62c8198b4fe167199cc7bf0064 #20597
