### PR TITLE
GHA/linux: replace scan-build with clang-tidy

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -289,7 +289,7 @@ jobs:
 
           - name: 'clang-tidy H3 c-ares !examples'
             install_packages: clang-20 clang-tidy-20 libidn2-dev libssh-dev libnghttp2-dev
-            install_steps: skipall
+            install_steps: skiprun
             install_steps_brew: openssl libngtcp2 libnghttp3 c-ares
             CC: clang-20
             LDFLAGS: -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libnghttp3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/c-ares/lib


### PR DESCRIPTION
`scan-build` is a (Perl) wrapper around clang's built-in `--analyze`
option. Which look similar or identical to clang-tidy checkers under
the `clang-analyzer-*` namespace:
https://clang.llvm.org/docs/ClangStaticAnalyzer.html

Unless somebody has other information, it appears redundant to run
scan-build in parallel with clang-tidy in CI, now that the latter is
working reliably and with good performance for all curl components.

Another scan-build issue is the lack of a markup to suppress false
positives. It ignores `NOLINT`, yet finds the same false positives as
clang-tidy. This happens with scan-build v20+. v18 is silent, but it's
a blocker to upgrade to a newer version.

scan-build may still be a useful when combined with autotools, where
clang-tidy support is incomplete, slow (no parallelism), and uses
a distinct make target, which does not build binaries in the same pass.
But, scan-build also lacks extra checkers that are now enabled for
clang-tidy.

The clang-tidy job is also 30-40s faster than the one it replaced.

Also:
- drop scan-build job configured the same way as a clang-tidy one.
  CI time saved: 6m30s
- bump to clang-20 (from 18) in the replacement job.
- build tests in the replacement job.
  To verify a cmake command-line reconstruction issue only hit in this
  job in CI.
  CI time cost: 1m40s
- replacement job caught a minor, new, issue.
  Ref: b2076d3c2f5386068d9b0199f25a81147784d8ac #20752
- drop unused scan-build logic.

Bug: https://github.com/curl/curl/pull/20732#issuecomment-3963873838
Ref: https://github.com/curl/curl/pull/20732#issuecomment-3967479228

---

Before: https://github.com/curl/curl/actions/runs/22466648624/job/65074048881
After: https://github.com/curl/curl/actions/runs/22467420456/job/65076579641?pr=20751
