### PR TITLE
GHA/linux: tidy up and extend address-sanitizer job options

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -348,12 +348,13 @@ jobs:
             CFLAGS: >-
               -fsanitize=address,bounds,leak,signed-integer-overflow,undefined
               -fno-sanitize-recover=address,bounds,leak,signed-integer-overflow,undefined
+              -fPIC
 
             LDFLAGS: >-
               -fsanitize=address,bounds,leak,signed-integer-overflow,undefined
               -fno-sanitize-recover=address,bounds,leak,signed-integer-overflow,undefined -ldl -lubsan
 
-            generate: -DENABLE_DEBUG=ON -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH=ON
+            generate: -DENABLE_DEBUG=ON -DCURL_USE_LIBSSH=ON
 
           - name: 'address-sanitizer H3 c-ares'
             install_packages: clang-20 libubsan1 libasan8 libtsan2


### PR DESCRIPTION
Also tried `integer` which has hits, but too slow to be practical to run on
every commit.
