### PR TITLE
clang-tidy: enable scanning headers

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -42,3 +42,5 @@ Checks:
 
 CheckOptions:
   misc-header-include-cycle.IgnoredFilesList: 'curl/curl.h'
+
+HeaderFilterRegex: '.*'


### PR DESCRIPTION
By setting `HeaderFilterRegex: '.*'`.
