### PR TITLE
tool_formparse: pass on errors from my_get_line when reading headers

### DIFF
--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -464,6 +464,10 @@ static int read_field_headers(FILE *fp, struct curl_slist **pheaders)
       break;
     }
   }
+  if(error && !err) {
+    errorf("Failed to read field headers");
+    err = -1;
+  }
   curlx_dyn_free(&line);
   return err;
 }


### PR DESCRIPTION
The read_field_headers() function would return "ok" even if the underlying file read returned error, thus would the parent not become aware of the problem.

Follow-up to f847d2ed0244319ee6b5e9b054c

Found by Codex Security