### PR TITLE
netrc: skip malformed macdef lines

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -195,6 +195,9 @@ static NETRCcode netrc_get_token(const char **tokp,
   if(*statep == MACDEF) {
     if((*tok == '\n') || (*tok == '\r'))
       *statep = NOTHING; /* end of macro definition */
+    *lineend = TRUE;
+    *tokp = tok;
+    return NETRC_OK;
   }
 
   if(!*tok || (*tok == '\n')) {

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -224,7 +224,7 @@ test1650 test1651 test1652 test1653 test1654 test1655 test1656 test1657 \
 test1658 test1659 test1660 test1661 test1662 test1663 test1664 test1665 \
 test1666 test1667 \
 \
-test1670 test1671 \
+test1670 test1671 test1672 \
 \
 test1680 test1681 test1682 test1683 test1684 \
 \

--- a/tests/data/test1672
+++ b/tests/data/test1672
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+netrc
+macdef
+</keywords>
+</info>
+
+<reply>
+<data>
+HTTP/1.1 200 OK
+Content-Length: 6
+Content-Type: text/html
+Funny-head: yesyes
+
+12345
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+netrc parser skips macdef even with broken quote
+</name>
+<command>
+--netrc --netrc-file %LOGDIR/netrc%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+<file name="%LOGDIR/netrc%TESTNUMBER" >
+
+macdef testmacro
+	bin
+	cd "broken quote
+	put password.bin
+	quit
+
+machine %HOSTIP login user1 password passwd1
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic %b64[user1:passwd1]b64%
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
When skipping macdef lines inside netrc files, ignore it completely and do not tokenize or bail out on bad quotes.

Follow-up to 3b43a05e000aa8f65bda51

Spotted by Codex Security