### PR TITLE
hostip: enable Curl_resolver_error for synch resolves

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -874,7 +874,6 @@ CURLcode Curl_resolv_pollset(struct Curl_easy *data,
  * resolve error
  */
 
-#ifdef USE_CURL_ASYNC
 CURLcode Curl_resolver_error(struct Curl_easy *data, const char *detail)
 {
   struct connectdata *conn = data->conn;
@@ -895,4 +894,4 @@ CURLcode Curl_resolver_error(struct Curl_easy *data, const char *detail)
         detail ? " (" : "", detail ? detail : "", detail ? ")" : "");
   return result;
 }
-#endif /* USE_CURL_ASYNC */
+


### PR DESCRIPTION
It is called from hostip_resolv() unconditionally and causes link errors otherwise.

Follow-up from 96d5b5c688c