### PR TITLE
docs: fix bad practice in --follow example

### DIFF
--- a/docs/cmdline-opts/follow.md
+++ b/docs/cmdline-opts/follow.md
@@ -13,7 +13,8 @@ See-also:
   - proto-redir
   - max-redirs
 Example:
-  - -X POST --follow $URL
+  - -X DELETE --follow $URL
+  - --follow $URL
 ---
 
 # `--follow`


### PR DESCRIPTION
Fixes #20715
Replaces the `-X POST --follow` example with better alternatives (`--follow` alone, and `-d "payload" --follow`). 