### PR TITLE
configure: prefer dependency-specific variables over `$withval`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3090,7 +3090,7 @@ case "$OPT_H2" in
     dnl --with-nghttp2 option used with path
     want_nghttp2="yes"
     want_nghttp2_path="$withval"
-    want_nghttp2_pkg_config_path="$withval/lib/pkgconfig"
+    want_nghttp2_pkg_config_path="$OPT_H2/lib/pkgconfig"
     ;;
 esac
 
@@ -3186,7 +3186,7 @@ case "$OPT_TCP2" in
   *)
     dnl --with-ngtcp2 option used with path
     want_tcp2="yes"
-    want_tcp2_path="$withval/lib/pkgconfig"
+    want_tcp2_path="$OPT_TCP2/lib/pkgconfig"
     ;;
 esac
 
@@ -3634,7 +3634,7 @@ case "$OPT_NGHTTP3" in
   *)
     dnl --with-nghttp3 option used with path
     want_nghttp3="yes"
-    want_nghttp3_path="$withval/lib/pkgconfig"
+    want_nghttp3_path="$OPT_NGHTTP3/lib/pkgconfig"
     ;;
 esac
 


### PR DESCRIPTION
Tidy up, for robustness and consistency.

Ref: #20943
Cherry-picked from #20920
