### PR TITLE
curlx_now(), prevent zero timestamp

### DIFF
--- a/lib/curlx/timeval.c
+++ b/lib/curlx/timeval.c
@@ -166,6 +166,8 @@ void curlx_pnow(struct curltime *pnow)
    */
   pnow->tv_sec = time(NULL);
   pnow->tv_usec = 0;
+  if(!pnow->tv_sec) /* avoid a `now` fully zero */
+    pnow->tv_usec = 1;
 }
 
 #endif


### PR DESCRIPTION
As code checks `curltime` values for zero and interprets this as not-initialized or "forever" in several places, make sure `curlx_now()` never returns a zero timestamp.