### PR TITLE
x509asn1: move declaration to header

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -427,7 +427,6 @@ static CURLcode utf8asn1str(struct dynbuf *to, int type, const char *from,
  *
  * @unittest 1666
  */
-UNITTEST CURLcode encodeOID(struct dynbuf *buf, const char *b, const char *e);
 UNITTEST CURLcode encodeOID(struct dynbuf *store,
                             const char *beg, const char *end)
 {

--- a/lib/vtls/x509asn1.h
+++ b/lib/vtls/x509asn1.h
@@ -77,6 +77,9 @@ CURLcode Curl_verifyhost(struct Curl_cfilter *cf, struct Curl_easy *data,
                          const char *beg, const char *end);
 
 #ifdef UNITTESTS
+UNITTEST CURLcode encodeOID(struct dynbuf *store,
+                            const char *beg, const char *end);
+
 #if defined(USE_GNUTLS) || defined(USE_SCHANNEL) || defined(USE_MBEDTLS) || \
   defined(USE_RUSTLS)
 


### PR DESCRIPTION
Fixing clang-tidy warning:
```
tests/unit/unit1666.c:50:12: error: call to undeclared function 'encodeOID'; ISO C99 and later do not support implicit function declarations [clang-diagnostic-implicit-function-declaration]
   50 |   result = encodeOID(dbuf, oid, oid + spec->size);
      |            ^
```
Ref: https://github.com/curl/curl/actions/runs/23297585235/job/67749144361?pr=21008#step:46:736

Follow-up to 673e14cd33ef720b8c2b7e3485084e6e41a2c9dd #21003
