### PR TITLE
build: limit `unitprotos.h` include to `units` target

### DIFF
--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -43,10 +43,6 @@ extern const struct entry_s s_entries[];
 
 extern int unitfail; /* for unittests */
 
-#if defined(UNITTESTS) && defined(BUILDING_LIBCURL)
-#include "unitprotos.h"
-#endif
-
 #include "curlx/base64.h" /* for curlx_base64* */
 #include "curlx/dynbuf.h" /* for curlx_dyn_*() */
 #include "curlx/fopen.h" /* for curlx_f*() */

--- a/tests/libtest/unitcheck.h
+++ b/tests/libtest/unitcheck.h
@@ -23,6 +23,10 @@
  ***************************************************************************/
 #include "first.h"
 
+#ifdef BUILDING_LIBCURL
+#include "unitprotos.h"
+#endif
+
 /* The fail macros mark the current test step as failed, and continue */
 #define fail_if(expr, msg)                                             \
   do {                                                                 \


### PR DESCRIPTION
To omit it from `tunits`.

Also: move the include to `unitcheck.h` to save a guard.

Ref: https://github.com/curl/curl/pull/21014#issuecomment-4093742896
Reported-by: Daniel Stenberg
Fixes #21021
Follow-up to 98d8e82c7471232639841eb63e16bb979a30acb4 #21014
