### PR TITLE
tool_main: avoid potential NULL reference if an init step failed

### DIFF
--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -161,13 +161,13 @@ int main(int argc, char *argv[])
   /* win32_init must be called before other init routines. */
   result = win32_init();
   if(result) {
-    errorf("(%d) Windows-specific init failed", result);
+    curl_mfprintf(tool_stderr, "(%d) Windows-specific init failed", result);
     return (int)result;
   }
 #endif
 
   if(main_checkfds()) {
-    errorf("out of file descriptors");
+    curl_mfprintf(tool_stderr, "out of file descriptors");
     return CURLE_FAILED_INIT;
   }
 

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -78,7 +78,8 @@ static void voutf(const char *prefix, const char *fmt, va_list ap)
  */
 void notef(const char *fmt, ...)
 {
-  if(global->tracetype) {
+  DEBUGASSERT(global);
+  if(global && global->tracetype) {
     va_list ap;
     va_start(ap, fmt);
     voutf(NOTE_PREFIX, fmt, ap);
@@ -92,7 +93,8 @@ void notef(const char *fmt, ...)
  */
 void warnf(const char *fmt, ...)
 {
-  if(!global->silent) {
+  DEBUGASSERT(global);
+  if(global && !global->silent) {
     va_list ap;
     va_start(ap, fmt);
     voutf(WARN_PREFIX, fmt, ap);
@@ -128,7 +130,8 @@ void helpf(const char *fmt, ...)
  */
 void errorf(const char *fmt, ...)
 {
-  if(!global->silent || global->showerror) {
+  DEBUGASSERT(global);
+  if(global && (!global->silent || global->showerror)) {
     va_list ap;
     va_start(ap, fmt);
     voutf(ERROR_PREFIX, fmt, ap);


### PR DESCRIPTION
It could happen when `main_checkfds()` failed.

Fix by using `curl_mfprintf()` before global init and adding debug 
asserts and checks for a NULL `global` before use in message functions.

Found by Codex Security

Follow-up to 3b40128b0f11a3dee5524e92768ff18046db20f2 #18213
