### PR TITLE
docs: handle error in `curl_global_init*` examples

### DIFF
--- a/docs/libcurl/curl_global_init.md
+++ b/docs/libcurl/curl_global_init.md
@@ -117,11 +117,16 @@ elapses.
 ~~~c
 int main(void)
 {
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  CURLcode result;
 
-  /* use libcurl, then before exiting... */
+  result = curl_global_init(CURL_GLOBAL_DEFAULT);
 
-  curl_global_cleanup();
+  if(result == CURLE_OK) {
+
+    /* use libcurl, then before exiting... */
+
+    curl_global_cleanup();
+  }
 }
 ~~~
 

--- a/docs/libcurl/curl_global_init_mem.md
+++ b/docs/libcurl/curl_global_init_mem.md
@@ -84,9 +84,18 @@ extern void *calloc_cb(size_t, size_t);
 
 int main(void)
 {
-  curl_global_init_mem(CURL_GLOBAL_DEFAULT, malloc_cb,
-                       free_cb, realloc_cb,
-                       strdup_cb, calloc_cb);
+  CURLcode result;
+
+  result = curl_global_init_mem(CURL_GLOBAL_DEFAULT, malloc_cb,
+                                free_cb, realloc_cb,
+                                strdup_cb, calloc_cb);
+
+  if(result == CURLE_OK) {
+
+    /* use libcurl, then before exiting... */
+
+    curl_global_cleanup();
+  }
 }
 ~~~
 


### PR DESCRIPTION
Also:
- call cleanup in `curl_global_init_mem()` example.

---

https://github.com/curl/curl/pull/20866/files?w=1