### PR TITLE
generate.bat: fix typo breaking VC11 and VC12 runs

### DIFF
--- a/projects/Windows/generate.bat
+++ b/projects/Windows/generate.bat
@@ -165,12 +165,12 @@ rem
     set "R02=v100"
     set "R03=VC10"
     set "R04=4.0"
-  ) else if "%1%" == "VC11" (
+  ) else if "%1" == "VC11" (
     set "R01=12.00"
     set "R02=v110"
     set "R03=VC11"
     set "R04=4.0"
-  ) else if "%1%" == "VC12" (
+  ) else if "%1" == "VC12" (
     set "R01=12.00"
     set "R02=v120"
     set "R03=VC12"


### PR DESCRIPTION
Follow-up to 57d349fe0eee7e1f3eb68dc

Found by Codex Security