### PR TITLE
GHA: make typos ignore RELEASE-NOTES

### DIFF
--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -28,8 +28,8 @@ extend-exclude = [
   "projects/vms/*",
   "projects/Windows/tmpl/curl.vcxproj",
   "projects/Windows/tmpl/libcurl.vcxproj",
+  "RELEASE-NOTES",
   "scripts/wcurl",
   "tests/data/test*",
   "tests/unit/unit1625.c",
-  "RELEASES-NOTES"
 ]


### PR DESCRIPTION
The file is almost entirely made up by first-lines of previous git commits, and we usually push it without a PR cycle, making it annoying to trigger on typos later as they then show in independent PRs by other people.