### PR TITLE
GHA/http3-linux: add CI reproducer for `--with-ngtcp2=<path>` regression

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -354,11 +354,11 @@ jobs:
       matrix:
         build:
           - name: 'openssl'
-            PKG_CONFIG_PATH: /home/runner/openssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
+            PKG_CONFIG_PATH: /home/runner/openssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             tflags: '--min=1640'
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/openssl/build/lib
-              --with-openssl=/home/runner/openssl/build --with-ngtcp2=/home/runner/ngtcp2/build --enable-ssls-export
+              --with-openssl=/home/runner/openssl/build --with-ngtcp2 --enable-ssls-export
 
           - name: 'openssl'
             install_steps: skipall
@@ -370,6 +370,7 @@ jobs:
 
           - name: 'libressl'
             install_steps: skipall
+            # Intentionally using '--with-ngtcp2=<path>' to test this way of configuration, in addition to '--with-ngtcp2' + 'PKG_CONFIG_PATH' in other jobs.
             PKG_CONFIG_PATH: /home/runner/libressl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/libressl/build/lib
@@ -377,7 +378,6 @@ jobs:
               --enable-unity
 
           - name: 'libressl'
-            # Intentionally using '--with-ngtcp2=<path>' to test this way of configuration, in addition to '--with-ngtcp2' + 'PKG_CONFIG_PATH' in other jobs.
             PKG_CONFIG_PATH: /home/runner/libressl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             tflags: '--min=1790'
             generate: >-
@@ -385,10 +385,10 @@ jobs:
 
           - name: 'awslc'
             install_steps: skipall
-            PKG_CONFIG_PATH: /home/runner/awslc/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
+            PKG_CONFIG_PATH: /home/runner/awslc/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/awslc/build/lib
-              --with-openssl=/home/runner/awslc/build --with-ngtcp2=/home/runner/ngtcp2/build --enable-ssls-export
+              --with-openssl=/home/runner/awslc/build --with-ngtcp2 --enable-ssls-export
 
           - name: 'awslc'
             PKG_CONFIG_PATH: /home/runner/awslc/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
@@ -399,7 +399,6 @@ jobs:
 
           - name: 'boringssl'
             install_steps: skipall
-            # Intentionally using '--with-ngtcp2' + 'PKG_CONFIG_PATH' to test this way of configuration, in addition to '--with-ngtcp2=<path>' in other jobs.
             PKG_CONFIG_PATH: /home/runner/boringssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2-boringssl/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/boringssl/build/lib
@@ -415,7 +414,6 @@ jobs:
           - name: 'gnutls'
             install_packages: libp11-kit-dev libssh-dev
             install_steps: skipall
-            # Intentionally using '--with-ngtcp2' + 'PKG_CONFIG_PATH' to test this way of configuration, in addition to '--with-ngtcp2=<path>' in other jobs.
             PKG_CONFIG_PATH: /home/runner/nettle/build/lib64/pkgconfig:/home/runner/gnutls/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             LDFLAGS: -Wl,-rpath,/home/runner/gnutls/build/lib -Wl,-rpath,/home/runner/nettle/build/lib64 -Wl,-rpath,/home/runner/ngtcp2/build/lib
             configure: >-
@@ -433,10 +431,10 @@ jobs:
           - name: 'wolfssl'
             install_packages: libssh2-1-dev
             install_steps: skipall
-            PKG_CONFIG_PATH: /home/runner/wolfssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
+            PKG_CONFIG_PATH: /home/runner/wolfssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/wolfssl/build/lib
-              --with-wolfssl=/home/runner/wolfssl/build --with-ngtcp2=/home/runner/ngtcp2/build --enable-ech --with-libssh2 --enable-ssls-export
+              --with-wolfssl=/home/runner/wolfssl/build --with-ngtcp2 --enable-ech --with-libssh2 --enable-ssls-export
               --enable-unity
 
           - name: 'wolfssl'


### PR DESCRIPTION
Configure LibreSSL autotools job with `--with-ngtcp=<path>` instead of
adding ngtcp2 to `PKG_CONFIG_PATH`. To test this way of configuration in
CI and test for the regression reported in #20889.

Turns out this way of configuration isn't affected by the detection
issue in this particular case.

It also works for other backends except for these two, subject to 
separate fixes:
- BoringSSL fix: https://github.com/ngtcp2/ngtcp2/pull/2070
- GnuTLS fix and BoringSSL workaround: #20920

Follow-up to 666db801963afca671ee5fa83bd2e9ed79fb8886 #20891
Follow-up to 8db0e286b363ad788d6dc0779d605b83c7ed4caf #18189
Follow-up to 99500660af19f89069e71c2251c13963401b3806 #18028 #18022

---

- [x] move configure pkg-config trace feature to sep PR, and rebase on. → #20931

---

- Tested OK with current master: https://github.com/curl/curl/actions/runs/23112010665/job/67131008707?pr=20926
- #20889 error reproduces with the fix reverted: https://github.com/curl/curl/actions/runs/23112334831/job/67131894726?pr=20926#step:18:310
- pkg-config trace feature tests in all AM jobs:
  H3 Linux: https://github.com/curl/curl/actions/runs/23121500311/job/67156293555?pr=20926#step:18:330 (fail, pkgconf)
  Linux: https://github.com/curl/curl/actions/runs/23121500329/job/67156283850?pr=20926#step:39:232 (slackware is pkg-config)
  Windows: https://github.com/curl/curl/actions/runs/23120741088/job/67154236531?pr=20926
  Old Linux: https://github.com/curl/curl/actions/runs/23121500323/job/67156272080?pr=20926#step:21:224 (pkg-config)
  non-native: https://github.com/curl/curl/actions/runs/23120741100/job/67154216142?pr=20926
  H3 Linux: https://github.com/curl/curl/actions/runs/23120741073/job/67154235113?pr=20926
  Linux: https://github.com/curl/curl/actions/runs/23121129085/job/67155256452?pr=20926 (pkg-config all lines)
  Old Linux: https://github.com/curl/curl/actions/runs/23121129078/job/67155255953?pr=20926#step:21:203 (pkg-config all lines)