### PR TITLE
configure: fix LibreSSL ngtcp2 1.15.0+ crypto lib selection logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3314,8 +3314,8 @@ if test "$USE_NGTCP2" = "1" && test "$OPENSSL_ENABLED" = "1" && test "$HAVE_LIBR
   fi
 fi
 
-if test "$USE_NGTCP2" = "1" && test "$OPENSSL_ENABLED" = "1" && test "$OPENSSL_IS_BORINGSSL" != "1" &&
-   test "$OPENSSL_QUIC_API2" != "1"; then
+if test "$USE_NGTCP2" = "1" && test "$OPENSSL_ENABLED" = "1" && test "$HAVE_LIBRESSL" != "1" &&
+   test "$OPENSSL_IS_BORINGSSL" != "1" && test "$OPENSSL_QUIC_API2" != "1"; then
 
   dnl backup the pre-ngtcp2_crypto_quictls variables
   CLEANLDFLAGS="$LDFLAGS"


### PR DESCRIPTION
Regression since curl 8.18.0.

Reported-by: Michael Hendricks
Fixes #20889
Regression from 8db0e286b363ad788d6dc0779d605b83c7ed4caf #18189

---

Seen when configuring ngtcp2 with `--with-ngtcp2=<ngtcp2-root>`.

A potential workaround may be to use
`PKG_CONFIG_PATH=<ngtcp2-root>/lib/pkgconfig --with-ngtcp2` to
configure ngtcp2, as in `docs/HTTP3.md`, and in CI.
Refs:
3c64ffaff4cd8c8275627dd2e17b6879a1d32262 #18415 #18188
99500660af19f89069e71c2251c13963401b3806 #18028 #18022

or passing `--with-nghttp3=`, or?
