### PR TITLE
content_encoding: return 'identity' if none other exists

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -622,6 +622,9 @@ char *Curl_get_content_encodings(void)
         result = curlx_dyn_add(&enc, ce->name);
     }
   }
+  if(!result && !curlx_dyn_len(&enc))
+    result = curlx_dyn_add(&enc, CONTENT_ENCODING_DEFAULT);
+
   if(!result)
     return curlx_dyn_ptr(&enc);
   return NULL;


### PR DESCRIPTION
This fixes a regression and accidental changed behavior shipped in 8.18.0 (via 6b9c75e219cdcfd3e17e78).

When the setopt is set to "" and curl is built without support for a single compression algorithm, it used to use "identity" but recently did not.

Spotted by Codex Security