### PR TITLE
GHA/linux: switch clang-tidy job to cmake for 2x speed, bump to v20, enable for tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -275,35 +275,7 @@ jobs:
               -DCURL_ZLIB=OFF -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF
               -DCURL_DISABLE_LDAP=ON -DUSE_LIBIDN2=OFF -DCURL_USE_LIBSSH2=OFF
 
-          - name: 'clang-tidy CMAKE 19'
-            install_packages: clang-19 clang-tidy-19 libssl-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev libkrb5-dev librtmp-dev libgnutls28-dev
-            install_steps: skiprun mbedtls-latest-intel rustls wolfssl-opensslextra-intel
-            install_steps_brew: gsasl
-            make-custom-target: tidy
-            CC: clang-19
-            LDFLAGS: -Wl,-rpath,/home/runner/wolfssl-opensslextra/lib -Wl,-rpath,/home/runner/mbedtls/lib -Wl,-rpath,/home/runner/rustls/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/gsasl/lib
-            PKG_CONFIG_PATH: /home/runner/wolfssl-opensslextra/lib/pkgconfig:/home/runner/mbedtls/lib/pkgconfig:/home/runner/rustls/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/gsasl/lib/pkgconfig
-            generate: >-
-              -DCURL_USE_OPENSSL=ON -DCURL_USE_WOLFSSL=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_RUSTLS=ON
-              -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON
-              -DUSE_ECH=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON
-              -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-19
-
-          - name: 'clang-tidy CMAKE 19 CONCAT'
-            install_packages: clang-19 clang-tidy-19 libssl-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev libkrb5-dev librtmp-dev libgnutls28-dev
-            install_steps: skiprun mbedtls-latest-intel rustls wolfssl-opensslextra-intel
-            install_steps_brew: gsasl
-            make-custom-target: tidy
-            CC: clang-19
-            LDFLAGS: -Wl,-rpath,/home/runner/wolfssl-opensslextra/lib -Wl,-rpath,/home/runner/mbedtls/lib -Wl,-rpath,/home/runner/rustls/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/gsasl/lib
-            PKG_CONFIG_PATH: /home/runner/wolfssl-opensslextra/lib/pkgconfig:/home/runner/mbedtls/lib/pkgconfig:/home/runner/rustls/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/gsasl/lib/pkgconfig
-            generate: >-
-              -DCURL_USE_OPENSSL=ON -DCURL_USE_WOLFSSL=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_RUSTLS=ON
-              -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON
-              -DUSE_ECH=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON
-              -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-19 -D_CURL_TESTS_CONCAT=ON
-
-          - name: 'clang-tidy CMAKE 20'
+          - name: 'clang-tidy'
             install_packages: clang-20 clang-tidy-20 libssl-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev libkrb5-dev librtmp-dev libgnutls28-dev
             install_steps: skiprun mbedtls-latest-intel rustls wolfssl-opensslextra-intel
             install_steps_brew: gsasl
@@ -316,20 +288,6 @@ jobs:
               -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON
               -DUSE_ECH=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-20
-
-          - name: 'clang-tidy CMAKE 20 CONCAT'
-            install_packages: clang-20 clang-tidy-20 libssl-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev libkrb5-dev librtmp-dev libgnutls28-dev
-            install_steps: skiprun mbedtls-latest-intel rustls wolfssl-opensslextra-intel
-            install_steps_brew: gsasl
-            make-custom-target: tidy
-            CC: clang-20
-            LDFLAGS: -Wl,-rpath,/home/runner/wolfssl-opensslextra/lib -Wl,-rpath,/home/runner/mbedtls/lib -Wl,-rpath,/home/runner/rustls/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/gsasl/lib
-            PKG_CONFIG_PATH: /home/runner/wolfssl-opensslextra/lib/pkgconfig:/home/runner/mbedtls/lib/pkgconfig:/home/runner/rustls/lib/pkgconfig:/home/linuxbrew/.linuxbrew/opt/gsasl/lib/pkgconfig
-            generate: >-
-              -DCURL_USE_OPENSSL=ON -DCURL_USE_WOLFSSL=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_RUSTLS=ON
-              -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON
-              -DUSE_ECH=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON
-              -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-20 -D_CURL_TESTS_CONCAT=ON
 
           - name: 'scan-build'
             install_packages: clang-tools clang libssl-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev libgss-dev librtmp-dev libgnutls28-dev


### PR DESCRIPTION
Checking lib and src under 3m15s versus 7m15s.

Downside: autotools clang-tidy support is no longer CI-tested.

The reason for the slowness is invoking a single clang-tidy command with
all source files, and clang-tidy checking them in a single thread,
sequentially. clang-tidy offers a `run-clang-tidy` Python script for 
parallel  processing, which may help with this. However at this point
it's more practical to use cmake, which also supports verifying the
whole codebase, not only lib and src.

Also:
- bump clang-tidy to the latest available, v20 (from v18).
- enable running clang-tidy on tests. Takes under 2 minutes.

Also tried `_CURL_TESTS_CONCAT=ON`, it brings down the build tests step
from 1m47s to 54s, saving 1 minute. Skipped using it for now.

---

Before: https://github.com/curl/curl/actions/runs/22417013270/job/64905162776?pr=20725
After: https://github.com/curl/curl/actions/runs/22417013270/job/64905162796?pr=20725

- [x] rebase on the fix that moves away wolfSSL headers from curl_setup.h. #20726
