### PR TITLE
libtest: drop duplicate include

### DIFF
--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -43,10 +43,6 @@ extern const struct entry_s s_entries[];
 
 extern int unitfail; /* for unittests */
 
-#ifdef UNITTESTS
-#include "unitprotos.h"
-#endif
-
 #include "curlx/base64.h" /* for curlx_base64* */
 #include "curlx/dynbuf.h" /* for curlx_dyn_*() */
 #include "curlx/fopen.h" /* for curlx_f*() */


### PR DESCRIPTION
Include moved to `unitcheck.h` earlier.

Follow-up to 96d5b5c688c48a8f58ded1563ed0c5c47c877e32 #20864
Ref: 8a1f361716ab0bbf1e15f8a9914b9f1f07855bae #21024
