### PR TITLE
x509asn1: fix to return error in an error case from `encodeOID()`

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -442,7 +442,7 @@ static CURLcode encodeOID(struct dynbuf *store,
     x = 0;
     do {
       if(x & 0xFF000000)
-        return CURLE_OK;
+        return CURLE_BAD_FUNCTION_ARGUMENT;
       else if(beg == end)
         return CURLE_BAD_FUNCTION_ARGUMENT;
       y = *(const unsigned char *)beg++;


### PR DESCRIPTION
Found by Codex Security

Follow-up to d8b0318ad6da7e51f7c94df00a5f165a52580889 #3582
