### PR TITLE
badwords-all: stop checking source code comments

### DIFF
--- a/scripts/badwords-all
+++ b/scripts/badwords-all
@@ -11,4 +11,4 @@ use File::Basename;
 chdir dirname(__FILE__) . '/..';
 
 exit system('scripts/badwords', ('scripts/badwords.txt',
-    '**.md', 'projects/OS400/README.OS400', 'src', 'lib', 'include', 'docs/examples')) >> 8;
+    '**.md', 'projects/OS400/README.OS400', 'include', 'docs/examples')) >> 8;


### PR DESCRIPTION
The code runs under different rules than documentation and these checks cause too much friction with too little gain.

Leave checking of the public include files since they are almost documentation.