### PR TITLE
openssl: fix memory leaks in ECH code (OpenSSL 3)

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4136,7 +4136,9 @@ static void ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL *ssl,
   else
     infof(data, "ECH: no retry_configs (rv = %d)", rv);
 #ifndef HAVE_BORINGSSL_LIKE
-  OPENSSL_free((void *)rcs);
+  OPENSSL_free(inner);
+  OPENSSL_free(rcs);
+  OPENSSL_free(outer);
 #endif
   return;
 }


### PR DESCRIPTION
Also drop an unnecessary cast.

Found by Codex Security

Follow-up to a362962b7289ec02b412890c9515657cf0ed50ac #11922