### PR TITLE
GHA/curl-for-win: enable c-ares with HTTPS-RR in an existing job

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -122,7 +122,7 @@ jobs:
             sh -c ./_ci-linux-debian.sh
 
   mac-clang:
-    name: 'macOS clang (x86_64)'
+    name: 'macOS clang cares (x86_64)'
     runs-on: macos-latest
     timeout-minutes: 10
     env:
@@ -137,7 +137,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-mac-x64'
+          export CW_CONFIG='-main-werror-cares-unitybatch-mac-x64'
           export CW_REVISION="${GITHUB_SHA}"
           sh -c ./_ci-mac-homebrew.sh
 


### PR DESCRIPTION
c-ares builds have been sped up within curl-for-win using, pre-fills. It
allows building it with acceptable performance, making it practical to
use it, alongside HTTPS-RR, in curl CI and possibly in curl-for-win. It
has been enabled in its dev branch for a while.

Ref: https://github.com/curl/curl-for-win/commit/61a73541201692136af12548737781f79f1ecd64

---

- [x] ~~rebase on #21056~~. → not needed after 789282cb8d49a12ffb1e028bdd7ccd066772b782 #20911
- [x] split off fixes into 2 sep PRs. → #21057, #21056
- [x] perhaps keep it `unsigned char` to keep struct size, and cast where needed. [YES, fixed with a single cast]
