### PR TITLE
asyn-ares: drop orphaned variable references

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -896,7 +896,6 @@ CURLcode Curl_async_ares_set_dns_interface(struct Curl_easy *data)
   return CURLE_OK;
 #else /* c-ares version too old! */
   (void)data;
-  (void)interf;
   return CURLE_NOT_BUILT_IN;
 #endif
 }
@@ -925,7 +924,6 @@ CURLcode Curl_async_ares_set_dns_local_ip4(struct Curl_easy *data)
   return CURLE_OK;
 #else /* c-ares version too old! */
   (void)data;
-  (void)local_ip4;
   return CURLE_NOT_BUILT_IN;
 #endif
 }


### PR DESCRIPTION
In rare, conditional `#if` branches.

Found by Codex Security

Follow-up to ac7e2c3dc693b43c61898aea89f1a80037505c36 #17450
Follow-up to 7bf576064c21fe0bb03a67c382d692ebbb9e3426 #17167
