### PR TITLE
tool: add check for curlinfo->age when determining if ssh backend is libssh2

### DIFF
--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -184,7 +184,8 @@ CURLcode get_libcurl_info(void)
     ++feature_count;
   }
 
-  feature_libssh2 = curlinfo->libssh_version &&
+  feature_libssh2 = curlinfo->age >= CURLVERSION_FOURTH &&
+                    curlinfo->libssh_version &&
                     !strncmp("libssh2", curlinfo->libssh_version, 7);
   return CURLE_OK;
 }


### PR DESCRIPTION
The code failed to check for the version, and could thus read memory past the existing curl_version_info_data structure. This could lead to a crash.