### PR TITLE
pingpong: cleanup timeleft handling

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -657,7 +657,7 @@ static CURLcode getftpresponse(struct Curl_easy *data,
 
   while(!*ftpcodep && !result) {
     /* check and reset timeout value every lap */
-    timediff_t timeout = Curl_pp_state_timeout(data, pp);
+    timediff_t timeout = Curl_pp_state_timeleft_ms(data, pp);
     timediff_t interval_ms;
 
     if(timeout <= 0) {

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -39,29 +39,21 @@
 #include "select.h"
 #include "progress.h"
 
-/* Returns timeout in ms. 0 or negative number means the timeout has already
-   triggered */
-timediff_t Curl_pp_state_timeout(struct Curl_easy *data,
-                                 struct pingpong *pp)
+timediff_t Curl_pp_state_timeleft_ms(struct Curl_easy *data,
+                                     struct pingpong *pp)
 {
-  timediff_t timeout_ms, xfer_timeout_ms;
-  timediff_t response_time = data->set.server_response_timeout ?
-    data->set.server_response_timeout : RESP_TIMEOUT;
+  timediff_t xfer_remain_ms;
+  timediff_t remain_ms = data->set.server_response_timeout ?
+    data->set.server_response_timeout : PINGPONG_TIMEOUT_MS;
 
-  /* if CURLOPT_SERVER_RESPONSE_TIMEOUT is set, use that to determine
-     remaining time, or use pp->response because SERVER_RESPONSE_TIMEOUT is
-     supposed to govern the response for any given server response, not for
-     the time from connect to the given server response. */
-
-  /* Without a requested timeout, we only wait 'response_time' seconds for the
-     full response to arrive before we bail out */
-  timeout_ms = response_time -
-               curlx_ptimediff_ms(Curl_pgrs_now(data), &pp->response);
-  /* transfer timeout can be 0, which means no timeout applies */
-  xfer_timeout_ms = Curl_timeleft_ms(data);
-  if(xfer_timeout_ms && (xfer_timeout_ms < timeout_ms))
-    return xfer_timeout_ms;
-  return timeout_ms;
+  /* If the overall transfer has less time remaining than pingpong
+   * has otherwise for the state, return that. */
+  remain_ms -= curlx_ptimediff_ms(Curl_pgrs_now(data), &pp->response);
+  /* transfer remaining time is 0, when it has no timeout. */
+  xfer_remain_ms = Curl_timeleft_ms(data);
+  if(xfer_remain_ms)
+    return CURLMIN(remain_ms, xfer_remain_ms);
+  return remain_ms;
 }
 
 /*
@@ -75,7 +67,7 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
   curl_socket_t sock = conn->sock[FIRSTSOCKET];
   int rc;
   timediff_t interval_ms;
-  timediff_t timeout_ms = Curl_pp_state_timeout(data, pp);
+  timediff_t timeout_ms = Curl_pp_state_timeleft_ms(data, pp);
   CURLcode result = CURLE_OK;
 
   if(timeout_ms <= 0) {

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -70,6 +70,10 @@ struct pingpong {
                          read */
 };
 
+/* Default pingpong response timeout in milliseconds, unless a transfer
+ * has CURLOPT_SERVER_RESPONSE_TIMEOUT(_MS) set. */
+#define PINGPONG_TIMEOUT_MS      (60 * 1000)
+
 #define PINGPONG_SETUP(pp, s, e) \
   do {                           \
     (pp)->statemachine = s;      \
@@ -88,10 +92,10 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data, struct pingpong *pp,
 /* initialize stuff to prepare for reading a fresh new response */
 void Curl_pp_init(struct pingpong *pp, const struct curltime *pnow);
 
-/* Returns timeout in ms. 0 or negative number means the timeout has already
-   triggered */
-timediff_t Curl_pp_state_timeout(struct Curl_easy *data,
-                                 struct pingpong *pp);
+/* Returns time remaining in ms. 0 or negative number means the
+  timeout has already triggered */
+timediff_t Curl_pp_state_timeleft_ms(struct Curl_easy *data,
+                                     struct pingpong *pp);
 
 /***********************************************************************
  *

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -120,9 +120,6 @@ typedef curl_off_t curl_prot_t;
 /* length of longest IPv6 address string including the trailing null */
 #define MAX_IPADR_LEN sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255")
 
-/* Default FTP/IMAP etc response timeout in milliseconds */
-#define RESP_TIMEOUT (60 * 1000)
-
 /* Max string input length is a precaution against abuse and to detect junk
    input easier and better. */
 #define CURL_MAX_INPUT_LENGTH 8000000


### PR DESCRIPTION
- Move `RESP_TIMEOUT` from urldata.h to pingpong.h as `PINGPONG_TIMEOUT_MS`.
- Rename `Curl_pp_state_timeout()` to `Curl_pp_state_timeleft_ms()` as the function returns the time left, not the timeout.
- Update implementation comments and variable names