### PR TITLE
tool_operate: fix condition for loading `curl-ca-bundle.crt` (Windows)

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2119,7 +2119,7 @@ static CURLcode cacertpaths(struct OperationConfig *config)
   }
 
 #ifdef _WIN32
-  if(!env) {
+  if(!config->capath && !config->cacert) {
 #ifdef CURL_CA_SEARCH_SAFE
     char *cacert = NULL;
     FILE *cafile = tool_execpath("curl-ca-bundle.crt", &cacert);


### PR DESCRIPTION
It was incorrecly loaded with env `CURL_CA_BUNDLE` unset +
`SSL_CERT_DIR` set + `SSL_CERT_FILE` unset.

Found by Codex Security

Follow-up to 29bce9857a12b6cfa726a506ab99c4c4c7969364 #11325 #11531
