### PR TITLE
dnscache.h: include curlx/timeval.h for struct curltime

### DIFF
--- a/lib/dnscache.h
+++ b/lib/dnscache.h
@@ -26,6 +26,7 @@
 #include "curl_setup.h"
 
 #include "hash.h"
+#include "curlx/timeval.h"
 
 struct addrinfo;
 struct hostent;


### PR DESCRIPTION
Follow-up to 96d5b5c688c48a8f5
