### PR TITLE
curl_get_line: error out on read errors

### DIFF
--- a/lib/curl_get_line.c
+++ b/lib/curl_get_line.c
@@ -40,6 +40,8 @@ CURLcode Curl_get_line(struct dynbuf *buf, FILE *input, bool *eof)
   while(1) {
     size_t rlen;
     const char *b = fgets(buffer, sizeof(buffer), input);
+    if(!b && ferror(input))
+      return CURLE_READ_ERROR;
 
     *eof = feof(input);
 


### PR DESCRIPTION
Missing ferror handling in Curl_get_line causes infinite loops on I/O errors, leading to denial-of-service hangs for config/cache file loads.

Follow-up to 769ccb4d4261a75c8a4

Pointed out by Codex Security