### PR TITLE
GHA/macos: restore compatibility with Intel runners

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -630,7 +630,7 @@ jobs:
         run: |
           if [ "${MATRIX_COMPILER}" = 'gcc-13' ] && [ "${MATRIX_IMAGE}" = 'macos-15' ]; then
             # Ref: https://github.com/Homebrew/homebrew-core/issues/194778#issuecomment-2793243409
-            "$(brew --prefix)"/opt/gcc@13/libexec/gcc/aarch64-apple-darwin24/13/install-tools/mkheaders
+            "$(brew --prefix gcc@13)"/libexec/gcc/aarch64-apple-darwin24/13/install-tools/mkheaders
           fi
 
           if [[ "${MATRIX_COMPILER}" = 'gcc'* ]]; then


### PR DESCRIPTION
By generalizing Homebrew prefix in shared code paths, where missing.
No strong reason, sometimes it's useful for tests.

Follow-up to e5316069f13ec9189d9fe0499dc09afaa9fb5cee #18818
