### PR TITLE
usercertinmem: use the correct cert BIO

### DIFF
--- a/docs/examples/usercertinmem.c
+++ b/docs/examples/usercertinmem.c
@@ -108,7 +108,7 @@ static CURLcode sslctx_function(CURL *curl, void *sslctx, void *pointer)
     printf("BIO_new_mem_buf failed\n");
   }
 
-  pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+  pkey = PEM_read_bio_PrivateKey(kbio, NULL, NULL, NULL);
   if(!pkey) {
     printf("Failed EVP_PKEY_new()\n");
   }


### PR DESCRIPTION
PEM_read_bio_PrivateKey() is called with the wrong BIO, so the private key is not loaded.

Follow-up to 8494012196474ee0541

Pointed out by Codex Security