### PR TITLE
fix !no_signal mixup in resolve refactor

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -637,7 +637,7 @@ static CURLcode resolv_alarm_timeout(struct Curl_easy *data,
 
   DEBUGASSERT(hostname && *hostname);
   DEBUGASSERT(timeoutms > 0);
-  DEBUGASSERT(data->set.no_signal);
+  DEBUGASSERT(!data->set.no_signal);
 #ifndef CURL_DISABLE_DOH
   DEBUGASSERT(!data->set.doh);
 #endif
@@ -783,7 +783,7 @@ CURLcode Curl_resolv(struct Curl_easy *data,
     return CURLE_OPERATION_TIMEDOUT;
 
 #ifdef USE_ALARM_TIMEOUT
-  if(timeoutms && !data->set.no_signal) {
+  if(timeoutms && data->set.no_signal) {
     /* Cannot use ALARM when signals are disabled */
     timeoutms = 0;
   }

--- a/tests/http/test_06_eyeballs.py
+++ b/tests/http/test_06_eyeballs.py
@@ -105,6 +105,8 @@ class TestEyeballs:
     # check timers when trying 3 unresponsive addresses
     @pytest.mark.skipif(condition=not Env.curl_has_feature('IPv6'),
                         reason='curl lacks ipv6 support')
+    @pytest.mark.skipif(condition=not Env.curl_has_feature('AsynchDNS'),
+                        reason='curl lacks async DNS support')
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_06_13_timers(self, env: Env):
         curl = CurlClient(env=env)


### PR DESCRIPTION
When extracting the resolve case using alarm timers, the check for "we are not allowed to use signals" was refactored wrong.