### PR TITLE
imap: reset the UIDVALIDITY state between transfers

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -776,6 +776,7 @@ static CURLcode imap_perform_select(struct Curl_easy *data,
 
   /* Invalidate old information as we are switching mailboxes */
   Curl_safefree(imapc->mailbox);
+  imapc->mb_uidvalidity_set = FALSE;
 
   /* Check we have a mailbox */
   if(!imap->mailbox) {
@@ -1703,6 +1704,7 @@ static void imap_easy_reset(struct IMAP *imap)
   Curl_safefree(imap->query);
   Curl_safefree(imap->custom);
   Curl_safefree(imap->custom_params);
+  imap->uidvalidity_set = FALSE;
   /* Clear the transfer mode for the next request */
   imap->transfer = PPTRANSFER_BODY;
 }


### PR DESCRIPTION
uidvalidity_set and mb_uidvalidity_set flags were never reset, leaving a risk for stale UIDVALIDITY state across transfers and mailbox switches.

Follow-up to fb6a4802d7a76d8e36652b

Spotted by Codex Security