### PR TITLE
servers.pm: fix to check gopher6 server on its ipv6 port

### DIFF
--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2461,7 +2461,7 @@ sub startservers {
         elsif($what eq "gopher-ipv6") {
             if($run{'gopher-ipv6'} &&
                !responsive_http_server("gopher", $verbose, "ipv6",
-                                       protoport("gopher"))) {
+                                       protoport("gopher6"))) {
                 if(stopserver('gopher-ipv6')) {
                     return ("failed stopping unresponsive GOPHER-IPv6 server", 3);
                 }


### PR DESCRIPTION
Found by Codex Security

---

I think this didn't cause an issue because there is only one gopher-ipv6 test.
