### PR TITLE
openssl+ech: workaround for insecure handshakes

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4348,9 +4348,18 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
       case SSL_ECH_STATUS_BAD_CALL:
         status = "bad call (unexpected)";
         break;
-      case SSL_ECH_STATUS_BAD_NAME:
-        status = "bad name (unexpected)";
+      case SSL_ECH_STATUS_BAD_NAME: {
+        struct ssl_primary_config *conn_config =
+          Curl_ssl_cf_get_primary_config(cf);
+        if(!conn_config->verifypeer && !conn_config->verifyhost &&
+           inner && !strcmp(inner, connssl->peer.hostname)) {
+          status = "bad name (tolerated without peer verification)";
+          rv = SSL_ECH_STATUS_SUCCESS;
+        }
+        else
+          status = "bad name (unexpected)";
         break;
+      }
       default:
         status = "unexpected status";
         infof(data, "ECH: unexpected status %d", rv);


### PR DESCRIPTION
OpenSSL 4.0.0-dev supports ECH with one flaw. If peer verification is not enabled, it will report SSL_ECH_STATUS_BAD_NAME on the ECH status.

Provide a workaround in libcurl that checks the inner name used in ECH was the peer's hostname, both verify peer and host are disabled and then accept the BAD_NAME without failing the connect.

refs #20655