### PR TITLE
extract-unit-protos: retain internal paths for includes

### DIFF
--- a/scripts/extract-unit-protos
+++ b/scripts/extract-unit-protos
@@ -81,7 +81,6 @@ for my $f (sort keys %inc) {
     $f =~ s/\.c/.h/; # .h extension
 
     if(-f $f) {
-        $f =~ s/.*\///; # cut the path off
         print "#include \"$f\"\n";
     }
 }


### PR DESCRIPTION
Follow-up to 3058ed3df873c21ebba2007c3b12ed9f37558bfe #20623
