### PR TITLE
genserv.pl: make external calls safe

### DIFF
--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -54,16 +54,9 @@ sub redir {
     my $hideerr = shift if($_[0] =~ /^2>/);
     open(my $outfd, $outfn) || die if($outfn);
     my $pid = open3(my $in, my $out, my $err = gensym, @_);
-    if(!$hideerr) {
-        while(<$err>) { print STDERR $_; };
-    }
-    if($outfn) {
-        while(<$out>) { print $outfd $_; };
-        close($outfd);
-    }
-    else {
-        while(<$out>) { print $_; };
-    }
+    if(!$hideerr) { while(<$err>) { print STDERR $_; }; }
+    if($outfn) { while(<$out>) { print $outfd $_; }; close($outfd); }
+    else { while(<$out>) { print $_; }; }
     waitpid($pid, 0);
 }
 


### PR DESCRIPTION
By passing command-line as separate arguments instead of using a single
string. This needs skipping the shell, so rework redirections to use 
Perl `open3()`.

Also explored to use `-out` to avoid redirections, but it makes the
command-line incompatible with some OpenSSL implementations/versions
(e.g. on default macOS), and would still need a solution for
`2>/dev/null`.

Ref: https://perldoc.perl.org/IPC::Open3

---

- [x] make the 5 calls continue to redirect stderr to /dev/null