### PR TITLE
unit3205: drop `NOLINT`

### DIFF
--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -562,13 +562,11 @@ static CURLcode test_unit3205(const char *arg)
     if(test->id >= 0x0011 && test->id < 0x0017) {
       if(expect && memcmp(expect, "EDH-", 4) == 0) {
         curlx_strcopy(alt, sizeof(alt), expect, strlen(expect));
-        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-        expect = (const char *)memcpy(alt, "DHE-", 4);
+        expect = (const char *)memcpy(alt, "DHE-", sizeof("DHE-") - 1);
       }
       if(expect && memcmp(expect + 4, "EDH-", 4) == 0) {
         curlx_strcopy(alt, sizeof(alt), expect, strlen(expect));
-        /* NOLINTNEXTLINE(bugprone-not-null-terminated-result) */
-        expect = (const char *)memcpy(alt + 4, "DHE-", 4) - 4;
+        expect = (const char *)memcpy(alt + 4, "DHE-", sizeof("DHE-") - 1) - 4;
       }
     }
 


### PR DESCRIPTION
In favor of a small code change the silences the clang-tidy warning.

Follow-up to b1f853a3849d0e8116ae4e2aedfb9ca65f92282d #20731