### PR TITLE
openssl: trace count of found / imported Windows native CA roots

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2994,8 +2994,8 @@ static CURLcode ossl_win_load_store(struct Curl_easy *data,
     CertCloseStore(hStore, 0);
 
     CURL_TRC_CF(data, cf,
-                "ossl_win_load_store() found: %zu imported: %zu certs.",
-                total, imported);
+                "ossl_win_load_store() found: %zu imported: %zu certs in %s.",
+                total, imported, win_store);
 
     if(result)
       return result;


### PR DESCRIPTION
To help understanding what's happening on systems where native CA misses
to verify legitimate public websites.

Also:
- drop a superfluous, hanging, `else`.

Ref: #20897
