### PR TITLE
hostip: fix unity + c-ares + HTTPS-RR builds

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -801,11 +801,10 @@ CURLcode Curl_resolv(struct Curl_easy *data,
   return hostip_resolv(data, hostname, port, ip_version, TRUE, entry);
 }
 
-
-#ifdef USE_CURL_ASYNC
 CURLcode Curl_resolv_take_result(struct Curl_easy *data,
                                  struct Curl_dns_entry **pdns)
 {
+#ifdef USE_CURL_ASYNC
   struct Curl_resolv_async *async = data->state.async;
   CURLcode result;
 
@@ -848,8 +847,12 @@ CURLcode Curl_resolv_take_result(struct Curl_easy *data,
   }
 
   return result;
-}
+#else
+  (void)data;
+  (void)pdns;
+  return CURLE_NOT_BUILT_IN;
 #endif
+}
 
 CURLcode Curl_resolv_pollset(struct Curl_easy *data,
                              struct easy_pollset *ps)

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -106,12 +106,8 @@ CURLcode Curl_resolv_timeout(struct Curl_easy *data,
                              struct Curl_dns_entry **entry,
                              timediff_t timeoutms);
 
-#ifdef USE_CURL_ASYNC
 CURLcode Curl_resolv_take_result(struct Curl_easy *data,
                                  struct Curl_dns_entry **pdns);
-#else
-#define Curl_resolv_take_result(x, y) CURLE_NOT_BUILT_IN
-#endif
 
 CURLcode Curl_resolv_pollset(struct Curl_easy *data,
                              struct easy_pollset *ps);


### PR DESCRIPTION
Fixing (as seen in curl-for-win dev branch):
```
In file included from _a64-linux-gnu-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_1_c.c:85:
lib/hostip.c:1473:10: error: redefinition of 'CURLE_NOT_BUILT_IN' as different kind of symbol
 1473 | CURLcode Curl_resolv_check(struct Curl_easy *data,
      |          ^
lib/hostip.h:195:33: note: expanded from macro 'Curl_resolv_check'
  195 | #define Curl_resolv_check(x, y) CURLE_NOT_BUILT_IN
      |                                 ^
include/curl/curl.h:523:3: note: previous definition is here
  523 |   CURLE_NOT_BUILT_IN,            /* 4 - [was obsoleted in August 2007 for
      |   ^
In file included from _a64-linux-gnu-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_1_c.c:85:
lib/hostip.c:1474:56: error: expected ';' after top level declarator
 1474 |                            struct Curl_dns_entry **dns)
      |                                                        ^
      |                                                        ;
2 errors generated.
```

Root cause may be a discrepancy in the `USE_CURL_ASYNC` value as set in
`hostip.h` vs. in `hostip.c`, but couldn't spot a culprit.

Follow-up to f142056e01f2e3c58f89aaea80d131f129774d3e #17125
Cherry-picked from #21032

---

- [ ] rebase onto #21027?
