### PR TITLE
setopt: refuse blobs with zero length

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -107,7 +107,7 @@ CURLcode Curl_setblobopt(struct curl_blob **blobp,
 
   if(blob) {
     struct curl_blob *nblob;
-    if(blob->len > CURL_MAX_INPUT_LENGTH)
+    if(!blob->len || (blob->len > CURL_MAX_INPUT_LENGTH))
       return CURLE_BAD_FUNCTION_ARGUMENT;
     nblob = (struct curl_blob *)
       curlx_malloc(sizeof(struct curl_blob) +


### PR DESCRIPTION
A blob must have a length or it will not be accepted. By enforcing the check here, TLS backend code can rely on the fact that the length is always non-zero from this point.

Reported-by: aisle-research-bot
URL: https://github.com/curl/curl/pull/20689#pullrequestreview-3846390367