### PR TITLE
tool_doswin: avoid memory-leak with CURL_FN_SANITIZE_*

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -512,10 +512,14 @@ SANITIZEcode sanitize_file_name(char ** const sanitized, const char *file_name,
   }
 
 #ifdef DEBUGBUILD
-  if(getenv("CURL_FN_SANITIZE_BAD"))
+  if(getenv("CURL_FN_SANITIZE_BAD")) {
+    curlx_free(target);
     return SANITIZE_ERR_INVALID_PATH;
-  if(getenv("CURL_FN_SANITIZE_OOM"))
+  }
+  if(getenv("CURL_FN_SANITIZE_OOM")) {
+    curlx_free(target);
     return SANITIZE_ERR_OUT_OF_MEMORY;
+  }
 #endif
 
   *sanitized = target;


### PR DESCRIPTION
This is debug-only code

Follow-up to 20900e4a1e3

Found by Codex Security