### PR TITLE
always use Curl_1st_fatal instead of Curl_1st_err

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1157,12 +1157,14 @@ CURLcode curl_easy_pause(CURL *d, int action)
   if((send_paused != send_paused_new) ||
      (send_paused_new != Curl_creader_is_paused(data))) {
     changed = TRUE;
-    result = Curl_1st_err(result, Curl_xfer_pause_send(data, send_paused_new));
+    result = Curl_1st_fatal(
+      result, Curl_xfer_pause_send(data, send_paused_new));
   }
 
   if(recv_paused != recv_paused_new) {
     changed = TRUE;
-    result = Curl_1st_err(result, Curl_xfer_pause_recv(data, recv_paused_new));
+    result = Curl_1st_fatal(
+      result, Curl_xfer_pause_recv(data, recv_paused_new));
   }
 
   /* If not completely pausing both directions now, run again in any case. */

--- a/lib/http.c
+++ b/lib/http.c
@@ -4169,7 +4169,7 @@ static CURLcode http_on_response(struct Curl_easy *data,
 out:
   if(last_hd) {
     /* if not written yet, write it now */
-    result = Curl_1st_err(
+    result = Curl_1st_fatal(
       result, http_write_header(data, last_hd, last_hd_len));
   }
   if(conn_changed) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -703,7 +703,7 @@ static CURLcode multi_done(struct Curl_easy *data,
   }
 
   /* Make sure that transfer client writes are really done now. */
-  result = Curl_1st_err(result, Curl_xfer_write_done(data, premature));
+  result = Curl_1st_fatal(result, Curl_xfer_write_done(data, premature));
 
   /* Inform connection filters that this transfer is done */
   Curl_conn_ev_data_done(data, premature);

--- a/lib/url.c
+++ b/lib/url.c
@@ -3772,11 +3772,6 @@ void *Curl_conn_meta_get(struct connectdata *conn, const char *key)
   return Curl_hash_pick(&conn->meta_hash, CURL_UNCONST(key), strlen(key) + 1);
 }
 
-CURLcode Curl_1st_err(CURLcode r1, CURLcode r2)
-{
-  return r1 ? r1 : r2;
-}
-
 CURLcode Curl_1st_fatal(CURLcode r1, CURLcode r2)
 {
   if(r1 && (r1 != CURLE_AGAIN))

--- a/lib/url.h
+++ b/lib/url.h
@@ -86,15 +86,8 @@ CURLcode Curl_conn_upkeep(struct Curl_easy *data,
                           struct connectdata *conn);
 
 /**
- * Always eval all arguments, return the first result != CURLE_OK.
- * A non-short-circuit evaluation.
- */
-CURLcode Curl_1st_err(CURLcode r1, CURLcode r2);
-
-/**
  * Always eval all arguments, return the first
  * result != (CURLE_OK|CURLE_AGAIN) or `r1`.
- * A non-short-circuit evaluation.
  */
 CURLcode Curl_1st_fatal(CURLcode r1, CURLcode r2);
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1461,8 +1461,8 @@ static CURLcode cf_ngtcp2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   result = CURLE_AGAIN;
 
 out:
-  result = Curl_1st_err(result, cf_progress_egress(cf, data, &pktx));
-  result = Curl_1st_err(result, check_and_set_expiry(cf, data, &pktx));
+  result = Curl_1st_fatal(result, cf_progress_egress(cf, data, &pktx));
+  result = Curl_1st_fatal(result, check_and_set_expiry(cf, data, &pktx));
 denied:
   CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_recv(blen=%zu) -> %d, %zu",
               stream ? stream->id : -1, blen, result, *pnread);
@@ -1788,7 +1788,7 @@ static CURLcode cf_ngtcp2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   result = cf_progress_egress(cf, data, &pktx);
 
 out:
-  result = Curl_1st_err(result, check_and_set_expiry(cf, data, &pktx));
+  result = Curl_1st_fatal(result, check_and_set_expiry(cf, data, &pktx));
 denied:
   CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_send(len=%zu) -> %d, %zu",
               stream ? stream->id : -1, len, result, *pnwritten);

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -918,7 +918,7 @@ static CURLcode cf_quiche_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     result = CURLE_AGAIN;
 
 out:
-  result = Curl_1st_err(result, cf_flush_egress(cf, data));
+  result = Curl_1st_fatal(result, cf_flush_egress(cf, data));
   if(*pnread > 0)
     ctx->data_recvd += *pnread;
   CURL_TRC_CF(data, cf, "[%" PRIu64 "] cf_recv(len=%zu) -> %d, %zu, total=%"
@@ -1144,7 +1144,7 @@ static CURLcode cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
 
 out:
-  result = Curl_1st_err(result, cf_flush_egress(cf, data));
+  result = Curl_1st_fatal(result, cf_flush_egress(cf, data));
 
   CURL_TRC_CF(data, cf, "[%" PRIu64 "] cf_send(len=%zu) -> %d, %zu",
               stream ? stream->id : (uint64_t)~0, len,


### PR DESCRIPTION
Curl_1st_err() does not return the second error if the first result is CURLE_AGAIN. This may cause errors to not become noticeable when they should be.

Replace all use of Curl_1st_err() with Curl_1st_fatal(), which handles CURLE_AGAIN as a not-a-real-error case.