### PR TITLE
cmake: silence potential unused var warnings in C++ test snippet

### DIFF
--- a/tests/cmake/test.cpp
+++ b/tests/cmake/test.cpp
@@ -27,6 +27,9 @@
 class CurlClass {
 public:
   void curl_multi_setopt(void *a, int b, long c) {
+    (void)a;
+    (void)b;
+    (void)c;
     std::cout << curl_version() << std::endl;
   }
 };


### PR DESCRIPTION
Follow-up to 6ad50dc2859e9ea764aafe51b34d430a663fb1d3 #20687
