### PR TITLE
tests/server: fix to clear the complete `srvr_sockaddr_union_t` variable

### DIFF
--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -531,6 +531,7 @@ static int test_dnsd(int argc, const char **argv)
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
     srvr_sockaddr_union_t localaddr;
+    memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
     if(!use_ipv6)
 #endif
@@ -539,7 +540,6 @@ static int test_dnsd(int argc, const char **argv)
     else
       la_size = sizeof(localaddr.sa6);
 #endif
-    memset(&localaddr.sa, 0, (size_t)la_size);
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1162,6 +1162,7 @@ static int test_rtspd(int argc, const char *argv[])
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
     srvr_sockaddr_union_t localaddr;
+    memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
     if(!use_ipv6)
 #endif
@@ -1170,7 +1171,6 @@ static int test_rtspd(int argc, const char *argv[])
     else
       la_size = sizeof(localaddr.sa6);
 #endif
-    memset(&localaddr.sa, 0, (size_t)la_size);
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2214,6 +2214,7 @@ static int test_sws(int argc, const char *argv[])
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
     srvr_sockaddr_union_t localaddr;
+    memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
     if(socket_domain != AF_INET6)
 #endif
@@ -2222,7 +2223,6 @@ static int test_sws(int argc, const char *argv[])
     else
       la_size = sizeof(localaddr.sa6);
 #endif
-    memset(&localaddr.sa, 0, (size_t)la_size);
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1167,6 +1167,7 @@ static int test_tftpd(int argc, const char **argv)
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
     srvr_sockaddr_union_t localaddr;
+    memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
     if(!use_ipv6)
 #endif
@@ -1175,7 +1176,6 @@ static int test_tftpd(int argc, const char **argv)
     else
       la_size = sizeof(localaddr.sa6);
 #endif
-    memset(&localaddr.sa, 0, (size_t)la_size);
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -841,13 +841,13 @@ curl_socket_t sockdaemon(curl_socket_t sock,
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
     srvr_sockaddr_union_t localaddr;
+    memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
     if(socket_domain == AF_INET6)
       la_size = sizeof(localaddr.sa6);
     else
 #endif
       la_size = sizeof(localaddr.sa4);
-    memset(&localaddr.sa, 0, (size_t)la_size);
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       error = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",


### PR DESCRIPTION
Reported by clang-tidy (seen on Linux with v18, v19, v20, not on macOS):
```
tests/server/dnsd.c:552:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/dnsd.c:556:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/rtspd.c:1183:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/rtspd.c:1187:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/sws.c:2235:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/sws.c:2239:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/tftpd.c:1188:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/tftpd.c:1192:14: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/util.c:860:21: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
tests/server/util.c:864:21: error: 1st function call argument is an uninitialized value [clang-analyzer-core.CallAndMessage]
```
Ref: https://github.com/curl/curl/actions/runs/22424827575/job/64930560425?pr=20725

Cherry-picked from #20725
