### PR TITLE
http2: clear the h2 session at delete

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -203,6 +203,7 @@ static void cf_h2_ctx_close(struct cf_h2_ctx *ctx)
 {
   if(ctx->h2) {
     nghttp2_session_del(ctx->h2);
+    ctx->h2 = NULL;
   }
 }
 


### PR DESCRIPTION
When calling nghttp2 to delete session, clear the pointer to avoid risk of UAF.

Pointed out by Codex Security