### PR TITLE
tests/server: drop unused `curlx/version_win32.c`

### DIFF
--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -46,7 +46,6 @@ CURLX_C = \
   ../../lib/curlx/strparse.c \
   ../../lib/curlx/timediff.c \
   ../../lib/curlx/timeval.c \
-  ../../lib/curlx/version_win32.c \
   ../../lib/curlx/wait.c \
   ../../lib/curlx/warnless.c \
   ../../lib/curlx/winapi.c


### PR DESCRIPTION
Previously used via `curlx/timeval.c`, but no longer after bumping
minimum target to Vista.

Follow-up to b17ef873ae2151263667f4b6fb6abfe337e687dc #18009
