### PR TITLE
cmake: mark two internal options as advanced

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,6 +604,7 @@ include(CheckTypeSize)
 include(CheckCSourceCompiles)
 
 option(_CURL_PREFILL "Fast-track known feature detection results (Windows, some Apple)" "${WIN32}")
+mark_as_advanced(_CURL_PREFILL)
 if(_CURL_PREFILL)
   if(WIN32)
     include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/win32-cache.cmake")

--- a/tests/certs/CMakeLists.txt
+++ b/tests/certs/CMakeLists.txt
@@ -33,6 +33,7 @@ add_custom_command(OUTPUT ${GENERATEDCERTS}
 add_custom_target(build-certs DEPENDS ${GENERATEDCERTS})
 
 option(_CURL_SKIP_BUILD_CERTS "Skip building certs with testdeps" OFF)  # Internal option to increase perf for build tests
+mark_as_advanced(_CURL_SKIP_BUILD_CERTS)
 if(NOT _CURL_SKIP_BUILD_CERTS)
   add_dependencies(testdeps build-certs)
 endif()


### PR DESCRIPTION
To omit them from CMake GUI option listings.

Follow-up to c37e06c642066b6cbf6b3c58278017ad40820bb3 #17962
Follow-up to 6ab1fa423bcc49a742b1cde2164ff981fdee38e8 #16278
