### PR TITLE
strerr: correct the strerror_s() return code condition

### DIFF
--- a/lib/curlx/strerr.c
+++ b/lib/curlx/strerr.c
@@ -263,7 +263,7 @@ const char *curlx_strerror(int err, char *buf, size_t buflen)
   *buf = '\0';
 
 #ifdef _WIN32
-  if((!strerror_s(buf, buflen, err) || !strcmp(buf, "Unknown error")) &&
+  if((strerror_s(buf, buflen, err) || !strcmp(buf, "Unknown error")) &&
 #ifdef USE_WINSOCK
      !get_winsock_error(err, buf, buflen) &&
 #endif


### PR DESCRIPTION
In curlx_strerror on Windows, the condition checks `!strerror_s(...)` (true on success) and therefore always evaluates the fallback block. Even when strerror_s successfully produced a valid errno message.

Follow-up to 1eca08a54177403205014

Pointed out by Codex Security