### PR TITLE
FAQ.md: point codeproject.com URL to archive.org copy

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -834,7 +834,7 @@ any modern compiler that allows for a 64-bit curl_off_t type. For older
 compilers or prior curl versions it may set a time that appears one hour off.
 This happens due to a flaw in how Windows stores and uses file modification
 times and it is not easily worked around. For more details [read
-this](https://www.codeproject.com/articles/Beating-the-Daylight-Savings-Time-Bug-and-Getting#comments-section).
+this](https://web.archive.org/web/20260105021457/www.codeproject.com/articles/Beating-the-Daylight-Savings-Time-Bug-and-Getting#comments-section).
 
 ## Redirects work in browser but not with curl
 


### PR DESCRIPTION
The original server closed down, linked page last seen on 2026-02-16.

Refs:
https://github.com/curl/curl/actions/runs/22051494128
https://web.archive.org/web/20250818150617/www.codeproject.com/info/Changes.aspx
