### PR TITLE
wolfssl: fix handling of abrupt connection close

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2022,7 +2022,7 @@ static CURLcode wssl_recv(struct Curl_cfilter *cf,
         CURL_TRC_CF(data, cf, "wssl_recv(len=%zu) -> AGAIN", blen);
         return CURLE_AGAIN;
       }
-      /* fall throught to default error handling below */
+      /* fall through to default error handling below */
       FALLTHROUGH();
     default:
       if(wssl->io_result == CURLE_AGAIN) {


### PR DESCRIPTION
A closed connection without TLS notify shutdowns, has been reported as a correct EOF instead of an error. Fix the error handling in wolfSSL backend receive handling.