### PR TITLE
getinfo: initialize `PureInfo` field `used_proxy`

### DIFF
--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -78,6 +78,7 @@ void Curl_initinfo(struct Curl_easy *data)
 
   info->conn_scheme = 0;
   info->conn_protocol = 0;
+  info->used_proxy = 0;
 
 #ifdef USE_SSL
   Curl_ssl_free_certinfo(data);


### PR DESCRIPTION
Found by Codex Security

Follow-up to cc04c7367740bb6db0e47368247b8b0c70c376cb #12719
