### PR TITLE
build: map Apple clang 26.4+ to llvm/clang 21.1

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -251,21 +251,22 @@ if(PICKY_COMPILER)
           -Wno-format-signedness           # clang 19.1  gcc  5.1  appleclang 17.0  # In clang-cl enums are signed ints by default
         )
       endif()
-      if(CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 21.1)
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 21.1) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 26.4))
         list(APPEND _picky_enable
-          -Warray-compare                  # clang 20.1  gcc 12.0  appleclang ?
-          -Wc++-hidden-decl                # clang 21.1            appleclang ?
-          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang ?
-          -Wno-implicit-void-ptr-cast      # clang 21.1            appleclang ?
-          -Wtentative-definition-compat    # clang 21.1            appleclang ?
+          -Warray-compare                  # clang 20.1  gcc 12.0  appleclang 26.4
+          -Wc++-hidden-decl                # clang 21.1            appleclang 26.4
+          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang 26.4
+          -Wno-implicit-void-ptr-cast      # clang 21.1            appleclang 26.4
+          -Wtentative-definition-compat    # clang 21.1            appleclang 26.4
         )
         if(WIN32)
           list(APPEND _picky_enable
-            -Wno-c++-keyword               # clang 21.1            appleclang ?  # `wchar_t` triggers it on Windows
+            -Wno-c++-keyword               # clang 21.1            appleclang 26.4  # `wchar_t` triggers it on Windows
           )
         else()
           list(APPEND _picky_enable
-            -Wc++-keyword                  # clang 21.1            appleclang ?
+            -Wc++-keyword                  # clang 21.1            appleclang 26.4
           )
         endif()
       endif()
@@ -284,7 +285,7 @@ if(PICKY_COMPILER)
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.5)
         list(APPEND _picky_enable
-          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang ?
+          -Wjump-misses-init               # clang 21.1  gcc  4.5  appleclang 26.4
         )
         if(MINGW)
           list(APPEND _picky_enable
@@ -332,7 +333,7 @@ if(PICKY_COMPILER)
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
         list(APPEND _picky_enable
-          -Warray-compare                  # clang 20.0  gcc 12.0  appleclang ?
+          -Warray-compare                  # clang 20.1  gcc 12.0  appleclang 26.4
           -Wenum-int-mismatch              #             gcc 13.0
           -Wxor-used-as-pow                # clang 10.0  gcc 13.0  appleclang 12.0
         )

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -120,7 +120,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
     compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
     if test "$appleclang" = "1" && test "$oldapple" = "0"; then
       dnl Starting with Xcode 7 / clang 3.7, Apple clang does not tell its upstream version
-      if   test "$compiler_num" -ge '1700'; then compiler_num='1901'
+      if   test "$compiler_num" -ge '2604'; then compiler_num='2101'
+      elif test "$compiler_num" -ge '1700'; then compiler_num='1901'
       elif test "$compiler_num" -ge '1600'; then compiler_num='1700'
       elif test "$compiler_num" -ge '1500'; then compiler_num='1600'
       elif test "$compiler_num" -ge '1400'; then compiler_num='1400'


### PR DESCRIPTION
Ref: https://en.wikipedia.org/wiki/Xcode#Xcode_26.0_(since_version_number_change)_2

---

- [x] rebase on #20716
