### PR TITLE
clang-tidy: add arg names to prototypes where missing (cont.)

### DIFF
--- a/lib/curlx/inet_pton.h
+++ b/lib/curlx/inet_pton.h
@@ -43,7 +43,7 @@
   inet_pton(x, y, z)
 #endif
 #else
-int curlx_inet_pton(int, const char *, void *);
+int curlx_inet_pton(int af, const char *src, void *dst);
 #endif /* HAVE_INET_PTON */
 
 #endif /* HEADER_CURL_INET_PTON_H */


### PR DESCRIPTION
Detected by `readability-named-parameter` with `HeaderFilterRegex: '.*'`,
or `CURL_CLANG_TIDYFLAGS='--header-filter=.*'`. Seen on Windows.

Follow-up to e8415ad3c7ab69a7056daa4b39e7a0044c43f5ba #20657
Follow-up to c878160e9c1f7366e64299aa02540d5495c3df9c #20624
