### PR TITLE
build: enable `-Wjump-misses-init` for clang 21+

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -255,6 +255,7 @@ if(PICKY_COMPILER)
         list(APPEND _picky_enable
           -Warray-compare                  # clang 20.1  gcc 12.0  appleclang ?
           -Wc++-hidden-decl                # clang 21.1            appleclang ?
+          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang ?
           -Wno-implicit-void-ptr-cast      # clang 21.1            appleclang ?
           -Wtentative-definition-compat    # clang 21.1            appleclang ?
         )
@@ -283,7 +284,7 @@ if(PICKY_COMPILER)
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.5)
         list(APPEND _picky_enable
-          -Wjump-misses-init               #             gcc  4.5
+          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang ?
         )
         if(MINGW)
           list(APPEND _picky_enable

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -951,6 +951,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl clang 21 or later
           if test "$compiler_num" -ge "2101"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c++-hidden-decl])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [jump-misses-init])
             tmp_CFLAGS="$tmp_CFLAGS -Wno-implicit-void-ptr-cast"
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [tentative-definition-compat])
             if test "$curl_cv_native_windows" = "yes"; then


### PR DESCRIPTION
Refs:
https://github.com/llvm/llvm-project/commit/543f112e148a81de290d099f10784dc3ff698aa4
https://github.com/llvm/llvm-project/commit/43c05d97389d479f78ca18b5d7957f51cb4022fd

Follow-up to db4d617c1cfbe74e010183a3595642434f55ea00 #16252
