### PR TITLE
test459: switch to mode="warn" for stderr check

### DIFF
--- a/tests/data/test459
+++ b/tests/data/test459
@@ -53,7 +53,7 @@ Content-Type: application/x-www-form-urlencoded
 
 arg
 </protocol>
-<stderr mode="text">
+<stderr mode="warn">
 Warning: %LOGDIR/config:1 Option 'data' uses argument with unquoted whitespace.%SP
 Warning: This may cause side-effects. Consider double quotes.
 </stderr>


### PR DESCRIPTION
In a -j192 build, this output used a three-digit number for the output, thus wrapping differently and causing it to error.

Reported-by: Carlos Henrique Lima Melara