### PR TITLE
configure: also trace two important pkg-config envs

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1336,7 +1336,7 @@ AC_DEFUN([CURL_TRACE_PCDIR], [
   dnl Example pkgconf line:
   dnl   libpkgconf/pkg.c:746 [pkgconf_pkg_t *pkgconf_pkg_try_specific_path(pkgconf_client_t *, [...]*)]: trying path: /usr/local/lib/pkgconfig for libngtcp2_crypto_gnutls
   dnl Rest of strings are for catching classic pkg-config lines.
-  trc=`CURL_EXPORT_PCDIR([$2]) dnl
+  trc=`CURL_EXPORT_PCDIR([$2])
     if test -n "$PKG_CONFIG_LIBDIR"; then
       echo "PKG_CONFIG_LIBDIR: '$PKG_CONFIG_LIBDIR'"
     fi
@@ -1344,7 +1344,7 @@ AC_DEFUN([CURL_TRACE_PCDIR], [
       echo "PKG_CONFIG_PATH: '$PKG_CONFIG_PATH'"
     fi
     $PKGCONFIG --exists --debug $1 2>&1 | $EGREP '(trying path:|Adding directory|Looking for|Scanning directory|Cannot open directory)' | $SED 's/^.*trying path:/trying path:/'`
-  msg=`CURL_EXPORT_PCDIR([$2]) dnl
+  msg=`CURL_EXPORT_PCDIR([$2])
     $PKGCONFIG --exists --print-errors $1 2>&1`
   if test -n "$msg"; then
     trc=`echo "$trc"; echo '==== error:'; echo "$msg"`


### PR DESCRIPTION
`PKG_CONFIG_LIBDIR` and `PKG_CONFIG_PATH`.

To help debugging dependency issues. Example:
```
configure: pkg-config --exists openssl trace:
---- begin
PKG_CONFIG_LIBDIR: '/home/runner/libressl/build/lib/pkgconfig'
PKG_CONFIG_PATH: '/home/runner/libressl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig'
trying path: /home/runner/libressl/build/lib/pkgconfig for openssl
trying path: /home/runner/libressl/build/lib/pkgconfig for libssl
trying path: /home/runner/libressl/build/lib/pkgconfig for libcrypto
---- end
```

Cherry-picked from #20920
Follow-up to 04d90b5deb332cd2359d5ba3f71804c55da14397 #20931
