### PR TITLE
http1: fix potential NULL dereference in `Curl_h1_req_parse_read()`

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -268,10 +268,9 @@ CURLcode Curl_h1_req_parse_read(struct h1_req_parser *parser,
   CURLcode result = CURLE_OK;
   size_t nread;
 
-  DEBUGASSERT(buf);
-
   *pnread = 0;
 
+  DEBUGASSERT(buf);
   if(!buf)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 


### PR DESCRIPTION
Reported by clang-tidy v22 with `clang-analyzer-*` explicitly enabled:

```
lib/http1.c:89:31: error: Subtraction of a non-null pointer
 (from variable 'line_end') and a null pointer (via field 'line')
 results in undefined behavior [clang-analyzer-core.NullPointerArithm]
   89 |   parser->line_len = line_end - parser->line + 1;
      |                               ^
```
Ref: https://github.com/curl/curl/actions/runs/22534731241/job/65279952830?pr=20778#step:11:85

Ref: #20778
