### PR TITLE
ldap: drop duplicate `ldap_set_option()` on Windows

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -388,7 +388,6 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
   }
 
 #ifdef USE_WIN32_LDAP
-  ldap_set_option(server, LDAP_OPT_PROTOCOL_VERSION, &ldap_proto);
   rc = ldap_win_bind(data, server, user, passwd);
 #else
   rc = ldap_simple_bind_s(server, user, passwd);


### PR DESCRIPTION
Already set after `ldap_sslinit()`/`ldap_init()` and before 
`ldap_ssl`-specific initialization.

Follow-up to 39d1976b7f709a516e3243338ebc0443bdd8d56d #19830
Follow-up to b41e65a8e3ed8fdafb535328997bedc925f21e37
Follow-up to b91421b10764c4b7450ea29d305cc65c3f828dd1

---

/cc @gknauf
