### PR TITLE
openssl channel_binding: lookup digest algorithm without NID

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5260,9 +5260,7 @@ static CURLcode ossl_get_channel_binding(struct Curl_easy *data,
                                          struct dynbuf *binding)
 {
   X509 *cert;
-  int mdnid, pknid, secbits;
-  uint32_t flags;
-  EVP_PKEY *pkey = NULL;
+  int mdnid;
   bool no_digest_acceptable = FALSE;
   const EVP_MD *algo_type = NULL;
   const char *algo_name = NULL;
@@ -5298,48 +5296,51 @@ static CURLcode ossl_get_channel_binding(struct Curl_easy *data,
     return CURLE_OK;
 
 #ifdef HAVE_OPENSSL3
-  pkey = X509_get0_pubkey(cert);
+  {
+    int pknid, secbits;
+    uint32_t flags;
+    EVP_PKEY *pkey = X509_get0_pubkey(cert);
 
-  if(!X509_get_signature_info(cert, &mdnid, &pknid, &secbits, &flags)) {
-    failf(data, "certificate signature algorithm not recognized");
-    result = CURLE_SSL_INVALIDCERTSTATUS;
-    goto out;
-  }
-
-  if(mdnid != NID_undef) {
-    if(mdnid == NID_md5 || mdnid == NID_sha1) {
-      algo_type = EVP_sha256();
+    if(!X509_get_signature_info(cert, &mdnid, &pknid, &secbits, &flags)) {
+      failf(data, "certificate signature algorithm not recognized");
+      result = CURLE_SSL_INVALIDCERTSTATUS;
+      goto out;
     }
-    else
-      algo_type = EVP_get_digestbynid(mdnid);
-  }
-  else if(pkey && !EVP_PKEY_is_a(pkey, OBJ_nid2sn(pknid))) {
-    /* The cert's pkey is different from the algorithm used to sign
-     * the certificate. Since the reported `mdnid` is undefined, there
-     * is no digest algorithm available here. This happens in PQC
-     * and is accepted, resulting in no addition to the binding. */
-    no_digest_acceptable = TRUE;
-  }
-  else if(pkey) {
-    /* cert's pkey type is the same as the cert signer (or same family).
-     * Ask for the mandatory/advisory digest algorithm for the pkey.
-     */
-    char mdname[128] = "";
-    int rc = EVP_PKEY_get_default_digest_name(pkey, mdname, sizeof(mdname));
-    bool md_is_undef = !strcmp(mdname, "UNDEF");
 
-    if(rc == 2 && md_is_undef) {
-      /* OpenSSL declares "undef" the *mandatory* digest for this key.
-       * This is some PQC shit, accept it, no addition to binding. */
+    if(mdnid != NID_undef) {
+      if(mdnid == NID_md5 || mdnid == NID_sha1) {
+        algo_type = EVP_sha256();
+      }
+      else
+        algo_type = EVP_get_digestbynid(mdnid);
+    }
+    else if(pkey && !EVP_PKEY_is_a(pkey, OBJ_nid2sn(pknid))) {
+      /* The cert's pkey is different from the algorithm used to sign
+       * the certificate. Since the reported `mdnid` is undefined, there
+       * is no digest algorithm available here. This happens in PQC
+       * and is accepted, resulting in no addition to the binding. */
       no_digest_acceptable = TRUE;
     }
-    else if(rc > 0 && mdname[0] != '\0' && !md_is_undef) {
-      infof(data, "Digest algorithm : %s%s (derived from public key)"
-            ", but unavailable",
-            mdname, rc == 2 ? " [mandatory]" : " [advisory]");
+    else if(pkey) {
+      /* cert's pkey type is the same as the cert signer (or same family).
+       * Ask for the mandatory/advisory digest algorithm for the pkey.
+       */
+      char mdname[128] = "";
+      int rc = EVP_PKEY_get_default_digest_name(pkey, mdname, sizeof(mdname));
+      bool md_is_undef = !strcmp(mdname, "UNDEF");
+
+      if(rc == 2 && md_is_undef) {
+        /* OpenSSL declares "undef" the *mandatory* digest for this key.
+         * This is some PQC shit, accept it, no addition to binding. */
+        no_digest_acceptable = TRUE;
+      }
+      else if(rc > 0 && mdname[0] != '\0' && !md_is_undef) {
+        infof(data, "Digest algorithm : %s%s (derived from public key)"
+              ", but unavailable",
+              mdname, rc == 2 ? " [mandatory]" : " [advisory]");
+      }
     }
   }
-
 #else /* HAVE_OPENSSL3 */
 
   if(!OBJ_find_sigid_algs(X509_get_signature_nid(cert), &mdnid, NULL)) {


### PR DESCRIPTION
Use an alternate OpenSSL API to get the digest algorithm tied to a certificate signature to compute the channel binding.

Since we have no test infrastructure for this, it is a shot in the dark.

refs  #20590