### PR TITLE
Clear the sockaddr_in6 structure before use

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -680,6 +680,7 @@ static struct Curl_addrinfo *get_localhost6(int port, const char *name)
   if(!ca)
     return NULL;
 
+  memset(&sa6, 0, sizeof(sa6));
   sa6.sin6_family = AF_INET6;
   sa6.sin6_port = htons(port16);
   sa6.sin6_flowinfo = 0;


### PR DESCRIPTION
On Solaris this was causing intermittent issues when the private structure member __sin6_src_id had unexpectedly some value. connect(2) would then fail with EADDRNOTAVAIL.

This patch was used on Solaris builds for last two years: https://github.com/oracle/solaris-userland/blob/master/components/curl/patches/34396154.patch

I have modified it slightly to match what the function get_localhost below does.

Thank you for curl.