### PR TITLE
MANPAGE.md: clarify that building curl makes the man page too

### DIFF
--- a/docs/cmdline-opts/MANPAGE.md
+++ b/docs/cmdline-opts/MANPAGE.md
@@ -109,7 +109,7 @@ fresh version of the man page. Both cmake and configure builds invoke
 *managen* automatically.
 
 Only if you need something custom and special you need to care about invoking
-the managen tool manually, but then you use it like this:
+the *managen* tool manually, but then you use it like this:
 
 `managen mainpage [list of markdown option file names]`
 


### PR DESCRIPTION
Bonus: fix two mistakes on the file exension used.

Fixes #20699
Reported-by: sammydono on github