### PR TITLE
asyn-ares: fix HTTPS-lookup when not on port 443

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -728,7 +728,7 @@ CURLcode Curl_async_getaddrinfo(struct Curl_easy *data, const char *hostname,
     return CURLE_OUT_OF_MEMORY;
 #ifdef USE_HTTPSRR
   if(port != 443) {
-    rrname = curl_maprintf("_%d_.https.%s", port, hostname);
+    rrname = curl_maprintf("_%d._https.%s", port, hostname);
     if(!rrname)
       return CURLE_OUT_OF_MEMORY;
   }


### PR DESCRIPTION
Follow-up to 8d0bfe74fba1e8394e73d

Spotted by Codex Security