### PR TITLE
cmake: extend C89-specific warning suppressions to all llvm/clang

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -256,18 +256,6 @@ jobs:
             install_steps: pytest
             generate: -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=OFF -DCMAKE_C_STANDARD=90
             macos-version-min: '10.15'
-          - name: 'OpenSSL 10.15 C89 clang-17'
-            compiler: llvm@17
-            install: libnghttp3 libngtcp2
-            install_steps: pytest
-            generate: -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=OFF -DCMAKE_C_STANDARD=90
-            macos-version-min: '10.15'
-          - name: 'OpenSSL 10.15 C89 clang-18'
-            compiler: llvm@18
-            install: libnghttp3 libngtcp2
-            install_steps: pytest
-            generate: -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=OFF -DCMAKE_C_STANDARD=90
-            macos-version-min: '10.15'
           - name: 'OpenSSL SecTrust'
             compiler: clang
             install: libnghttp3 libngtcp2


### PR DESCRIPTION
From Apple clang-only prior to this patch.

Silencing (seen after macos-15 runner accidentally switched to 
llvm/clang by default):
```
/Users/runner/work/curl/curl/lib/curlx/warnless.h:64:1: error: '_Bool' is a C99 extension [-Werror,-Wc99-extensions]
   64 | bool curlx_sztouz(ssize_t sznum, size_t *puznum);
      | ^
/opt/homebrew/Cellar/llvm@18/18.1.8/lib/clang/18/include/stdbool.h:20:14: note: expanded from macro 'bool'
   20 | #define bool _Bool
      |              ^
[...]
```
Ref: https://github.com/curl/curl/actions/runs/23304345180/job/67774031335?pr=21014#step:11:39

Follow-up to 09c9afdd711d0b2ee9f524a235803e755e1074b7 #20363
Ref: https://github.com/actions/runner-images/issues/13827

---

Tested OK with llvm@18 on macOS: https://github.com/curl/curl/actions/runs/23306142749/job/67780679891?pr=21015
