### PR TITLE
connection_check, simplified

### DIFF
--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -240,7 +240,7 @@ static const struct Curl_protocol Curl_protocol_rtmp = {
   rtmp_disconnect,                      /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -290,7 +290,7 @@ static const struct Curl_protocol Curl_protocol_dict = {
   ZERO_NULL,                            /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/file.c
+++ b/lib/file.c
@@ -613,7 +613,7 @@ static const struct Curl_protocol Curl_protocol_file = {
   file_disconnect,                      /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4471,7 +4471,7 @@ static const struct Curl_protocol Curl_protocol_ftp = {
   ftp_disconnect,                  /* disconnect */
   ZERO_NULL,                       /* write_resp */
   ZERO_NULL,                       /* write_resp_hd */
-  ZERO_NULL,                       /* connection_check */
+  ZERO_NULL,                       /* connection_is_dead */
   ZERO_NULL,                       /* attach connection */
   ZERO_NULL,                       /* follow */
 };

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -187,7 +187,7 @@ static const struct Curl_protocol Curl_protocol_gopher = {
   ZERO_NULL,                            /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };
@@ -208,7 +208,7 @@ static const struct Curl_protocol Curl_protocol_gophers = {
   ZERO_NULL,                            /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/http.c
+++ b/lib/http.c
@@ -4997,7 +4997,7 @@ static const struct Curl_protocol Curl_protocol_http = {
   ZERO_NULL,                            /* disconnect */
   Curl_http_write_resp,                 /* write_resp */
   Curl_http_write_resp_hd,              /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   Curl_http_follow,                     /* follow */
 };

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -2317,7 +2317,7 @@ static const struct Curl_protocol Curl_protocol_imap = {
   imap_disconnect,                  /* disconnect */
   ZERO_NULL,                        /* write_resp */
   ZERO_NULL,                        /* write_resp_hd */
-  ZERO_NULL,                        /* connection_check */
+  ZERO_NULL,                        /* connection_is_dead */
   ZERO_NULL,                        /* attach connection */
   ZERO_NULL,                        /* follow */
 };

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -991,7 +991,7 @@ const struct Curl_protocol Curl_protocol_ldap = {
   ZERO_NULL,                            /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -979,7 +979,7 @@ static const struct Curl_protocol Curl_protocol_mqtts = {
   ZERO_NULL,                          /* disconnect */
   ZERO_NULL,                          /* write_resp */
   ZERO_NULL,                          /* write_resp_hd */
-  ZERO_NULL,                          /* connection_check */
+  ZERO_NULL,                          /* connection_is_dead */
   ZERO_NULL,                          /* attach connection */
   ZERO_NULL,                          /* follow */
 };
@@ -1004,7 +1004,7 @@ static const struct Curl_protocol Curl_protocol_mqtt = {
   ZERO_NULL,                          /* disconnect */
   ZERO_NULL,                          /* write_resp */
   ZERO_NULL,                          /* write_resp_hd */
-  ZERO_NULL,                          /* connection_check */
+  ZERO_NULL,                          /* connection_is_dead */
   ZERO_NULL,                          /* attach connection */
   ZERO_NULL,                          /* follow */
 };

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1276,7 +1276,7 @@ const struct Curl_protocol Curl_protocol_ldap = {
   oldap_disconnect,                     /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1707,7 +1707,7 @@ static const struct Curl_protocol Curl_protocol_pop3 = {
   pop3_disconnect,                  /* disconnect */
   pop3_write,                       /* write_resp */
   ZERO_NULL,                        /* write_resp_hd */
-  ZERO_NULL,                        /* connection_check */
+  ZERO_NULL,                        /* connection_is_dead */
   ZERO_NULL,                        /* attach connection */
   ZERO_NULL,                        /* follow */
 };

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -126,19 +126,13 @@ static CURLcode rtsp_setup_connection(struct Curl_easy *data,
 /*
  * Function to check on various aspects of a connection.
  */
-static uint32_t rtsp_conncheck(struct Curl_easy *data,
-                               struct connectdata *conn,
-                               uint32_t checks_to_perform)
+static bool rtsp_conn_is_dead(struct Curl_easy *data,
+                              struct connectdata *conn)
 {
-  unsigned int ret_val = CONNRESULT_NONE;
-
-  if(checks_to_perform & CONNCHECK_ISDEAD) {
-    bool input_pending;
-    if(!Curl_conn_is_alive(data, conn, &input_pending))
-      ret_val |= CONNRESULT_DEAD;
-  }
-
-  return ret_val;
+  bool input_pending;
+  /* Contrary to default handling, this protocol allows pending
+   * input on an unused connection. */
+  return !Curl_conn_is_alive(data, conn, &input_pending);
 }
 
 static CURLcode rtsp_connect(struct Curl_easy *data, bool *done)
@@ -1072,7 +1066,7 @@ static const struct Curl_protocol Curl_protocol_rtsp = {
   ZERO_NULL,                            /* disconnect */
   rtsp_rtp_write_resp,                  /* write_resp */
   rtsp_rtp_write_resp_hd,               /* write_resp_hd */
-  rtsp_conncheck,                       /* connection_check */
+  rtsp_conn_is_dead,                    /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   Curl_http_follow,                     /* follow */
 };

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -1223,7 +1223,7 @@ static const struct Curl_protocol Curl_protocol_smb = {
   ZERO_NULL,                            /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1999,7 +1999,7 @@ static const struct Curl_protocol Curl_protocol_smtp = {
   smtp_disconnect,                  /* disconnect */
   ZERO_NULL,                        /* write_resp */
   ZERO_NULL,                        /* write_resp_hd */
-  ZERO_NULL,                        /* connection_check */
+  ZERO_NULL,                        /* connection_is_dead */
   ZERO_NULL,                        /* attach connection */
   ZERO_NULL,                        /* follow */
 };

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1584,7 +1584,7 @@ static const struct Curl_protocol Curl_protocol_telnet = {
   ZERO_NULL,                            /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1347,7 +1347,7 @@ static const struct Curl_protocol Curl_protocol_tftp = {
   ZERO_NULL,                            /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/url.c
+++ b/lib/url.c
@@ -650,19 +650,12 @@ bool Curl_conn_seems_dead(struct connectdata *conn,
       /* avoid check if already too old */
       dead = TRUE;
     }
-    else if(conn->scheme->run->connection_check) {
+    else if(conn->scheme->run->connection_is_dead) {
       /* The protocol has a special method for checking the state of the
          connection. Use it to check if the connection is dead. */
-      unsigned int state;
-
-      /* briefly attach the connection to this transfer for the purpose of
-         checking it */
+      /* briefly attach the connection for the check */
       Curl_attach_connection(data, conn);
-
-      state = conn->scheme->run->connection_check(data, conn,
-                                                     CONNCHECK_ISDEAD);
-      dead = (state & CONNRESULT_DEAD);
-      /* detach the connection again */
+      dead = conn->scheme->run->connection_is_dead(data, conn);
       Curl_detach_connection(data);
     }
     else {
@@ -705,18 +698,7 @@ CURLcode Curl_conn_upkeep(struct Curl_easy *data,
 
   /* briefly attach for action */
   Curl_attach_connection(data, conn);
-  if(conn->scheme->run->connection_check) {
-    /* Do a protocol-specific keepalive check on the connection. */
-    unsigned int rc;
-    rc = conn->scheme->run->connection_check(data, conn,
-                                                CONNCHECK_KEEPALIVE);
-    if(rc & CONNRESULT_DEAD)
-      result = CURLE_RECV_ERROR;
-  }
-  else {
-    /* Do the generic action on the FIRSTSOCKET filter chain */
-    result = Curl_conn_keep_alive(data, conn, FIRSTSOCKET);
-  }
+  result = Curl_conn_keep_alive(data, conn, FIRSTSOCKET);
   Curl_detach_connection(data);
 
   conn->keepalive = *Curl_pgrs_now(data);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -492,12 +492,10 @@ struct Curl_protocol {
   CURLcode (*write_resp_hd)(struct Curl_easy *data,
                             const char *hd, size_t hdlen, bool is_eos);
 
-  /* This function can perform various checks on the connection. See
-     CONNCHECK_* for more information about the checks that can be performed,
-     and CONNRESULT_* for the results that can be returned. */
-  uint32_t (*connection_check)(struct Curl_easy *data,
-                               struct connectdata *conn,
-                               uint32_t checks_to_perform);
+  /* If used, this function checks for a connection managed by this
+    protocol and currently not in use, if it should be considered dead. */
+  bool (*connection_is_dead)(struct Curl_easy *data,
+                             struct connectdata *conn);
 
   /* attach() attaches this transfer to this connection */
   void (*attach)(struct Curl_easy *data, struct connectdata *conn);
@@ -553,13 +551,6 @@ struct Curl_scheme {
                                          SSL connection in the same family
                                          without having PROTOPT_SSL. */
 #define PROTOPT_CONN_REUSE (1 << 16)  /* this protocol can reuse connections */
-
-#define CONNCHECK_NONE 0                 /* No checks */
-#define CONNCHECK_ISDEAD (1 << 0)        /* Check if the connection is dead. */
-#define CONNCHECK_KEEPALIVE (1 << 1)     /* Perform any keepalive function. */
-
-#define CONNRESULT_NONE 0                /* No extra information. */
-#define CONNRESULT_DEAD (1 << 0)         /* The connection is dead. */
 
 #define TRNSPRT_NONE 0
 #define TRNSPRT_TCP  3

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2985,7 +2985,7 @@ const struct Curl_protocol Curl_protocol_scp = {
   scp_disconnect,               /* disconnect */
   ZERO_NULL,                    /* write_resp */
   ZERO_NULL,                    /* write_resp_hd */
-  ZERO_NULL,                    /* connection_check */
+  ZERO_NULL,                    /* connection_is_dead */
   ZERO_NULL,                    /* attach connection */
   ZERO_NULL,                    /* follow */
 };
@@ -3008,7 +3008,7 @@ const struct Curl_protocol Curl_protocol_sftp = {
   sftp_disconnect,                      /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3835,7 +3835,7 @@ const struct Curl_protocol Curl_protocol_scp = {
   scp_disconnect,                       /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ssh_attach,                           /* attach */
   ZERO_NULL,                            /* follow */
 };
@@ -3858,7 +3858,7 @@ const struct Curl_protocol Curl_protocol_sftp = {
   sftp_disconnect,                      /* disconnect */
   ZERO_NULL,                            /* write_resp */
   ZERO_NULL,                            /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ssh_attach,                           /* attach */
   ZERO_NULL,                            /* follow */
 };

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1930,7 +1930,7 @@ static const struct Curl_protocol Curl_protocol_ws = {
   ZERO_NULL,                            /* disconnect */
   Curl_http_write_resp,                 /* write_resp */
   Curl_http_write_resp_hd,              /* write_resp_hd */
-  ZERO_NULL,                            /* connection_check */
+  ZERO_NULL,                            /* connection_is_dead */
   ZERO_NULL,                            /* attach connection */
   Curl_http_follow,                     /* follow */
 };


### PR DESCRIPTION
The protocol handler method `connection_check` allowed to variable operations to trigger with variable result bits. Only the `CONNCHECK_ISDEAD` and `CONNRESULT_DEAD` were in use. Transform the function into `connection_is_dead` without extra parameter and a bool result.

- Remove defines for `CONNCHECK_*` and `CONNRESULT_*`
- Rename protocol function in handler comments
- Change RTSP implementation (only protocol that uses this)