### PR TITLE
mk-lib1521.pl: fix 4 callback function types passed to setopt

### DIFF
--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -309,10 +309,8 @@ static curl_prereq_callback prereqcb;
 static curl_conv_callback conv_from_network_cb;
 static curl_conv_callback conv_to_network_cb;
 static curl_conv_callback conv_from_utf8_cb;
-
 typedef size_t (*interleave_callback)(void *ptr, size_t size, size_t nmemb,
                                       void *userdata);
-
 static interleave_callback interleavecb;
 
 /* long options that are okay to return


### PR DESCRIPTION
Silencing these warnings (seen on Solaris 11 SPARC GCC 4.9.2 + OpenCSW):
```
lib1521.c: In function 'test_lib1521':
/include/curl/typecheck-gcc.h:93:13: warning: call to 'Wcurl_easy_setopt_err_conv_cb' declared with attribute warning: curl_easy_setopt expects a curl_conv_callback argument
curl_easy_setopt(curl, CURLOPT_CONV_FROM_NETWORK_FUNCTION,
curl_easy_setopt(curl, CURLOPT_CONV_TO_NETWORK_FUNCTION,
curl_easy_setopt(curl, CURLOPT_CONV_FROM_UTF8_FUNCTION,
/include/curl/typecheck-gcc.h:123:13: warning: call to 'Wcurl_easy_setopt_err_interleave_cb' declared with attribute warning: curl_easy_setopt expects a curl_interleave_callback argument
curl_easy_setopt(curl, CURLOPT_INTERLEAVEFUNCTION,
```
Ref: https://curl.se/dev/log.cgi?id=20260319160651-1785427#prob2

Follow-up to de0adda78c4c3ce6d221beefdcd4492412dcf287
