### PR TITLE
Revert "md5/md4: enable unaligned access fast path on powerpc64"

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -213,8 +213,7 @@ typedef struct md4_ctx MD4_CTX;
  * The check for little-endian architectures that tolerate unaligned memory
  * accesses is an optimization. Nothing will break if it does not work.
  */
-#if defined(__i386__) || defined(__x86_64__) || \
-    defined(__vax__) || defined(__powerpc64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
 #define MD4_SET(n) (*(const uint32_t *)(const void *)&ptr[(n) * 4])
 #define MD4_GET(n) MD4_SET(n)
 #else

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -294,8 +294,7 @@ typedef struct md5_ctx my_md5_ctx;
  * The check for little-endian architectures that tolerate unaligned memory
  * accesses is an optimization. Nothing will break if it does not work.
  */
-#if defined(__i386__) || defined(__x86_64__) || \
-    defined(__vax__) || defined(__powerpc64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
 #define MD5_SET(n) (*(const uint32_t *)(const void *)&ptr[(n) * 4])
 #define MD5_GET(n) MD5_SET(n)
 #else


### PR DESCRIPTION
This reverts commit 21fc17b265ca32c8a5a768dc7cd730754a104740.

PowerPC can run in either endian and the preprocessor does not know which.

Ref: #20985