### PR TITLE
ldap: fix to initialize cleartext connection on Windows

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -303,9 +303,8 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
   if(ldap_ssl)
     server = ldap_sslinit(host, (curl_ldap_num_t)ipquad.remote_port, 1);
   else
-#else
-    server = ldap_init(host, (curl_ldap_num_t)ipquad.remote_port);
 #endif
+    server = ldap_init(host, (curl_ldap_num_t)ipquad.remote_port);
   if(!server) {
     failf(data, "LDAP: cannot setup connect to %s:%u",
           conn->host.dispname, ipquad.remote_port);


### PR DESCRIPTION
Regression since curl 8.18.0.

Reported-by: Yoshiro Yoneya
Fixes #20927
Follow-up to 39d1976b7f709a516e3243338ebc0443bdd8d56d #19830
