### PR TITLE
fix(parallel): prevent deadlock and progress double-count on retry

### DIFF
--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -315,3 +315,26 @@ void progress_finalize(struct per_transfer *per)
     per->ultotal_added = TRUE;
   }
 }
+
+/*
+ * Reset progress accounting for a transfer that will be retried. Undo the
+ * effects of progress_meter() having already counted this transfer's totals
+ * so the retry does not double-count.
+ */
+void progress_reset_retry(struct per_transfer *per)
+{
+  if(per->dltotal_added) {
+    if(all_dltotal >= per->dltotal)
+      all_dltotal -= per->dltotal;
+    per->dltotal_added = FALSE;
+  }
+  if(per->ultotal_added) {
+    if(all_ultotal >= per->ultotal)
+      all_ultotal -= per->ultotal;
+    per->ultotal_added = FALSE;
+  }
+  per->dlnow = 0;
+  per->ulnow = 0;
+  per->dltotal = 0;
+  per->ultotal = 0;
+}

--- a/src/tool_progress.h
+++ b/src/tool_progress.h
@@ -36,6 +36,7 @@ bool progress_meter(CURLM *multi,
                     bool final);
 struct per_transfer;
 void progress_finalize(struct per_transfer *per);
+void progress_reset_retry(struct per_transfer *per);
 
 #ifdef UNITTESTS
 UNITTEST char *max5data(curl_off_t bytes, char *max5, size_t mlen);


### PR DESCRIPTION
Fixes #20669

Hi all,
I spent some time reproducing and investigating this issue locally, and I believe I've found the root causes and implemented a non-blocking fix.

### Reproduction
Confirmed the behavior described: `--retry N --retry-delay D --retry-all-errors --parallel` with a server returning HTTP 401 causes curl to either retry immediately (ignoring the delay) or hang indefinitely, with the parallel progress meter jumping to 200%.

### Root Cause 1 — Sleeping retries are never re-added to the multi handle
When a transfer completes and is marked for retry, `check_finished()` correctly computes the delay and sets `ended->startat = time(NULL) + delay / 1000`. It then marks `ended->added = FALSE` so `add_parallel_transfers()` will pick it up again once the delay elapses.
The problem is that `add_parallel_transfers()` is only reachable through the `mnotify(CURLMNOTIFY_INFO_READ)` → `check_finished()` callback chain, which requires a transfer completion event to fire. Once the last active handle finishes and only the sleeping retry remains, `still_running` drops to 0. `curl_multi_perform` has nothing to do, `mnotify` never fires, and `add_parallel_transfers` is never called again. The sleeping transfer is stuck.

### Root Cause 2 — Progress meter double-counts retried transfers
In `check_finished()`, `progress_finalize()` is called unconditionally — even when the transfer will be retried. This function moves `per->dlnow` into the static `all_dlalready` accumulator and marks `per->dltotal_added = TRUE`.
When the retry starts, the new in-progress bytes are summed with the old completed bytes, causing the percentage to reach ~200%.

### Proposed Solution
1. **For the deadlock:** I added a guarded call to `add_parallel_transfers()` directly in the `parallel_transfers()` main loop. This runs at most once per `curl_multi_poll` cycle, is completely non-blocking, and only activates when no handles are in-flight (`!s->still_running`). The existing `per->startat` check inside `add_parallel_transfers` naturally respects the retry delay.
2. **For the progress meter:** I moved `progress_finalize()` into the non-retry branch only. For the retry branch, I added a `progress_reset_retry()` function to undo any totals that `progress_meter()` already accumulated.

I've tested this locally (built with CMake) and it resolves both the ignored retry-delay and the 200% progress bar, with no regressions on normal parallel transfers. 

@bagder — I am submitting this PR for your review. I would appreciate your feedback on whether this placement of `add_parallel_transfers` aligns with your design intent for the multi-interface flow. I am completely open to making any adjustments required!