### PR TITLE
Fix: memory leak in `auth_create_digest_http_message()` in `lib/vauth/digest.c`

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -809,8 +809,10 @@ static CURLcode auth_create_digest_http_message(
     char *hashthis2;
 
     result = hash(hashbuf, (const unsigned char *)"", 0);
-    if(result)
+    if(result) {
+      curlx_free(hashthis);
       goto oom;
+    }
     convert_to_ascii(hashbuf, (unsigned char *)hashed);
 
     hashthis2 = curl_maprintf("%s:%s", hashthis, hashed);


### PR DESCRIPTION
### Bug description

While reviewing `auth_create_digest_http_message()` in `lib/vauth/digest.c`, I noticed an error path that may leak the heap-allocated buffer `hashthis`.

`hashthis` is allocated here (line **800**):
``` c
hashthis = curl_maprintf("%s:%s", request, uripath);
```
In the `auth-int` branch, if the subsequent `hash()` call fails, execution jumps to `oom:` without freeing `hashthis` (line **806–813**):
``` c
if(digest->qop && curl_strequal(digest->qop, "auth-int")) {
    /* We do not support auth-int for PUT or POST */
    char hashed[65];
    char *hashthis2;

    result = hash(hashbuf, (const unsigned char *)"", 0);
    if(result)
      goto oom;
}
```
However, the cleanup block does not free `hashthis` (line **953–960**):
``` c
oom:
    curlx_free(nonce_quoted);
    curlx_free(realm_quoted);
    curlx_free(uri_quoted);
    curlx_free(userp_quoted);
    if(result)
        curlx_dyn_free(&response);
    return result;
```
As a result, if the `hash()` call fails in the `auth-int` branch after `hashthis` has been allocated, the function jumps to `oom:` and returns without freeing `hashthis`, which may lead to a memory leak.

### Fix

Free `hashthis` before jumping to `oom:` when `hash()` fails. The fix is included in the commit.