### PR TITLE
http: restrict custom Host reuse on redirect

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2005,7 +2005,9 @@ static CURLcode http_set_aptr_host(struct Curl_easy *data)
 
   ptr = Curl_checkheaders(data, STRCONST("Host"));
   if(ptr && (!data->state.this_is_a_follow ||
-             curl_strequal(data->state.first_host, conn->host.name))) {
+             (curl_strequal(data->state.first_host, conn->host.name) &&
+              data->state.first_remote_port == conn->remote_port &&
+              data->state.first_remote_protocol == conn->scheme->protocol))) {
 #ifndef CURL_DISABLE_COOKIES
     /* If we have a given custom Host: header, we extract the hostname in
        order to possibly use it for cookie reasons later on. We only allow the

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -254,7 +254,7 @@ test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
-test2088 test2089 test2090 test2091 \
+test2088 test2089 test2090 test2091 test2092 \
 test2100 test2101 test2102 test2103 test2104 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 \

--- a/tests/data/test2092
+++ b/tests/data/test2092
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP proxy
+followlocation
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 301 OK swsbounce
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 4
+Location: http://deathstar.another.galaxy:9999/go/west/%TESTNUMBER
+
+moo
+</data>
+<data1 crlf="headers">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 4
+
+moo
+</data1>
+<datacheck crlf="headers">
+HTTP/1.1 301 OK swsbounce
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 4
+Location: http://deathstar.another.galaxy:9999/go/west/%TESTNUMBER
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 4
+
+moo
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP replace Host: when following Location: to same host on a new port
+</name>
+<command>
+http://deathstar.another.galaxy/%TESTNUMBER -L -H "Host: another.visitor.stay.a.while.stay.foreeeeeever" --proxy http://%HOSTIP:%HTTPPORT
+</command>
+<features>
+proxy
+</features>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://deathstar.another.galaxy/%TESTNUMBER HTTP/1.1
+Host: another.visitor.stay.a.while.stay.foreeeeeever
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://deathstar.another.galaxy:9999/go/west/%TESTNUMBER HTTP/1.1
+Host: deathstar.another.galaxy:9999
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+
+</verify>
+</testcase>


### PR DESCRIPTION
Only keep a user-supplied Host: header across redirects when host, port and protocol stay unchanged. Add a regression test for same-host redirects to a new port.