### PR TITLE
mbedtls: Guard TLS 1.3 + session tickets usage inside ifdef

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -814,6 +814,7 @@ static CURLcode mbed_configure_ssl(struct Curl_cfilter *cf,
 #endif
 
 #if defined(MBEDTLS_SSL_SESSION_TICKETS) && \
+  defined(MBEDTLS_SSL_PROTO_TLS1_3) &&      \
   MBEDTLS_VERSION_NUMBER >= 0x03060100 &&   \
   MBEDTLS_VERSION_NUMBER < 0x04000000
   /* New in mbedTLS 3.6.1, need to enable, default is now disabled. 4.0.0


### PR DESCRIPTION
If TLS 1.3 is not supported, the call to `mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets()` will fail during compilation:
```
../../curl-8.18.0/lib/vtls/mbedtls.c: In function 'mbed_connect_step1':
../../curl-8.18.0/lib/vtls/mbedtls.c:809:3: error: implicit declaration of function 'mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets' [-Werror=implicit-function-declaration]
   mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets(&backend->config,
   ^
../../curl-8.18.0/lib/vtls/mbedtls.c:809:3: warning: nested extern declaration of 'mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets' [-Wnested-externs]
```

Protect this call inside the `#ifdef` block by making sure that support for TLS 1.3 is defined.