### PR TITLE
HTTP3.md: minor improvements

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -51,7 +51,7 @@ placeholders for the version you build.
 
 OpenSSL v3.5.0+ requires *ngtcp2* v1.12.0+. Earlier versions do not work.
 
-Build OpenSSL (v3.5.0+) or fork LibreSSL, AWS-LC, BoringSSL or quictls:
+Build OpenSSL (v3.5.0+) or fork AWS-LC, BoringSSL, LibreSSL or quictls:
 
      # Instructions for OpenSSL v3.5.0+
      % git clone --depth 1 -b openssl-$OPENSSL_VERSION https://github.com/openssl/openssl


### PR DESCRIPTION
- document building curl with CMake.

- mention all supported forks in the OpenSSL section. Delete dedicated
  quictls section.

- add TLS-backend pkgconfig dir to `PKG_CONFIG_PATH` for correctness.
  OpenSSL-based ones often work without this, by finding system
  `openssl.pc`. For GnuTLS and wolfSSL this has a lesser chance. Best to
  point to them explicitly. (configure may technically be able to do
  this automatically, but it isn't implemented.)

- use `--with-ngtcp2=<path>` again, where possible.
  GnuTLS is the exception, pending fix in #20910.
  Same for BoringSSL, but not documented in `HTTP3.md`.

- replace `<somewhereN>` with `/path/to/depname` for clarity.

- move `LDFLAGS` after `./configure` for curl, to match dep builds.

- move `--with-ngtcp2` next to the TLS-backend option.

Follow-up to 1e3c2bec7eb735736755e15a48701f5b2d5b5979 #20926
Follow-up to 3c64ffaff4cd8c8275627dd2e17b6879a1d32262 #18415 #18188
Cherry-picked from #20920
