### PR TITLE
http: fix Curl_compareheader for multi value headers

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1400,8 +1400,8 @@ CURLcode Curl_http_follow(struct Curl_easy *data, const char *newurl,
 /*
  * Curl_compareheader()
  *
- * Returns TRUE if 'headerline' contains the 'header' with given 'content'.
- * Pass headers WITH the colon.
+ * Returns TRUE if 'headerline' contains the 'header' with given 'content'
+ * (within a comma-separated list of tokens). Pass 'header' WITH the colon.
  */
 bool Curl_compareheader(const char *headerline, /* line to check */
                         const char *header, /* header keyword _with_ colon */
@@ -1435,9 +1435,20 @@ bool Curl_compareheader(const char *headerline, /* line to check */
   if(curlx_strlen(&val) >= clen) {
     size_t len;
     p = curlx_str(&val);
-    for(len = curlx_strlen(&val); len >= curlx_strlen(&val); len--, p++) {
-      if(curl_strnequal(p, content, clen))
+    for(len = curlx_strlen(&val); len >= clen;) {
+      struct Curl_str next;
+      const char *o = p;
+      /* after a match there must be a comma, space, newline or null byte */
+      if(curl_strnequal(p, content, clen) &&
+         ((p[clen] == ',') || ISBLANK(p[clen]) || ISNEWLINE(p[clen]) ||
+          !p[clen]))
         return TRUE; /* match! */
+      /* advance to the next comma */
+      if(curlx_str_until(&p, &next, MAX_HTTP_RESP_HEADER_SIZE, ',') ||
+         curlx_str_single(&p, ','))
+        break; /* no comma, get out */
+      curlx_str_passblanks(&p);
+      len -= (p - o);
     }
   }
   return FALSE; /* no match */

--- a/tests/data/test1
+++ b/tests/data/test1
@@ -17,7 +17,7 @@ Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
 ETag: "21025-dc7-39462498"
 Accept-Ranges: bytes
 Content-Length: 6
-Connection: close
+Connection: something-close, close-something, close
 Content-Type: text/html
 Funny-head: yesyes
 

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -14,6 +14,7 @@ verbose logs
 <reply>
 <data crlf="headers" nocheck="yes">
 HTTP/1.1 200 OK
+Connection: close-not
 Content-Length: 0
 
 </data>


### PR DESCRIPTION
Follow-up to 04289c62dea22d28daa60. Regression shipped in 8.13.0.

- a logic error made it not loop and thus only match if the searched string was first

- it no longer matches a substring

Adjusted test 1 to use multiple values in the Connection: response header.

Reported-by: Henrique Pereira