### PR TITLE
url: use the socks type for socks proxy

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2248,16 +2248,16 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
    * connection that may exist registered to the same proxy host.
    ***********************************************************************/
   if(proxy || socksproxy) {
-    long ptype = conn->http_proxy.proxytype;
     if(proxy) {
-      result = parse_proxy(data, conn, proxy, ptype);
+      result = parse_proxy(data, conn, proxy, conn->http_proxy.proxytype);
       Curl_safefree(proxy); /* parse_proxy copies the proxy string */
       if(result)
         goto out;
     }
 
     if(socksproxy) {
-      result = parse_proxy(data, conn, socksproxy, ptype);
+      result = parse_proxy(data, conn, socksproxy,
+                           conn->socks_proxy.proxytype);
       /* parse_proxy copies the socks proxy string */
       Curl_safefree(socksproxy);
       if(result)


### PR DESCRIPTION
Reported by Codex Security