### PR TITLE
tool_operate: fix minor memory-leak on early error

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2296,7 +2296,6 @@ CURLcode operate(int argc, argv_item_t argv[])
     if(found_curlrc) {
       /* After parse_args so notef knows the verbosity */
       notef("Read config file from '%s'", curlrc_path);
-      curlx_free(curlrc_path);
     }
     if(err) {
       result = CURLE_OK;
@@ -2394,7 +2393,7 @@ CURLcode operate(int argc, argv_item_t argv[])
         errorf("out of memory");
     }
   }
-
+  curlx_free(curlrc_path);
   varcleanup();
 
   return result;


### PR DESCRIPTION
When .curlrc is parsed successfully but the tool exits early before parse_args() executes; the allocated path was not freed.

Spotted by Codex Security