### PR TITLE
cf-https-connect: silence `-Wimplicit-int-enum-cast` with HTTPS-RR + clang 21

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -678,7 +678,7 @@ CURLcode Curl_cf_https_setup(struct Curl_easy *data,
       size_t i;
       for(i = 0; i < CURL_ARRAYSIZE(rr->alpns) &&
                  alpn_count < CURL_ARRAYSIZE(alpn_ids); ++i) {
-        enum alpnid alpn = rr->alpns[i];
+        enum alpnid alpn = (enum alpnid)rr->alpns[i];
         if(cf_https_alpns_contain(alpn, alpn_ids, alpn_count))
           continue;
         switch(alpn) {


### PR DESCRIPTION
Fixing (seen in curl-for-win dev branch):
```
In file included from _a64-linux-gnu-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:34:
lib/cf-https-connect.c:681:28: error: implicit conversion from 'unsigned char' to enumeration type 'enum alpnid' is invalid in C++ [-Werror,-Wimplicit-int-enum-cast]
  681 |         enum alpnid alpn = rr->alpns[i];
      |                     ~~~~   ^~~~~~~~~~~~e
```

Ref: #21032

---

Confirmed working: https://github.com/curl/curl-for-win/actions/runs/23389993294
