### PR TITLE
build: enable `-Wformat-signedness`, fix issues found

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -250,7 +250,7 @@ if(PICKY_COMPILER)
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 19.1) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0))
         list(APPEND _picky_enable
-          -Wno-format-signedness           # clang 19.1  gcc  5.1  appleclang 17.0  # In clang-cl enums are signed ints by default
+          -Wformat-signedness              # clang 19.1  gcc  5.1  appleclang 17.0  # In clang-cl enums are signed ints by default
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 21.1) OR
@@ -306,7 +306,7 @@ if(PICKY_COMPILER)
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0)
         list(APPEND _picky_enable
           -Warray-bounds=2                 # clang  2.9  gcc  5.0 (clang default: -Warray-bounds)
-          -Wno-format-signedness           # clang 19.1  gcc  5.1  appleclang 17.0
+          -Wformat-signedness              # clang 19.1  gcc  5.1  appleclang 17.0
         )
       endif()
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0)

--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -134,8 +134,8 @@ int main(void)
           const char *url;
           CURL *curl = msg->easy_handle;
           curl_easy_getinfo(curl, CURLINFO_PRIVATE, &url);
-          fprintf(stderr, "R: %d - %s <%s>\n",
-                  msg->data.result, curl_easy_strerror(msg->data.result), url);
+          fprintf(stderr, "R: %d - %s <%s>\n", (int)msg->data.result,
+                  curl_easy_strerror(msg->data.result), url);
           curl_multi_remove_handle(multi, curl);
           curl_easy_cleanup(curl);
           left--;

--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -141,7 +141,7 @@ int main(void)
           left--;
         }
         else {
-          fprintf(stderr, "E: CURLMsg (%d)\n", msg->msg);
+          fprintf(stderr, "E: CURLMsg (%d)\n", (int)msg->msg);
         }
         if(transfers < NUM_URLS)
           add_transfer(multi, transfers++, &left);

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -164,7 +164,7 @@ int main(void)
     close(sockfd);
 
     if(result != CURLE_OK) {
-      printf("libcurl error: %d\n", result);
+      printf("libcurl error: %d\n", (int)result);
       return 4;
     }
   }

--- a/docs/examples/ftp-delete.c
+++ b/docs/examples/ftp-delete.c
@@ -74,7 +74,7 @@ int main(void)
 
     if(result != CURLE_OK) {
       /* we failed */
-      fprintf(stderr, "curl told us %d\n", result);
+      fprintf(stderr, "curl told us %d\n", (int)result);
     }
   }
 

--- a/docs/examples/ftpget.c
+++ b/docs/examples/ftpget.c
@@ -87,7 +87,7 @@ int main(void)
 
     if(result != CURLE_OK) {
       /* we failed */
-      fprintf(stderr, "curl told us %d\n", result);
+      fprintf(stderr, "curl told us %d\n", (int)result);
     }
   }
 

--- a/docs/examples/ftpgetinfo.c
+++ b/docs/examples/ftpgetinfo.c
@@ -90,7 +90,7 @@ int main(void)
     }
     else {
       /* we failed */
-      fprintf(stderr, "curl told us %d\n", result);
+      fprintf(stderr, "curl told us %d\n", (int)result);
     }
 
     /* always cleanup */

--- a/docs/examples/ftpsget.c
+++ b/docs/examples/ftpsget.c
@@ -92,7 +92,7 @@ int main(void)
 
     if(result != CURLE_OK) {
       /* we failed */
-      fprintf(stderr, "curl told us %d\n", result);
+      fprintf(stderr, "curl told us %d\n", (int)result);
     }
   }
 

--- a/docs/examples/log_failed_transfers.c
+++ b/docs/examples/log_failed_transfers.c
@@ -289,7 +289,7 @@ int main(void)
         failed = 0;
       }
       else {
-        mem_addf(&t->log, "Transfer failed: (%d) %s\n", result,
+        mem_addf(&t->log, "Transfer failed: (%d) %s\n", (int)result,
                  (errbuf[0] ? errbuf : curl_easy_strerror(result)));
         fprintf(stderr, "%s", t->log.recent);
         failed = 1;

--- a/docs/examples/multi-app.c
+++ b/docs/examples/multi-app.c
@@ -99,10 +99,12 @@ int main(void)
 
         switch(idx) {
         case HTTP_HANDLE:
-          printf("HTTP transfer completed with status %d\n", msg->data.result);
+          printf("HTTP transfer completed with status %d\n",
+                 (int)msg->data.result);
           break;
         case FTP_HANDLE:
-          printf("FTP transfer completed with status %d\n", msg->data.result);
+          printf("FTP transfer completed with status %d\n",
+                 (int)msg->data.result);
           break;
         }
       }

--- a/docs/examples/multi-legacy.c
+++ b/docs/examples/multi-legacy.c
@@ -177,10 +177,12 @@ int main(void)
 
         switch(idx) {
         case HTTP_HANDLE:
-          printf("HTTP transfer completed with status %d\n", msg->data.result);
+          printf("HTTP transfer completed with status %d\n",
+                 (int)msg->data.result);
           break;
         case FTP_HANDLE:
-          printf("FTP transfer completed with status %d\n", msg->data.result);
+          printf("FTP transfer completed with status %d\n",
+                 (int)msg->data.result);
           break;
         }
       }

--- a/docs/examples/sftpget.c
+++ b/docs/examples/sftpget.c
@@ -103,7 +103,7 @@ int main(void)
 
     if(result != CURLE_OK) {
       /* we failed */
-      fprintf(stderr, "curl told us %d\n", result);
+      fprintf(stderr, "curl told us %d\n", (int)result);
     }
   }
 

--- a/docs/examples/sslbackend.c
+++ b/docs/examples/sslbackend.c
@@ -54,7 +54,7 @@ int main(int argc, const char **argv)
 
     for(i = 0; list[i]; i++)
       printf("SSL backend #%d: '%s' (ID: %d)\n",
-             i, list[i]->name, list[i]->id);
+             i, list[i]->name, (int)list[i]->id);
 
     return 0;
   }

--- a/docs/examples/websocket-updown.c
+++ b/docs/examples/websocket-updown.c
@@ -69,7 +69,7 @@ static size_t read_cb(char *buf, size_t nitems, size_t buflen, void *p)
     result = curl_ws_start_frame(ctx->curl, CURLWS_TEXT,
                                  (curl_off_t)ctx->blen);
     if(result != CURLE_OK) {
-      fprintf(stderr, "error starting frame: %d\n", result);
+      fprintf(stderr, "error starting frame: %d\n", (int)result);
       return CURL_READFUNC_ABORT;
     }
   }

--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -94,7 +94,7 @@ retry:
     else {
       /* some other frame arrived. */
       fprintf(stderr, "ws: received frame of %u bytes rflags %x\n",
-              (unsigned int)rlen, meta->flags);
+              (unsigned int)rlen, (unsigned int)meta->flags);
       goto retry;
     }
   }

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -516,7 +516,6 @@ typedef int (*curl_prereq_callback)(void *clientp,
  */
 
 typedef enum {
-  CURLE_SIGNED = -1, /* to ensure signed type, never use! */
   CURLE_OK = 0,
   CURLE_UNSUPPORTED_PROTOCOL,    /* 1 */
   CURLE_FAILED_INIT,             /* 2 */

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -3030,7 +3030,6 @@ typedef enum {
 
 /* Different data locks for a single share */
 typedef enum {
-  CURL_LOCK_DATA_SIGNED = -1, /* to ensure signed type, never use! */
   CURL_LOCK_DATA_NONE = 0,
   /*  CURL_LOCK_DATA_SHARE is used internally to say that the locking is made
    *  to change the internal state of the share itself.

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2610,8 +2610,7 @@ struct curl_forms {
  *
  ***************************************************************************/
 typedef enum {
-  CURL_FORMADD_SIGNED = -1, /* to ensure signed type, never use! */
-  CURL_FORMADD_OK             CURL_DEPRECATED(7.56.0, "") = 0, /* no error */
+  CURL_FORMADD_OK             CURL_DEPRECATED(7.56.0, ""), /* 1st, no error */
 
   CURL_FORMADD_MEMORY         CURL_DEPRECATED(7.56.0, ""),
   CURL_FORMADD_OPTION_TWICE   CURL_DEPRECATED(7.56.0, ""),

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -516,6 +516,7 @@ typedef int (*curl_prereq_callback)(void *clientp,
  */
 
 typedef enum {
+  CURLE_SIGNED = -1, /* to ensure signed type, never use! */
   CURLE_OK = 0,
   CURLE_UNSUPPORTED_PROTOCOL,    /* 1 */
   CURLE_FAILED_INIT,             /* 2 */
@@ -2609,7 +2610,8 @@ struct curl_forms {
  *
  ***************************************************************************/
 typedef enum {
-  CURL_FORMADD_OK             CURL_DEPRECATED(7.56.0, ""), /* 1st, no error */
+  CURL_FORMADD_SIGNED = -1, /* to ensure signed type, never use! */
+  CURL_FORMADD_OK             CURL_DEPRECATED(7.56.0, "") = 0, /* no error */
 
   CURL_FORMADD_MEMORY         CURL_DEPRECATED(7.56.0, ""),
   CURL_FORMADD_OPTION_TWICE   CURL_DEPRECATED(7.56.0, ""),
@@ -3028,6 +3030,7 @@ typedef enum {
 
 /* Different data locks for a single share */
 typedef enum {
+  CURL_LOCK_DATA_SIGNED = -1, /* to ensure signed type, never use! */
   CURL_LOCK_DATA_NONE = 0,
   /*  CURL_LOCK_DATA_SHARE is used internally to say that the locking is made
    *  to change the internal state of the share itself.
@@ -3059,7 +3062,8 @@ typedef void (*curl_unlock_function)(CURL *handle,
                                      void *userptr);
 
 typedef enum {
-  CURLSHE_OK,  /* all is fine */
+  CURLSHE_SIGNED = -1, /* to ensure signed type, never use! */
+  CURLSHE_OK = 0,  /* all is fine */
   CURLSHE_BAD_OPTION, /* 1 */
   CURLSHE_IN_USE,     /* 2 */
   CURLSHE_INVALID,    /* 3 */

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -3060,8 +3060,7 @@ typedef void (*curl_unlock_function)(CURL *handle,
                                      void *userptr);
 
 typedef enum {
-  CURLSHE_SIGNED = -1, /* to ensure signed type, never use! */
-  CURLSHE_OK = 0,  /* all is fine */
+  CURLSHE_OK,  /* all is fine */
   CURLSHE_BAD_OPTION, /* 1 */
   CURLSHE_IN_USE,     /* 2 */
   CURLSHE_INVALID,    /* 3 */

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -87,7 +87,8 @@ typedef enum {
 #define CURLPIPE_MULTIPLEX 2L
 
 typedef enum {
-  CURLMSG_NONE, /* first, not used */
+  CURLMSG_SIGNED = -1, /* to ensure signed type, never use! */
+  CURLMSG_NONE = 0, /* first, not used */
   CURLMSG_DONE, /* This easy handle has completed. 'result' contains
                    the CURLcode of the transfer */
   CURLMSG_LAST /* last, not used */

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -87,8 +87,7 @@ typedef enum {
 #define CURLPIPE_MULTIPLEX 2L
 
 typedef enum {
-  CURLMSG_SIGNED = -1, /* to ensure signed type, never use! */
-  CURLMSG_NONE = 0, /* first, not used */
+  CURLMSG_NONE, /* first, not used */
   CURLMSG_DONE, /* This easy handle has completed. 'result' contains
                    the CURLcode of the transfer */
   CURLMSG_LAST /* last, not used */

--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -32,7 +32,8 @@ extern "C" {
 
 /* the error codes for the URL API */
 typedef enum {
-  CURLUE_OK,
+  CURLUE_SIGNED = -1, /* to ensure signed type, never use! */
+  CURLUE_OK = 0,
   CURLUE_BAD_HANDLE,          /* 1 */
   CURLUE_BAD_PARTPOINTER,     /* 2 */
   CURLUE_MALFORMED_INPUT,     /* 3 */

--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -32,8 +32,7 @@ extern "C" {
 
 /* the error codes for the URL API */
 typedef enum {
-  CURLUE_SIGNED = -1, /* to ensure signed type, never use! */
-  CURLUE_OK = 0,
+  CURLUE_OK,
   CURLUE_BAD_HANDLE,          /* 1 */
   CURLUE_BAD_PARTPOINTER,     /* 2 */
   CURLUE_MALFORMED_INPUT,     /* 3 */

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -314,7 +314,7 @@ CURLcode Curl_async_take_result(struct Curl_easy *data,
   }
 
   CURL_TRC_DNS(data, "ares: is_resolved() result=%d, dns=%sfound",
-               result, *pdns ? "" : "not ");
+               (int)result, *pdns ? "" : "not ");
   async_ares_cleanup(async);
 
 out:

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -635,7 +635,7 @@ CURLcode Curl_async_getaddrinfo(struct Curl_easy *data,
 out:
   if(result)
     CURL_TRC_DNS(data, "error queueing query %s:%d -> %d",
-                 async->hostname, async->port, result);
+                 async->hostname, async->port, (int)result);
   return result;
 }
 
@@ -759,7 +759,7 @@ out:
      (result != CURLE_COULDNT_RESOLVE_HOST) &&
      (result != CURLE_COULDNT_RESOLVE_PROXY)) {
     CURL_TRC_DNS(data, "Error %d resolving %s:%d",
-                 result, async->hostname, async->port);
+                 (int)result, async->hostname, async->port);
   }
   return result;
 }

--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -264,7 +264,7 @@ static CURLcode cf_dns_connect(struct Curl_cfilter *cf,
   }
 
   if(ctx->resolv_result) {
-    CURL_TRC_CF(data, cf, "error resolving: %d", ctx->resolv_result);
+    CURL_TRC_CF(data, cf, "error resolving: %d", (int)ctx->resolv_result);
     return ctx->resolv_result;
   }
 

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -737,7 +737,8 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
       CURL_TRC_CF(data, cf, "CONNECT receive");
       result = recv_CONNECT_resp(cf, data, ts, &done);
       if(result)
-        CURL_TRC_CF(data, cf, "error receiving CONNECT response: %d", result);
+        CURL_TRC_CF(data, cf, "error receiving CONNECT response: %d",
+                    (int)result);
       if(!result)
         result = Curl_pgrsUpdate(data);
       /* error or not complete yet. return for more multi-multi */

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -245,7 +245,7 @@ static CURLcode proxy_h2_nw_out_writer(void *writer_ctx,
     CURLcode result;
     result = Curl_conn_cf_send(cf->next, data, buf, buflen, FALSE, pnwritten);
     CURL_TRC_CF(data, cf, "[0] nw_out_writer(len=%zu) -> %d, %zu",
-                buflen, result, *pnwritten);
+                buflen, (int)result, *pnwritten);
     return result;
   }
   return CURLE_FAILED_INIT;
@@ -371,7 +371,7 @@ static CURLcode proxy_h2_progress_ingress(struct Curl_cfilter *cf,
 
     result = Curl_cf_recv_bufq(cf->next, data, &ctx->inbufq, 0, &nread);
     CURL_TRC_CF(data, cf, "[0] read %zu bytes nw data -> %d, %zu",
-                Curl_bufq_len(&ctx->inbufq), result, nread);
+                Curl_bufq_len(&ctx->inbufq), (int)result, nread);
     if(result) {
       if(result != CURLE_AGAIN) {
         failf(data, "Failed receiving HTTP2 proxy data");
@@ -975,7 +975,7 @@ static CURLcode cf_h2_proxy_ctx_init(struct Curl_cfilter *cf,
 out:
   if(cbs)
     nghttp2_session_callbacks_del(cbs);
-  CURL_TRC_CF(data, cf, "[0] init proxy ctx -> %d", result);
+  CURL_TRC_CF(data, cf, "[0] init proxy ctx -> %d", (int)result);
   return result;
 }
 
@@ -1135,7 +1135,7 @@ static CURLcode cf_h2_proxy_adjust_pollset(struct Curl_cfilter *cf,
 
     result = Curl_pollset_set(data, ps, sock, want_recv, want_send);
     CURL_TRC_CF(data, cf, "adjust_pollset, want_recv=%d want_send=%d -> %d",
-                want_recv, want_send, result);
+                want_recv, want_send, (int)result);
     CF_DATA_RESTORE(cf, save);
   }
   else if(ctx->sent_goaway && !cf->shutdown) {
@@ -1147,7 +1147,7 @@ static CURLcode cf_h2_proxy_adjust_pollset(struct Curl_cfilter *cf,
     want_recv = nghttp2_session_want_read(ctx->h2);
     result = Curl_pollset_set(data, ps, sock, want_recv, want_send);
     CURL_TRC_CF(data, cf, "adjust_pollset, want_recv=%d want_send=%d -> %d",
-                want_recv, want_send, result);
+                want_recv, want_send, (int)result);
     CF_DATA_RESTORE(cf, save);
   }
   return result;
@@ -1196,7 +1196,7 @@ static CURLcode tunnel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
 
   CURL_TRC_CF(data, cf, "[%d] tunnel_recv(len=%zu) -> %d, %zu",
-              ctx->tunnel.stream_id, len, result, *pnread);
+              ctx->tunnel.stream_id, len, (int)result, *pnread);
   return result;
 }
 
@@ -1242,7 +1242,7 @@ out:
     drain_tunnel(cf, data, &ctx->tunnel);
   }
   CURL_TRC_CF(data, cf, "[%d] cf_recv(len=%zu) -> %d, %zu",
-              ctx->tunnel.stream_id, len, result, *pnread);
+              ctx->tunnel.stream_id, len, (int)result, *pnread);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -1272,7 +1272,8 @@ static CURLcode cf_h2_proxy_send(struct Curl_cfilter *cf,
   }
 
   result = Curl_bufq_write(&ctx->tunnel.sendbuf, buf, len, pnwritten);
-  CURL_TRC_CF(data, cf, "cf_send(), bufq_write %d, %zu", result, *pnwritten);
+  CURL_TRC_CF(data, cf, "cf_send(), bufq_write %d, %zu", (int)result,
+              *pnwritten);
   if(result && (result != CURLE_AGAIN))
     goto out;
 
@@ -1310,7 +1311,7 @@ out:
   }
   CURL_TRC_CF(data, cf, "[%d] cf_send(len=%zu) -> %d, %zu, "
               "h2 windows %d-%d (stream-conn), buffers %zu-%zu (stream-conn)",
-              ctx->tunnel.stream_id, len, result, *pnwritten,
+              ctx->tunnel.stream_id, len, (int)result, *pnwritten,
               nghttp2_session_get_stream_remote_window_size(
                 ctx->h2, ctx->tunnel.stream_id),
               nghttp2_session_get_remote_window_size(ctx->h2),
@@ -1342,7 +1343,7 @@ static CURLcode cf_h2_proxy_flush(struct Curl_cfilter *cf,
 out:
   CURL_TRC_CF(data, cf, "[%d] flush -> %d, "
               "h2 windows %d-%d (stream-conn), buffers %zu-%zu (stream-conn)",
-              ctx->tunnel.stream_id, result,
+              ctx->tunnel.stream_id, (int)result,
               nghttp2_session_get_stream_remote_window_size(
                 ctx->h2, ctx->tunnel.stream_id),
               nghttp2_session_get_remote_window_size(ctx->h2),

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -575,7 +575,7 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
   }
 
 out:
-  CURL_TRC_CF(data, cf, "connect -> %d, done=%d", result, *done);
+  CURL_TRC_CF(data, cf, "connect -> %d, done=%d", (int)result, *done);
   return result;
 }
 
@@ -615,7 +615,7 @@ static CURLcode cf_hc_shutdown(struct Curl_cfilter *cf,
         result = ctx->ballers[i].result;
     }
   }
-  CURL_TRC_CF(data, cf, "shutdown -> %d, done=%d", result, *done);
+  CURL_TRC_CF(data, cf, "shutdown -> %d, done=%d", (int)result, *done);
   return result;
 }
 
@@ -634,7 +634,8 @@ static CURLcode cf_hc_adjust_pollset(struct Curl_cfilter *cf,
         continue;
       result = Curl_conn_cf_adjust_pollset(b->cf, data, ps);
     }
-    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %u socks", result, ps->n);
+    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %u socks", (int)result,
+                ps->n);
   }
   return result;
 }

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -497,7 +497,7 @@ evaluate:
                                  bs->cf_create);
       CURL_TRC_CF(data, cf, "starting %s attempt for ipv%s -> %d",
                   bs->running ? "next" : "first",
-                  (ai_family == AF_INET) ? "4" : "6", result);
+                  (ai_family == AF_INET) ? "4" : "6", (int)result);
       if(result)
         goto out;
       DEBUGASSERT(a);
@@ -526,7 +526,7 @@ evaluate:
           if(!a->inconclusive)
             continue;
           result = cf_ip_attempt_restart(a, cf, data);
-          CURL_TRC_CF(data, cf, "restarted baller %d -> %d", i, result);
+          CURL_TRC_CF(data, cf, "restarted baller %d -> %d", i, (int)result);
           if(result) /* serious failure */
             goto out;
           bs->last_attempt_started = *Curl_pgrs_now(data);
@@ -549,7 +549,7 @@ evaluate:
       result = CURLE_COULDNT_CONNECT;
       VERBOSE(i = 0);
       for(a = bs->running; a; a = a->next) {
-        CURL_TRC_CF(data, cf, "baller %d: result=%d", i, a->result);
+        CURL_TRC_CF(data, cf, "baller %d: result=%d", i, (int)a->result);
         if(a->result)
           result = a->result;
       }
@@ -813,7 +813,7 @@ static CURLcode cf_ip_happy_shutdown(struct Curl_cfilter *cf,
   }
 
   result = cf_ip_ballers_shutdown(&ctx->ballers, data, done);
-  CURL_TRC_CF(data, cf, "shutdown -> %d, done=%d", result, *done);
+  CURL_TRC_CF(data, cf, "shutdown -> %d, done=%d", (int)result, *done);
   return result;
 }
 
@@ -826,7 +826,8 @@ static CURLcode cf_ip_happy_adjust_pollset(struct Curl_cfilter *cf,
 
   if(!cf->connected) {
     result = cf_ip_ballers_pollset(&ctx->ballers, data, ps);
-    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %u socks", result, ps->n);
+    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %u socks", (int)result,
+                ps->n);
   }
   return result;
 }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1238,7 +1238,7 @@ out:
     cf->connected = TRUE;
   }
   CURL_TRC_CF(data, cf, "cf_socket_open() -> %d, fd=%" FMT_SOCKET_T,
-              result, ctx->sock);
+              (int)result, ctx->sock);
   return result;
 }
 
@@ -1530,7 +1530,7 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 #endif
 
   CURL_TRC_CF(data, cf, "send(len=%zu) -> %d, %zu",
-              orig_len, result, *pnwritten);
+              orig_len, (int)result, *pnwritten);
   cf->conn->sock[cf->sockindex] = fdsave;
   return result;
 }
@@ -1589,7 +1589,7 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
   }
 
-  CURL_TRC_CF(data, cf, "recv(len=%zu) -> %d, %zu", len, result, *pnread);
+  CURL_TRC_CF(data, cf, "recv(len=%zu) -> %d, %zu", len, (int)result, *pnread);
   if(!result && !ctx->got_first_byte) {
     ctx->first_byte_at = *Curl_pgrs_now(data);
     ctx->got_first_byte = TRUE;
@@ -1899,7 +1899,8 @@ static CURLcode cf_udp_connect(struct Curl_cfilter *cf,
   if(ctx->sock == CURL_SOCKET_BAD) {
     result = cf_socket_open(cf, data);
     if(result) {
-      CURL_TRC_CF(data, cf, "cf_udp_connect(), open failed -> %d", result);
+      CURL_TRC_CF(data, cf, "cf_udp_connect(), open failed -> %d",
+                  (int)result);
       goto out;
     }
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -2132,7 +2132,7 @@ static CURLcode cf_tcp_accept_connect(struct Curl_cfilter *cf,
   CURL_TRC_CF(data, cf, "Checking for incoming on fd=%" FMT_SOCKET_T
               " ip=%s:%d", ctx->sock, ctx->ip.local_ip, ctx->ip.local_port);
   socketstate = SOCKET_READABLE(ctx->sock, 0);
-  CURL_TRC_CF(data, cf, "socket_check -> %x", socketstate);
+  CURL_TRC_CF(data, cf, "socket_check -> %x", (unsigned int)socketstate);
   switch(socketstate) {
   case -1: /* error */
     /* let's die here */

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -202,7 +202,7 @@ CURLcode Curl_conn_shutdown(struct Curl_easy *data, int sockindex, bool *done)
       bool cfdone = FALSE;
       result = cf->cft->do_shutdown(cf, data, &cfdone);
       if(result) {
-        CURL_TRC_CF(data, cf, "shut down failed with %d", result);
+        CURL_TRC_CF(data, cf, "shut down failed with %d", (int)result);
         return result;
       }
       else if(!cfdone) {
@@ -553,7 +553,7 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
 
     result = cf->cft->do_connect(cf, data, done);
     CURL_TRC_CF(data, cf, "Curl_conn_connect(block=%d) -> %d, done=%d",
-                blocking, result, *done);
+                blocking, (int)result, *done);
     if(!result && *done) {
       /* Now that the complete filter chain is connected, let all filters
        * persist information at the connection. E.g. cf-socket sets the
@@ -568,7 +568,8 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
       goto out;
     }
     else if(result) {
-      CURL_TRC_CF(data, cf, "Curl_conn_connect(), filter returned %d", result);
+      CURL_TRC_CF(data, cf, "Curl_conn_connect(), filter returned %d",
+                  (int)result);
       VERBOSE(Curl_conn_trc_filters(data, sockindex, "failed to connect"));
       conn_report_connect_stats(cf, data);
       goto out;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -360,7 +360,8 @@ static CURLcode cf_setup_add_haproxy(struct Curl_cfilter *cf,
       }
       result = Curl_cf_haproxy_insert_after(cf, data);
       if(result) {
-        CURL_TRC_CF(data, cf, "adding HAPROXY filter failed -> %d", result);
+        CURL_TRC_CF(data, cf, "adding HAPROXY filter failed -> %d",
+                    (int)result);
         return result;
       }
       CURL_TRC_CF(data, cf, "added HAPROXY filter");
@@ -391,7 +392,7 @@ static CURLcode cf_setup_add_socks(struct Curl_cfilter *cf,
       cf->conn->socks_proxy.proxytype,
       cf->conn->socks_proxy.creds);
     if(result) {
-      CURL_TRC_CF(data, cf, "adding SOCKS filter failed -> %d", result);
+      CURL_TRC_CF(data, cf, "adding SOCKS filter failed -> %d", (int)result);
       return result;
     }
 
@@ -417,7 +418,7 @@ static CURLcode cf_setup_add_http_proxy(struct Curl_cfilter *cf,
         cf, data, cf->conn->http_proxy.peer);
       if(result) {
         CURL_TRC_CF(data, cf, "adding SSL filter for HTTP proxy failed -> %d",
-                    result);
+                    (int)result);
         return result;
       }
       CURL_TRC_CF(data, cf, "added SSL filter for HTTP proxy");
@@ -433,7 +434,7 @@ static CURLcode cf_setup_add_http_proxy(struct Curl_cfilter *cf,
         ctx->transport, cf->conn->http_proxy.proxytype);
       if(result) {
         CURL_TRC_CF(data, cf, "adding HTTP proxy tunnel filter failed -> %d",
-                    result);
+                    (int)result);
         return result;
       }
       CURL_TRC_CF(data, cf, "added HTTP proxy tunnel filter");
@@ -481,7 +482,7 @@ static CURLcode cf_setup_add_ip_happy(struct Curl_cfilter *cf,
                                       first_transport,
                                       tunnel_peer, ctx->transport);
     if(result) {
-      CURL_TRC_CF(data, cf, "adding happy eyeballs failed -> %d", result);
+      CURL_TRC_CF(data, cf, "adding happy eyeballs failed -> %d", (int)result);
       return result;
     }
 
@@ -522,12 +523,13 @@ static CURLcode cf_setup_add_origin_filters(struct Curl_cfilter *cf,
 
       result = Curl_cf_capsule_insert_after(cf, data);
       if(result) {
-        CURL_TRC_CF(data, cf, "adding capsule filter failed -> %d", result);
+        CURL_TRC_CF(data, cf, "adding capsule filter failed -> %d",
+                    (int)result);
         return result;
       }
       result = Curl_cf_quic_insert_after(cf, origin, peer);
       if(result) {
-        CURL_TRC_CF(data, cf, "adding QUIC filter failed -> %d", result);
+        CURL_TRC_CF(data, cf, "adding QUIC filter failed -> %d", (int)result);
         return result;
       }
       CURL_TRC_CF(data, cf, "added QUIC filter for origin");
@@ -548,7 +550,7 @@ static CURLcode cf_setup_add_origin_filters(struct Curl_cfilter *cf,
       result = Curl_cf_ssl_insert_after(cf, data, origin, peer);
       if(result) {
         CURL_TRC_CF(data, cf, "adding SSL filter for origin failed -> %d",
-                    result);
+                    (int)result);
         return result;
       }
       CURL_TRC_CF(data, cf, "added SSL filter for origin");

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -820,7 +820,8 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
 
       result = Curl_cwriter_create(&writer, data, cwt, phase);
       CURL_TRC_WRITE(data, "added %s decoder %s -> %d",
-                     is_transfer ? "transfer" : "content", cwt->name, result);
+                     is_transfer ? "transfer" : "content", cwt->name,
+                     (int)result);
       if(result)
         return result;
 

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -260,7 +260,7 @@ static OM_uint32 stub_gss_init_sec_context(
     used = curl_msnprintf(token, length, "%s:%.*s:%d:", creds,
                           (int)target_desc.length,
                           (const char *)target_desc.value,
-                          ctx->sent);
+                          (int)ctx->sent);
 
     gss_release_buffer(&minor_status, &target_desc);
   }

--- a/lib/curlx/strerr.c
+++ b/lib/curlx/strerr.c
@@ -268,7 +268,7 @@ const char *curlx_strerror(int err, char *buf, size_t buflen)
      !get_winsock_error(err, buf, buflen) &&
 #endif
      !curlx_get_winapi_error((DWORD)err, buf, buflen))
-    SNPRINTF(buf, buflen, "Unknown error %d (%#x)", err, err);
+    SNPRINTF(buf, buflen, "Unknown error %d (%#x)", err, (unsigned int)err);
 #else /* !_WIN32 */
 
 #if defined(HAVE_STRERROR_R) && defined(HAVE_POSIX_STRERROR_R)

--- a/lib/cw-pause.c
+++ b/lib/cw-pause.c
@@ -117,7 +117,8 @@ static CURLcode cw_pause_flush(struct Curl_easy *data,
       result = Curl_cwriter_write(data, cw_pause->next, (*plast)->type,
                                   (const char *)buf, wlen);
       CURL_TRC_WRITE(data, "[PAUSE] flushed %zu/%zu bytes, type=%x -> %d",
-                     wlen, ctx->buf_total, (*plast)->type, result);
+                     wlen, ctx->buf_total, (unsigned int)(*plast)->type,
+                     result);
       Curl_bufq_skip(&(*plast)->b, wlen);
       DEBUGASSERT(ctx->buf_total >= wlen);
       ctx->buf_total -= wlen;
@@ -128,7 +129,7 @@ static CURLcode cw_pause_flush(struct Curl_easy *data,
       result = Curl_cwriter_write(data, cw_pause->next, (*plast)->type,
                                   (const char *)buf, 0);
       CURL_TRC_WRITE(data, "[PAUSE] flushed 0/%zu bytes, type=%x -> %d",
-                     ctx->buf_total, (*plast)->type, result);
+                     ctx->buf_total, (unsigned int)(*plast)->type, result);
     }
 
     if(Curl_bufq_is_empty(&(*plast)->b)) {
@@ -165,7 +166,7 @@ static CURLcode cw_pause_write(struct Curl_easy *data,
       wtype &= ~CLIENTWRITE_EOS;
     result = Curl_cwriter_write(data, writer->next, wtype, buf, wlen);
     CURL_TRC_WRITE(data, "[PAUSE] writing %zu/%zu bytes of type %x -> %d",
-                   wlen, blen, wtype, result);
+                   wlen, blen, (unsigned int)wtype, result);
     if(result)
       return result;
     buf += wlen;
@@ -191,8 +192,8 @@ static CURLcode cw_pause_write(struct Curl_easy *data,
       result = Curl_bufq_cwrite(&ctx->buf->b, buf, blen, &nwritten);
     }
     CURL_TRC_WRITE(data, "[PAUSE] buffer %zu more bytes of type %x, "
-                   "total=%zu -> %d", nwritten, type, ctx->buf_total + wlen,
-                   result);
+                   "total=%zu -> %d", nwritten, (unsigned int)type,
+                   ctx->buf_total + wlen, result);
     if(result)
       return result;
     buf += nwritten;

--- a/lib/cw-pause.c
+++ b/lib/cw-pause.c
@@ -118,7 +118,7 @@ static CURLcode cw_pause_flush(struct Curl_easy *data,
                                   (const char *)buf, wlen);
       CURL_TRC_WRITE(data, "[PAUSE] flushed %zu/%zu bytes, type=%x -> %d",
                      wlen, ctx->buf_total, (unsigned int)(*plast)->type,
-                     result);
+                     (int)result);
       Curl_bufq_skip(&(*plast)->b, wlen);
       DEBUGASSERT(ctx->buf_total >= wlen);
       ctx->buf_total -= wlen;
@@ -129,7 +129,8 @@ static CURLcode cw_pause_flush(struct Curl_easy *data,
       result = Curl_cwriter_write(data, cw_pause->next, (*plast)->type,
                                   (const char *)buf, 0);
       CURL_TRC_WRITE(data, "[PAUSE] flushed 0/%zu bytes, type=%x -> %d",
-                     ctx->buf_total, (unsigned int)(*plast)->type, result);
+                     ctx->buf_total, (unsigned int)(*plast)->type,
+                     (int)result);
     }
 
     if(Curl_bufq_is_empty(&(*plast)->b)) {
@@ -166,7 +167,7 @@ static CURLcode cw_pause_write(struct Curl_easy *data,
       wtype &= ~CLIENTWRITE_EOS;
     result = Curl_cwriter_write(data, writer->next, wtype, buf, wlen);
     CURL_TRC_WRITE(data, "[PAUSE] writing %zu/%zu bytes of type %x -> %d",
-                   wlen, blen, (unsigned int)wtype, result);
+                   wlen, blen, (unsigned int)wtype, (int)result);
     if(result)
       return result;
     buf += wlen;
@@ -193,7 +194,7 @@ static CURLcode cw_pause_write(struct Curl_easy *data,
     }
     CURL_TRC_WRITE(data, "[PAUSE] buffer %zu more bytes of type %x, "
                    "total=%zu -> %d", nwritten, (unsigned int)type,
-                   ctx->buf_total + wlen, result);
+                   ctx->buf_total + wlen, (int)result);
     if(result)
       return result;
     buf += nwritten;

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -319,7 +319,7 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
                      sizeof(doh_req->req_body),
                      &doh_req->req_body_len);
   if(d) {
-    failf(data, "Failed to encode DoH packet [%d]", d);
+    failf(data, "Failed to encode DoH packet [%d]", (int)d);
     result = CURLE_OUT_OF_MEMORY;
     goto error;
   }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -732,7 +732,7 @@ static CURLcode getftpresponse(struct Curl_easy *data,
 
   pp->pending_resp = FALSE;
   CURL_TRC_FTP(data, "getftpresponse -> result=%d, nread=%zu, ftpcode=%d",
-               result, *nreadp, *ftpcodep);
+               (int)result, *nreadp, *ftpcodep);
 
   return result;
 }
@@ -3839,7 +3839,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
   /* Send any post-transfer QUOTE strings? */
   if(!status && !result && !premature && data->set.postquote)
     result = ftp_sendquote(data, ftpc, data->set.postquote);
-  CURL_TRC_FTP(data, "[%s] done, result=%d", FTP_CSTATE(ftpc), result);
+  CURL_TRC_FTP(data, "[%s] done, result=%d", FTP_CSTATE(ftpc), (int)result);
   return result;
 }
 
@@ -4448,7 +4448,8 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
   ftpc->use_ssl = data->set.use_ssl;
   ftpc->ccc = data->set.ftp_ccc;
 
-  CURL_TRC_FTP(data, "[%s] setup connection -> %d", FTP_CSTATE(ftpc), result);
+  CURL_TRC_FTP(data, "[%s] setup connection -> %d", FTP_CSTATE(ftpc),
+               (int)result);
   return result;
 }
 

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -305,7 +305,7 @@ static CURLcode hds_cw_collect_write(struct Curl_easy *data,
          CURLH_HEADER)));
     CURLcode result = Curl_headers_push(data, buf, blen, htype);
     CURL_TRC_WRITE(data, "header_collect pushed(type=%x, len=%zu) -> %d",
-                   htype, blen, result);
+                   htype, blen, (int)result);
     if(result)
       return result;
   }

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -734,7 +734,7 @@ out:
       failf(data, "Could not resolve: %s:%u", hostname, port);
     }
     else {
-      failf(data, "Error %d resolving %s:%u", result, hostname, port);
+      failf(data, "Error %d resolving %s:%u", (int)result, hostname, port);
     }
   }
   else if(cache_dns && *pdns) {
@@ -1073,7 +1073,7 @@ CURLcode Curl_resolv_take_result(struct Curl_easy *data, uint32_t resolv_id,
   }
   else if(result) {
     failf(data, "Error %d resolving %s:%u",
-          result, async->hostname, async->port);
+          (int)result, async->hostname, async->port);
   }
   return result;
 }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -853,7 +853,7 @@ static int push_promise(struct Curl_cfilter *cf,
 
     result = http2_data_setup(cf, newhandle, &newstream);
     if(result) {
-      failf(data, "error setting up stream: %d", result);
+      failf(data, "error setting up stream: %d", (int)result);
       discard_newhandle(cf, newhandle);
       rv = CURL_PUSH_DENY;
       goto fail;
@@ -902,7 +902,7 @@ static void h2_xfer_write_resp_hd(struct Curl_cfilter *cf,
       stream->xfer_result = cf_h2_update_local_win(cf, data, stream);
     if(stream->xfer_result)
       CURL_TRC_CF(data, cf, "[%d] error %d writing %zu bytes of headers",
-                  stream->id, stream->xfer_result, blen);
+                  stream->id, (int)stream->xfer_result, blen);
   }
 }
 
@@ -919,7 +919,7 @@ static void h2_xfer_write_resp(struct Curl_cfilter *cf,
     struct cf_h2_ctx *ctx = cf->ctx;
     CURL_TRC_CF(data, cf, "[%d] error %d writing %zu bytes of data, "
                 "RST-ing stream",
-                stream->id, stream->xfer_result, blen);
+                stream->id, (int)stream->xfer_result, blen);
     nghttp2_submit_rst_stream(ctx->h2, 0, stream->id,
                               (uint32_t)NGHTTP2_ERR_CALLBACK_FAILURE);
   }
@@ -1383,7 +1383,7 @@ static void cf_h2_header_error(struct Curl_cfilter *cf,
 {
   struct cf_h2_ctx *ctx = cf->ctx;
 
-  failf(data, "Error receiving HTTP2 header: %d(%s)", result,
+  failf(data, "Error receiving HTTP2 header: %d(%s)", (int)result,
         curl_easy_strerror(result));
   if(stream) {
     nghttp2_submit_rst_stream(ctx->h2, NGHTTP2_FLAG_NONE,
@@ -1614,7 +1614,7 @@ static ssize_t req_body_read_callback(nghttp2_session *session,
     nread = (ssize_t)n;
 
   CURL_TRC_CF(data_s, cf, "[%d] req_body_read(len=%zu) eos=%d -> %zd, %d",
-              stream_id, length, stream->body_eos, nread, result);
+              stream_id, length, stream->body_eos, nread, (int)result);
 
   if(stream->body_eos && Curl_bufq_is_empty(&stream->sendbuf)) {
     *data_flags = NGHTTP2_DATA_FLAG_EOF;
@@ -1748,7 +1748,7 @@ static CURLcode http2_handle_stream_close(struct Curl_cfilter *cf,
   result = CURLE_OK;
 
 out:
-  CURL_TRC_CF(data, cf, "handle_stream_close -> %d, %zu", result, *pnlen);
+  CURL_TRC_CF(data, cf, "handle_stream_close -> %d, %zu", (int)result, *pnlen);
   return result;
 }
 
@@ -1857,7 +1857,7 @@ static CURLcode stream_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   if(result && (result != CURLE_AGAIN))
     CURL_TRC_CF(data, cf, "[%d] stream_recv(len=%zu) -> %d, %zu",
-                stream->id, len, result, *pnread);
+                stream->id, len, (int)result, *pnread);
   return result;
 }
 
@@ -1908,7 +1908,7 @@ static CURLcode h2_progress_ingress(struct Curl_cfilter *cf,
     result = Curl_cf_recv_bufq(cf->next, data, &ctx->inbufq, 0, &nread);
     if(result) {
       if(result != CURLE_AGAIN) {
-        failf(data, "Failed receiving HTTP2 data: %d(%s)", result,
+        failf(data, "Failed receiving HTTP2 data: %d(%s)", (int)result,
               curl_easy_strerror(result));
         return result;
       }
@@ -2003,7 +2003,7 @@ out:
   }
   CURL_TRC_CF(data, cf, "[%d] cf_recv(len=%zu) -> %d, %zu, "
               "window=%d/%d, connection %d/%d",
-              stream->id, len, result, *pnread,
+              stream->id, len, (int)result, *pnread,
               nghttp2_session_get_stream_effective_recv_data_length(
                 ctx->h2, stream->id),
               nghttp2_session_get_stream_effective_local_window_size(
@@ -2188,7 +2188,7 @@ static CURLcode h2_submit(struct h2_stream_ctx **pstream,
 
 out:
   CURL_TRC_CF(data, cf, "[%d] submit -> %d, %zu",
-              stream ? stream->id : -1, result, *pnwritten);
+              stream ? stream->id : -1, (int)result, *pnwritten);
   curlx_safefree(nva);
   *pstream = stream;
   Curl_dynhds_free(&h2_headers);
@@ -2222,7 +2222,7 @@ static CURLcode cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     DEBUGASSERT(eos);
     result = cf_h2_body_send(cf, data, stream, buf, 0, eos, &n);
     CURL_TRC_CF(data, cf, "[%d] cf_body_send last CHUNK -> %d, %zu, eos=%d",
-                stream->id, result, n, eos);
+                stream->id, (int)result, n, eos);
     if(result)
       goto out;
     *pnwritten = len;
@@ -2230,7 +2230,7 @@ static CURLcode cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   else {
     result = cf_h2_body_send(cf, data, stream, buf, len, eos, pnwritten);
     CURL_TRC_CF(data, cf, "[%d] cf_body_send(len=%zu) -> %d, %zu, eos=%d",
-                stream->id, len, result, *pnwritten, eos);
+                stream->id, len, (int)result, *pnwritten, eos);
   }
 
   /* Call the nghttp2 send loop and flush to write ALL buffered data,
@@ -2266,7 +2266,7 @@ out:
     CURL_TRC_CF(data, cf, "[%d] cf_send(len=%zu) -> %d, %zu, "
                 "eos=%d, h2 windows %d-%d (stream-conn), "
                 "buffers %zu-%zu (stream-conn)",
-                stream->id, len, result, *pnwritten,
+                stream->id, len, (int)result, *pnwritten,
                 stream->body_eos,
                 nghttp2_session_get_stream_remote_window_size(
                   ctx->h2, stream->id),
@@ -2277,7 +2277,7 @@ out:
   else {
     CURL_TRC_CF(data, cf, "cf_send(len=%zu) -> %d, %zu, "
                 "connection-window=%d, nw_send_buffer(%zu)",
-                len, result, *pnwritten,
+                len, (int)result, *pnwritten,
                 nghttp2_session_get_remote_window_size(ctx->h2),
                 Curl_bufq_len(&ctx->outbufq));
   }
@@ -2310,7 +2310,7 @@ out:
     CURL_TRC_CF(data, cf, "[%d] flush -> %d, "
                 "h2 windows %d-%d (stream-conn), "
                 "buffers %zu-%zu (stream-conn)",
-                stream->id, result,
+                stream->id, (int)result,
                 nghttp2_session_get_stream_remote_window_size(
                   ctx->h2, stream->id),
                 nghttp2_session_get_remote_window_size(ctx->h2),
@@ -2320,7 +2320,7 @@ out:
   else {
     CURL_TRC_CF(data, cf, "flush -> %d, "
                 "connection-window=%d, nw_send_buffer(%zu)",
-                result, nghttp2_session_get_remote_window_size(ctx->h2),
+                (int)result, nghttp2_session_get_remote_window_size(ctx->h2),
                 Curl_bufq_len(&ctx->outbufq));
   }
   CF_DATA_RESTORE(cf, save);
@@ -2539,7 +2539,7 @@ static CURLcode cf_h2_connect(struct Curl_cfilter *cf,
   result = CURLE_OK;
 
 out:
-  CURL_TRC_CF(data, cf, "cf_connect() -> %d, %d, ", result, *done);
+  CURL_TRC_CF(data, cf, "cf_connect() -> %d, %d, ", (int)result, *done);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -2922,7 +2922,7 @@ CURLcode Curl_http2_upgrade(struct Curl_easy *data,
     result = Curl_bufq_write(&ctx->inbufq,
                              (const unsigned char *)mem, nread, &copied);
     if(result) {
-      failf(data, "error on copying HTTP Upgrade response: %d", result);
+      failf(data, "error on copying HTTP Upgrade response: %d", (int)result);
       return CURLE_RECV_ERROR;
     }
     if(copied < nread) {

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -154,7 +154,8 @@ static CURLcode httpchunk_readwrite(struct Curl_easy *data,
         if(ch->hexindex == 0) {
           /* This is illegal data, we received junk where we expected
              a hexadecimal digit. */
-          failf(data, "chunk hex-length char not a hex digit: 0x%x", *buf);
+          failf(data, "chunk hex-length char not a hex digit: 0x%x",
+                (unsigned int)*buf);
           ch->state = CHUNK_FAILED;
           ch->last_code = CHUNKE_ILLEGAL_HEX;
           return CURLE_RECV_ERROR;

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -548,7 +548,7 @@ static CURLcode add_last_chunk(struct Curl_easy *data,
 out:
   curl_slist_free_all(trailers);
   CURL_TRC_READ(data, "http_chunk, added last chunk with trailers "
-                "from client -> %d", result);
+                "from client -> %d", (int)result);
   return result;
 }
 
@@ -596,7 +596,7 @@ static CURLcode add_chunk(struct Curl_easy *data,
     if(!result)
       result = Curl_bufq_cwrite(&ctx->chunkbuf, "\r\n", 2, &n);
     CURL_TRC_READ(data, "http_chunk, made chunk of %zu bytes -> %d",
-                  nread, result);
+                  nread, (int)result);
     if(result)
       return result;
   }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -566,7 +566,7 @@ static CURLcode imap_perform_upgrade_tls(struct Curl_easy *data,
   DEBUGASSERT(!imapc->ssldone);
   result = Curl_conn_connect(data, FIRSTSOCKET, FALSE, &ssldone);
   DEBUGF(infof(data, "imap_perform_upgrade_tls, connect -> %d, %d",
-               result, ssldone));
+               (int)result, ssldone));
   if(!result && ssldone) {
     imapc->ssldone = ssldone;
     /* perform CAPA now, changes imapc->state out of IMAP_UPGRADETLS */

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1909,7 +1909,7 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
   /* Once we have errored, we will return the same error forever */
   if(ctx->errored) {
     CURL_TRC_READ(data, "cr_mime_read(len=%zu) is errored -> %d, eos=0",
-                  blen, ctx->error_result);
+                  blen, (int)ctx->error_result);
     *pnread = 0;
     *peos = FALSE;
     return ctx->error_result;
@@ -2026,8 +2026,8 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
   }
 
   CURL_TRC_READ(data, "cr_mime_read(len=%zu, total=%" FMT_OFF_T
-                ", read=%" FMT_OFF_T ") -> %d, %zu, %d",
-                blen, ctx->total_len, ctx->read_len, result, *pnread, *peos);
+                ", read=%" FMT_OFF_T ") -> %d, %zu, %d", blen,
+                ctx->total_len, ctx->read_len, (int)result, *pnread, *peos);
   return result;
 }
 

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -424,7 +424,7 @@ static CURLcode mqtt_verify_connack(struct Curl_easy *data)
 
   if(ptr[0] != 0x00 || ptr[1] != 0x00) {
     failf(data, "Expected %02x%02x but got %02x%02x",
-          0x00, 0x00, ptr[0], ptr[1]);
+          0x00U, 0x00U, (unsigned char)ptr[0], (unsigned char)ptr[1]);
     curlx_dyn_reset(&mq->recvbuf);
     return CURLE_WEIRD_SERVER_REPLY;
   }

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -771,7 +771,7 @@ static CURLcode mqtt_do(struct Curl_easy *data, bool *done)
 
   result = mqtt_connect(data);
   if(result) {
-    failf(data, "Error %d sending MQTT CONNECT request", result);
+    failf(data, "Error %d sending MQTT CONNECT request", (int)result);
     return result;
   }
   mqstate(data, MQTT_FIRST, MQTT_CONNACK);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1214,7 +1214,7 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
   if(result) {
     if(result == CURLE_OUT_OF_MEMORY)
       return CURLM_OUT_OF_MEMORY;
-    failf(data, "error determining pollset: %d", result);
+    failf(data, "error determining pollset: %d", (int)result);
     return CURLM_INTERNAL_ERROR;
   }
 
@@ -2517,7 +2517,7 @@ static CURLMcode multistate_connecting(struct Curl_easy *data,
     }
     else if(*result) {
       /* failure detected */
-      CURL_TRC_M(data, "connect failed -> %d", *result);
+      CURL_TRC_M(data, "connect failed -> %d", (int)*result);
       multi_posttransfer(data);
       multi_done(data, *result, TRUE);
       *stream_error = TRUE;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1204,7 +1204,8 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
       break;
 
     default:
-      failf(data, "multi_getsock: unexpected multi state %d", data->mstate);
+      failf(data, "multi_getsock: unexpected multi state %d",
+            (int)data->mstate);
       DEBUGASSERT(0);
       break;
     }

--- a/lib/peer.c
+++ b/lib/peer.c
@@ -445,7 +445,7 @@ CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,
   result = peer_create(&pp, ppeer);
   if(result)
     failf(data, "Error %d creating peer for %s:%u",
-          result, pp.host_user.str, pp.port);
+          (int)result, pp.host_user.str, pp.port);
 
 out:
   peer_parse_clear(&pp);
@@ -522,10 +522,10 @@ CURLcode Curl_peer_from_connect_to(struct Curl_easy *data,
 #endif
 
   result = peer_create(&pp, ppeer);
-  CURL_TRC_M(data, "connect-to peer_create2 -> %d", result);
+  CURL_TRC_M(data, "connect-to peer_create2 -> %d", (int)result);
 
 out:
-  CURL_TRC_M(data, "parse connect_to peer: %s -> %d", connect_to, result);
+  CURL_TRC_M(data, "parse connect_to peer: %s -> %d", connect_to, (int)result);
   peer_parse_clear(&pp);
   return result;
 }

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -496,7 +496,7 @@ static CURLcode pop3_perform_upgrade_tls(struct Curl_easy *data,
   DEBUGASSERT(!pop3c->ssldone);
   result = Curl_conn_connect(data, FIRSTSOCKET, FALSE, &ssldone);
   DEBUGF(infof(data, "pop3_perform_upgrade_tls, connect -> %d, %d",
-               result, ssldone));
+               (int)result, ssldone));
   if(!result && ssldone) {
     pop3c->ssldone = ssldone;
     /* perform CAPA now, changes pop3c->state out of POP3_UPGRADETLS */

--- a/lib/request.c
+++ b/lib/request.c
@@ -334,7 +334,7 @@ static CURLcode req_flush(struct Curl_easy *data)
       result = Curl_xfer_send_shutdown(data, &done);
       if(result && data->req.shutdown_err_ignore) {
         infof(data, "Shutdown send direction error: %d. Broken server? "
-              "Proceeding as if everything is ok.", result);
+              "Proceeding as if everything is ok.", (int)result);
         result = CURLE_OK;
         done = TRUE;
       }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -893,7 +893,7 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
    * writer deal with it (it will report EXCESS and fail the transfer). */
   DEBUGF(infof(data, "rtsp_rtp_write_resp(len=%zu, in_header=%d, done=%d, "
                "rtspc->state=%d, req.size=%" FMT_OFF_T ")",
-               blen, rtspc->in_header, data->req.done, rtspc->state,
+               blen, rtspc->in_header, data->req.done, (int)rtspc->state,
                data->req.size));
   if(!result && (is_eos || blen)) {
     result = Curl_client_write(data, CLIENTWRITE_BODY |

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -194,7 +194,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
       return CURLE_OK;
     result = Curl_cwriter_write(data, writer->next, type, buf, nbytes);
     CURL_TRC_WRITE(data, "download_write header(type=%x, blen=%zu) -> %d",
-                   type, nbytes, result);
+                   (unsigned int)type, nbytes, result);
     return result;
   }
 
@@ -215,7 +215,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
     /* BODY arrives although we want none, bail out */
     streamclose(data->conn, "ignoring body");
     CURL_TRC_WRITE(data, "download_write body(type=%x, blen=%zu), "
-                   "did not want a BODY", type, nbytes);
+                   "did not want a BODY", (unsigned int)type, nbytes);
     data->req.download_done = TRUE;
     if(data->info.header_size)
       /* if headers have been received, this is fine */
@@ -259,7 +259,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
   if(!data->req.ignorebody && (nwrite || (type & CLIENTWRITE_EOS))) {
     result = Curl_cwriter_write(data, writer->next, type, buf, nwrite);
     CURL_TRC_WRITE(data, "download_write body(type=%x, blen=%zu) -> %d",
-                   type, nbytes, result);
+                   (unsigned int)type, nbytes, result);
     if(result)
       return result;
   }
@@ -397,7 +397,7 @@ CURLcode Curl_client_write(struct Curl_easy *data, int type, const char *buf,
 
   result = Curl_cwriter_write(data, data->req.writer_stack, type, buf, len);
   CURL_TRC_WRITE(data, "client_write(type=%x, len=%zu) -> %d",
-                 type, len, result);
+                 (unsigned int)type, len, result);
   return result;
 }
 

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -103,7 +103,7 @@ CURLcode Curl_client_start(struct Curl_easy *data)
       result = r->crt->cntrl(data, r, CURL_CRCNTRL_REWIND);
       if(result) {
         failf(data, "rewind of client reader '%s' failed: %d",
-              r->crt->name, result);
+              r->crt->name, (int)result);
         return result;
       }
       r = r->next;
@@ -194,7 +194,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
       return CURLE_OK;
     result = Curl_cwriter_write(data, writer->next, type, buf, nbytes);
     CURL_TRC_WRITE(data, "download_write header(type=%x, blen=%zu) -> %d",
-                   (unsigned int)type, nbytes, result);
+                   (unsigned int)type, nbytes, (int)result);
     return result;
   }
 
@@ -259,7 +259,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
   if(!data->req.ignorebody && (nwrite || (type & CLIENTWRITE_EOS))) {
     result = Curl_cwriter_write(data, writer->next, type, buf, nwrite);
     CURL_TRC_WRITE(data, "download_write body(type=%x, blen=%zu) -> %d",
-                   (unsigned int)type, nbytes, result);
+                   (unsigned int)type, nbytes, (int)result);
     if(result)
       return result;
   }
@@ -397,7 +397,7 @@ CURLcode Curl_client_write(struct Curl_easy *data, int type, const char *buf,
 
   result = Curl_cwriter_write(data, data->req.writer_stack, type, buf, len);
   CURL_TRC_WRITE(data, "client_write(type=%x, len=%zu) -> %d",
-                 (unsigned int)type, len, result);
+                 (unsigned int)type, len, (int)result);
   return result;
 }
 
@@ -732,7 +732,7 @@ static CURLcode cr_in_read(struct Curl_easy *data,
   }
   CURL_TRC_READ(data, "cr_in_read(len=%zu, total=%" FMT_OFF_T
                 ", read=%" FMT_OFF_T ") -> %d, nread=%zu, eos=%d",
-                blen, ctx->total_len, ctx->read_len, result,
+                blen, ctx->total_len, ctx->read_len, (int)result,
                 *pnread, *peos);
   return result;
 }
@@ -1055,7 +1055,7 @@ static CURLcode cr_lc_read(struct Curl_easy *data,
 
 out:
   CURL_TRC_READ(data, "cr_lc_read(len=%zu) -> %d, nread=%zu, eos=%d",
-                blen, result, *pnread, *peos);
+                blen, (int)result, *pnread, *peos);
   return result;
 }
 
@@ -1140,7 +1140,7 @@ CURLcode Curl_creader_set_fread(struct Curl_easy *data, curl_off_t len)
   result = do_init_reader_stack(data, r);
 out:
   CURL_TRC_READ(data, "add fread reader, len=%" FMT_OFF_T " -> %d",
-                len, result);
+                len, (int)result);
   return result;
 }
 
@@ -1218,7 +1218,7 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
 
 out:
   CURL_TRC_READ(data, "client_read(len=%zu) -> %d, nread=%zu, eos=%d",
-                blen, result, *nread, *eos);
+                blen, (int)result, *nread, *eos);
   return result;
 }
 
@@ -1404,7 +1404,7 @@ CURLcode Curl_creader_set_buf(struct Curl_easy *data,
   cl_reset_reader(data);
   result = do_init_reader_stack(data, r);
 out:
-  CURL_TRC_READ(data, "add buf reader, len=%zu -> %d", blen, result);
+  CURL_TRC_READ(data, "add buf reader, len=%zu -> %d", blen, (int)result);
   return result;
 }
 
@@ -1437,7 +1437,7 @@ CURLcode Curl_creader_unpause(struct Curl_easy *data)
 
   while(reader) {
     result = reader->crt->cntrl(data, reader, CURL_CRCNTRL_UNPAUSE);
-    CURL_TRC_READ(data, "unpausing %s -> %d", reader->crt->name, result);
+    CURL_TRC_READ(data, "unpausing %s -> %d", reader->crt->name, (int)result);
     if(result)
       break;
     reader = reader->next;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -802,7 +802,7 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
   if((arg > ok) || (arg < 0))
     /* reserve other values for future use */
     infof(data, "boolean setopt(%d) got unsupported argument %ld,"
-          " treated as %d", option, arg, enabled);
+          " treated as %d", (int)option, arg, enabled);
 
   return CURLE_OK;
 }

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2947,6 +2947,6 @@ CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...)
 
   va_end(arg);
   if(result == CURLE_BAD_FUNCTION_ARGUMENT)
-    failf(data, "setopt 0x%x got bad argument", option);
+    failf(data, "setopt 0x%x got bad argument", (unsigned int)option);
   return result;
 }

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -347,7 +347,7 @@ static CURLcode cr_eob_read(struct Curl_easy *data,
     /* Get more and convert it when needed */
     result = Curl_creader_read(data, reader->next, buf, blen, &nread, &eos);
     CURL_TRC_SMTP(data, "cr_eob_read, next_read(len=%zu) -> %d, %zu eos=%d",
-                  blen, result, nread, eos);
+                  blen, (int)result, nread, eos);
     if(result)
       return result;
 
@@ -432,7 +432,7 @@ static CURLcode cr_eob_read(struct Curl_easy *data,
   }
   *peos = (bool)ctx->eos;
   DEBUGF(infof(data, "cr_eob_read(%zu) -> %d, %zu, %d",
-               blen, result, *pnread, *peos));
+               blen, (int)result, *pnread, *peos));
   return result;
 }
 
@@ -700,7 +700,7 @@ static CURLcode smtp_perform_upgrade_tls(struct Curl_easy *data,
   DEBUGASSERT(!smtpc->ssldone);
   result = Curl_conn_connect(data, FIRSTSOCKET, FALSE, &ssldone);
   DEBUGF(infof(data, "smtp_perform_upgrade_tls, connect -> %d, %d",
-               result, ssldone));
+               (int)result, ssldone));
   if(!result && ssldone) {
     smtpc->ssldone = ssldone;
     /* perform EHLO now, changes smtp->state out of SMTP_UPGRADETLS */
@@ -1743,7 +1743,7 @@ static CURLcode smtp_done(struct Curl_easy *data, CURLcode status,
   /* Clear the transfer mode for the next request */
   smtp->transfer = PPTRANSFER_BODY;
   CURL_TRC_SMTP(data, "smtp_done(status=%d, premature=%d) -> %d",
-                status, premature, result);
+                (int)status, premature, (int)result);
   return result;
 }
 
@@ -1804,7 +1804,7 @@ static CURLcode smtp_perform(struct Curl_easy *data,
 
 out:
   CURL_TRC_SMTP(data, "smtp_perform() -> %d, connected=%d, done=%d",
-                result, *connected, *dophase_done);
+                (int)result, *connected, *dophase_done);
   return result;
 }
 
@@ -1853,7 +1853,7 @@ static CURLcode smtp_regular_transfer(struct Curl_easy *data,
     result = smtp_dophase_done(data, smtp, connected);
 
   CURL_TRC_SMTP(data, "smtp_regular_transfer() -> %d, done=%d",
-                result, *dophase_done);
+                (int)result, *dophase_done);
   return result;
 }
 
@@ -1885,7 +1885,7 @@ static CURLcode smtp_do(struct Curl_easy *data, bool *done)
     return result;
 
   result = smtp_regular_transfer(data, smtpc, smtp, done);
-  CURL_TRC_SMTP(data, "smtp_do() -> %d, done=%d", result, *done);
+  CURL_TRC_SMTP(data, "smtp_do() -> %d, done=%d", (int)result, *done);
   return result;
 }
 
@@ -1936,7 +1936,8 @@ static CURLcode smtp_doing(struct Curl_easy *data, bool *dophase_done)
     DEBUGF(infof(data, "DO phase is complete"));
   }
 
-  CURL_TRC_SMTP(data, "smtp_doing() -> %d, done=%d", result, *dophase_done);
+  CURL_TRC_SMTP(data, "smtp_doing() -> %d, done=%d", (int)result,
+                *dophase_done);
   return result;
 }
 
@@ -1978,7 +1979,7 @@ static CURLcode smtp_setup_connection(struct Curl_easy *data,
     result = CURLE_OUT_OF_MEMORY;
 
 out:
-  CURL_TRC_SMTP(data, "smtp_setup_connection() -> %d", result);
+  CURL_TRC_SMTP(data, "smtp_setup_connection() -> %d", (int)result);
   return result;
 }
 

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1277,11 +1277,11 @@ static CURLcode socks_cf_adjust_pollset(struct Curl_cfilter *cf,
     case SOCKS5_ST_REQ0_SEND:
     case SOCKS5_ST_AUTH_SEND:
     case SOCKS5_ST_REQ1_SEND:
-      CURL_TRC_CF(data, cf, "adjust pollset out (%d)", sx->state);
+      CURL_TRC_CF(data, cf, "adjust pollset out (%d)", (int)sx->state);
       result = Curl_pollset_set_out_only(data, ps, sock);
       break;
     default:
-      CURL_TRC_CF(data, cf, "adjust pollset in (%d)", sx->state);
+      CURL_TRC_CF(data, cf, "adjust pollset in (%d)", (int)sx->state);
       result = Curl_pollset_set_in_only(data, ps, sock);
       break;
     }

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -647,14 +647,15 @@ const char *Curl_sspi_strerror(SECURITY_STATUS err, char *buf, size_t buflen)
                    "SEC_E_ILLEGAL_MESSAGE (0x%08lx) - This error usually "
                    "occurs when a fatal SSL/TLS alert is received (e.g. "
                    "handshake failed). More detail may be available in "
-                   "the Windows System event log.", err);
+                   "the Windows System event log.", (unsigned long)err);
   }
   else {
     char msgbuf[256];
     if(curlx_get_winapi_error((DWORD)err, msgbuf, sizeof(msgbuf)))
-      curl_msnprintf(buf, buflen, "%s (0x%08lx) - %s", txt, err, msgbuf);
+      curl_msnprintf(buf, buflen, "%s (0x%08lx) - %s", txt, (unsigned long)err,
+                     msgbuf);
     else
-      curl_msnprintf(buf, buflen, "%s (0x%08lx)", txt, err);
+      curl_msnprintf(buf, buflen, "%s (0x%08lx)", txt, (unsigned long)err);
   }
 #else /* CURLVERBOSE */
   if(err == SEC_E_OK)

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -404,7 +404,6 @@ const char *curl_share_strerror(CURLSHcode error)
   case CURLSHE_NOT_BUILT_IN:
     return "Feature not enabled in this library";
 
-  case CURLSHE_SIGNED:
   case CURLSHE_LAST:
     break;
   }

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -404,6 +404,7 @@ const char *curl_share_strerror(CURLSHcode error)
   case CURLSHE_NOT_BUILT_IN:
     return "Feature not enabled in this library";
 
+  case CURLSHE_SIGNED:
   case CURLSHE_LAST:
     break;
   }
@@ -517,6 +518,7 @@ const char *curl_url_strerror(CURLUcode error)
   case CURLUE_TOO_LARGE:
     return "A value or data field is larger than allowed";
 
+  case CURLUE_SIGNED:
   case CURLUE_LAST:
     break;
   }

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -517,7 +517,6 @@ const char *curl_url_strerror(CURLUcode error)
   case CURLUE_TOO_LARGE:
     return "A value or data field is larger than allowed";
 
-  case CURLUE_SIGNED:
   case CURLUE_LAST:
     break;
   }

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -874,7 +874,7 @@ static CURLcode tftp_state_machine(struct tftp_conn *state,
     infof(data, "%s", "TFTP finished");
     break;
   default:
-    DEBUGF(infof(data, "STATE: %d", state->state));
+    DEBUGF(infof(data, "STATE: %d", (int)state->state));
     failf(data, "%s", "Internal state machine error");
     result = CURLE_TFTP_ILLEGAL;
     break;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -332,7 +332,7 @@ static CURLcode sendrecv_dl(struct Curl_easy *data,
 out:
   Curl_multi_xfer_buf_release(data, xfer_buf);
   if(result)
-    DEBUGF(infof(data, "sendrecv_dl() -> %d", result));
+    DEBUGF(infof(data, "sendrecv_dl() -> %d", (int)result));
   return result;
 }
 
@@ -425,7 +425,7 @@ CURLcode Curl_sendrecv(struct Curl_easy *data)
 
 out:
   if(result)
-    DEBUGF(infof(data, "Curl_sendrecv() -> %d", result));
+    DEBUGF(infof(data, "Curl_sendrecv() -> %d", (int)result));
   return result;
 }
 
@@ -777,7 +777,7 @@ CURLcode Curl_xfer_write_resp(struct Curl_easy *data,
     data->req.download_done = TRUE;
   }
   CURL_TRC_WRITE(data, "xfer_write_resp(len=%zu, eos=%d) -> %d",
-                 blen, is_eos, result);
+                 blen, is_eos, (int)result);
   return result;
 }
 
@@ -834,7 +834,7 @@ CURLcode Curl_xfer_send(struct Curl_easy *data,
     data->info.request_size += *pnwritten;
 
   DEBUGF(infof(data, "Curl_xfer_send(len=%zu, eos=%d) -> %d, %zu",
-               blen, eos, result, *pnwritten));
+               blen, eos, (int)result, *pnwritten));
   return result;
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -2982,7 +2982,7 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
     result = Curl_conn_setup(data, conn, FIRSTSOCKET, CURL_CF_SSL_DEFAULT);
     if(!result)
       result = Curl_headers_init(data);
-    CURL_TRC_M(data, "Curl_conn_setup() -> %d", result);
+    CURL_TRC_M(data, "Curl_conn_setup() -> %d", (int)result);
   }
 
 out:

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -844,7 +844,8 @@ static CURLcode auth_create_digest_http_message(
 
   if(digest->qop)
     hashthis = curl_maprintf("%s:%s:%08x:%s:%s:%s", ha1, digest->nonce,
-                             digest->nc, digest->cnonce, digest->qop, ha2);
+                             (unsigned int)digest->nc, digest->cnonce,
+                             digest->qop, ha2);
   else
     hashthis = curl_maprintf("%s:%s:%s", ha1, digest->nonce, ha2);
 
@@ -909,7 +910,7 @@ static CURLcode auth_create_digest_http_message(
                             nonce_quoted,
                             uri_quoted,
                             digest->cnonce,
-                            digest->nc,
+                            (unsigned int)digest->nc,
                             digest->qop,
                             request_digest);
 

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -456,7 +456,8 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     if(status == SEC_E_OK)
       output_token_len = chlg_buf[4].cbBuffer;
     else { /* delete the context so a new one can be made */
-      infof(data, "digest_sspi: MakeSignature failed, error 0x%08lx", status);
+      infof(data, "digest_sspi: MakeSignature failed, error 0x%08lx",
+            (unsigned long)status);
       Curl_pSecFn->DeleteSecurityContext(digest->http_context);
       curlx_safefree(digest->http_context);
     }

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -298,7 +298,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                                   &attrs, NULL);
   if(status != SEC_E_OK) {
     infof(data, "NTLM handshake failure (type-3 message): Status=0x%08lx",
-          status);
+          (unsigned long)status);
 
     if(status == SEC_E_INSUFFICIENT_MEMORY)
       return CURLE_OUT_OF_MEMORY;

--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -1141,7 +1141,7 @@ out:
     result = Curl_cf_ngtcp2_cmn_set_expiry(cf, data, &pktx);
   }
   if(result || *done)
-    CURL_TRC_CF(data, cf, "connect -> %d, done=%d", result, *done);
+    CURL_TRC_CF(data, cf, "connect -> %d, done=%d", (int)result, *done);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -1182,7 +1182,8 @@ CURLcode Curl_cf_ngtcp2_cmn_shutdown(struct Curl_cfilter *cf,
         goto out;
       }
       else if(result) {
-        CURL_TRC_CF(data, cf, "shutdown, error %d flushing sendbuf", result);
+        CURL_TRC_CF(data, cf, "shutdown, error %d flushing sendbuf",
+                    (int)result);
         *done = TRUE;
         goto out;
       }
@@ -1210,7 +1211,7 @@ CURLcode Curl_cf_ngtcp2_cmn_shutdown(struct Curl_cfilter *cf,
                                (size_t)nwritten, &n);
       if(result) {
         CURL_TRC_CF(data, cf, "error %d adding shutdown packets to sendbuf, "
-                    "aborting shutdown", result);
+                    "aborting shutdown", (int)result);
         goto out;
       }
 
@@ -1229,7 +1230,8 @@ CURLcode Curl_cf_ngtcp2_cmn_shutdown(struct Curl_cfilter *cf,
       goto out;
     }
     else if(result) {
-      CURL_TRC_CF(data, cf, "shutdown, error %d flushing sendbuf", result);
+      CURL_TRC_CF(data, cf, "shutdown, error %d flushing sendbuf",
+                  (int)result);
       *done = TRUE;
       goto out;
     }
@@ -1681,7 +1683,8 @@ CURLcode Curl_cf_ngtcp2_progress_ingress(struct Curl_cfilter *cf,
         return CURLE_OK;
       }
       if(result) {
-        CURL_TRC_CF(data, cf, "ingress, recv from tunnel failed: %d", result);
+        CURL_TRC_CF(data, cf, "ingress, recv from tunnel failed: %d",
+                    (int)result);
         return result;
       }
       if(nread == 0) {
@@ -1856,7 +1859,7 @@ void Curl_cf_ngtcp2_h3_stream_close(struct Curl_cfilter *cf,
     result = Curl_cf_ngtcp2_progress_egress(cf, data, NULL);
     if(result)
       CURL_TRC_CF(data, cf, "[%" PRId64 "] cancel stream -> %d",
-                  stream->id, result);
+                  stream->id, (int)result);
   }
 }
 
@@ -1914,7 +1917,7 @@ bool Curl_cf_ngtcp2_cmn_conn_is_alive(struct Curl_cfilter *cf,
        only "protocol frames" */
     *input_pending = FALSE;
     result = Curl_cf_ngtcp2_progress_ingress(cf, data, NULL);
-    CURL_TRC_CF(data, cf, "is_alive, progress ingress -> %d", result);
+    CURL_TRC_CF(data, cf, "is_alive, progress ingress -> %d", (int)result);
     alive = result ? FALSE : TRUE;
   }
 

--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -1104,7 +1104,7 @@ out:
     result = CURLE_COULDNT_CONNECT;
     if(cerr) {
       CURL_TRC_CF(data, cf, "connect error, type=%d, code=%" PRIu64,
-                  cerr->type, cerr->error_code);
+                  (int)cerr->type, cerr->error_code);
       switch(cerr->type) {
       case NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION:
         CURL_TRC_CF(data, cf, "error in version negotiation");
@@ -1196,7 +1196,7 @@ CURLcode Curl_cf_ngtcp2_cmn_shutdown(struct Curl_cfilter *cf,
       (uint8_t *)buffer, sizeof(buffer),
       &ctx->last_error, pktx.ts);
     CURL_TRC_CF(data, cf, "start shutdown(err_type=%d, err_code=%"
-                PRIu64 ") -> %zd", ctx->last_error.type,
+                PRIu64 ") -> %zd", (int)ctx->last_error.type,
                 ctx->last_error.error_code, (ssize_t)nwritten);
     /* there are cases listed in ngtcp2 documentation where this call
      * may fail. Since we are doing a connection shutdown as graceful

--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -1591,7 +1591,7 @@ static CURLcode cf_ngtcp2_recv_pkts(const unsigned char *buf, size_t buflen,
 
   if(ecn)
     CURL_TRC_CF(pktx->data, pktx->cf, "vquic_recv(len=%zu, gso=%zu, ecn=%x)",
-                buflen, gso_size, ecn);
+                buflen, gso_size, (unsigned int)ecn);
   ngtcp2_addr_init(&path.local, (struct sockaddr *)&ctx->q.local_addr,
                    ctx->q.local_addrlen);
   ngtcp2_addr_init(&path.remote, (struct sockaddr *)remote_addr,

--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -774,7 +774,7 @@ static CURLcode cf_h3_proxy_send(struct Curl_cfilter *cf,
     result = cf_h3_proxy_sendbuf_add(data, stream, buf, len, pnwritten);
     CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_send, add to "
                 "sendbuf(len=%zu) -> %d, %zu",
-                stream->id, len, result, *pnwritten);
+                stream->id, len, (int)result, *pnwritten);
     if(result)
       goto out;
     (void)nghttp3_conn_resume_stream(ctx->h3conn, stream->id);
@@ -791,7 +791,7 @@ out:
                           Curl_cf_ngtcp2_cmn_set_expiry(cf, data, &pktx));
 denied:
   CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_send(len=%zu) -> %d, %zu",
-              stream ? stream->id : -1, len, result, *pnwritten);
+              stream ? stream->id : -1, len, (int)result, *pnwritten);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -843,7 +843,7 @@ static CURLcode cf_h3_proxy_recv(struct Curl_cfilter *cf,
     result = Curl_bufq_cread(&pctx->tunnel.recvbuf, buf, len, pnread);
     if(result) {
       CURL_TRC_CF(data, cf, "[%" PRId64 "] read inbufq(len=%zu) -> %zu, %d",
-                  stream->id, len, *pnread, result);
+                  stream->id, len, *pnread, (int)result);
       goto out;
     }
   }
@@ -875,7 +875,7 @@ out:
                           Curl_cf_ngtcp2_cmn_set_expiry(cf, data, &pktx));
 denied:
   CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_recv(len=%zu) -> %d, %zu",
-              stream ? stream->id : -1, len, result, *pnread);
+              stream ? stream->id : -1, len, (int)result, *pnread);
   CF_DATA_RESTORE(cf, save);
   return result;
 }

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -134,7 +134,8 @@ static void h3_xfer_write_resp_hd(struct Curl_cfilter *cf,
     stream->xfer_result = Curl_xfer_write_resp_hd(data, buf, buflen, eos);
     if(stream->xfer_result)
       CURL_TRC_CF(data, cf, "[%" PRId64 "] error %d writing %zu "
-                  "bytes of headers", stream->id, stream->xfer_result, buflen);
+                  "bytes of headers", stream->id, (int)stream->xfer_result,
+                  buflen);
   }
 }
 
@@ -154,7 +155,7 @@ static void h3_xfer_write_resp(struct Curl_cfilter *cf,
     /* If the transfer write is errored, we do not want any more data */
     if(stream->xfer_result) {
       CURL_TRC_CF(data, cf, "[%" PRId64 "] error %d writing %zu bytes of data",
-                  stream->id, stream->xfer_result, buflen);
+                  stream->id, (int)stream->xfer_result, buflen);
     }
   }
 }
@@ -545,7 +546,7 @@ out:
     result = ctx->tls_vrfy_result;
 denied:
   CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_recv(buflen=%zu) -> %d, %zu",
-              stream ? stream->id : -1, buflen, result, *pnread);
+              stream ? stream->id : -1, buflen, (int)result, *pnread);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -817,7 +818,7 @@ static CURLcode cf_ngtcp2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
     result = h3_stream_open(cf, data, buf, len, pnwritten);
     if(result) {
-      CURL_TRC_CF(data, cf, "failed to open stream -> %d", result);
+      CURL_TRC_CF(data, cf, "failed to open stream -> %d", (int)result);
       goto out;
     }
     VERBOSE(stream = H3_STREAM_CTX(ctx, data));
@@ -855,7 +856,7 @@ static CURLcode cf_ngtcp2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     result = Curl_bufq_write(&stream->sendbuf, buf, len, pnwritten);
     CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_send, add to "
                 "sendbuf(len=%zu) -> %d, %zu",
-                stream->id, len, result, *pnwritten);
+                stream->id, len, (int)result, *pnwritten);
     if(result)
       goto out;
     (void)nghttp3_conn_resume_stream(ctx->h3conn, stream->id);
@@ -874,7 +875,7 @@ out:
     result = ctx->tls_vrfy_result;
 denied:
   CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_send(len=%zu) -> %d, %zu",
-              stream ? stream->id : -1, len, result, *pnwritten);
+              stream ? stream->id : -1, len, (int)result, *pnwritten);
   CF_DATA_RESTORE(cf, save);
   return result;
 }

--- a/lib/vquic/cf-quiche.c
+++ b/lib/vquic/cf-quiche.c
@@ -519,10 +519,14 @@ static void cf_quiche_process_ev(struct Curl_cfilter *cf,
                                  struct h3_stream_ctx *stream,
                                  quiche_h3_event *ev)
 {
+  enum quiche_h3_event_type type;
+
   if(!stream)
     return;
 
-  switch(quiche_h3_event_type(ev)) {
+  type = quiche_h3_event_type(ev);
+
+  switch(type) {
   case QUICHE_H3_EVENT_HEADERS: {
     struct cb_ctx cb_ctx;
     stream->resp_got_header = TRUE;
@@ -568,7 +572,7 @@ static void cf_quiche_process_ev(struct Curl_cfilter *cf,
 
   default:
     CURL_TRC_CF(data, cf, "[%" PRIu64 "] recv, unhandled event %d",
-                stream->id, quiche_h3_event_type(ev));
+                stream->id, (int)type);
     break;
   }
 }

--- a/lib/vquic/cf-quiche.c
+++ b/lib/vquic/cf-quiche.c
@@ -303,7 +303,7 @@ static void cf_quiche_stream_close(struct Curl_cfilter *cf,
     result = cf_flush_egress(cf, data);
     if(result)
       CURL_TRC_CF(data, cf, "[%" PRIu64 "] stream close, flush egress -> %d",
-                  stream->id, result);
+                  stream->id, (int)result);
   }
 }
 
@@ -343,7 +343,8 @@ static void cf_quiche_write_hd(struct Curl_cfilter *cf,
     stream->xfer_result = Curl_xfer_write_resp_hd(data, buf, blen, eos);
     if(stream->xfer_result)
       CURL_TRC_CF(data, cf, "[%" PRIu64 "] error %d writing %zu "
-                  "bytes of headers", stream->id, stream->xfer_result, blen);
+                  "bytes of headers", stream->id, (int)stream->xfer_result,
+                  blen);
   }
 }
 
@@ -423,7 +424,7 @@ static int cb_each_header(uint8_t *name, size_t name_len,
 
   if(result) {
     CURL_TRC_CF(x->data, x->cf, "[%" PRIu64 "] on header error %d",
-                stream->id, result);
+                stream->id, (int)result);
     if(!stream->xfer_result)
       stream->xfer_result = result;
   }
@@ -464,7 +465,7 @@ static void cf_quiche_flush_body(struct Curl_cfilter *cf,
       Curl_bufq_skip(&ctx->writebuf, blen);
       if(stream->xfer_result) {
         CURL_TRC_CF(data, cf, "[%" PRIu64 "] error %d writing %zu bytes"
-                    " of data", stream->id, stream->xfer_result, blen);
+                    " of data", stream->id, (int)stream->xfer_result, blen);
       }
     }
     else
@@ -501,9 +502,9 @@ static void cf_quiche_recv_body(struct Curl_cfilter *cf,
       break;
     else if(result) {
       CURL_TRC_CF(data, cf, "[%" PRIu64 "] recv_body error %d",
-                  stream->id, result);
+                  stream->id, (int)result);
       failf(data, "[%" PRIu64 "] Error %d in HTTP/3 response body for stream",
-            stream->id, result);
+            stream->id, (int)result);
       stream->closed = TRUE;
       stream->reset = TRUE;
       stream->send_closed = TRUE;
@@ -880,7 +881,7 @@ static CURLcode recv_closed_stream(struct Curl_cfilter *cf,
           vquic_h3_err_str(stream->error3));
     result = data->req.bytecount ? CURLE_PARTIAL_FILE : CURLE_HTTP3;
     CURL_TRC_CF(data, cf, "[%" PRIu64 "] cf_recv, was reset -> %d",
-                stream->id, result);
+                stream->id, (int)result);
   }
   else if(!stream->resp_got_header) {
     failf(data, "HTTP/3 stream %" PRIu64 " was closed cleanly, but before "
@@ -931,7 +932,8 @@ out:
   if(*pnread > 0)
     ctx->data_recvd += *pnread;
   CURL_TRC_CF(data, cf, "[%" PRIu64 "] cf_recv(len=%zu) -> %d, %zu, total=%"
-              FMT_OFF_T, stream->id, blen, result, *pnread, ctx->data_recvd);
+              FMT_OFF_T, stream->id, blen, (int)result, *pnread,
+              ctx->data_recvd);
   return result;
 }
 
@@ -1157,7 +1159,7 @@ out:
 
   CURL_TRC_CF(data, cf, "[%" PRIu64 "] cf_send(len=%zu) -> %d, %zu",
               stream ? stream->id : (uint64_t)~0, len,
-              result, *pnwritten);
+              (int)result, *pnwritten);
   return result;
 }
 
@@ -1241,7 +1243,7 @@ static CURLcode cf_quiche_cntrl(struct Curl_cfilter *cf,
       body[0] = 'X';
       result = cf_quiche_send(cf, data, body, 0, TRUE, &sent);
       CURL_TRC_CF(data, cf, "[%" PRIu64 "] DONE_SEND -> %d, %zu",
-                  stream->id, result, sent);
+                  stream->id, (int)result, sent);
     }
     break;
   }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -259,7 +259,7 @@ static CURLcode send_packet_no_gso(struct Curl_cfilter *cf,
 out:
   CURL_TRC_CF(data, cf,
               "vquic_%s(len=%zu, gso=%zu, calls=%zu) -> %d, sent=%zu",
-              VQUIC_SEND_METHOD, pktlen, gsolen, calls, result, *psent);
+              VQUIC_SEND_METHOD, pktlen, gsolen, calls, (int)result, *psent);
   return result;
 }
 
@@ -297,7 +297,7 @@ static CURLcode send_packet_no_gso_cf(struct Curl_cfilter *cf,
 out:
   CURL_TRC_CF(data, cf,
               "vquic_cf_send(len=%zu, gso=%zu, calls=%zu) -> %d, sent=%zu",
-              pktlen, gsolen, calls, result, *psent);
+              pktlen, gsolen, calls, (int)result, *psent);
   return result;
 }
 
@@ -327,7 +327,7 @@ static CURLcode vquic_send_packets(struct Curl_cfilter *cf,
     result = do_sendmsg(cf, data, qctx, pkt, pktlen, gsolen, psent);
     CURL_TRC_CF(data, cf,
                 "vquic_%s(len=%zu, gso=%zu, calls=1) -> %d, sent=%zu",
-                VQUIC_SEND_METHOD, pktlen, gsolen, result, *psent);
+                VQUIC_SEND_METHOD, pktlen, gsolen, (int)result, *psent);
   }
   if(!result)
     qctx->last_io = qctx->last_op;
@@ -532,7 +532,7 @@ out:
   if(total_nread || result)
     CURL_TRC_CF(data, cf,
                 "vquic_recvmmsg(len=%zu, packets=%zu, calls=%zu) -> %d",
-                total_nread, pkts, calls, result);
+                total_nread, pkts, calls, (int)result);
   Curl_multi_xfer_sockbuf_release(data, sockbuf);
   return result;
 }
@@ -616,7 +616,7 @@ out:
   if(total_nread || result)
     CURL_TRC_CF(data, cf,
                 "vquic_recvmsg(len=%zu, packets=%zu, calls=%zu) -> %d",
-                total_nread, pkts, calls, result);
+                total_nread, pkts, calls, (int)result);
   return result;
 }
 
@@ -681,7 +681,7 @@ out:
   if(total_nread || result)
     CURL_TRC_CF(data, cf,
                 "vquic_recvfrom(len=%zu, packets=%zu, calls=%zu) -> %d",
-                total_nread, pkts, calls, result);
+                total_nread, pkts, calls, (int)result);
   return result;
 }
 #endif /* !HAVE_SENDMMSG && !HAVE_SENDMSG */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2469,7 +2469,7 @@ static CURLcode myssh_pollset(struct Curl_easy *data,
     if(waitfor & REQ_IO_SEND)
       flags |= CURL_POLL_OUT;
     DEBUGASSERT(flags);
-    CURL_TRC_SSH(data, "pollset, flags=%x", flags);
+    CURL_TRC_SSH(data, "pollset, flags=%x", (unsigned int)flags);
     return Curl_pollset_change(data, ps, sock, flags, 0);
   }
   /* While we still have a session, we listen incoming data. */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2444,7 +2444,7 @@ static CURLcode myssh_statemachine(struct Curl_easy *data,
   if(!result && (sshc->state == SSH_STOP))
     result = sshc->actualcode;
   CURL_TRC_SSH(data, "[%s] statemachine() -> %d, block=%d",
-               Curl_ssh_statename(sshc->state), result, *block);
+               Curl_ssh_statename(sshc->state), (int)result, *block);
   return result;
 }
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3209,7 +3209,7 @@ static CURLcode ssh_pollset(struct Curl_easy *data,
     if(waitfor & REQ_IO_SEND)
       flags |= CURL_POLL_OUT;
     DEBUGASSERT(flags);
-    CURL_TRC_SSH(data, "pollset, flags=%x", flags);
+    CURL_TRC_SSH(data, "pollset, flags=%x", (unsigned int)flags);
     return Curl_pollset_change(data, ps, sock, flags, 0);
   }
   /* While we still have a session, we listen incoming data. */

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3183,7 +3183,7 @@ static CURLcode ssh_statemachine(struct Curl_easy *data,
     result = CURLE_OK;
   }
   CURL_TRC_SSH(data, "[%s] statemachine() -> %d, block=%d",
-               Curl_ssh_statename(sshc->state), result, *block);
+               Curl_ssh_statename(sshc->state), (int)result, *block);
 
   return result;
 }
@@ -3844,7 +3844,7 @@ static CURLcode sftp_disconnect(struct Curl_easy *data,
       CURL_TRC_SSH(data, "DISCONNECT starts now");
       myssh_to(data, sshc, SSH_SFTP_SHUTDOWN);
       result = ssh_block_statemach(data, sshc, sshp, TRUE);
-      CURL_TRC_SSH(data, "DISCONNECT is done -> %d", result);
+      CURL_TRC_SSH(data, "DISCONNECT is done -> %d", (int)result);
     }
     sshc_cleanup(sshc, data, TRUE);
   }

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -95,7 +95,7 @@ static ssize_t gtls_push(void *s, const void *buf, size_t blen)
   DEBUGASSERT(data);
   result = Curl_conn_cf_send(cf->next, data, buf, blen, FALSE, &nwritten);
   CURL_TRC_CF(data, cf, "gtls_push(len=%zu) -> %d, %zu",
-              blen, result, nwritten);
+              blen, (int)result, nwritten);
   backend->gtls.io_result = result;
   if(result) {
     /* !checksrc! disable ERRNOVAR 1 */
@@ -128,7 +128,8 @@ static ssize_t gtls_pull(void *s, void *buf, size_t blen)
   }
 
   result = Curl_conn_cf_recv(cf->next, data, buf, blen, &nread);
-  CURL_TRC_CF(data, cf, "gtls_pull(len=%zu) -> %d, %zu", blen, result, nread);
+  CURL_TRC_CF(data, cf, "gtls_pull(len=%zu) -> %d, %zu", blen, (int)result,
+              nread);
   backend->gtls.io_result = result;
   if(result) {
     /* !checksrc! disable ERRNOVAR 1 */
@@ -2047,7 +2048,8 @@ out:
   }
   *done = ((connssl->state == ssl_connection_complete) ||
            (connssl->state == ssl_connection_deferred));
-  CURL_TRC_CF(data, cf, "gtls_connect_common() -> %d, done=%d", result, *done);
+  CURL_TRC_CF(data, cf, "gtls_connect_common() -> %d, done=%d", (int)result,
+              *done);
   return result;
 }
 
@@ -2122,7 +2124,7 @@ static CURLcode gtls_send(struct Curl_cfilter *cf,
 
 out:
   CURL_TRC_CF(data, cf, "gtls_send(len=%zu) -> %d, %zu",
-              blen, result, *pnwritten);
+              blen, (int)result, *pnwritten);
   return result;
 }
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -141,7 +141,7 @@ static int mbedtls_bio_cf_write(void *bio,
 
   result = Curl_conn_cf_send(cf->next, data, buf, blen, FALSE, &nwritten);
   CURL_TRC_CF(data, cf, "mbedtls_bio_cf_out_write(len=%zu) -> %d, %zu",
-              blen, result, nwritten);
+              blen, (int)result, nwritten);
   if(result == CURLE_AGAIN)
     return MBEDTLS_ERR_SSL_WANT_WRITE;
   return result ? -1 : (int)nwritten;
@@ -163,7 +163,7 @@ static int mbedtls_bio_cf_read(void *bio, unsigned char *buf, size_t blen)
 
   result = Curl_conn_cf_recv(cf->next, data, (char *)buf, blen, &nread);
   CURL_TRC_CF(data, cf, "mbedtls_bio_cf_in_read(len=%zu) -> %d, %zu",
-              blen, result, nread);
+              blen, (int)result, nread);
   if(result == CURLE_AGAIN)
     return MBEDTLS_ERR_SSL_WANT_READ;
   /* nread is never larger than int here */
@@ -1262,7 +1262,7 @@ static CURLcode mbed_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
 
   CURL_TRC_CF(data, cf, "mbedtls_ssl_write(len=%zu) -> %d, %zu",
-              len, result, *pnwritten);
+              len, (int)result, *pnwritten);
   return result;
 }
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -464,7 +464,8 @@ static int mbed_verify_cb(void *ptr, mbedtls_x509_crt *crt,
     mbedtls_x509_crt_verify_info(buf, sizeof(buf), "", *flags);
     failf(data, "mbedTLS: %s", buf);
 #else
-    failf(data, "mbedTLS: certificate verification error 0x%08x", *flags);
+    failf(data, "mbedTLS: certificate verification error 0x%08x",
+          (unsigned int)*flags);
 #endif
   }
 
@@ -529,7 +530,7 @@ static CURLcode mbed_load_cacert(struct Curl_cfilter *cf,
     if(ret < 0) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
       failf(data, "mbedTLS: error importing CA cert blob: (-0x%04X) %s",
-            -ret, errorbuf);
+            (unsigned int)-ret, errorbuf);
       return CURLE_SSL_CERTPROBLEM;
     }
   }
@@ -541,7 +542,7 @@ static CURLcode mbed_load_cacert(struct Curl_cfilter *cf,
     if(ret < 0) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
       failf(data, "mbedTLS: error reading CA cert file %s: (-0x%04X) %s",
-            ssl_cafile, -ret, errorbuf);
+            ssl_cafile, (unsigned int)-ret, errorbuf);
       return CURLE_SSL_CACERT_BADFILE;
     }
 #else
@@ -557,7 +558,7 @@ static CURLcode mbed_load_cacert(struct Curl_cfilter *cf,
     if(ret < 0) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
       failf(data, "mbedTLS: error reading CA cert path %s: (-0x%04X) %s",
-            ssl_capath, -ret, errorbuf);
+            ssl_capath, (unsigned int)-ret, errorbuf);
 
       if(verifypeer)
         return CURLE_SSL_CACERT_BADFILE;
@@ -595,7 +596,7 @@ static CURLcode mbed_load_clicert(struct Curl_cfilter *cf,
     if(ret) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
       failf(data, "mbedTLS: error reading client cert file %s: (-0x%04X) %s",
-            ssl_cert, -ret, errorbuf);
+            ssl_cert, (unsigned int)-ret, errorbuf);
 
       return CURLE_SSL_CERTPROBLEM;
     }
@@ -642,7 +643,7 @@ static CURLcode mbed_load_clicert(struct Curl_cfilter *cf,
     if(ret) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
       failf(data, "mbedTLS: error reading client cert blob: (-0x%04X) %s",
-            -ret, errorbuf);
+            (unsigned int)-ret, errorbuf);
       return CURLE_SSL_CERTPROBLEM;
     }
   }
@@ -689,7 +690,7 @@ static CURLcode mbed_load_privkey(struct Curl_cfilter *cf,
       if(ret) {
         mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
         failf(data, "mbedTLS: error reading private key %s: (-0x%04X) %s",
-              ssl_config->primary.key, -ret, errorbuf);
+              ssl_config->primary.key, (unsigned int)-ret, errorbuf);
         return CURLE_SSL_CERTPROBLEM;
       }
 #else
@@ -735,7 +736,7 @@ static CURLcode mbed_load_privkey(struct Curl_cfilter *cf,
       if(ret) {
         mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
         failf(data, "mbedTLS: error parsing private key: (-0x%04X) %s",
-              -ret, errorbuf);
+              (unsigned int)-ret, errorbuf);
         return CURLE_SSL_CERTPROBLEM;
       }
     }
@@ -764,7 +765,7 @@ static CURLcode mbed_load_crl(struct Curl_cfilter *cf,
     if(ret) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
       failf(data, "mbedTLS: error reading CRL file %s: (-0x%04X) %s",
-            ssl_crlfile, -ret, errorbuf);
+            ssl_crlfile, (unsigned int)-ret, errorbuf);
 
       return CURLE_SSL_CRL_BADFILE;
     }
@@ -859,7 +860,7 @@ static CURLcode mbed_configure_ssl(struct Curl_cfilter *cf,
   if(ret) {
     mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
     failf(data, "mbedTLS: ssl_setup failed: "
-          "(-0x%04X) %s", -ret, errorbuf);
+          "(-0x%04X) %s", (unsigned int)-ret, errorbuf);
     return CURLE_SSL_CONNECT_ERROR;
   }
 
@@ -910,12 +911,12 @@ static CURLcode mbed_configure_ssl(struct Curl_cfilter *cf,
       ret = mbedtls_ssl_session_load(&session, sc_session->sdata,
                                      sc_session->sdata_len);
       if(ret) {
-        failf(data, "SSL session error loading: -0x%x", -ret);
+        failf(data, "SSL session error loading: -0x%x", (unsigned int)-ret);
       }
       else {
         ret = mbedtls_ssl_set_session(&backend->ssl, &session);
         if(ret)
-          failf(data, "SSL session error setting: -0x%x", -ret);
+          failf(data, "SSL session error setting: -0x%x", (unsigned int)-ret);
         else
           infof(data, "SSL reusing session ID");
       }
@@ -1054,7 +1055,7 @@ static CURLcode mbed_connect_step2(struct Curl_cfilter *cf,
                 mbedtls_ssl_get_version_number(&backend->ssl));
     mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
     failf(data, "ssl_handshake returned: (-0x%04X) %s",
-          -ret, errorbuf);
+          (unsigned int)-ret, errorbuf);
     return CURLE_SSL_CONNECT_ERROR;
   }
 
@@ -1166,7 +1167,7 @@ static CURLcode mbed_new_session(struct Curl_cfilter *cf,
   ret = mbedtls_ssl_get_session(&backend->ssl, &session);
   msession_alloced = (ret != MBEDTLS_ERR_SSL_ALLOC_FAILED);
   if(ret) {
-    failf(data, "mbedtls_ssl_get_session returned -0x%x", -ret);
+    failf(data, "mbedtls_ssl_get_session returned -0x%x", (unsigned int)-ret);
     result = CURLE_SSL_CONNECT_ERROR;
     goto out;
   }
@@ -1185,7 +1186,7 @@ static CURLcode mbed_new_session(struct Curl_cfilter *cf,
 
   ret = mbedtls_ssl_session_save(&session, sdata, slen, &slen);
   if(ret) {
-    failf(data, "failed to serialize session: -0x%x", -ret);
+    failf(data, "failed to serialize session: -0x%x", (unsigned int)-ret);
     goto out;
   }
 
@@ -1237,7 +1238,7 @@ static CURLcode mbed_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
   else {
     CURL_TRC_CF(data, cf, "mbedtls_ssl_write(len=%zu) -> -0x%04X",
-                len, -nwritten);
+                len, (unsigned int)-nwritten);
     switch(nwritten) {
 #ifdef MBEDTLS_SSL_PROTO_TLS1_3
     case MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET:
@@ -1305,7 +1306,8 @@ static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
         connssl->io_need = CURL_SSL_IO_NEED_SEND;
         goto out;
       default:
-        CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X", -ret);
+        CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X",
+                    (unsigned int)-ret);
         result = CURLE_RECV_ERROR;
         goto out;
       }
@@ -1346,7 +1348,8 @@ static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
     connssl->io_need = CURL_SSL_IO_NEED_SEND;
   }
   else {
-    CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X", -ret);
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X",
+                (unsigned int)-ret);
     result = CURLE_RECV_ERROR;
   }
 
@@ -1396,7 +1399,7 @@ static CURLcode mbed_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   else {
     char errorbuf[128];
     CURL_TRC_CF(data, cf, "mbedtls_ssl_read(len=%zu) -> -0x%04X",
-                buffersize, -nread);
+                buffersize, (unsigned int)-nread);
     switch(nread) {
 #ifdef MBEDTLS_SSL_SESSION_TICKETS
     case MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET:
@@ -1416,7 +1419,8 @@ static CURLcode mbed_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
       break;
     default:
       mbedtls_strerror(nread, errorbuf, sizeof(errorbuf));
-      failf(data, "ssl_read returned: (-0x%04X) %s", -nread, errorbuf);
+      failf(data, "ssl_read returned: (-0x%04X) %s", (unsigned int)-nread,
+            errorbuf);
       result = CURLE_RECV_ERROR;
       break;
     }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2065,7 +2065,7 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
     break;
   default:
     DEBUGASSERT(0);
-    failf(data, "unexpected SSL peer type: %d", peer->type);
+    failf(data, "unexpected SSL peer type: %d", (int)peer->type);
     return CURLE_PEER_FAILED_VERIFICATION;
   }
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -581,7 +581,7 @@ static int ossl_bio_cf_out_write(BIO *bio, const char *buf, int blen)
                              (const uint8_t *)buf, (size_t)blen, FALSE,
                              &nwritten);
   CURL_TRC_CF(data, cf, "ossl_bio_cf_out_write(len=%d) -> %d, %zu",
-              blen, result, nwritten);
+              blen, (int)result, nwritten);
   BIO_clear_retry_flags(bio);
   octx->io_result = result;
   if(result) {
@@ -610,7 +610,7 @@ static int ossl_bio_cf_in_read(BIO *bio, char *buf, int blen)
 
   result = Curl_conn_cf_recv(cf->next, data, buf, (size_t)blen, &nread);
   CURL_TRC_CF(data, cf, "ossl_bio_cf_in_read(len=%d) -> %d, %zu",
-              blen, result, nread);
+              blen, (int)result, nread);
   BIO_clear_retry_flags(bio);
   octx->io_result = result;
   if(result) {
@@ -3012,7 +3012,7 @@ static CURLcode ossl_load_trust_anchors(struct Curl_cfilter *cf,
     result = load_cacert_from_memory(store, conn_config->ca_info_blob);
     if(result) {
       failf(data, "error adding trust anchors from certificate blob: %d",
-            result);
+            (int)result);
       return result;
     }
     infof(data, "  CA Blob from configuration");
@@ -3539,7 +3539,8 @@ static CURLcode ossl_init_ech(struct ossl_ctx *octx,
                                        peer->origin->hostname, outername,
                                        0 /* do send outer */);
     if(result != 1) {
-      infof(data, "ECH: rv failed to set server name(s) %d [ERROR]", result);
+      infof(data, "ECH: rv failed to set server name(s) %d [ERROR]",
+            (int)result);
       return CURLE_SSL_CONNECT_ERROR;
     }
   }
@@ -5247,7 +5248,7 @@ out:
     connssl->input_pending = FALSE;
   }
   CURL_TRC_CF(data, cf, "ossl_recv(len=%zu) -> %d, %zu (in_pending=%d)",
-              buffersize, result, *pnread, connssl->input_pending);
+              buffersize, (int)result, *pnread, connssl->input_pending);
   return result;
 }
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -415,7 +415,7 @@ static CURLcode ossl_certchain(struct Curl_easy *data, SSL *ssl)
     if(result)
       break;
 
-    BIO_printf(mem, "%lx", X509_get_version(x));
+    BIO_printf(mem, "%lx", (unsigned long)X509_get_version(x));
     result = push_certinfo(data, mem, "Version", i);
     if(result)
       break;
@@ -2494,7 +2494,7 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
     verstr = "TLSv1.3";
     break;
   default:
-    curl_msnprintf(unknown, sizeof(unknown), "(%x)", ssl_ver);
+    curl_msnprintf(unknown, sizeof(unknown), "(%x)", (unsigned int)ssl_ver);
     verstr = unknown;
     break;
   }
@@ -3373,7 +3373,7 @@ static CURLcode ossl_init_session_and_alpns(
                   scs->alpn ? scs->alpn : "-");
             octx->reused_session = TRUE;
             infof(data, "SSL verify result: %lx",
-                  SSL_get_verify_result(octx->ssl));
+                  (unsigned long)SSL_get_verify_result(octx->ssl));
 #ifdef HAVE_OPENSSL_EARLYDATA
             if(ssl_config->earlydata && scs->alpn &&
                SSL_SESSION_get_max_early_data(ssl_session) &&
@@ -4787,7 +4787,7 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
 
   ossl_verify = SSL_get_verify_result(octx->ssl);
   ssl_config->certverifyresult = ossl_verify;
-  infof(data, "OpenSSL verify result: %lx", ossl_verify);
+  infof(data, "OpenSSL verify result: %lx", (unsigned long)ossl_verify);
 
   verified = (ossl_verify == X509_V_OK);
   if(verified)

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1149,7 +1149,7 @@ static CURLcode cr_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   DEBUGASSERT(backend);
 
-  CURL_TRC_CF(data, cf, "cr_connect, state=%d", connssl->state);
+  CURL_TRC_CF(data, cf, "cr_connect, state=%d", (int)connssl->state);
   *done = FALSE;
 
 #ifdef USE_ECH

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -118,7 +118,7 @@ static int read_cb(void *userdata, uint8_t *buf, uintptr_t len,
     connssl->peer_closed = TRUE;
   *out_n = (uintptr_t)nread;
   CURL_TRC_CF(io_ctx->data, io_ctx->cf, "cf->next recv(len=%zu) -> %d, %zu",
-              (size_t)len, result, nread);
+              (size_t)len, (int)result, nread);
   return ret;
 }
 
@@ -141,7 +141,7 @@ static int write_cb(void *userdata, const uint8_t *buf, uintptr_t len,
   }
   *out_n = (uintptr_t)nwritten;
   CURL_TRC_CF(io_ctx->data, io_ctx->cf, "cf->next send(len=%zu) -> %d, %zu",
-              len, result, nwritten);
+              len, (int)result, nwritten);
   return ret;
 }
 
@@ -252,7 +252,7 @@ static CURLcode cr_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
 out:
   CURL_TRC_CF(data, cf, "rustls_recv(len=%zu) -> %d, %zu",
-              plainlen, result, *pnread);
+              plainlen, (int)result, *pnread);
   return result;
 }
 
@@ -328,7 +328,7 @@ static CURLcode cr_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(backend->plain_out_buffered) {
     result = cr_flush_out(cf, data, rconn);
     CURL_TRC_CF(data, cf, "cf_send: flushing %zu previously added bytes -> %d",
-                backend->plain_out_buffered, result);
+                backend->plain_out_buffered, (int)result);
     if(result)
       return result;
     if(blen > backend->plain_out_buffered) {
@@ -374,7 +374,7 @@ static CURLcode cr_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
 out:
   CURL_TRC_CF(data, cf, "rustls_send(len=%zu) -> %d, %zu",
-              plainlen, result, *pnwritten);
+              plainlen, (int)result, *pnwritten);
   return result;
 }
 
@@ -1166,7 +1166,7 @@ static CURLcode cr_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
     result =
       cr_init_backend(cf, data,
                       (struct rustls_ssl_backend_data *)connssl->backend);
-    CURL_TRC_CF(data, cf, "cr_connect, init backend -> %d", result);
+    CURL_TRC_CF(data, cf, "cr_connect, init backend -> %d", (int)result);
     if(result)
       return result;
     connssl->state = ssl_connection_negotiating;
@@ -1358,7 +1358,7 @@ static CURLcode cr_shutdown(struct Curl_cfilter *cf, struct Curl_easy *data,
       goto out;
     }
     DEBUGASSERT(result);
-    CURL_TRC_CF(data, cf, "shutdown send failed: %d", result);
+    CURL_TRC_CF(data, cf, "shutdown send failed: %d", (int)result);
     goto out;
   }
 
@@ -1375,7 +1375,7 @@ static CURLcode cr_shutdown(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
   else if(result) {
     DEBUGASSERT(result);
-    CURL_TRC_CF(data, cf, "shutdown, error: %d", result);
+    CURL_TRC_CF(data, cf, "shutdown, error: %d", (int)result);
   }
   else if(nread == 0) {
     /* We got the close notify alert and are done. */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2190,7 +2190,7 @@ static CURLcode schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
       if(result == CURLE_AGAIN)
         SCH_DEV(infof(data, "schannel: recv returned CURLE_AGAIN"));
       else {
-        infof(data, "schannel: recv returned error %d", result);
+        infof(data, "schannel: recv returned error %d", (int)result);
         backend->recv_unrecoverable_err = result;
       }
     }
@@ -2509,7 +2509,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
       else {
         if(!backend->recv_connection_closed) {
           result = CURLE_SEND_ERROR;
-          failf(data, "schannel: error sending close msg: %d", result);
+          failf(data, "schannel: error sending close msg: %d", (int)result);
           goto out;
         }
         /* Looks like server already closed the connection.
@@ -2532,7 +2532,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
     }
     else if(result) {
-      CURL_TRC_CF(data, cf, "SSL shutdown, error %d", result);
+      CURL_TRC_CF(data, cf, "SSL shutdown, error %d", (int)result);
       result = CURLE_RECV_ERROR;
     }
     else if(nread == 0) {

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1025,7 +1025,7 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
                 connssl->earlydata_state > ssl_earlydata_none);
   }
 out:
-  CURL_TRC_CF(data, cf, "cf_connect() -> %d, done=%d", result, *done);
+  CURL_TRC_CF(data, cf, "cf_connect() -> %d, done=%d", (int)result, *done);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -1215,7 +1215,7 @@ static CURLcode ssl_cf_shutdown(struct Curl_cfilter *cf,
 
     CF_DATA_SAVE(save, cf, data);
     result = connssl->ssl_impl->shut_down(cf, data, TRUE, done);
-    CURL_TRC_CF(data, cf, "cf_shutdown -> %d, done=%d", result, *done);
+    CURL_TRC_CF(data, cf, "cf_shutdown -> %d, done=%d", (int)result, *done);
     CF_DATA_RESTORE(cf, save);
     cf->shutdown = (result || *done);
   }
@@ -1567,7 +1567,8 @@ CURLcode Curl_ssl_cfilter_remove(struct Curl_easy *data,
       if(!result && !done) /* blocking failed? */
         result = CURLE_SSL_SHUTDOWN_FAILED;
       Curl_conn_cf_discard(&cf, data);
-      CURL_TRC_CF(data, cf, "shutdown and remove SSL, done -> %d", result);
+      CURL_TRC_CF(data, cf, "shutdown and remove SSL, done -> %d",
+                  (int)result);
       break;
     }
   }

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -917,8 +917,8 @@ out:
   else
     CURL_TRC_SSLS(data, "added session for %s [proto=0x%x, "
                   "valid_secs=%" FMT_OFF_T ", alpn=%s, earlydata=%zu, "
-                  "quic_tp=%s], peer has %zu sessions now",
-                  ssl_peer_key, s->ietf_tls_id, s->valid_until - now,
+                  "quic_tp=%s], peer has %zu sessions now", ssl_peer_key,
+                  (unsigned int)s->ietf_tls_id, s->valid_until - now,
                   s->alpn, s->earlydata_max, s->quic_tp ? "yes" : "no",
                   peer ? Curl_llist_count(&peer->sessions) : 0);
   return result;
@@ -990,7 +990,7 @@ CURLcode Curl_ssl_scache_take(struct Curl_cfilter *cf,
     *ps = s;
     CURL_TRC_SSLS(data, "took session for %s [proto=0x%x, "
                   "alpn=%s, earlydata=%zu, quic_tp=%s], %zu sessions remain",
-                  ssl_peer_key, s->ietf_tls_id, s->alpn,
+                  ssl_peer_key, (unsigned int)s->ietf_tls_id, s->alpn,
                   s->earlydata_max, s->quic_tp ? "yes" : "no",
                   Curl_llist_count(&peer->sessions));
   }

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -902,7 +902,7 @@ static CURLcode cf_scache_add_session(struct Curl_cfilter *cf,
 
   result = cf_ssl_add_peer(data, scache, ssl_peer_key, conn_config, &peer);
   if(result || !peer) {
-    CURL_TRC_SSLS(data, "unable to add scache peer: %d", result);
+    CURL_TRC_SSLS(data, "unable to add scache peer: %d", (int)result);
     Curl_ssl_session_destroy(s);
     goto out;
   }
@@ -912,7 +912,7 @@ static CURLcode cf_scache_add_session(struct Curl_cfilter *cf,
 out:
   if(result) {
     failf(data, "[SCACHE] failed to add session for %s, error=%d",
-          ssl_peer_key, result);
+          ssl_peer_key, (int)result);
   }
   else
     CURL_TRC_SSLS(data, "added session for %s [proto=0x%x, "
@@ -1022,7 +1022,7 @@ CURLcode Curl_ssl_scache_add_obj(struct Curl_cfilter *cf,
 
   result = cf_ssl_add_peer(data, scache, ssl_peer_key, conn_config, &peer);
   if(result || !peer) {
-    CURL_TRC_SSLS(data, "unable to add scache peer: %d", result);
+    CURL_TRC_SSLS(data, "unable to add scache peer: %d", (int)result);
     goto out;
   }
 

--- a/lib/vtls/vtls_spack.c
+++ b/lib/vtls/vtls_spack.c
@@ -225,7 +225,7 @@ CURLcode Curl_ssl_session_pack(struct Curl_easy *data,
   }
 
   if(result)
-    CURL_TRC_SSLS(data, "error packing data: %d", result);
+    CURL_TRC_SSLS(data, "error packing data: %d", (int)result);
   return result;
 }
 
@@ -311,7 +311,7 @@ CURLcode Curl_ssl_session_unpack(struct Curl_easy *data,
 
 out:
   if(result) {
-    CURL_TRC_SSLS(data, "error unpacking data: %d", result);
+    CURL_TRC_SSLS(data, "error unpacking data: %d", (int)result);
     Curl_ssl_session_destroy(s);
   }
   else

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -323,7 +323,7 @@ static int wssl_bio_cf_out_write(WOLFSSL_BIO *bio, const char *buf, int blen)
                              (const uint8_t *)buf, blen, FALSE, &nwritten);
   wssl->io_result = result;
   CURL_TRC_CF(data, cf, "bio_write(len=%d) -> %d, %zu",
-              blen, result, nwritten);
+              blen, (int)result, nwritten);
 #ifdef USE_FULL_BIO
   wolfSSL_BIO_clear_retry_flags(bio);
 #endif
@@ -360,7 +360,7 @@ static int wssl_bio_cf_in_read(WOLFSSL_BIO *bio, char *buf, int blen)
      * server response. This allows sending of ClientHello without delay. */
     result = Curl_wssl_setup_x509_store(cf, data, wssl);
     if(result) {
-      CURL_TRC_CF(data, cf, "Curl_wssl_setup_x509_store() -> %d", result);
+      CURL_TRC_CF(data, cf, "Curl_wssl_setup_x509_store() -> %d", (int)result);
       wssl->io_result = result;
       return -1;
     }
@@ -368,7 +368,8 @@ static int wssl_bio_cf_in_read(WOLFSSL_BIO *bio, char *buf, int blen)
 
   result = Curl_conn_cf_recv(cf->next, data, buf, blen, &nread);
   wssl->io_result = result;
-  CURL_TRC_CF(data, cf, "bio_read(len=%d) -> %d, %zu", blen, result, nread);
+  CURL_TRC_CF(data, cf, "bio_read(len=%d) -> %d, %zu", blen, (int)result,
+              nread);
 #ifdef USE_FULL_BIO
   wolfSSL_BIO_clear_retry_flags(bio);
 #endif
@@ -1720,7 +1721,7 @@ static CURLcode wssl_handshake(struct Curl_cfilter *cf, struct Curl_easy *data)
      * store to verify the coming certificate from the server */
     result = Curl_wssl_setup_x509_store(cf, data, wssl);
     if(result) {
-      CURL_TRC_CF(data, cf, "Curl_wssl_setup_x509_store() -> %d", result);
+      CURL_TRC_CF(data, cf, "Curl_wssl_setup_x509_store() -> %d", (int)result);
       return result;
     }
   }
@@ -1913,7 +1914,7 @@ static CURLcode wssl_send(struct Curl_cfilter *cf,
 
 out:
   CURL_TRC_CF(data, cf, "wssl_send(len=%zu) -> %d, %zu",
-              blen, result, *pnwritten);
+              blen, (int)result, *pnwritten);
   return result;
 }
 

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -727,7 +727,7 @@ static CURLcode ws_cw_write(struct Curl_easy *data,
     result = Curl_bufq_write(&ctx->buf, (const uint8_t *)buf,
                              nbytes, &nwritten);
     if(result) {
-      infof(data, "[WS] error adding data to buffer %d", result);
+      infof(data, "[WS] error adding data to buffer %d", (int)result);
       return result;
     }
   }
@@ -996,7 +996,7 @@ static CURLcode ws_enc_add_pending(struct Curl_easy *data,
                             &ws->sendbuf);
   if(result) {
     CURL_TRC_WS(data, "ws_enc_cntrl(), error adding head: %d",
-                result);
+                (int)result);
     goto out;
   }
   result = ws_enc_write_payload(&ws->enc, data, ws->pending.payload,
@@ -1004,7 +1004,7 @@ static CURLcode ws_enc_add_pending(struct Curl_easy *data,
                                 &ws->sendbuf, &n);
   if(result) {
     CURL_TRC_WS(data, "ws_enc_cntrl(), error adding payload: %d",
-                result);
+                (int)result);
     goto out;
   }
   if(n != ws->pending.payload_len) {
@@ -1066,7 +1066,8 @@ static CURLcode ws_enc_send(struct Curl_easy *data,
                                fragsize : (curl_off_t)buflen,
                                &ws->sendbuf);
     if(result) {
-      CURL_TRC_WS(data, "curl_ws_send(), error writing frame head %d", result);
+      CURL_TRC_WS(data, "curl_ws_send(), error writing frame head %d",
+                  (int)result);
       return result;
     }
   }
@@ -1220,7 +1221,7 @@ static CURLcode cr_ws_read(struct Curl_easy *data,
 
 out:
   CURL_TRC_READ(data, "cr_ws_read(len=%zu) -> %d, nread=%zu, eos=%d",
-                blen, result, *pnread, *peos);
+                blen, (int)result, *pnread, *peos);
   return result;
 }
 
@@ -1444,7 +1445,7 @@ out:
   if(ws_enc_reader)
     Curl_creader_free(data, ws_enc_reader);
   if(result)
-    CURL_TRC_WS(data, "Curl_ws_accept() failed -> %d", result);
+    CURL_TRC_WS(data, "Curl_ws_accept() failed -> %d", (int)result);
   else
     CURL_TRC_WS(data, "websocket established, %s mode",
                 data->set.connect_only ? "connect-only" : "callback");
@@ -1679,7 +1680,7 @@ static CURLcode ws_flush(struct Curl_easy *data, struct websocket *ws,
         return result;
       }
       else if(result) {
-        failf(data, "[WS] flush, write error %d", result);
+        failf(data, "[WS] flush, write error %d", (int)result);
         return result;
       }
       else {
@@ -1770,7 +1771,7 @@ static CURLcode ws_send_raw(struct Curl_easy *data, const void *buffer,
   }
 
   CURL_TRC_WS(data, "ws_send_raw(len=%zu) -> %d, %zu",
-              buflen, result, *pnwritten);
+              buflen, (int)result, *pnwritten);
   return result;
 }
 
@@ -1846,7 +1847,7 @@ CURLcode curl_ws_send(CURL *curl, const void *buffer_arg,
 out:
   CURL_TRC_WS(data, "curl_ws_send(len=%zu, fragsize=%" FMT_OFF_T
               ", flags=%x, raw=%d) -> %d, %zu",
-              buflen, fragsize, flags, data->set.ws_raw_mode, result,
+              buflen, fragsize, flags, data->set.ws_raw_mode, (int)result,
               *pnsent);
   return result;
 }
@@ -1918,7 +1919,7 @@ CURL_EXTERN CURLcode curl_ws_start_frame(CURL *curl,
                              &ws->sendbuf);
   if(result)
     CURL_TRC_WS(data, "curl_start_frame(), error adding frame head %d",
-                result);
+                (int)result);
 
 out:
   return result;

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -948,7 +948,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
 
           dnl clang 19 or later
           if test "$compiler_num" -ge "1901"; then
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-format-signedness"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [format-signedness])
           fi
 
           dnl clang 20 or later
@@ -1144,7 +1144,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl Only gcc 5 or later
           if test "$compiler_num" -ge "500"; then
             tmp_CFLAGS="$tmp_CFLAGS -Warray-bounds=2"
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-format-signedness"
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [format-signedness])
           fi
 
           dnl Only gcc 6 or later

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
   /* win32_init must be called before other init routines. */
   result = win32_init();
   if(result) {
-    errorf("(%d) Windows-specific init failed", result);
+    errorf("(%d) Windows-specific init failed", (int)result);
     return (int)result;
   }
 #endif

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -616,7 +616,7 @@ static CURLcode post_check_result(struct per_transfer *per, CURLcode result)
   if(!config->synthetic_error && result &&
      (!global->silent || global->showerror)) {
     const char *msg = per->errorbuffer;
-    curl_mfprintf(tool_stderr, "curl: (%d) %s\n", result,
+    curl_mfprintf(tool_stderr, "curl: (%d) %s\n", (int)result,
                   msg[0] ? msg : curl_easy_strerror(result));
     if(result == CURLE_PEER_FAILED_VERIFICATION)
       fputs(CURL_CA_CERT_ERRORMSG, tool_stderr);
@@ -697,7 +697,7 @@ static CURLcode post_close_output(struct per_transfer *per,
     if(!result && rc) {
       /* something went wrong in the writing process */
       result = CURLE_WRITE_ERROR;
-      errorf("curl: (%d) Failed writing body", result);
+      errorf("curl: (%d) Failed writing body", (int)result);
     }
     if(result && config->rm_partial) {
       curlx_struct_stat st;
@@ -856,7 +856,7 @@ static CURLcode append2query(struct OperationConfig *config,
       if(uerr) {
         result = urlerr_cvt(uerr);
         errorf("(%d) Could not parse the URL, "
-               "failed to set query", result);
+               "failed to set query", (int)result);
         config->synthetic_error = TRUE;
       }
       else {

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -109,7 +109,7 @@ CURLcode tool_ssls_load(struct OperationConfig *config,
     result = curl_easy_ssls_import(easy, NULL, shmac, shmac_len, sdata,
                                    sdata_len);
     if(result) {
-      warnf("import of session from line %d rejected(%d)", i, result);
+      warnf("import of session from line %d rejected(%d)", i, (int)result);
       continue;
     }
     ++imported;
@@ -179,7 +179,7 @@ static CURLcode tool_ssls_exp(CURL *easy, void *userptr,
 out:
   if(result)
     warnf("Warning: error saving SSL session for '%s': %d", session_key,
-          result);
+          (int)result);
   curlx_free(enc);
   return result;
 }

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -564,7 +564,7 @@ void glob_show_error(struct URLGlob *glob, const char *url, FILE *error,
     t = glob->error;
 
   /* send error description to the error-stream */
-  curl_mfprintf(error, "curl: (%d) %s\n", result, t);
+  curl_mfprintf(error, "curl: (%d) %s\n", (int)result, t);
 }
 
 CURLcode glob_url(struct URLGlob *glob, const char *url, curl_off_t *urlnum,

--- a/tests/libtest/cli_ftp_upload.c
+++ b/tests/libtest/cli_ftp_upload.c
@@ -169,7 +169,7 @@ static CURLcode test_cli_ftp_upload(const char *URL)
   curl_global_cleanup();
   curl_slist_free_all(host);
 
-  curl_mfprintf(stderr, "transfer result: %d\n", result);
+  curl_mfprintf(stderr, "transfer result: %d\n", (int)result);
   return result;
 #else /* !CURL_DISABLE_FTP */
   (void)URL;

--- a/tests/libtest/cli_h2_pausing.c
+++ b/tests/libtest/cli_h2_pausing.c
@@ -265,7 +265,7 @@ static CURLcode test_cli_h2_pausing(const char *URL)
               curl_mfprintf(stderr, "ERROR: [%zu] done, paused=%d, "
                             "resumed=%d, result %d - wtf?\n", i,
                             handles[i].paused,
-                            handles[i].resumed, msg->data.result);
+                            handles[i].resumed, (int)msg->data.result);
               result = (CURLcode)1;
               goto cleanup;
             }

--- a/tests/libtest/cli_h2_upgrade_extreme.c
+++ b/tests/libtest/cli_h2_upgrade_extreme.c
@@ -126,7 +126,7 @@ static CURLcode test_cli_h2_upgrade_extreme(const char *URL)
         }
         else if(msg->data.result) {
           curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
-                        ": failed with %d\n", xfer_id, msg->data.result);
+                        ": failed with %d\n", xfer_id, (int)msg->data.result);
           goto cleanup;
         }
         else if(status != 206) {

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -220,7 +220,7 @@ static int my_progress_d_cb(void *userdata,
 #endif
       default:
         curl_mfprintf(stderr, "[t-%zu] info SSL_PTR backend=%d, ptr=%p\n",
-                      t->idx, tls->backend, tls->internals);
+                      t->idx, (int)tls->backend, tls->internals);
         break;
       }
     }

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -147,7 +147,7 @@ static int my_progress_d_cb(void *userdata,
     result = curl_easy_getinfo(t->curl, CURLINFO_TLS_SSL_PTR, &tls);
     if(result) {
       curl_mfprintf(stderr, "[t-%zu] info CURLINFO_TLS_SSL_PTR failed: %d\n",
-                    t->idx, result);
+                    t->idx, (int)result);
       assert(0);
     }
     else {
@@ -502,7 +502,7 @@ static CURLcode test_cli_hx_download(const char *URL)
           t->done = 1;
           t->result = m->data.result;
           curl_mfprintf(stderr, "[t-%zu] FINISHED with result %d\n",
-                        t->idx, t->result);
+                        t->idx, (int)t->result);
           if(use_earlydata) {
             curl_off_t sent;
             curl_easy_getinfo(easy, CURLINFO_EARLYDATA_SENT_T, &sent);

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -199,7 +199,7 @@ static int my_progress_d_cb(void *userdata,
           (struct rustls_connection *)tls->internals);
         assert(v);
         curl_mfprintf(stderr, "[t-%zu] info rustls TLS version 0x%x\n",
-                      t->idx, v);
+                      t->idx, (unsigned int)v);
         break;
       }
 #endif
@@ -214,7 +214,7 @@ static int my_progress_d_cb(void *userdata,
         assert(sspi_status == SEC_E_OK);
         (void)sspi_status;
         curl_mfprintf(stderr, "[t-%zu] info Schannel TLS version 0x%08lx\n",
-                      t->idx, info.dwProtocol);
+                      t->idx, (unsigned long)info.dwProtocol);
         break;
       }
 #endif

--- a/tests/libtest/cli_hx_upload.c
+++ b/tests/libtest/cli_hx_upload.c
@@ -395,7 +395,7 @@ static CURLcode test_cli_hx_upload(const char *URL)
 
       curl_mfprintf(stderr, "[t-%zu] STARTING\n", t->idx);
       rc = curl_easy_perform(curl);
-      curl_mfprintf(stderr, "[t-%zu] DONE -> %d\n", t->idx, rc);
+      curl_mfprintf(stderr, "[t-%zu] DONE -> %d\n", t->idx, (int)rc);
       t->curl = NULL;
       curl_easy_reset(curl);
     }
@@ -448,7 +448,7 @@ static CURLcode test_cli_hx_upload(const char *URL)
             t->done = 1;
             curl_mfprintf(stderr, "[t-%zu] FINISHED, "
                           "result=%d, response=%ld\n",
-                          t->idx, m->data.result, res_status);
+                          t->idx, (int)m->data.result, res_status);
             if(use_earlydata) {
               curl_off_t sent;
               curl_easy_getinfo(easy, CURLINFO_EARLYDATA_SENT_T, &sent);

--- a/tests/libtest/cli_tls_session_reuse.c
+++ b/tests/libtest/cli_tls_session_reuse.c
@@ -209,7 +209,7 @@ static CURLcode test_cli_tls_session_reuse(const char *URL)
         }
         else if(msg->data.result) {
           curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
-                        ": failed with %d\n", xfer_id, msg->data.result);
+                        ": failed with %d\n", xfer_id, (int)msg->data.result);
           goto cleanup;
         }
         else if(status != 200) {

--- a/tests/libtest/cli_ws_data.c
+++ b/tests/libtest/cli_ws_data.c
@@ -37,13 +37,13 @@ static CURLcode test_ws_data_m2_check_recv(const struct curl_ws_frame *frame,
   if(frame->flags & CURLWS_CLOSE) {
     curl_mfprintf(stderr, "recv_data: unexpected CLOSE frame from server, "
                   "got %zu bytes, offset=%zu, rflags %x\n",
-                  nread, r_offset, frame->flags);
+                  nread, r_offset, (unsigned int)frame->flags);
     return CURLE_RECV_ERROR;
   }
   if(!r_offset && !(frame->flags & CURLWS_BINARY)) {
     curl_mfprintf(stderr, "recv_data: wrong frame, got %zu bytes, offset=%zu, "
                   "rflags %x\n",
-                  nread, r_offset, frame->flags);
+                  nread, r_offset, (unsigned int)frame->flags);
     return CURLE_RECV_ERROR;
   }
   if(frame->offset != (curl_off_t)r_offset) {

--- a/tests/libtest/cli_ws_data.c
+++ b/tests/libtest/cli_ws_data.c
@@ -104,7 +104,7 @@ static CURLcode test_ws_data_m2_echo(const char *url,
   curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
   result = curl_easy_perform(curl);
-  curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", result);
+  curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", (int)result);
   if(result != CURLE_OK)
     goto out;
 
@@ -120,8 +120,8 @@ static CURLcode test_ws_data_m2_echo(const char *url,
         sblock = (result == CURLE_AGAIN);
         if(!result || (result == CURLE_AGAIN)) {
           curl_mfprintf(stderr, "curl_ws_send(len=%zu) -> %d, "
-                        "%zu (%" CURL_FORMAT_CURL_OFF_T "/%zu)\n",
-                        slen, result, nwritten, (curl_off_t)(len - slen), len);
+                        "%zu (%" CURL_FORMAT_CURL_OFF_T "/%zu)\n", slen,
+                        (int)result, nwritten, (curl_off_t)(len - slen), len);
           sbuf += nwritten;
           slen -= nwritten;
         }
@@ -140,8 +140,8 @@ static CURLcode test_ws_data_m2_echo(const char *url,
                               &nread, &frame);
         if(!result || (result == CURLE_AGAIN)) {
           rblock = (result == CURLE_AGAIN);
-          curl_mfprintf(stderr, "curl_ws_recv(len=%zu) -> %d, %zu (%ld/%zu) "
-                        "\n", rlen, result, nread, (long)(len - rlen), len);
+          curl_mfprintf(stderr, "curl_ws_recv(len=%zu) -> %d, %zu (%ld/%zu)\n",
+                        rlen, (int)result, nread, (long)(len - rlen), len);
           if(!result) {
             result = test_ws_data_m2_check_recv(frame, len - rlen, nread, len);
             if(result)

--- a/tests/libtest/cli_ws_pingpong.c
+++ b/tests/libtest/cli_ws_pingpong.c
@@ -78,7 +78,7 @@ static CURLcode test_cli_ws_pingpong(const char *URL)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
     result = curl_easy_perform(curl);
-    curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", result);
+    curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", (int)result);
     if(result == CURLE_OK)
       result = pingpong(curl, payload);
 

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -298,5 +298,5 @@ int main(int argc, const char **argv)
 
   /* Regular program status codes are limited to 0..127 and 126 and 127 have
    * special meanings by the shell, so limit a normal return code to 125 */
-  return (int)result <= 125 ? (int)result : 125;
+  return result <= 125 ? result : 125;
 }

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -187,7 +187,7 @@ CURLcode ws_recv_pong(CURL *curl, const char *expected_payload)
 
   if(!(meta->flags & CURLWS_PONG)) {
     curl_mfprintf(stderr, "recv_pong: wrong frame, got %zu bytes rflags %x\n",
-                  rlen, meta->flags);
+                  rlen, (unsigned int)meta->flags);
     return CURLE_RECV_ERROR;
   }
 

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -169,7 +169,7 @@ CURLcode ws_send_ping(CURL *curl, const char *send_payload)
   CURLcode result = curl_ws_send(curl, send_payload, strlen(send_payload),
                                  &sent, 0, CURLWS_PING);
   curl_mfprintf(stderr, "ws: curl_ws_send returned %d, sent %zu\n",
-                result, sent);
+                (int)result, sent);
   return result;
 }
 
@@ -181,7 +181,7 @@ CURLcode ws_recv_pong(CURL *curl, const char *expected_payload)
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(result) {
     curl_mfprintf(stderr, "ws: curl_ws_recv returned %d, received %zu\n",
-                  result, rlen);
+                  (int)result, rlen);
     return result;
   }
 
@@ -207,7 +207,7 @@ void ws_close(CURL *curl)
   size_t sent;
   CURLcode result = curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
   curl_mfprintf(stderr, "ws: curl_ws_send returned %d, sent %zu\n",
-                result, sent);
+                (int)result, sent);
 }
 #endif /* CURL_DISABLE_WEBSOCKETS */
 
@@ -289,7 +289,7 @@ int main(int argc, const char **argv)
 #endif
 
   result = entry_func(URL);
-  curl_mfprintf(stderr, "Test ended with result %d\n", result);
+  curl_mfprintf(stderr, "Test ended with result %d\n", (int)result);
 
 #ifdef _WIN32
   /* flush buffers of all streams regardless of mode */

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -201,16 +201,16 @@ void ws_close(CURL *curl);  /* close the connection */
 
 /* ---------------------------------------------------------------- */
 
-#define exe_easy_setopt(A, B, C, Y, Z)                  \
-  do {                                                  \
-    CURLcode ec = curl_easy_setopt(A, B, C);            \
-    if(ec != CURLE_OK) {                                \
-      curl_mfprintf(stderr,                             \
-                    "%s:%d curl_easy_setopt() failed, " \
-                    "with code %d (%s)\n",              \
-                    Y, Z, ec, curl_easy_strerror(ec));  \
-      result = ec;                                      \
-    }                                                   \
+#define exe_easy_setopt(A, B, C, Y, Z)                      \
+  do {                                                      \
+    CURLcode ec = curl_easy_setopt(A, B, C);                \
+    if(ec != CURLE_OK) {                                    \
+      curl_mfprintf(stderr,                                 \
+                    "%s:%d curl_easy_setopt() failed, "     \
+                    "with code %d (%s)\n",                  \
+                    Y, Z, (int)ec, curl_easy_strerror(ec)); \
+      result = ec;                                          \
+    }                                                       \
   } while(0)
 
 #define res_easy_setopt(A, B, C) \
@@ -559,16 +559,16 @@ void ws_close(CURL *curl);  /* close the connection */
 
 /* ---------------------------------------------------------------- */
 
-#define exe_global_init(A, Y, Z)                        \
-  do {                                                  \
-    CURLcode ec = curl_global_init(A);                  \
-    if(ec != CURLE_OK) {                                \
-      curl_mfprintf(stderr,                             \
-                    "%s:%d curl_global_init() failed, " \
-                    "with code %d (%s)\n",              \
-                    Y, Z, ec, curl_easy_strerror(ec));  \
-      result = ec;                                      \
-    }                                                   \
+#define exe_global_init(A, Y, Z)                            \
+  do {                                                      \
+    CURLcode ec = curl_global_init(A);                      \
+    if(ec != CURLE_OK) {                                    \
+      curl_mfprintf(stderr,                                 \
+                    "%s:%d curl_global_init() failed, "     \
+                    "with code %d (%s)\n",                  \
+                    Y, Z, (int)ec, curl_easy_strerror(ec)); \
+      result = ec;                                          \
+    }                                                       \
   } while(0)
 
 #define chk_global_init(A, Y, Z) \

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -102,12 +102,12 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
   result = curl_easy_perform(curl);
   if(result != p->result) {
     curl_mprintf("%zu: bad error code (%d): resume=%s, fail=%s, http416=%s, "
-                 "content-range=%s, expected=%d\n", num, result,
+                 "content-range=%s, expected=%d\n", num, (int)result,
                  (p->flags & F_RESUME) ? "yes" : "no",
                  (p->flags & F_FAIL) ? "yes" : "no",
                  (p->flags & F_HTTP416) ? "yes" : "no",
                  (p->flags & F_CONTENTRANGE) ? "yes" : "no",
-                 p->result);
+                 (int)p->result);
     return 1;
   }
   if(hasbody && (p->flags & F_IGNOREBODY)) {

--- a/tests/libtest/lib1485.c
+++ b/tests/libtest/lib1485.c
@@ -47,10 +47,10 @@ static size_t t1485_header_callback(char *ptr, size_t size, size_t nmemb,
     /* end of a response */
     result = curl_easy_getinfo(st->curl, CURLINFO_RESPONSE_CODE, &httpcode);
     curl_mfprintf(stderr, "header_callback, get status: %ld, %d\n",
-                  httpcode, result);
+                  httpcode, (int)result);
     if(httpcode < 100 || httpcode >= 1000) {
       curl_mfprintf(stderr, "header_callback, invalid status: %ld, %d\n",
-                    httpcode, result);
+                    httpcode, (int)result);
       return CURLE_WRITE_ERROR;
     }
     st->http_status = (int)httpcode;
@@ -58,7 +58,7 @@ static size_t t1485_header_callback(char *ptr, size_t size, size_t nmemb,
       result = curl_easy_getinfo(st->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                               &clen);
       curl_mfprintf(stderr, "header_callback, info Content-Length: "
-                    "%" CURL_FORMAT_CURL_OFF_T ", %d\n", clen, result);
+                    "%" CURL_FORMAT_CURL_OFF_T ", %d\n", clen, (int)result);
       if(result) {
         st->result = result;
         return CURLE_WRITE_ERROR;

--- a/tests/libtest/lib1509.c
+++ b/tests/libtest/lib1509.c
@@ -66,7 +66,7 @@ static CURLcode test_lib1509(const char *URL)
   if(code != CURLE_OK) {
     curl_mfprintf(stderr, "%s:%d curl_easy_perform() failed, "
                   "with code %d (%s)\n",
-                  __FILE__, __LINE__, code, curl_easy_strerror(code));
+                  __FILE__, __LINE__, (int)code, curl_easy_strerror(code));
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
@@ -75,7 +75,7 @@ static CURLcode test_lib1509(const char *URL)
   if(code != CURLE_OK) {
     curl_mfprintf(stderr, "%s:%d curl_easy_getinfo() failed, "
                   "with code %d (%s)\n",
-                  __FILE__, __LINE__, code, curl_easy_strerror(code));
+                  __FILE__, __LINE__, (int)code, curl_easy_strerror(code));
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }

--- a/tests/libtest/lib1515.c
+++ b/tests/libtest/lib1515.c
@@ -128,7 +128,8 @@ static CURLcode test_lib1515(const char *URL)
     /* second request must succeed like the first one */
     result = do_one_request(multi, target_url, dns_entry);
     if(result != CURLE_OK) {
-      curl_mfprintf(stderr, "request %s failed with %d\n", target_url, result);
+      curl_mfprintf(stderr, "request %s failed with %d\n", target_url,
+                    (int)result);
       goto test_cleanup;
     }
 

--- a/tests/libtest/lib1518.c
+++ b/tests/libtest/lib1518.c
@@ -84,7 +84,7 @@ static CURLcode test_lib1518(const char *URL)
                "redirects %ld\n"
                "effectiveurl %s\n"
                "redirecturl %s\n",
-               result,
+               (int)result,
                curlResponseCode,
                curlRedirectCount,
                effectiveUrl,

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -87,7 +87,7 @@ static CURLcode test_lib1522(const char *URL)
     }
   }
   else {
-    curl_mprintf("curl_easy_perform() failed. e = %d\n", code);
+    curl_mprintf("curl_easy_perform() failed. e = %d\n", (int)code);
   }
 test_cleanup:
   curl_slist_free_all(pHeaderList);

--- a/tests/libtest/lib1523.c
+++ b/tests/libtest/lib1523.c
@@ -66,11 +66,11 @@ static CURLcode test_lib1523(const char *URL)
 
   result = run(curl, 1, 2);
   if(result)
-    curl_mfprintf(stderr, "error (%d) %s\n", result, buffer);
+    curl_mfprintf(stderr, "error (%d) %s\n", (int)result, buffer);
 
   result = run(curl, 12000, 1);
   if(result != CURLE_OPERATION_TIMEDOUT)
-    curl_mfprintf(stderr, "error (%d) %s\n", result, buffer);
+    curl_mfprintf(stderr, "error (%d) %s\n", (int)result, buffer);
   else
     result = CURLE_OK;
 

--- a/tests/libtest/lib1531.c
+++ b/tests/libtest/lib1531.c
@@ -128,7 +128,7 @@ static CURLcode test_lib1531(const char *URL)
     msg = curl_multi_info_read(multi, &msgs_left);
     if(msg && msg->msg == CURLMSG_DONE) {
       curl_mprintf("HTTP transfer completed with status %d\n",
-                   msg->data.result);
+                   (int)msg->data.result);
       break;
     }
 

--- a/tests/libtest/lib1532.c
+++ b/tests/libtest/lib1532.c
@@ -41,7 +41,7 @@ static CURLcode test_lib1532(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 
@@ -49,7 +49,7 @@ static CURLcode test_lib1532(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(httpcode != 200) {
@@ -66,7 +66,7 @@ static CURLcode test_lib1532(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(httpcode) {

--- a/tests/libtest/lib1533.c
+++ b/tests/libtest/lib1533.c
@@ -98,7 +98,7 @@ static CURLcode perform_and_check_connections(CURL *curl,
 
   result = curl_easy_perform(curl);
   if(result != CURLE_OK) {
-    curl_mfprintf(stderr, "curl_easy_perform() failed with %d\n", result);
+    curl_mfprintf(stderr, "curl_easy_perform() failed with %d\n", (int)result);
     return TEST_ERR_MAJOR_BAD;
   }
 

--- a/tests/libtest/lib1534.c
+++ b/tests/libtest/lib1534.c
@@ -42,7 +42,7 @@ static CURLcode test_lib1534(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(filetime != -1) {
@@ -60,7 +60,7 @@ static CURLcode test_lib1534(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 
@@ -71,7 +71,7 @@ static CURLcode test_lib1534(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(filetime != 30) {
@@ -97,7 +97,7 @@ static CURLcode test_lib1534(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(filetime != -1) {
@@ -117,7 +117,7 @@ static CURLcode test_lib1534(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(filetime != -1) {

--- a/tests/libtest/lib1535.c
+++ b/tests/libtest/lib1535.c
@@ -43,7 +43,7 @@ static CURLcode test_lib1535(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(protocol) {
@@ -60,7 +60,7 @@ static CURLcode test_lib1535(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 
@@ -72,7 +72,7 @@ static CURLcode test_lib1535(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(protocol != CURLPROTO_HTTP) {
@@ -100,7 +100,7 @@ static CURLcode test_lib1535(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(protocol) {
@@ -121,7 +121,7 @@ static CURLcode test_lib1535(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(protocol) {

--- a/tests/libtest/lib1536.c
+++ b/tests/libtest/lib1536.c
@@ -42,7 +42,7 @@ static CURLcode test_lib1536(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(scheme) {
@@ -59,7 +59,7 @@ static CURLcode test_lib1536(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 
@@ -70,7 +70,7 @@ static CURLcode test_lib1536(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(!scheme || memcmp(scheme, "http", 5) != 0) {
@@ -96,7 +96,7 @@ static CURLcode test_lib1536(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(scheme) {
@@ -115,7 +115,7 @@ static CURLcode test_lib1536(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   if(scheme) {

--- a/tests/libtest/lib1538.c
+++ b/tests/libtest/lib1538.c
@@ -52,7 +52,7 @@ static CURLcode test_lib1538(const char *URL)
     curl_mprintf("s%d: %s\n", (int)shareret, curl_share_strerror(shareret));
   }
   for(urlret = CURLUE_OK; urlret <= CURLUE_LAST; urlret++) {
-    curl_mprintf("u%d: %s\n", urlret, curl_url_strerror(urlret));
+    curl_mprintf("u%d: %s\n", (int)urlret, curl_url_strerror(urlret));
   }
 
   return result;

--- a/tests/libtest/lib1538.c
+++ b/tests/libtest/lib1538.c
@@ -49,7 +49,7 @@ static CURLcode test_lib1538(const char *URL)
     curl_mprintf("m%d: %s\n", mresult, curl_multi_strerror(mresult));
   }
   for(shareret = CURLSHE_OK; shareret <= CURLSHE_LAST; shareret++) {
-    curl_mprintf("s%d: %s\n", shareret, curl_share_strerror(shareret));
+    curl_mprintf("s%d: %s\n", (int)shareret, curl_share_strerror(shareret));
   }
   for(urlret = CURLUE_OK; urlret <= CURLUE_LAST; urlret++) {
     curl_mprintf("u%d: %s\n", urlret, curl_url_strerror(urlret));

--- a/tests/libtest/lib1538.c
+++ b/tests/libtest/lib1538.c
@@ -43,7 +43,7 @@ static CURLcode test_lib1538(const char *URL)
   curl_url_strerror((CURLUcode)-INT_MAX);
   /* NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange) */
   for(easyret = CURLE_OK; easyret <= CURL_LAST; easyret++) {
-    curl_mprintf("e%d: %s\n", easyret, curl_easy_strerror(easyret));
+    curl_mprintf("e%d: %s\n", (int)easyret, curl_easy_strerror(easyret));
   }
   for(mresult = CURLM_CALL_MULTI_PERFORM; mresult <= CURLM_LAST; mresult++) {
     curl_mprintf("m%d: %s\n", mresult, curl_multi_strerror(mresult));

--- a/tests/libtest/lib1541.c
+++ b/tests/libtest/lib1541.c
@@ -34,7 +34,7 @@ struct t1541_transfer_status {
 static void t1541_geterr(const char *name, CURLcode val, int lineno)
 {
   curl_mprintf("CURLINFO_%s returned %d, \"%s\" on line %d\n",
-               name, val, curl_easy_strerror(val), lineno);
+               name, (int)val, curl_easy_strerror(val), lineno);
 }
 
 static void report_time(const char *key, const char *where, curl_off_t time,

--- a/tests/libtest/lib1555.c
+++ b/tests/libtest/lib1555.c
@@ -44,9 +44,9 @@ static int progressCallback(void *arg,
   (void)ultotal;
   (void)ulnow;
   result = curl_easy_recv(t1555_curl, buffer, 256, &n);
-  curl_mprintf("curl_easy_recv returned %d\n", result);
+  curl_mprintf("curl_easy_recv returned %d\n", (int)result);
   result = curl_easy_send(t1555_curl, buffer, n, &n);
-  curl_mprintf("curl_easy_send returned %d\n", result);
+  curl_mprintf("curl_easy_send returned %d\n", (int)result);
 
   return 1;
 }

--- a/tests/libtest/lib1556.c
+++ b/tests/libtest/lib1556.c
@@ -60,7 +60,7 @@ static CURLcode test_lib1556(const char *URL)
   if(code != CURLE_OK) {
     curl_mfprintf(stderr, "%s:%d curl_easy_perform() failed, "
                   "with code %d (%s)\n",
-                  __FILE__, __LINE__, code, curl_easy_strerror(code));
+                  __FILE__, __LINE__, (int)code, curl_easy_strerror(code));
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }

--- a/tests/libtest/lib1558.c
+++ b/tests/libtest/lib1558.c
@@ -47,7 +47,7 @@ static CURLcode test_lib1558(const char *URL)
     goto test_cleanup;
   }
 
-  curl_mprintf("Protocol: %lx\n", protocol);
+  curl_mprintf("Protocol: %lx\n", (unsigned long)protocol);
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();

--- a/tests/libtest/lib1558.c
+++ b/tests/libtest/lib1558.c
@@ -36,14 +36,14 @@ static CURLcode test_lib1558(const char *URL)
   result = curl_easy_perform(curl);
   if(result) {
     curl_mfprintf(stderr, "curl_easy_perform() returned %d (%s)\n",
-                  result, curl_easy_strerror(result));
+                  (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 
   result = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
   if(result) {
     curl_mfprintf(stderr, "curl_easy_getinfo() returned %d (%s)\n",
-                  result, curl_easy_strerror(result));
+                  (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib1559.c
+++ b/tests/libtest/lib1559.c
@@ -57,13 +57,13 @@ static CURLcode test_lib1559(const char *URL)
   if(u) {
     CURLUcode uc = curl_url_set(u, CURLUPART_URL, longurl, 0);
     curl_mprintf("CURLUPART_URL %d bytes URL == %d (%s)\n",
-                 EXCESSIVE, uc, curl_url_strerror(uc));
+                 EXCESSIVE, (int)uc, curl_url_strerror(uc));
     uc = curl_url_set(u, CURLUPART_SCHEME, longurl, CURLU_NON_SUPPORT_SCHEME);
     curl_mprintf("CURLUPART_SCHEME %d bytes scheme == %d (%s)\n",
-                 EXCESSIVE, uc, curl_url_strerror(uc));
+                 EXCESSIVE, (int)uc, curl_url_strerror(uc));
     uc = curl_url_set(u, CURLUPART_USER, longurl, 0);
     curl_mprintf("CURLUPART_USER %d bytes user == %d (%s)\n",
-                 EXCESSIVE, uc, curl_url_strerror(uc));
+                 EXCESSIVE, (int)uc, curl_url_strerror(uc));
     curl_url_cleanup(u);
   }
 

--- a/tests/libtest/lib1559.c
+++ b/tests/libtest/lib1559.c
@@ -47,11 +47,11 @@ static CURLcode test_lib1559(const char *URL)
 
   result = curl_easy_setopt(curl, CURLOPT_URL, longurl);
   curl_mprintf("CURLOPT_URL %d bytes URL == %d\n",
-               EXCESSIVE, result);
+               EXCESSIVE, (int)result);
 
   result = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, longurl);
   curl_mprintf("CURLOPT_POSTFIELDS %d bytes data == %d\n",
-               EXCESSIVE, result);
+               EXCESSIVE, (int)result);
 
   u = curl_url();
   if(u) {

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -2196,7 +2196,7 @@ static int huge(void)
     if(!rc) {
       curl_url_get(urlp, part[i], &partp, 0);
       if(!partp || strcmp(partp, &bigpart[1 - (i == 4)])) {
-        curl_mprintf("URL %d part %u: failure\n", i, part[i]);
+        curl_mprintf("URL %d part %d: failure\n", i, (int)part[i]);
         error++;
       }
       curl_free(partp);

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -76,7 +76,7 @@ static int checkparts(CURLU *u, const char *in, const char *wanted,
                      z ? " " : "", z ? z : "");
     }
     else
-      curl_msnprintf(bufp, len, "%s[%d]", buf[0] ? " | " : "", rc);
+      curl_msnprintf(bufp, len, "%s[%d]", buf[0] ? " | " : "", (int)rc);
 
     n = strlen(bufp);
     bufp += n;
@@ -1612,7 +1612,7 @@ static int set_url(void)
       if(rc) {
         curl_mfprintf(stderr, "%s:%d Set URL %s returned %d (%s)\n",
                       __FILE__, __LINE__, set_url_list[i].set,
-                      rc, curl_url_strerror(rc));
+                      (int)rc, curl_url_strerror(rc));
         error++;
       }
       else {
@@ -1620,7 +1620,7 @@ static int set_url(void)
         rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
         if(rc) {
           curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
-                        __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                        __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
           error++;
         }
         else if(checkurl(set_url_list[i].in, url, set_url_list[i].out)) {
@@ -1631,7 +1631,7 @@ static int set_url(void)
     }
     else if(rc != set_url_list[i].ucode) {
       curl_mfprintf(stderr, "Set URL\nin: %s\nreturned %d (expected %d)\n",
-                    set_url_list[i].in, rc, set_url_list[i].ucode);
+                    set_url_list[i].in, (int)rc, (int)set_url_list[i].ucode);
       error++;
     }
     curl_url_cleanup(urlp);
@@ -1669,8 +1669,8 @@ static int setget_parts(bool has_utf8)
         if(uc != setget_parts_list[i].pcode) {
           curl_mfprintf(stderr,
                         "updateurl\nin: %s\nreturned %d (expected %d)\n",
-                        setget_parts_list[i].set, uc,
-                        setget_parts_list[i].pcode);
+                        setget_parts_list[i].set,
+                        (int)uc, (int)setget_parts_list[i].pcode);
           error++;
         }
         if(!uc) {
@@ -1683,7 +1683,7 @@ static int setget_parts(bool has_utf8)
       }
       else if(rc != CURLUE_OK) {
         curl_mfprintf(stderr, "Set parts\nin: %s\nreturned %d (expected %d)\n",
-                      setget_parts_list[i].in, rc, 0);
+                      setget_parts_list[i].in, (int)rc, 0);
         error++;
       }
     }
@@ -1716,7 +1716,8 @@ static int set_parts(void)
 
       if(uc != set_parts_list[i].pcode) {
         curl_mfprintf(stderr, "updateurl\nin: %s\nreturned %d (expected %d)\n",
-                      set_parts_list[i].set, uc, set_parts_list[i].pcode);
+                      set_parts_list[i].set,
+                      (int)uc, (int)set_parts_list[i].pcode);
         error++;
       }
       if(!uc) {
@@ -1724,7 +1725,7 @@ static int set_parts(void)
         rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
         if(rc) {
           curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
-                        __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                        __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
           error++;
         }
         else if(checkurl(set_parts_list[i].in, url, set_parts_list[i].out)) {
@@ -1735,7 +1736,8 @@ static int set_parts(void)
     }
     else if(rc != set_parts_list[i].ucode) {
       curl_mfprintf(stderr, "Set parts\nin: %s\nreturned %d (expected %d)\n",
-                    set_parts_list[i].in, rc, set_parts_list[i].ucode);
+                    set_parts_list[i].in,
+                    (int)rc, (int)set_parts_list[i].ucode);
       error++;
     }
     curl_url_cleanup(urlp);
@@ -1763,7 +1765,7 @@ static int get_url(bool has_utf8)
         rc = curl_url_get(urlp, CURLUPART_URL, &url, get_url_list[i].getflags);
         if(rc) {
           curl_mfprintf(stderr, "%s:%d returned %d (%s). URL: '%s'\n",
-                        __FILE__, __LINE__, rc, curl_url_strerror(rc),
+                        __FILE__, __LINE__, (int)rc, curl_url_strerror(rc),
                         get_url_list[i].in);
           error++;
         }
@@ -1774,7 +1776,7 @@ static int get_url(bool has_utf8)
       }
       if(rc != get_url_list[i].ucode) {
         curl_mfprintf(stderr, "Get URL\nin: %s\nreturned %d (expected %d)\n",
-                      get_url_list[i].in, rc, get_url_list[i].ucode);
+                      get_url_list[i].in, (int)rc, (int)get_url_list[i].ucode);
         error++;
       }
     }
@@ -1801,7 +1803,8 @@ static int get_parts(bool has_utf8)
                         get_parts_list[i].urlflags);
       if(rc != get_parts_list[i].ucode) {
         curl_mfprintf(stderr, "Get parts\nin: %s\nreturned %d (expected %d)\n",
-                      get_parts_list[i].in, rc, get_parts_list[i].ucode);
+                      get_parts_list[i].in,
+                      (int)rc, (int)get_parts_list[i].ucode);
         error++;
       }
       else if(get_parts_list[i].ucode) {
@@ -1858,7 +1861,7 @@ static int append(void)
       ;
     else if(rc != append_list[i].ucode) {
       curl_mfprintf(stderr, "Append\nin: %s\nreturned %d (expected %d)\n",
-                    append_list[i].in, rc, append_list[i].ucode);
+                    append_list[i].in, (int)rc, (int)append_list[i].ucode);
       error++;
     }
     else if(append_list[i].ucode) {
@@ -1869,7 +1872,7 @@ static int append(void)
       rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
       if(rc) {
         curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
-                      __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                      __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
         error++;
       }
       else {
@@ -1897,7 +1900,7 @@ static int scopeid(void)
                     "https://[fe80::20c:29ff:fe9c:409b%25eth0]/hello.html", 0);
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr, "%s:%d curl_url_set returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1905,7 +1908,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1916,7 +1919,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1924,7 +1927,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1935,7 +1938,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1943,7 +1946,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1954,7 +1957,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1962,7 +1965,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1973,7 +1976,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1984,7 +1987,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_ZONEID returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1995,7 +1998,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_ZONEID returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -2003,7 +2006,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -2083,7 +2086,7 @@ static int get_nothing(void)
 
   rc = curl_url_get(u, CURLUPART_ZONEID, &p, 0);
   if(rc != CURLUE_NO_ZONEID) {
-    curl_mfprintf(stderr, "unexpected return code %d on line %d\n", rc,
+    curl_mfprintf(stderr, "unexpected return code %d on line %d\n", (int)rc,
                   __LINE__);
     error++;
     curl_free(p);

--- a/tests/libtest/lib1565.c
+++ b/tests/libtest/lib1565.c
@@ -130,7 +130,7 @@ static CURLcode test_lib1565(const char *URL)
       else {
         curl_mfprintf(stderr,
                       "%s:%d Got an unexpected message from curl: %d\n",
-                      __FILE__, __LINE__, message->msg);
+                      __FILE__, __LINE__, (int)message->msg);
         result = TEST_ERR_MAJOR_BAD;
         goto test_cleanup;
       }

--- a/tests/libtest/lib1597.c
+++ b/tests/libtest/lib1597.c
@@ -96,7 +96,8 @@ static CURLcode test_lib1597(const char *URL)
   for(i = 0; prots[i].in; i++) {
     result = curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, prots[i].in);
     if(result != *prots[i].result_exp) {
-      curl_mprintf("unexpectedly '%s' returned %d\n", prots[i].in, result);
+      curl_mprintf("unexpectedly '%s' returned %d\n", prots[i].in,
+                   (int)result);
       break;
     }
   }

--- a/tests/libtest/lib1906.c
+++ b/tests/libtest/lib1906.c
@@ -45,7 +45,7 @@ static CURLcode test_lib1906(const char *URL)
   if(result != CURLE_COULDNT_CONNECT && result != CURLE_OPERATION_TIMEDOUT) {
     curl_mfprintf(stderr, "failure expected, "
                   "curl_easy_perform returned %d: <%s>, <%s>\n",
-                  result, curl_easy_strerror(result), error_buffer);
+                  (int)result, curl_easy_strerror(result), error_buffer);
     if(result == CURLE_OK)
       result = TEST_ERR_MAJOR_BAD;  /* force an error return */
     goto test_cleanup;
@@ -65,7 +65,7 @@ static CURLcode test_lib1906(const char *URL)
   if(result)
     curl_mfprintf(stderr, "success expected, "
                   "curl_easy_perform returned %d: <%s>, <%s>\n",
-                  result, curl_easy_strerror(result), error_buffer);
+                  (int)result, curl_easy_strerror(result), error_buffer);
 
   /* print URL */
   curl_url_get(curlu, CURLUPART_URL, &url_after, 0);

--- a/tests/libtest/lib1907.c
+++ b/tests/libtest/lib1907.c
@@ -39,7 +39,7 @@ static CURLcode test_lib1907(const char *URL)
   if(!result)
     curl_mfprintf(stderr, "failure expected, "
                   "curl_easy_perform returned %d: <%s>, <%s>\n",
-                  result, curl_easy_strerror(result), error_buffer);
+                  (int)result, curl_easy_strerror(result), error_buffer);
 
   /* print the used URL */
   if(!curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url_after))

--- a/tests/libtest/lib1911.c
+++ b/tests/libtest/lib1911.c
@@ -78,7 +78,7 @@ static CURLcode test_lib1911(const char *URL)
       default:
         /* all other return codes are unexpected */
         curl_mfprintf(stderr, "curl_easy_setopt(%s...) returned %d\n",
-                      o->name, result);
+                      o->name, (int)result);
         error++;
         break;
       }

--- a/tests/libtest/lib1915.c
+++ b/tests/libtest/lib1915.c
@@ -124,7 +124,7 @@ static CURLcode test_lib1915(const char *URL)
   curl = NULL;
   if(result == CURLE_OPERATION_TIMEDOUT) /* we expect that on Windows */
     result = CURLE_COULDNT_CONNECT;
-  curl_mprintf("First request returned %d\n", result);
+  curl_mprintf("First request returned %d\n", (int)result);
   result = CURLE_OK;
 
   easy_init(curl);
@@ -141,7 +141,7 @@ static CURLcode test_lib1915(const char *URL)
   result = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
   curl = NULL;
-  curl_mprintf("Second request returned %d\n", result);
+  curl_mprintf("Second request returned %d\n", (int)result);
 
 test_cleanup:
   curl_easy_cleanup(curl);

--- a/tests/libtest/lib1916.c
+++ b/tests/libtest/lib1916.c
@@ -45,7 +45,7 @@ static CURLcode test_lib1916(const char *URL)
     }
     result = curl_easy_perform(curl);
     if(result) {
-      curl_mprintf("result: %d\n", result);
+      curl_mprintf("result: %d\n", (int)result);
     }
     curl_easy_cleanup(curl);
   }

--- a/tests/libtest/lib1918.c
+++ b/tests/libtest/lib1918.c
@@ -38,11 +38,11 @@ static CURLcode test_lib1918(const char *URL)
 
     if(ename->id != o->id) {
       curl_mprintf("name lookup id %d does not match %d\n",
-                   ename->id, o->id);
+                   (int)ename->id, (int)o->id);
     }
     else if(eid->id != o->id) {
       curl_mprintf("ID lookup %d does not match %d\n",
-                   ename->id, o->id);
+                   (int)ename->id, (int)o->id);
     }
   }
   curl_global_cleanup();

--- a/tests/libtest/lib1922.c
+++ b/tests/libtest/lib1922.c
@@ -82,7 +82,7 @@ static CURLcode test_lib1922(const char *URL)
   result = curl_easy_perform(curl);
   if(result) {
     curl_mfprintf(stderr, "First perform failed: %d (%s)\n",
-                  result, curl_easy_strerror(result));
+                  (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
   curl_mprintf("First request: HTTPS cache populated\n");
@@ -104,7 +104,7 @@ static CURLcode test_lib1922(const char *URL)
   result = curl_easy_perform(dup);
   if(result != CURLE_COULDNT_CONNECT) {
     curl_mfprintf(stderr, "Dup perform unexpected result: %d (%s)\n",
-                  result, curl_easy_strerror(result));
+                  (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -65,7 +65,7 @@ static CURLcode test_lib1945(const char *URL)
   }
   result = curl_easy_perform(curl);
   if(result) {
-    curl_mprintf("badness: %d\n", result);
+    curl_mprintf("badness: %d\n", (int)result);
   }
   t1945_showem(curl, CURLH_CONNECT | CURLH_HEADER | CURLH_TRAILER | CURLH_1XX);
 

--- a/tests/libtest/lib2032.c
+++ b/tests/libtest/lib2032.c
@@ -153,7 +153,7 @@ static CURLcode test_lib2032(const char *URL) /* libntlmconnect */
     multi_perform(multi, &running);
 
     curl_mfprintf(stderr, "%s:%d running %d state %d\n",
-                  __FILE__, __LINE__, running, state);
+                  __FILE__, __LINE__, running, (int)state);
 
     abort_on_test_timeout();
 
@@ -177,7 +177,8 @@ static CURLcode test_lib2032(const char *URL) /* libntlmconnect */
       }
       state =
         num_handles < MAX_EASY_HANDLES ? ReadyForNewHandle : NoMoreHandles;
-      curl_mfprintf(stderr, "%s:%d new state %d\n", __FILE__, __LINE__, state);
+      curl_mfprintf(stderr, "%s:%d new state %d\n",
+                    __FILE__, __LINE__, (int)state);
     }
 
     multi_timeout(multi, &timeout);

--- a/tests/libtest/lib2032.c
+++ b/tests/libtest/lib2032.c
@@ -47,7 +47,7 @@ static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
   if(result != CURLE_OK) {
     curl_mfprintf(stderr, "%s:%d curl_easy_getinfo() failed, "
                   "with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     ntlmcb_res = TEST_ERR_MAJOR_BAD;
     return failure;
   }

--- a/tests/libtest/lib2082.c
+++ b/tests/libtest/lib2082.c
@@ -88,7 +88,8 @@ static CURLcode test_lib2082(const char *URL)  /* libprereq */
     if(result) {
       curl_mfprintf(stderr,
                     "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                    __FILE__, __LINE__, result, curl_easy_strerror(result));
+                    __FILE__, __LINE__, (int)result,
+                    curl_easy_strerror(result));
       goto test_cleanup;
     }
   }

--- a/tests/libtest/lib2301.c
+++ b/tests/libtest/lib2301.c
@@ -86,7 +86,7 @@ static CURLcode test_lib2301(const char *URL)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, t2301_write_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, curl);
     result = curl_easy_perform(curl);
-    curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", result);
+    curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", (int)result);
 #if 0
     if(result == CURLE_OK)
       t2301_websocket(curl);

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -48,7 +48,7 @@ static void flush_data(struct ws_data *wd)
 
   curl_mprintf("\n");
   if(wd->has_meta)
-    curl_mprintf("RECFLAGS: %x\n", wd->meta_flags);
+    curl_mprintf("RECFLAGS: %x\n", (unsigned int)wd->meta_flags);
   else
     curl_mfprintf(stderr, "RECFLAGS: NULL\n");
   wd->blen = 0;

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -115,7 +115,7 @@ static CURLcode test_lib2302(const char *URL)
       curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, t2302_write_cb);
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ws_data);
       result = curl_easy_perform(curl);
-      curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", result);
+      curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", (int)result);
       /* always cleanup */
       curl_easy_cleanup(curl);
       flush_data(&ws_data);

--- a/tests/libtest/lib2304.c
+++ b/tests/libtest/lib2304.c
@@ -34,7 +34,7 @@ static CURLcode recv_any(CURL *curl)
     return result;
 
   curl_mfprintf(stderr, "recv_any: got %zu bytes rflags %x\n", rlen,
-                meta->flags);
+                (unsigned int)meta->flags);
   return CURLE_OK;
 }
 

--- a/tests/libtest/lib2304.c
+++ b/tests/libtest/lib2304.c
@@ -75,7 +75,7 @@ static CURLcode test_lib2304(const char *URL)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
     result = curl_easy_perform(curl);
-    curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", result);
+    curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", (int)result);
     if(result == CURLE_OK)
       t2304_websocket(curl);
 

--- a/tests/libtest/lib2308.c
+++ b/tests/libtest/lib2308.c
@@ -42,7 +42,7 @@ static CURLcode test_lib2308(const char *URL)
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cb_curl);
   curl_easy_setopt(curl, CURLOPT_URL, URL);
   result = curl_easy_perform(curl);
-  curl_mprintf("Returned %d, should be %d.\n", result, CURLE_WRITE_ERROR);
+  curl_mprintf("Returned %d, should be %d.\n", (int)result, CURLE_WRITE_ERROR);
   fflush(stdout);
   curl_easy_cleanup(curl);
   curl_global_cleanup();

--- a/tests/libtest/lib2309.c
+++ b/tests/libtest/lib2309.c
@@ -51,7 +51,8 @@ static CURLcode test_lib2309(const char *URL)
     curldupe = curl_easy_duphandle(curl);
     if(curldupe) {
       result = curl_easy_perform(curldupe);
-      curl_mprintf("Returned %d, should be %d.\n", result, CURLE_WRITE_ERROR);
+      curl_mprintf("Returned %d, should be %d.\n", (int)result,
+                   CURLE_WRITE_ERROR);
       fflush(stdout);
       curl_easy_cleanup(curldupe);
     }

--- a/tests/libtest/lib2405.c
+++ b/tests/libtest/lib2405.c
@@ -43,7 +43,7 @@
 
 #define test_check(expected_fds)                                             \
   if(result != CURLE_OK) {                                                   \
-    curl_mfprintf(stderr, "test failed with code: %d\n", result);            \
+    curl_mfprintf(stderr, "test failed with code: %d\n", (int)result);       \
     goto test_cleanup;                                                       \
   }                                                                          \
   else if(fd_count != (expected_fds)) {                                      \

--- a/tests/libtest/lib2700.c
+++ b/tests/libtest/lib2700.c
@@ -57,7 +57,7 @@ retry:
   }
   if(result) {
     curl_mfprintf(stderr, "%s:%d curl_ws_send() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     assert(nsent == 0);
     return result;
   }
@@ -86,7 +86,7 @@ retry:
   }
   if(result) {
     curl_mfprintf(stderr, "%s:%d curl_ws_recv() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     assert(nread == 0);
     return result;
   }
@@ -128,7 +128,7 @@ retry:
   }
   if(result) {
     curl_mfprintf(stderr, "%s:%d curl_ws_send() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     assert(nsent == 0);
     return result;
   }
@@ -157,7 +157,7 @@ retry:
   }
   if(result) {
     curl_mfprintf(stderr, "%s:%d curl_ws_recv() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     assert(nread == 0);
     return result;
   }
@@ -234,7 +234,7 @@ static CURLcode test_lib2700(const char *URL)
   if(result) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib3010.c
+++ b/tests/libtest/lib3010.c
@@ -39,7 +39,8 @@ static CURLcode test_lib3010(const char *URL)
     if(result) {
       curl_mfprintf(stderr,
                     "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                    __FILE__, __LINE__, result, curl_easy_strerror(result));
+                    __FILE__, __LINE__, (int)result,
+                    curl_easy_strerror(result));
       goto test_cleanup;
     }
     curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &follow_url);
@@ -50,7 +51,8 @@ static CURLcode test_lib3010(const char *URL)
     if(result) {
       curl_mfprintf(stderr,
                     "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                    __FILE__, __LINE__, result, curl_easy_strerror(result));
+                    __FILE__, __LINE__, (int)result,
+                    curl_easy_strerror(result));
       goto test_cleanup;
     }
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -76,7 +76,7 @@ cleanup:
     if(results[i] != CURLE_OK) {
       curl_mfprintf(stderr, "%s:%d thread[%u]: curl_global_init() failed,"
                     "with code %d (%s)\n", __FILE__, __LINE__,
-                    i, results[i], curl_easy_strerror(results[i]));
+                    i, (int)results[i], curl_easy_strerror(results[i]));
       result = TEST_ERR_MAJOR_BAD;
     }
   }
@@ -133,7 +133,7 @@ cleanup:
     if(results[i] != CURLE_OK) {
       curl_mfprintf(stderr, "%s:%d thread[%u]: curl_global_init() failed,"
                     "with code %d (%s)\n", __FILE__, __LINE__,
-                    i, results[i], curl_easy_strerror(results[i]));
+                    i, (int)results[i], curl_easy_strerror(results[i]));
       result = TEST_ERR_MAJOR_BAD;
     }
   }

--- a/tests/libtest/lib3033.c
+++ b/tests/libtest/lib3033.c
@@ -69,7 +69,8 @@ static CURLcode t3033_req_test(CURLM *multi, CURL *curl,
 
       result = msg->data.result;
       if(result != CURLE_OK) {
-        curl_mfprintf(stderr, "curl_multi_info_read() returned %d\n", result);
+        curl_mfprintf(stderr, "curl_multi_info_read() returned %d\n",
+                      (int)result);
         goto test_cleanup;
       }
 

--- a/tests/libtest/lib3034.c
+++ b/tests/libtest/lib3034.c
@@ -57,7 +57,7 @@ static CURLcode test_lib3034(const char *URL)
   if(result != CURLE_SEND_FAIL_REWIND) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_perform() failed with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib3100.c
+++ b/tests/libtest/lib3100.c
@@ -54,7 +54,7 @@ static CURLcode test_lib3100(const char *URL)
 
   result = curl_easy_perform(curl);
   if(result != CURLE_OK) {
-    curl_mfprintf(stderr, "Failed to send DESCRIBE: %d\n", result);
+    curl_mfprintf(stderr, "Failed to send DESCRIBE: %d\n", (int)result);
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -70,7 +70,7 @@ static void t506_test_lock(CURL *curl, curl_lock_data data,
     pcounter = &user->cookie_counter;
     break;
   default:
-    curl_mfprintf(stderr, "lock: no such data: %d\n", data);
+    curl_mfprintf(stderr, "lock: no such data: %d\n", (int)data);
     return;
   }
 
@@ -109,7 +109,7 @@ static void t506_test_unlock(CURL *curl, curl_lock_data data, void *useptr)
     locknum = 2;
     break;
   default:
-    curl_mfprintf(stderr, "unlock: no such data: %d\n", data);
+    curl_mfprintf(stderr, "unlock: no such data: %d\n", (int)data);
     return;
   }
 

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -369,7 +369,8 @@ test_cleanup:
   curl_mprintf("SHARE_CLEANUP\n");
   scode = curl_share_cleanup(share);
   if(scode != CURLSHE_OK)
-    curl_mfprintf(stderr, "curl_share_cleanup failed, code errno %d\n", scode);
+    curl_mfprintf(stderr, "curl_share_cleanup failed, code errno %d\n",
+                  (int)scode);
 
   curl_mprintf("GLOBAL_CLEANUP\n");
   curl_global_cleanup();

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -158,7 +158,7 @@ static void *t506_test_fire(void *ptr)
   if(result) {
     int i = 0;
     curl_mfprintf(stderr, "perform URL '%s' repeat %d failed, curlcode %d\n",
-                  tdata->url, i, result);
+                  tdata->url, i, (int)result);
   }
 
   curl_mprintf("CLEANUP\n");

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -394,23 +394,23 @@ static CURLcode test_lib530(const char *URL)
      callback calls */
   result = testone(URL, 0, 0); /* no callback fails */
   if(result)
-    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), result);
+    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), (int)result);
 
   result = testone(URL, 1, 0); /* fail 1st call to timer callback */
   if(!result)
-    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), result);
+    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), (int)result);
 
   result = testone(URL, 2, 0); /* fail 2nd call to timer callback */
   if(!result)
-    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), result);
+    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), (int)result);
 
   result = testone(URL, 0, 2); /* fail 2nd call to socket callback */
   if(!result)
-    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), result);
+    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), (int)result);
 
   result = testone(URL, 0, 3); /* fail 3rd call to socket callback */
   if(!result)
-    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), result);
+    curl_mfprintf(stderr, "%s FAILED: %d\n", t530_tag(), (int)result);
 
   return CURLE_OK;
 }

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -204,7 +204,7 @@ static int t530_checkForCompletion(CURLM *multi, int *success)
     }
     else {
       curl_mfprintf(stderr, "%s got an unexpected message from curl: %d\n",
-                    t530_tag(), message->msg);
+                    t530_tag(), (int)message->msg);
       result = 1;
       *success = 0;
     }

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -158,7 +158,7 @@ static CURLcode loop(int num, CURLM *multi, const char *url,
       if(msg->msg == CURLMSG_DONE) {
         size_t i;
         CURL *curl = msg->easy_handle;
-        curl_mfprintf(stderr, "R: %d - %s\n", msg->data.result,
+        curl_mfprintf(stderr, "R: %d - %s\n", (int)msg->data.result,
                       curl_easy_strerror(msg->data.result));
         curl_multi_remove_handle(multi, curl);
         curl_easy_cleanup(curl);

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -170,7 +170,7 @@ static CURLcode loop(int num, CURLM *multi, const char *url,
         }
       }
       else
-        curl_mfprintf(stderr, "E: CURLMsg (%d)\n", msg->msg);
+        curl_mfprintf(stderr, "E: CURLMsg (%d)\n", (int)msg->msg);
     }
 
     res_test_timedout();

--- a/tests/libtest/lib554.c
+++ b/tests/libtest/lib554.c
@@ -93,7 +93,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
   }
 
   if(formrc)
-    curl_mprintf("curl_formadd(1) = %d\n", formrc);
+    curl_mprintf("curl_formadd(1) = %d\n", (int)formrc);
 
   /* Now add the same data with another name and make it not look like
      a file upload but still using the callback */
@@ -110,7 +110,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
                         CURLFORM_END);
 
   if(formrc)
-    curl_mprintf("curl_formadd(2) = %d\n", formrc);
+    curl_mprintf("curl_formadd(2) = %d\n", (int)formrc);
 
   /* Fill in the filename field */
   formrc = curl_formadd(&formpost,
@@ -119,7 +119,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
                         CURLFORM_COPYCONTENTS, "postit2.c",
                         CURLFORM_END);
   if(formrc)
-    curl_mprintf("curl_formadd(3) = %d\n", formrc);
+    curl_mprintf("curl_formadd(3) = %d\n", (int)formrc);
 
   /* Fill in a submit field too */
   formrc = curl_formadd(&formpost,
@@ -130,7 +130,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
                         CURLFORM_END);
 
   if(formrc)
-    curl_mprintf("curl_formadd(4) = %d\n", formrc);
+    curl_mprintf("curl_formadd(4) = %d\n", (int)formrc);
 
   formrc = curl_formadd(&formpost, &lastptr,
                         CURLFORM_COPYNAME, "somename",
@@ -140,7 +140,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
                         CURLFORM_END);
 
   if(formrc)
-    curl_mprintf("curl_formadd(5) = %d\n", formrc);
+    curl_mprintf("curl_formadd(5) = %d\n", (int)formrc);
 
   curl = curl_easy_init();
   if(!curl) {

--- a/tests/libtest/lib574.c
+++ b/tests/libtest/lib574.c
@@ -55,12 +55,12 @@ static CURLcode test_lib574(const char *URL)
 
   result = curl_easy_perform(curl);
   if(result) {
-    curl_mfprintf(stderr, "curl_easy_perform() failed %d\n", result);
+    curl_mfprintf(stderr, "curl_easy_perform() failed %d\n", (int)result);
     goto test_cleanup;
   }
   result = curl_easy_perform(curl);
   if(result) {
-    curl_mfprintf(stderr, "curl_easy_perform() failed %d\n", result);
+    curl_mfprintf(stderr, "curl_easy_perform() failed %d\n", (int)result);
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -151,7 +151,7 @@ static int t582_checkForCompletion(CURLM *multi, int *success)
     }
     else {
       curl_mfprintf(stderr, "Got an unexpected message from curl: %d\n",
-                    message->msg);
+                    (int)message->msg);
       result = 1;
       *success = 0;
     }

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -118,7 +118,7 @@ static void *t586_test_fire(void *ptr)
   if(result != CURLE_OK) {
     int i = 0;
     curl_mfprintf(stderr, "perform URL '%s' repeat %d failed, curlcode %d\n",
-                  tdata->url, i, result);
+                  tdata->url, i, (int)result);
   }
 
   curl_mprintf("CLEANUP\n");

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -231,7 +231,8 @@ test_cleanup:
   curl_mprintf("SHARE_CLEANUP\n");
   scode = curl_share_cleanup(share);
   if(scode != CURLSHE_OK)
-    curl_mfprintf(stderr, "curl_share_cleanup failed, code errno %d\n", scode);
+    curl_mfprintf(stderr, "curl_share_cleanup failed, code errno %d\n",
+                  (int)scode);
 
   curl_mprintf("GLOBAL_CLEANUP\n");
   curl_global_cleanup();

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -60,7 +60,7 @@ static void t586_test_lock(CURL *curl, curl_lock_data data,
     what = "ssl_session";
     break;
   default:
-    curl_mfprintf(stderr, "lock: no such data: %d\n", data);
+    curl_mfprintf(stderr, "lock: no such data: %d\n", (int)data);
     return;
   }
   curl_mprintf("lock:   %-6s [%s]: %d\n", what, user->text, user->counter);
@@ -87,7 +87,7 @@ static void t586_test_unlock(CURL *curl, curl_lock_data data, void *useptr)
     what = "ssl_session";
     break;
   default:
-    curl_mfprintf(stderr, "unlock: no such data: %d\n", data);
+    curl_mfprintf(stderr, "unlock: no such data: %d\n", (int)data);
     return;
   }
   curl_mprintf("unlock: %-6s [%s]: %d\n", what, user->text, user->counter);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -79,7 +79,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_CONTENTHEADER, headers,
                         CURLFORM_END);
   if(formrc) {
-    curl_mprintf("curl_formadd(1) = %d\n", formrc);
+    curl_mprintf("curl_formadd(1) = %d\n", (int)formrc);
     goto test_cleanup;
   }
 
@@ -101,7 +101,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(2) = %d\n", formrc);
+    curl_mprintf("curl_formadd(2) = %d\n", (int)formrc);
     goto test_cleanup;
   }
 
@@ -121,7 +121,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(3) = %d\n", formrc);
+    curl_mprintf("curl_formadd(3) = %d\n", (int)formrc);
     goto test_cleanup;
   }
 
@@ -132,7 +132,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_FILECONTENT, libtest_arg2,
                         CURLFORM_END);
   if(formrc) {
-    curl_mprintf("curl_formadd(4) = %d\n", formrc);
+    curl_mprintf("curl_formadd(4) = %d\n", (int)formrc);
     goto test_cleanup;
   }
 
@@ -152,7 +152,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(5) = %d\n", formrc);
+    curl_mprintf("curl_formadd(5) = %d\n", (int)formrc);
     goto test_cleanup;
   }
 
@@ -164,7 +164,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(6) = %d\n", formrc);
+    curl_mprintf("curl_formadd(6) = %d\n", (int)formrc);
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib651.c
+++ b/tests/libtest/lib651.c
@@ -53,7 +53,7 @@ static CURLcode test_lib651(const char *URL)
                         CURLFORM_COPYCONTENTS, testbuf,
                         CURLFORM_END);
   if(formrc)
-    curl_mprintf("curl_formadd(1) = %d\n", formrc);
+    curl_mprintf("curl_formadd(1) = %d\n", (int)formrc);
 
   curl = curl_easy_init();
   if(!curl) {

--- a/tests/libtest/lib655.c
+++ b/tests/libtest/lib655.c
@@ -91,7 +91,7 @@ static CURLcode test_lib655(const char *URL)
   if(result != CURLE_ABORTED_BY_CALLBACK) {
     curl_mfprintf(stderr, "curl_easy_perform should have returned "
                   "CURLE_ABORTED_BY_CALLBACK but instead returned error %d\n",
-                  result);
+                  (int)result);
     if(result == CURLE_OK)
       result = TEST_ERR_FAILURE;
     goto test_cleanup;

--- a/tests/libtest/lib658.c
+++ b/tests/libtest/lib658.c
@@ -61,8 +61,8 @@ static CURLcode test_lib658(const char *URL)
 
   if(result) {
     curl_mfprintf(stderr, "%s:%d curl_easy_perform() failed "
-                  "with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  "with code %d (%s)\n", __FILE__, __LINE__,
+                  (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib659.c
+++ b/tests/libtest/lib659.c
@@ -60,7 +60,7 @@ static CURLcode test_lib659(const char *URL)
   if(result) {
     curl_mfprintf(stderr, "%s:%d curl_easy_perform() failed "
                   "with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib661.c
+++ b/tests/libtest/lib661.c
@@ -156,7 +156,7 @@ static CURLcode test_lib661(const char *URL)
 test_cleanup:
 
   if(result)
-    curl_mfprintf(stderr, "test encountered error %d\n", result);
+    curl_mfprintf(stderr, "test encountered error %d\n", (int)result);
   curl_slist_free_all(slist);
   curl_free(newURL);
   curl_easy_cleanup(curl);

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -122,7 +122,7 @@ static CURLcode test_lib670(const char *URL)
     if(result != CURLE_OK) {
       curl_mfprintf(stderr,
                     "Something went wrong when building the "
-                    "mime structure: %d\n", result);
+                    "mime structure: %d\n", (int)result);
       goto test_cleanup;
     }
 

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -143,7 +143,7 @@ static CURLcode test_lib670(const char *URL)
                           CURLFORM_CONTENTLEN, (curl_off_t)2,
                           CURLFORM_END);
     if(formrc) {
-      curl_mfprintf(stderr, "curl_formadd() = %d\n", formrc);
+      curl_mfprintf(stderr, "curl_formadd() = %d\n", (int)formrc);
       goto test_cleanup;
     }
 

--- a/tests/libtest/lib674.c
+++ b/tests/libtest/lib674.c
@@ -62,7 +62,7 @@ static CURLcode test_lib674(const char *URL)
   if(result) {
     curl_mfprintf(stderr, "%s:%d curl_easy_perform() failed "
                   "with code %d (%s)\n",
-                  __FILE__, __LINE__, result, curl_easy_strerror(result));
+                  __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib677.c
+++ b/tests/libtest/lib677.c
@@ -84,7 +84,7 @@ static CURLcode test_lib677(const char *URL)
         }
         else if(ec) {
           curl_mfprintf(stderr, "curl_easy_send() failed, with code %d (%s)\n",
-                        ec, curl_easy_strerror(ec));
+                        (int)ec, curl_easy_strerror(ec));
           result = ec;
           goto test_cleanup;
         }
@@ -105,7 +105,7 @@ static CURLcode test_lib677(const char *URL)
         }
         else if(ec) {
           curl_mfprintf(stderr, "curl_easy_recv() failed, with code %d (%s)\n",
-                        ec, curl_easy_strerror(ec));
+                        (int)ec, curl_easy_strerror(ec));
           result = ec;
           goto test_cleanup;
         }

--- a/tests/libtest/lib758.c
+++ b/tests/libtest/lib758.c
@@ -491,7 +491,7 @@ static CURLcode test_lib758(const char *URL)
      callback calls */
   result = t758_one(URL, 0, 0); /* no callback fails */
   if(result)
-    curl_mfprintf(stderr, "%s FAILED: %d\n", t758_tag(), result);
+    curl_mfprintf(stderr, "%s FAILED: %d\n", t758_tag(), (int)result);
 
   return result;
 }

--- a/tests/libtest/lib758.c
+++ b/tests/libtest/lib758.c
@@ -250,7 +250,7 @@ static int t758_checkForCompletion(CURLM *multi, int *success)
     }
     else {
       curl_mfprintf(stderr, "%s got an unexpected message from curl: %d\n",
-                    t758_tag(), message->msg);
+                    t758_tag(), (int)message->msg);
       result = 1;
       *success = 0;
     }

--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -244,20 +244,20 @@ static size_t readcb(char *buffer,
 static void errlongzero(const char *name, CURLcode result, int lineno)
 {
   curl_mprintf("%s set to 0 returned %d, \\"%s\\" on line %d\\n",
-               name, result, curl_easy_strerror(result), lineno);
+               name, (int)result, curl_easy_strerror(result), lineno);
 }
 
 static void errlong(const char *name, CURLcode result, int lineno)
 {
 $allowednumerrors
   curl_mprintf("%s set to non-zero returned %d, \\"%s\\" on line %d\\n",
-               name, result, curl_easy_strerror(result), lineno);
+               name, (int)result, curl_easy_strerror(result), lineno);
 }
 
 static void errneg(const char *name, CURLcode result, int lineno)
 {
   curl_mprintf("%s set to -1 returned %d, \\"%s\\" on line %d\\n",
-               name, result, curl_easy_strerror(result), lineno);
+               name, (int)result, curl_easy_strerror(result), lineno);
 }
 
 static void errstring(const char *name, CURLcode result, int lineno)
@@ -266,25 +266,25 @@ static void errstring(const char *name, CURLcode result, int lineno)
      when given a strange string input */
 $allowedstringerrors
   curl_mprintf("%s set to a string returned %d, \\"%s\\" on line %d\\n",
-               name, result, curl_easy_strerror(result), lineno);
+               name, (int)result, curl_easy_strerror(result), lineno);
 }
 
 static void err(const char *name, CURLcode result, int lineno)
 {
   curl_mprintf("%s returned %d, \\"%s\\" on line %d\\n",
-               name, result, curl_easy_strerror(result), lineno);
+               name, (int)result, curl_easy_strerror(result), lineno);
 }
 
 static void errnull(const char *name, CURLcode result, int lineno)
 {
   curl_mprintf("%s set to NULL returned %d, \\"%s\\" on line %d\\n",
-               name, result, curl_easy_strerror(result), lineno);
+               name, (int)result, curl_easy_strerror(result), lineno);
 }
 
 static void t1521_geterr(const char *name, CURLcode result, int lineno)
 {
   curl_mprintf("CURLINFO_%s returned %d, \\"%s\\" on line %d\\n",
-               name, result, curl_easy_strerror(result), lineno);
+               name, (int)result, curl_easy_strerror(result), lineno);
 }
 
 static curl_progress_callback progresscb;

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -492,7 +492,7 @@ create_resp(int qid, const struct sockaddr *addr, curl_socklen_t addrlen,
       const unsigned char *store = ipv4_pref;
       if(add_answer(&resp->body, store, sizeof(ipv4_pref), QTYPE_A))
         goto error;
-      logmsg("[%d] response A (%x) '%s'", qid, QTYPE_A,
+      logmsg("[%d] response A (%x) '%s'", qid, (unsigned int)QTYPE_A,
              curlx_inet_ntop(AF_INET, store, addrbuf, sizeof(addrbuf)));
     }
     if(!ancount_a)
@@ -503,7 +503,7 @@ create_resp(int qid, const struct sockaddr *addr, curl_socklen_t addrlen,
       const unsigned char *store = ipv6_pref;
       if(add_answer(&resp->body, store, sizeof(ipv6_pref), QTYPE_AAAA))
         goto error;
-      logmsg("[%d] response AAAA (%x) '%s'", qid, QTYPE_AAAA,
+      logmsg("[%d] response AAAA (%x) '%s'", qid, (unsigned int)QTYPE_AAAA,
              curlx_inet_ntop(AF_INET6, store, addrbuf, sizeof(addrbuf)));
     }
     if(!ancount_aaaa)
@@ -516,8 +516,8 @@ create_resp(int qid, const struct sockaddr *addr, curl_socklen_t addrlen,
                httpsrr.dlen);
         goto error;
       }
-      logmsg("[%d] response HTTPS (%x), %zu bytes", qid, QTYPE_HTTPS,
-             httpsrr.dlen);
+      logmsg("[%d] response HTTPS (%x), %zu bytes", qid,
+             (unsigned int)QTYPE_HTTPS, httpsrr.dlen);
     }
     else
       logmsg("[%d] response HTTPS, no record", qid);

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1794,7 +1794,7 @@ http_connect_cleanup:
 static void http_upgrade(struct sws_httprequest *req)
 {
   (void)req;
-  logmsg("Upgraded to ... %u", req->upgrade_request);
+  logmsg("Upgraded to ... %d", (int)req->upgrade_request);
   /* left to implement */
 }
 

--- a/tests/test1119.pl
+++ b/tests/test1119.pl
@@ -179,10 +179,8 @@ for my $e (sort @syms) {
     # *_LAST and *_LASTENTRY are suffix for the placeholders used for the
     # last entry in many enum series.
     #
-    # *_SIGNED is a suffix to make enums a signed type.
-    #
 
-    if($e =~ /(OBSOLETE|CURLE_RESERVED|^CURL_EXTERN|^CURLINC_|_LAST\z|_LASTENTRY\z|_SIGNED\z|^CURL_TEMP_)/) {
+    if($e =~ /(OBSOLETE|CURLE_RESERVED|^CURL_EXTERN|^CURLINC_|_LAST\z|_LASTENTRY\z|^CURL_TEMP_)/) {
         $ignored++;
         next;
     }

--- a/tests/test1119.pl
+++ b/tests/test1119.pl
@@ -179,8 +179,10 @@ for my $e (sort @syms) {
     # *_LAST and *_LASTENTRY are suffix for the placeholders used for the
     # last entry in many enum series.
     #
+    # *_SIGNED is a suffix to make enums a signed type.
+    #
 
-    if($e =~ /(OBSOLETE|CURLE_RESERVED|^CURL_EXTERN|^CURLINC_|_LAST\z|_LASTENTRY\z|^CURL_TEMP_)/) {
+    if($e =~ /(OBSOLETE|CURLE_RESERVED|^CURL_EXTERN|^CURLINC_|_LAST\z|_LASTENTRY\z|_SIGNED\z|^CURL_TEMP_)/) {
         $ignored++;
         next;
     }

--- a/tests/test1477.pl
+++ b/tests/test1477.pl
@@ -49,7 +49,7 @@ sub scanheader {
         $line++;
         if($_ =~ /^  (CURL(E|UE|SHE|HE|M)_[A-Z0-9_]*)/) {
             my ($name)=($1);
-            if(($name !~ /(OBSOLETE|CURLE_RESERVED)/) && ($name !~ /_LAST\z/)) {
+            if(($name !~ /(OBSOLETE|CURLE_RESERVED)/) && ($name !~ /(_LAST|_SIGNED)\z/)) {
                 push @hnames, $name;
                 if($wherefrom{$name}) {
                     print STDERR "double: $name\n";

--- a/tests/test1477.pl
+++ b/tests/test1477.pl
@@ -49,7 +49,7 @@ sub scanheader {
         $line++;
         if($_ =~ /^  (CURL(E|UE|SHE|HE|M)_[A-Z0-9_]*)/) {
             my ($name)=($1);
-            if(($name !~ /(OBSOLETE|CURLE_RESERVED)/) && ($name !~ /(_LAST|_SIGNED)\z/)) {
+            if(($name !~ /(OBSOLETE|CURLE_RESERVED)/) && ($name !~ /_LAST\z/)) {
                 push @hnames, $name;
                 if($wherefrom{$name}) {
                     print STDERR "double: $name\n";

--- a/tests/tunit/tool1623.c
+++ b/tests/tunit/tool1623.c
@@ -104,14 +104,14 @@ static CURLcode test_tool1623(const char *arg)
     ParameterError err = GetSizeParameter(check[i].input, &output);
     if(err != check[i].err)
       curl_mprintf("'%s' unexpectedly returned %d \n",
-                   check[i].input, err);
+                   check[i].input, (int)err);
     else if(check[i].amount != output)
       curl_mprintf("'%s' unexpectedly gave %" FMT_OFF_T "\n",
                    check[i].input, output);
     else {
 #if 0 /* enable for debugging */
       if(err)
-        curl_mprintf("'%s' returned %d\n", check[i].input, err);
+        curl_mprintf("'%s' returned %d\n", check[i].input, (int)err);
       else
         curl_mprintf("'%s' == %" FMT_OFF_T "\n", check[i].input, output);
 #endif

--- a/tests/unit/unit1302.c
+++ b/tests/unit/unit1302.c
@@ -144,7 +144,8 @@ static CURLcode test_unit1302(const char *arg)
     /* then verify decode */
     result = curlx_base64_decode(e->output, &decoded, &dlen);
     if(result != CURLE_OK) {
-      curl_mfprintf(stderr, "Test %u URL decode returned %d\n", i, result);
+      curl_mfprintf(stderr, "Test %u URL decode returned %d\n", i,
+                    (int)result);
       unitfail++;
     }
     if(dlen != e->ilen) {
@@ -190,7 +191,7 @@ static CURLcode test_unit1302(const char *arg)
     if(result != CURLE_BAD_CONTENT_ENCODING) {
       curl_mfprintf(stderr, "Test %u URL bad decoded badly. "
                     "Returned '%d', expected '%d'\n",
-                    i, result, CURLE_BAD_CONTENT_ENCODING);
+                    i, (int)result, CURLE_BAD_CONTENT_ENCODING);
       unitfail++;
     }
   }

--- a/tests/unit/unit1302.c
+++ b/tests/unit/unit1302.c
@@ -144,8 +144,7 @@ static CURLcode test_unit1302(const char *arg)
     /* then verify decode */
     result = curlx_base64_decode(e->output, &decoded, &dlen);
     if(result != CURLE_OK) {
-      curl_mfprintf(stderr, "Test %u URL decode returned %d\n", i,
-                    (int)result);
+      curl_mfprintf(stderr, "Test %u URL decode returned %d\n", i, result);
       unitfail++;
     }
     if(dlen != e->ilen) {
@@ -191,7 +190,7 @@ static CURLcode test_unit1302(const char *arg)
     if(result != CURLE_BAD_CONTENT_ENCODING) {
       curl_mfprintf(stderr, "Test %u URL bad decoded badly. "
                     "Returned '%d', expected '%d'\n",
-                    i, (int)result, CURLE_BAD_CONTENT_ENCODING);
+                    i, result, CURLE_BAD_CONTENT_ENCODING);
       unitfail++;
     }
   }

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -155,7 +155,7 @@ static CURLcode test_unit1650(const char *arg)
                                 buffer, sizeof(buffer), &size);
     if(rc != req[i].rc) {
       curl_mfprintf(stderr, "req %zu: Expected return code %d got %d\n", i,
-                    req[i].rc, rc);
+                    (int)req[i].rc, (int)rc);
       abort_if(rc != req[i].rc, "return code");
     }
     if(size != req[i].size) {
@@ -184,7 +184,7 @@ static CURLcode test_unit1650(const char *arg)
                          resp[i].type, &d);
     if(rc != resp[i].rc) {
       curl_mfprintf(stderr, "resp %zu: Expected return code %d got %d\n", i,
-                    resp[i].rc, rc);
+                    (int)resp[i].rc, (int)rc);
       abort_if(rc != resp[i].rc, "return code");
     }
     len = sizeof(buffer);
@@ -240,7 +240,7 @@ static CURLcode test_unit1650(const char *arg)
                          i, CURL_DNS_TYPE_A, &d);
     if(!rc) {
       /* none of them should work */
-      curl_mfprintf(stderr, "%zu: %d\n", i, rc);
+      curl_mfprintf(stderr, "%zu: %d\n", i, (int)rc);
       abort_if(!rc, "error rc");
     }
   }
@@ -254,7 +254,7 @@ static CURLcode test_unit1650(const char *arg)
                          sizeof(full49) - i - 1, CURL_DNS_TYPE_A, &d);
     if(!rc) {
       /* none of them should work */
-      curl_mfprintf(stderr, "2 %zu: %d\n", i, rc);
+      curl_mfprintf(stderr, "2 %zu: %d\n", i, (int)rc);
       abort_if(!rc, "error rc");
     }
   }
@@ -272,7 +272,8 @@ static CURLcode test_unit1650(const char *arg)
     curl_msnprintf((char *)buffer, sizeof(buffer),
                    "%u.%u.%u.%u", p[0], p[1], p[2], p[3]);
     if(rc || strcmp((const char *)buffer, "127.0.0.1")) {
-      curl_mfprintf(stderr, "bad address decoded: %s, rc == %d\n", buffer, rc);
+      curl_mfprintf(stderr, "bad address decoded: %s, rc == %d\n", buffer,
+                    (int)rc);
       abort_if(rc || strcmp((const char *)buffer, "127.0.0.1"), "bad address");
     }
     fail_if(d.numcname, "bad cname counter");

--- a/tests/unit/unit1656.c
+++ b/tests/unit/unit1656.c
@@ -42,7 +42,7 @@ static bool do_test(const struct test_spec *spec, size_t i,
   result = GTime2str(dbuf, in, in + strlen(in));
   if(result != spec->result_exp) {
     curl_mfprintf(stderr, "test %zu: expect result %d, got %d\n",
-                  i, spec->result_exp, result);
+                  i, (int)spec->result_exp, (int)result);
     return FALSE;
   }
   else if(!result && strcmp(spec->exp_output, curlx_dyn_ptr(dbuf))) {

--- a/tests/unit/unit1657.c
+++ b/tests/unit/unit1657.c
@@ -72,7 +72,7 @@ static bool do_test1657(const struct test1657_spec *spec, size_t i,
   curlx_dyn_reset(buf);
   result = spec->setbuf(spec, buf);
   if(result) {
-    curl_mfprintf(stderr, "test %zu: error setting buf %d\n", i, result);
+    curl_mfprintf(stderr, "test %zu: error setting buf %d\n", i, (int)result);
     return FALSE;
   }
   in = curlx_dyn_ptr(buf);
@@ -80,7 +80,7 @@ static bool do_test1657(const struct test1657_spec *spec, size_t i,
   result = ptr ? CURLE_OK : CURLE_BAD_FUNCTION_ARGUMENT;
   if(result != spec->result_exp) {
     curl_mfprintf(stderr, "test %zu: expect result %d, got %d\n",
-                  i, spec->result_exp, result);
+                  i, (int)spec->result_exp, (int)result);
     return FALSE;
   }
   return TRUE;

--- a/tests/unit/unit1658.c
+++ b/tests/unit/unit1658.c
@@ -46,7 +46,7 @@ static void rrresults(struct Curl_https_rrinfo *rr, CURLcode result)
 {
   char *p = rrbuffer;
   const char *pend = rrbuffer + sizeof(rrbuffer);
-  curl_msnprintf(rrbuffer, sizeof(rrbuffer), "r:%d|", (int)result);
+  curl_msnprintf(rrbuffer, sizeof(rrbuffer), "r:%d|", result);
   p += strlen(rrbuffer);
 
   if(rr) {

--- a/tests/unit/unit1658.c
+++ b/tests/unit/unit1658.c
@@ -46,7 +46,7 @@ static void rrresults(struct Curl_https_rrinfo *rr, CURLcode result)
 {
   char *p = rrbuffer;
   const char *pend = rrbuffer + sizeof(rrbuffer);
-  curl_msnprintf(rrbuffer, sizeof(rrbuffer), "r:%d|", result);
+  curl_msnprintf(rrbuffer, sizeof(rrbuffer), "r:%d|", (int)result);
   p += strlen(rrbuffer);
 
   if(rr) {

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -127,12 +127,12 @@ static CURLcode test_unit1660(const char *arg)
 
       if(result != headers[i].result) {
         curl_mfprintf(stderr, "Curl_hsts_parse(%s) failed: %d\n",
-                      headers[i].hdr, result);
+                      headers[i].hdr, (int)result);
         unitfail++;
         continue;
       }
       else if(result) {
-        curl_mprintf("Input %d: error %d\n", i, result);
+        curl_mprintf("Input %d: error %d\n", i, (int)result);
         continue;
       }
     }

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -132,7 +132,7 @@ static CURLcode test_unit1660(const char *arg)
         continue;
       }
       else if(result) {
-        curl_mprintf("Input %d: error %d\n", i, (int)result);
+        curl_mprintf("Input %d: error %d\n", i, result);
         continue;
       }
     }

--- a/tests/unit/unit1664.c
+++ b/tests/unit/unit1664.c
@@ -367,7 +367,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *orgline = line;
       int rc = curlx_str_newline(&line);
       curl_mprintf("%d: (%%%02x) %d, line %d\n",
-                   i, *orgline, rc, (int)(line - orgline));
+                   i, (unsigned int)*orgline, rc, (int)(line - orgline));
     }
   }
 

--- a/tests/unit/unit1666.c
+++ b/tests/unit/unit1666.c
@@ -49,7 +49,7 @@ static bool test1666(const struct test_1666 *spec, size_t i,
   result = encodeOID(dbuf, oid, oid + spec->size);
   if(result != spec->result_exp) {
     curl_mfprintf(stderr, "test %zu: expect result %d, got %d\n",
-                  i, spec->result_exp, result);
+                  i, (int)spec->result_exp, (int)result);
     if(!spec->result_exp) {
       curl_mfprintf(stderr, "test %zu: expected output '%s'\n",
                     i, spec->dotted);

--- a/tests/unit/unit1667.c
+++ b/tests/unit/unit1667.c
@@ -57,7 +57,7 @@ static bool test1667(const struct test_1667 *spec, size_t i,
   result = ASN1tostr(dbuf, &elem);
   if(result != spec->result_exp) {
     curl_mfprintf(stderr, "test %zu (type %u): expect result %d, got %d\n",
-                  i, spec->tag, spec->result_exp, result);
+                  i, spec->tag, (int)spec->result_exp, (int)result);
     if(!spec->result_exp) {
       curl_mfprintf(stderr, "test %zu: expected output '%s'\n",
                     i, spec->out);

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -343,7 +343,7 @@ static CURLcode test_unit1675(const char *arg)
       uc = curl_url_set(base, CURLUPART_URL, tests[i].base, 0);
       if(uc) {
         curl_mfprintf(stderr, "failed to parse %u base %s -> %d\n", i,
-                      tests[i].base, uc);
+                      tests[i].base, (int)uc);
         fails++;
         goto loop_end;
       }
@@ -358,7 +358,7 @@ static CURLcode test_unit1675(const char *arg)
       if(uc) {
         curl_mfprintf(stderr, "failed to parse %u href %s://%s:%s%s -> %d\n",
                       i, tests[i].scheme, tests[i].host, tests[i].port,
-                      tests[i].path, uc);
+                      tests[i].path, (int)uc);
         fails++;
         goto loop_end;
       }

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -425,7 +425,7 @@ loop_end:
          (u.options && tests[i].options &&
           strcmp(u.options, tests[i].options)) ||
          offset != tests[i].offset) {
-        curl_mfprintf(stderr, "%d: parse_hostname_login('%s') host failed:"
+        curl_mfprintf(stderr, "%u: parse_hostname_login('%s') host failed:"
                       " expected '%d/%s/%s/%s/%zu', got '%d/%s/%s/%s/%zu'\n",
                       i, tests[i].in, (int)tests[i].uc, tests[i].user,
                       tests[i].password, tests[i].options, tests[i].offset,

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -263,7 +263,7 @@ static void check_result(const struct test_case *tc, struct test_result *tr)
     /* on CI we encounter the TIMEOUT result, since images get less CPU
      * and events are not as sharply timed. */
     curl_msprintf(msg, "%d: expected result %d but got %d",
-                  tc->id, tc->result_exp, tr->result);
+                  tc->id, (int)tc->result_exp, (int)tr->result);
     fail(msg);
   }
   if(tr->cf4.creations != tc->exp_cf4_creations) {

--- a/tests/unit/unit2603.c
+++ b/tests/unit/unit2603.c
@@ -76,7 +76,7 @@ static void parse_success(const struct tcase *t)
     result = Curl_h1_req_parse_read(&p, buf, buflen, t->default_scheme,
                                     t->custom_method, 0, &nread);
     if(result) {
-      curl_mfprintf(stderr, "got result %d parsing: '%s'\n", result, buf);
+      curl_mfprintf(stderr, "got result %d parsing: '%s'\n", (int)result, buf);
       fail("error consuming");
     }
     in_consumed += nread;

--- a/tests/unit/unit2604.c
+++ b/tests/unit/unit2604.c
@@ -87,9 +87,9 @@ static CURLcode test_unit2604(const char *arg)
     const char *cp = i == 0 ? cp0 : list[i].cp;
     CURLcode result = Curl_get_pathname(&cp, &path, list[i].home);
     curl_mprintf("%d - Curl_get_pathname(\"%s\", ... \"%s\") == %d\n", i,
-                 list[i].cp, list[i].home, list[i].result);
+                 list[i].cp, list[i].home, (int)list[i].result);
     if(result != list[i].result) {
-      curl_mprintf("... returned %d\n", result);
+      curl_mprintf("... returned %d\n", (int)result);
       unitfail++;
     }
     if(!result) {

--- a/tests/unit/unit2605.c
+++ b/tests/unit/unit2605.c
@@ -83,7 +83,7 @@ static CURLcode test_unit2605(const char *arg)
       result = Curl_ssh_range(curl, list[i].r, list[i].filesize, &start,
                               &size);
       if(result != list[i].result) {
-        curl_mprintf("... returned %d\n", result);
+        curl_mprintf("... returned %d\n", (int)result);
         unitfail++;
       }
       if(!result) {


### PR DESCRIPTION
Adjust code to avoid `-Wformat-signedness` warnings, while making sure
that enums are always cast to a known type when passing them to `printf`
functions, to support compilers and compiler settings where enums are
not default-size signed ints.

- cast integers printed as hex to `unsigned`. (63 times, 20 of them in
  `mbedtls.c`)
- cast misc enums to `int` for printing. (31 times)
- cast `CURL_LOCK_DATA_*` enums to `int`. (4 times)
- cast `CURL_FORMADD_*` enums to `int`. (13 times)
- cast `CURLSHE_*` enums to `int`. (3 times)
- cast `CURLUE_*` enums to `int`. (33 times)
- cast `CURLMSG_*` enums to `int`. (6 times)
- cast `CURLE_*` enums to `int`. (~380 times)
- unit1675: fix mask.
  Follow-up to 7c34365ccea19949317878c7fcd5f7376e2e09f1 #21879

Ref: #18343 (initial attempt)

---

- [x] address remaining warnings by syncing format with type, or by fixing/adding/deleting a cast.
- [x] maybe drop the negative enum method, and add casts?
- [x] maybe drop casts for hex and enums and not enforce? [hex/octal casts are not significant in numbers] [MAYBE: stop enforcing, if this turns out to be a maintenance/development hassle.]
- [x] maybe keep the -1 solution for `CURLE_*`? [NO, it changes the public interface, also not general solution]
- [x] maybe convert `CURLE_*` to macros? [NO, changes public interface, intrusive and not general solution]

Ref GCC bug from 2015: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66249
