### PR TITLE
system_win32: replace manual init code with `curlx_now_init()` call

### DIFF
--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -27,6 +27,7 @@
 
 #include "system_win32.h"
 #include "curl_sspi.h"
+#include "curlx/timeval.h"
 
 /* Curl_win32_init() performs Win32 global initialization */
 CURLcode Curl_win32_init(long flags)
@@ -76,7 +77,7 @@ CURLcode Curl_win32_init(long flags)
   }
 #endif
 
-  QueryPerformanceFrequency(&Curl_freq);
+  curlx_now_init();
   return CURLE_OK;
 }
 


### PR DESCRIPTION
The actual init code remains identical after this patch. To make it
clearer where this initialization is called from, and to dedupe code.

Follow-up to b17ef873ae2151263667f4b6fb6abfe337e687dc #18009
