### PR TITLE
multi: fix unreachable code compiler warning

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -301,8 +301,10 @@ struct Curl_multi *Curl_multi_handle(uint32_t xfer_table_size,
   }
 #endif
 
+#ifdef USE_IPV6
   if(Curl_probeipv6(multi))
     goto error;
+#endif
 
   return multi;
 


### PR DESCRIPTION
```
lib/multi.c:305:5: error: code will never be executed [clang-diagnostic-unreachable-code]
  305 |     goto error;
      |     ^~~~~~~~~~
```

Cherry-picked from #20774
