### PR TITLE
curl-wolfssl.m4: fix to use the correct value for pkg-config directory

### DIFF
--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -32,7 +32,7 @@ case "$OPT_WOLFSSL" in
     wolfpkg=""
     ;;
   *)
-    wolfpkg="$withval/lib/pkgconfig"
+    wolfpkg="$OPT_WOLFSSL/lib/pkgconfig"
     ;;
 esac
 


### PR DESCRIPTION
Before this patch the `$withval` variable may have contained `yes` or
other unrelated values, instead of the wolfSSL directory configured via
`--with-wolfssl=`.

Fixing:
```
checking for wolfssl options with pkg-config... found
configure: pkg-config --exists wolfssl trace:
---- begin
PKG_CONFIG_PATH: |/home/runner/wolfssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig|
PKG_CONFIG_LIBDIR: |yes/lib/pkgconfig|         <=============== 'yes' used as base directory
trying path: /home/runner/wolfssl/build/lib/pkgconfig for wolfssl
---- end
```
Ref: https://github.com/curl/curl/actions/runs/23146424326/job/67235762794?pr=20920#step:18:245

Cherry-picked from #20920
