### PR TITLE
synctime: fix off-by-one read and write to a read-only buffer (Windows)

### DIFF
--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -139,7 +139,7 @@ static size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
         size_t len = nmemb < sizeof(header) ? nmemb : sizeof(header) - 1;
         memcpy(header, field, len);
         header[len] = 0; /* null-terminate local copy */
-        RetVal = sscanf(field, "Date: %25s %hu %25s %hu %hu:%hu:%hu",
+        RetVal = sscanf(header, "Date: %25s %hu %25s %hu %hu:%hu:%hu",
                         TmpStr1, &SYSTime.wDay, TmpStr2, &SYSTime.wYear,
                         &SYSTime.wHour, &SYSTime.wMinute,
                         &SYSTime.wSecond);


### PR DESCRIPTION
Also making the `--synctime` option work.

Off-by-one found by Codex Security

Assisted-by: Jay Satiro

---

- [x] Needs rework to avoid writing into a read-only buffer. Also possibly to avoid `sscanf()`.