### PR TITLE
tool_operhlp: fix `add_file_name_to_url()` result on OOM

### DIFF
--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -102,11 +102,7 @@ CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename)
       goto out;
     }
     uerr = curl_url_get(uh, CURLUPART_QUERY, &query, 0);
-    if(uerr) {
-      result = urlerr_cvt(uerr);
-      goto out;
-    }
-    if(query) {
+    if(!uerr && query) {
       curl_free(query);
       result = CURLE_OK;
       goto out;


### PR DESCRIPTION
Return `CURLE_OUT_OF_MEMORY` instead of `CURLE_URL_MALFORMAT` when
`curl_url()`, `curl_easy_escape()`, or `curl_maprintf()` calls failed.

Found by Codex Security

Also reuse deinit code from a success branch.
