### PR TITLE
tool_msgs: avoid null pointer deref for early errors

### DIFF
--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -78,7 +78,7 @@ static void voutf(const char *prefix, const char *fmt, va_list ap)
  */
 void notef(const char *fmt, ...)
 {
-  if(global->tracetype) {
+  if(global && global->tracetype) {
     va_list ap;
     va_start(ap, fmt);
     voutf(NOTE_PREFIX, fmt, ap);
@@ -92,7 +92,7 @@ void notef(const char *fmt, ...)
  */
 void warnf(const char *fmt, ...)
 {
-  if(!global->silent) {
+  if(!global || !global->silent) {
     va_list ap;
     va_start(ap, fmt);
     voutf(WARN_PREFIX, fmt, ap);
@@ -128,7 +128,7 @@ void helpf(const char *fmt, ...)
  */
 void errorf(const char *fmt, ...)
 {
-  if(!global->silent || global->showerror) {
+  if(!global || !global->silent || global->showerror) {
     va_list ap;
     va_start(ap, fmt);
     voutf(ERROR_PREFIX, fmt, ap);


### PR DESCRIPTION
When errorf()/warnf() is used early on, before the global pointer is setup, curl would previosly deref the null pointer.

Follow-up to 3b40128b0f11a3

Found by Codex Security