### PR TITLE
rand: drop scan-build silencer

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -228,12 +228,6 @@ CURLcode Curl_rand_hex(struct Curl_easy *data, unsigned char *rnd, size_t num)
   unsigned char buffer[128];
   DEBUGASSERT(num > 1);
 
-#ifdef __clang_analyzer__
-  /* This silences a scan-build warning about accessing this buffer with
-     uninitialized memory. */
-  memset(buffer, 0, sizeof(buffer));
-#endif
-
   if((num / 2 >= sizeof(buffer)) || !(num & 1)) {
     /* make sure it fits in the local buffer and that it is an odd number! */
     DEBUGF(infof(data, "invalid buffer size with Curl_rand_hex"));


### PR DESCRIPTION
scan-build has been dropped in favor of clang-tidy and this false
positive no longer triggers with it.

Follow-up to ce4db9c2efca0bd89e556e231d940c988d84a606 #20751
Follow-up to 02f207a76b45129e4d033c099e6d17581801c76e
