### PR TITLE
ECH definitions cleanup

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -52,15 +52,6 @@
 #define PORT_MQTT   1883
 #define PORT_MQTTS  8883
 
-#ifdef USE_ECH
-/* CURLECH_ bits for the tls_ech option */
-#define CURLECH_DISABLE    (1 << 0)
-#define CURLECH_GREASE     (1 << 1)
-#define CURLECH_ENABLE     (1 << 2)
-#define CURLECH_HARD       (1 << 3)
-#define CURLECH_CLA_CFG    (1 << 4)
-#endif
-
 #ifndef CURL_DISABLE_WEBSOCKETS
 /* CURLPROTO_GOPHERS (29) is the highest publicly used protocol bit number,
  * the rest are internal information. If we use higher bits we only do this on

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -84,6 +84,9 @@
 #include "curlx/strcopy.h"
 #include "curlx/strdup.h"
 #include "vtls/apple.h"
+#ifdef USE_ECH
+#include "curlx/base64.h"
+#endif
 
 #include <openssl/rand.h>
 #include <openssl/x509v3.h>
@@ -3488,7 +3491,7 @@ static CURLcode ossl_init_ech(struct ossl_ctx *octx,
   int trying_ech_now = 0;
   CURLcode result;
 
-  if(!ECH_ENABLED(data))
+  if(!CURLECH_ENABLED(data))
     return CURLE_OK;
 
   if(data->set.tls_ech & CURLECH_GREASE) {
@@ -4119,7 +4122,7 @@ static void ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL *ssl,
 #endif
 
   /* nothing to trace if not doing ECH */
-  if(!ECH_ENABLED(data))
+  if(!CURLECH_ENABLED(data))
     return;
 #ifndef HAVE_BORINGSSL_LIKE
   rv = SSL_ech_get1_retry_config(ssl, &rcs, &rcl);
@@ -4317,7 +4320,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
     Curl_ossl_report_handshake(data, octx);
 
 #if defined(HAVE_SSL_SET1_ECH_CONFIG_LIST) && !defined(HAVE_BORINGSSL_LIKE)
-    if(ECH_ENABLED(data)) {
+    if(CURLECH_ENABLED(data)) {
       char *inner = NULL, *outer = NULL;
       const char *status = NULL;
       int rv;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -40,6 +40,9 @@
 #include "vtls/keylog.h"
 #include "vtls/cipher_suite.h"
 #include "vtls/x509asn1.h"
+#ifdef USE_ECH
+#include "curlx/base64.h"
+#endif
 
 struct rustls_ssl_backend_data {
   const struct rustls_client_config *config;
@@ -570,7 +573,7 @@ init_config_builder(struct Curl_easy *data,
   }
 
 #ifdef USE_ECH
-  if(ECH_ENABLED(data)) {
+  if(CURLECH_ENABLED(data)) {
     tls_versions[0] = RUSTLS_TLS_VERSION_TLSV1_3;
     tls_versions_len = 1;
     infof(data, "rustls: ECH enabled, forcing TLSv1.3");
@@ -1065,7 +1068,7 @@ static CURLcode cr_init_backend(struct Curl_cfilter *cf,
   }
 
 #ifdef USE_ECH
-  if(ECH_ENABLED(data)) {
+  if(CURLECH_ENABLED(data)) {
     result = init_config_builder_ech(data, connssl, config_builder);
     if(result != CURLE_OK && data->set.tls_ech & CURLECH_HARD) {
       rustls_client_config_builder_free(config_builder);

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -49,8 +49,14 @@ struct dynbuf;
 #define SSLSUPP_ISSUERCERT_BLOB (1 << 14) /* CURLOPT_ISSUERCERT_BLOB */
 
 #ifdef USE_ECH
-#include "curlx/base64.h"
-#define ECH_ENABLED(data) \
+/* CURLECH_ bits for the tls_ech option */
+#define CURLECH_DISABLE    (1 << 0)
+#define CURLECH_GREASE     (1 << 1)
+#define CURLECH_ENABLE     (1 << 2)
+#define CURLECH_HARD       (1 << 3)
+#define CURLECH_CLA_CFG    (1 << 4)
+
+#define CURLECH_ENABLED(data) \
   ((data)->set.tls_ech && !((data)->set.tls_ech & CURLECH_DISABLE))
 #endif /* USE_ECH */
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -65,6 +65,9 @@
 #include "curlx/strdup.h"
 #include "curlx/strcopy.h"
 #include "vtls/x509asn1.h"
+#ifdef USE_ECH
+#include "curlx/base64.h"
+#endif
 
 #include <wolfssl/ssl.h>
 #include <wolfssl/error-ssl.h>
@@ -1345,7 +1348,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
 #endif /* HAVE_SECURE_RENEGOTIATION */
 
 #ifdef HAVE_WOLFSSL_CTX_GENERATEECHCONFIG
-  if(ECH_ENABLED(data)) {
+  if(CURLECH_ENABLED(data)) {
     int trying_ech_now = 0;
 
     if(data->set.str[STRING_ECH_PUBLIC]) {


### PR DESCRIPTION
- Move ECH related defines to vtls.h
- Prefix all defines with `CURLECH_`
- Move base64.h include from vtls.h to implementations