### PR TITLE
unit3205: suppress two clang-tidy false positives

### DIFF
--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -562,10 +562,12 @@ static CURLcode test_unit3205(const char *arg)
     if(test->id >= 0x0011 && test->id < 0x0017) {
       if(expect && memcmp(expect, "EDH-", 4) == 0) {
         curlx_strcopy(alt, sizeof(alt), expect, strlen(expect));
+        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
         expect = (const char *)memcpy(alt, "DHE-", 4);
       }
       if(expect && memcmp(expect + 4, "EDH-", 4) == 0) {
         curlx_strcopy(alt, sizeof(alt), expect, strlen(expect));
+        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
         expect = (const char *)memcpy(alt + 4, "DHE-", 4) - 4;
       }
     }


### PR DESCRIPTION
Silencing:
```
tests/unit/unit3205.c:565:32: error: the result from calling 'memcpy' is not null-terminated [bugprone-not-null-terminated-result]
  565 |         expect = (const char *)memcpy(alt, "DHE-", 4);
      |                                ^~~~~~            ~~~
      |                                strcpy
tests/unit/unit3205.c:569:32: error: the result from calling 'memcpy' is not null-terminated [bugprone-not-null-terminated-result]
  569 |         expect = (const char *)memcpy(alt + 4, "DHE-", 4) - 4;
      |                                ^~~~~~                ~~~
      |                                strcpy
```
Ref: https://github.com/curl/curl/actions/runs/22425366818/job/64932197466?pr=20725

Cherry-picked from #20725