### PR TITLE
protocol: use scheme names lowercase

### DIFF
--- a/lib/protocol.c
+++ b/lib/protocol.c
@@ -359,7 +359,7 @@ const struct Curl_scheme Curl_scheme_rtsp = {
 };
 
 const struct Curl_scheme Curl_scheme_sftp = {
-  "SFTP",                               /* scheme */
+  "sftp",                               /* scheme */
 #ifndef USE_SSH
   NULL,
 #else
@@ -373,7 +373,7 @@ const struct Curl_scheme Curl_scheme_sftp = {
 };
 
 const struct Curl_scheme Curl_scheme_scp = {
-  "SCP",                                /* scheme */
+  "scp",                                /* scheme */
 #ifndef USE_SSH
   NULL,
 #else
@@ -468,7 +468,7 @@ const struct Curl_scheme Curl_scheme_tftp = {
 };
 
 const struct Curl_scheme Curl_scheme_ws = {
-  "WS",                                 /* scheme */
+  "ws",                                 /* scheme */
 #if defined(CURL_DISABLE_WEBSOCKETS) || defined(CURL_DISABLE_HTTP)
   ZERO_NULL,
 #else
@@ -482,7 +482,7 @@ const struct Curl_scheme Curl_scheme_ws = {
 };
 
 const struct Curl_scheme Curl_scheme_wss = {
-  "WSS",                                /* scheme */
+  "wss",                                /* scheme */
 #if defined(CURL_DISABLE_WEBSOCKETS) || defined(CURL_DISABLE_HTTP) || \
     !defined(USE_SSL)
   ZERO_NULL,

--- a/tests/unit/unit1627.c
+++ b/tests/unit/unit1627.c
@@ -25,6 +25,7 @@
 
 #include "urldata.h"
 #include "url.h"
+#include "strcase.h"
 
 static CURLcode test_unit1627(const char *arg)
 {
@@ -68,6 +69,7 @@ static CURLcode test_unit1627(const char *arg)
   (void)arg;
 
   for(i = 0; i < CURL_ARRAYSIZE(okay); i++) {
+    char buffer[32];
     const struct Curl_scheme *get = Curl_get_scheme(okay[i]);
     if(get) {
       /* verify that we got the correct scheme */
@@ -78,6 +80,13 @@ static CURLcode test_unit1627(const char *arg)
       curl_mprintf("Input: %s, expected okay\n", okay[i]);
       break;
     }
+    Curl_strntolower(buffer, okay[i], strlen(okay[i]));
+    buffer[ strlen(okay[i]) ] = 0;
+    if(strcmp(buffer, get->name)) {
+      curl_mprintf("Input: %s is not lowercase: %s\n", buffer, get->name);
+      break;
+    }
+
   }
   for(j = 0; j < CURL_ARRAYSIZE(notokay); j++) {
     const struct Curl_scheme *get = Curl_get_scheme(notokay[j]);


### PR DESCRIPTION
When composing the `<scheme>_proxy` environment variable, we assume the handler->scheme name is already lowercase.

This makes unit test 1627 verify that is the case.

Follow-up to c294f9cb564a2d550826cd5

Spotted by Codex Security