### PR TITLE
hostip: drop guard from `Curl_resolver_error()` definition

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -873,8 +873,6 @@ CURLcode Curl_resolv_pollset(struct Curl_easy *data,
  * Curl_resolver_error() calls failf() with the appropriate message after a
  * resolve error
  */
-
-#ifdef USE_CURL_ASYNC
 CURLcode Curl_resolver_error(struct Curl_easy *data, const char *detail)
 {
   struct connectdata *conn = data->conn;
@@ -895,4 +893,3 @@ CURLcode Curl_resolver_error(struct Curl_easy *data, const char *detail)
         detail ? " (" : "", detail ? detail : "", detail ? ")" : "");
   return result;
 }
-#endif /* USE_CURL_ASYNC */


### PR DESCRIPTION
To sync with its declaration.

Fixing (seen when building trurl in curl-for-win):
```
ld.lld: error: undefined symbol: Curl_resolver_error
```
Ref: https://github.com/curl/curl-for-win/actions/runs/23388349475/job/68038915761#step:3:7469

---

confirmed fixed in curl-for-win: https://github.com/curl/curl-for-win/actions/runs/23388903917/job/68040303835
