### PR TITLE
sha512_256: optimize big-endian 64-bit load/store macros

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -274,6 +274,98 @@ static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *context)
 /* Bits manipulation macros and functions.
    Can be moved to other headers to reuse. */
 
+/* Optimized big-endian 64-bit load/store.
+ *
+ * On big-endian platforms the in-memory byte order already matches, so a
+ * plain memcpy (optimized by the compiler to a single load/store) is
+ * sufficient.
+ *
+ * On little-endian with GCC/Clang, __builtin_bswap64 compiles to a single
+ * instruction: bswap on x86-64, rev on AArch64, ldbrx/stdbrx on POWER.
+ * MSVC provides _byteswap_uint64 for the same purpose.
+ *
+ * The memcpy idiom is used instead of pointer casts to avoid undefined
+ * behavior from unaligned access or strict-aliasing violations -- the
+ * input data pointer is not guaranteed to be 8-byte aligned.
+ *
+ * The original byte-by-byte implementation is kept as the fallback. */
+
+/* Detect which byte-swap intrinsic is available. */
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#  define CURL_BE64_NATIVE 1
+#elif defined(__has_builtin)
+#  if __has_builtin(__builtin_bswap64)
+#    define CURL_HAVE_BSWAP64 1
+#  endif
+#endif
+
+#if !defined(CURL_BE64_NATIVE) && !defined(CURL_HAVE_BSWAP64)
+#  if defined(__GNUC__) && \
+    (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+#    define CURL_HAVE_BSWAP64 1
+#  elif defined(_MSC_VER)
+#    include <stdlib.h>
+#    define CURL_HAVE_MSVC_BSWAP64 1
+#  endif
+#endif
+
+/* Define the load/store helpers. */
+#if defined(CURL_BE64_NATIVE)
+
+static CURL_FORCEINLINE uint64_t curl_be64_load(const void *ptr)
+{
+  uint64_t v;
+  memcpy(&v, ptr, sizeof(v));
+  return v;
+}
+
+static CURL_FORCEINLINE void curl_be64_store(void *ptr, uint64_t val)
+{
+  memcpy(ptr, &val, sizeof(val));
+}
+
+#define CURL_GET_64BIT_BE(ptr)       curl_be64_load(ptr)
+#define CURL_PUT_64BIT_BE(ptr, val)  curl_be64_store(ptr, val)
+
+#elif defined(CURL_HAVE_BSWAP64)
+
+static CURL_FORCEINLINE uint64_t curl_be64_load(const void *ptr)
+{
+  uint64_t v;
+  memcpy(&v, ptr, sizeof(v));
+  return __builtin_bswap64(v);
+}
+
+static CURL_FORCEINLINE void curl_be64_store(void *ptr, uint64_t val)
+{
+  uint64_t tmp = __builtin_bswap64(val);
+  memcpy(ptr, &tmp, sizeof(tmp));
+}
+
+#define CURL_GET_64BIT_BE(ptr)       curl_be64_load(ptr)
+#define CURL_PUT_64BIT_BE(ptr, val)  curl_be64_store(ptr, val)
+
+#elif defined(CURL_HAVE_MSVC_BSWAP64)
+
+static CURL_FORCEINLINE uint64_t curl_be64_load(const void *ptr)
+{
+  uint64_t v;
+  memcpy(&v, ptr, sizeof(v));
+  return _byteswap_uint64(v);
+}
+
+static CURL_FORCEINLINE void curl_be64_store(void *ptr, uint64_t val)
+{
+  uint64_t tmp = _byteswap_uint64(val);
+  memcpy(ptr, &tmp, sizeof(tmp));
+}
+
+#define CURL_GET_64BIT_BE(ptr)       curl_be64_load(ptr)
+#define CURL_PUT_64BIT_BE(ptr, val)  curl_be64_store(ptr, val)
+
+#else
+/* Original byte-by-byte fallback */
+
 #define CURL_GET_64BIT_BE(ptr)                       \
   (((uint64_t)(((const uint8_t *)(ptr))[0]) << 56) | \
    ((uint64_t)(((const uint8_t *)(ptr))[1]) << 48) | \
@@ -295,6 +387,8 @@ static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *context)
     ((uint8_t *)(ptr))[1] = (uint8_t)(((uint64_t)(val)) >> 48); \
     ((uint8_t *)(ptr))[0] = (uint8_t)(((uint64_t)(val)) >> 56); \
   } while(0)
+
+#endif /* big-endian load/store optimization */
 
 /* Defined as a function. The macro version may duplicate the binary code
  * size as each argument is used twice, so if any calculation is used


### PR DESCRIPTION
## Summary

Optimize the SHA-512/256 `CURL_GET_64BIT_BE` / `CURL_PUT_64BIT_BE` macros, which the source code itself identifies as "obvious targets for optimization."

**Before:** 8 byte loads + 7 shifts + 7 ORs per 64-bit value (22 operations per load)

**After:**
- **Big-endian** (POWER, s390x, SPARC): `memcpy` -- compiler emits a single load/store, no byte swapping needed
- **Little-endian GCC/Clang**: `memcpy` + `__builtin_bswap64` -- single `bswap` (x86-64), `rev` (AArch64), or `ldbrx`/`stdbrx` (POWER)
- **MSVC**: `memcpy` + `_byteswap_uint64`
- **Other**: original byte-by-byte fallback preserved

## Why memcpy instead of pointer casts

The `Curl_sha512_256_transform()` function is called with raw user data pointers (line 636: `Curl_sha512_256_transform(ctx->H, data)`) that are **not guaranteed to be 8-byte aligned**. Using `*(uint64_t *)ptr` would be undefined behavior on platforms requiring aligned access. The `memcpy` idiom avoids both alignment UB and strict-aliasing violations, and modern compilers optimize it to a single load instruction regardless.

## Compiler output verification

On x86-64 with GCC -O2, the `curl_be64_load` function compiles to:
```asm
mov    (%rdi),%rax
bswap  %rax
ret
```

On big-endian POWER8, it would be a single `ld` (no swap needed).

## Test plan

- [x] Verified GCC x86-64 generates single `bswap` instruction
- [x] Preprocessor logic tested: all four paths (native BE, `__has_builtin`, GCC version fallback, MSVC, byte-by-byte) are reachable
- [x] Original fallback preserved for compilers without intrinsics
- [ ] CI: relies on curl's existing SHA-512/256 test coverage