### PR TITLE
Fix SOCK_CLOEXEC handling to maintain socktype equality checks

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1042,15 +1042,16 @@ static CURLcode set_remote_ip(struct Curl_cfilter *cf,
 
 /* to figure out the type of the socket safely, remove the possibly ORed
    bits before comparing */
-#if defined(SOCK_CLOEXEC) && defined(SOCK_NONBLOCK)
-#define SOCKTYPE(x) ((x) &~ (SOCK_CLOEXEC|SOCK_NONBLOCK))
-#elif defined(SOCK_CLOEXEC)
-#define SOCKTYPE(x) ((x) &~ SOCK_CLOEXEC)
-#elif defined(SOCK_NONBLOCK)
-#define SOCKTYPE(x) ((x) &~ SOCK_NONBLOCK)
-#else
-#define SOCKTYPE(x) (x)
+static int cf_socktype(int x)
+{
+#ifdef SOCK_CLOEXEC
+  x &= ~SOCK_CLOEXEC;
 #endif
+#ifdef SOCK_NONBLOCK
+  x &= ~SOCK_NONBLOCK;
+#endif
+  return x;
+}
 
 static CURLcode cf_socket_open(struct Curl_cfilter *cf,
                                struct Curl_easy *data)
@@ -1107,10 +1108,10 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
 #ifdef USE_IPV6
   is_tcp = (ctx->addr.family == AF_INET ||
             ctx->addr.family == AF_INET6) &&
-    SOCKTYPE(ctx->addr.socktype) == SOCK_STREAM;
+    cf_socktype(ctx->addr.socktype) == SOCK_STREAM;
 #else
   is_tcp = (ctx->addr.family == AF_INET) &&
-    SOCKTYPE(ctx->addr.socktype) == SOCK_STREAM;
+    cf_socktype(ctx->addr.socktype) == SOCK_STREAM;
 #endif
   if(is_tcp && data->set.tcp_nodelay)
     tcpnodelay(cf, data, ctx->sock);
@@ -1175,7 +1176,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
     }
   }
 #endif
-  ctx->sock_connected = (SOCKTYPE(ctx->addr.socktype) != SOCK_DGRAM);
+  ctx->sock_connected = (cf_socktype(ctx->addr.socktype) != SOCK_DGRAM);
 out:
   if(result) {
     if(ctx->sock != CURL_SOCKET_BAD) {


### PR DESCRIPTION
socket_open unconditionally ORs SOCK_CLOEXEC into addr->socktype. The same addr structure is later reused in cf_socket_open, which checks ctx->addr.socktype == SOCK_STREAM to decide whether to enable TCP_NODELAY and TCP keepalive. With SOCK_CLOEXEC set, the equality check fails, so TCP-specific options are skipped and ctx->sock_connected is also computed against SOCK_DGRAM with a mismatching value.

Follow-up to 05367694ecf24a5d39f

Found by Codex Security

/cc @ibookstein 