### PR TITLE
transfer: enable custom methods again on next transfer

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -490,6 +490,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
   data->state.requests = 0;
   data->state.followlocation = 0; /* reset the location-follow counter */
   data->state.this_is_a_follow = FALSE; /* reset this */
+  data->state.http_ignorecustom = FALSE; /* use custom HTTP method */
   data->state.errorbuf = FALSE; /* no error has occurred */
 #ifndef CURL_DISABLE_HTTP
   Curl_http_neg_init(data, &data->state.http_neg);


### PR DESCRIPTION
`http_ignorecustom` is set on redirect handling but was not reset between transfers, so once a redirect occurs in the new follow modes, custom request methods were ignored for later transfers on the same handle.

Follow-up to fb13923dd67d5196c47e8d

Detected by Codex Security