### PR TITLE
GHA/macos: bump runner to macos-26 in clang-tidy jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -271,7 +271,7 @@ jobs:
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON -DUSE_APPLE_IDN=ON -DUSE_NGTCP2=ON -DCURL_DISABLE_VERBOSE_STRINGS=ON -DUSE_APPLE_SECTRUST=ON
           - name: 'MultiSSL AppleIDN clang-tidy +examples'
             image: macos-26
-            compiler: llvm
+            compiler: clang
             install: llvm gnutls nettle libressl krb5 mbedtls gsasl rustls-ffi rtmpdump libssh fish
             install_steps: skiprun
             chkprefill: _chkprefill
@@ -286,7 +286,7 @@ jobs:
 
           - name: 'HTTP/3 clang-tidy'
             image: macos-26
-            compiler: llvm
+            compiler: clang
             install: llvm libnghttp3 libngtcp2 openldap krb5
             install_steps: skipall
             generate: >-


### PR DESCRIPTION
Tiny difference in practice:
Apple clang 17.0.0.17000013 → 17.0.0.17000603

To use the most recent tools for static analyses.
