### PR TITLE
docs: use dot instead of comma at end of sentences

### DIFF
--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -48,7 +48,7 @@ By submitting a patch to the curl project, you are assumed to have the right
 to the code and to be allowed by your employer or whatever to hand over that
 patch/code to us. We credit you for your changes as far as possible, to give
 credit but also to keep a trace back to who made what changes. Please always
-provide us with your full real name when contributing,
+provide us with your full real name when contributing.
 
 ## What To Read
 

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -47,7 +47,7 @@ Subject Alternate Name field in the certificate matches the hostname in the
 URL to which you told curl to connect.
 
 When the *verify* value is 0, the connection succeeds regardless of the names
-in the certificate. Use that ability with caution,
+in the certificate. Use that ability with caution.
 
 This option controls checking the server's certificate's claimed identity. The
 separate CURLOPT_SSL_VERIFYPEER(3) options enables/disables verification that


### PR DESCRIPTION
Some sentences incorrectly ended with a command instead of a dot.

---

Found this while reading the docs for `CURLOPT_SSL_VERIFYHOST.md`. It's very nit-picky, but thought it was worth fixing anyway.