### PR TITLE
cmake: stop disabling C4774 after replacing `snprintf()`, update comment (MSVC)

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -411,7 +411,6 @@ if(PICKY_COMPILER)
     # volatile access of '<expression>' is subject to /volatile:<iso|ms> setting;
     #   consider using __iso_volatile_load/store intrinsic functions (ARM64)
     list(APPEND _picky "-wd4746")
-  # list(APPEND _picky "-wd4774")  # 'snprintf': format string expected in argument 3 is not a string literal
     list(APPEND _picky "-wd4820")  # 'A': 'N' bytes padding added after data member 'B'
     if(MSVC_VERSION GREATER_EQUAL 1900)
       list(APPEND _picky "-wd5045")  # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified


### PR DESCRIPTION
- update comment for `-wd4710` option.
  Ref: https://ci.appveyor.com/project/curlorg/curl/builds/53627545
- stop suppressing C4774. Not triggered by the replacement call
  `vsnprintf()`, as also confirmed by local tests.
  Follow-up to https://github.com/curl/curl/commit/192b9214a7cf9082665ce460617308cb4836850b
  Ref: https://devblogs.microsoft.com/cppblog/format-specifiers-checking/
  Ref: https://learn.microsoft.com/cpp/error-messages/compiler-warnings/compiler-warnings-c4600-through-c4799

Follow-up to 64f28b8f8859fc80816f7db3b5c4b6f2fd84bd27 #20765
