### PR TITLE
os400sys: fix typo in comment (symetry -> symmetry)

### DIFF
--- a/projects/OS400/os400sys.c
+++ b/projects/OS400/os400sys.c
@@ -218,7 +218,7 @@ static char *buffer_undef(localkey_t key, long size)
        * buffer headers. */
       locbufs = calloc((size_t)LK_LAST, sizeof(*locbufs));
       if(!locbufs) {
-        pthread_mutex_unlock(&mutex); /* For symetry: will probably fail. */
+        pthread_mutex_unlock(&mutex); /* For symmetry: will probably fail. */
         return (char *)NULL;
       }
       else


### PR DESCRIPTION
Fix a simple typo in a comment: `symetry` should be `symmetry`.

Closes #20815