### PR TITLE
config2setopts: restore proper ignoring of CAINFO BLOB option errors

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -308,7 +308,7 @@ static CURLcode ssl_ca_setopts(struct OperationConfig *config, CURL *curl)
     blob.flags = CURL_BLOB_NOCOPY;
     notef("Using embedded CA bundle (%zu bytes)", blob.len);
     result = curl_easy_setopt(curl, CURLOPT_CAINFO_BLOB, &blob);
-    if(result == CURLE_NOT_BUILT_IN) {
+    if((result == CURLE_NOT_BUILT_IN) || (result == CURLE_UNKNOWN_OPTION)) {
       warnf("ignoring %s, not supported by libcurl with %s",
             "embedded CA bundle", ssl_backend());
       result = CURLE_OK;
@@ -321,7 +321,7 @@ static CURLcode ssl_ca_setopts(struct OperationConfig *config, CURL *curl)
     blob.flags = CURL_BLOB_NOCOPY;
     notef("Using embedded CA bundle, for proxies (%zu bytes)", blob.len);
     result = curl_easy_setopt(curl, CURLOPT_PROXY_CAINFO_BLOB, &blob);
-    if(result == CURLE_NOT_BUILT_IN) {
+    if((result == CURLE_NOT_BUILT_IN) || (result == CURLE_UNKNOWN_OPTION)) {
       warnf("ignoring %s, not supported by libcurl with %s",
             "embedded CA bundle", ssl_backend());
       result = CURLE_OK;


### PR DESCRIPTION
A regression from refactors

Spotted by Codex Security