### PR TITLE
netrc: remove unused parsenetrc() macro for netrc-disabled

### DIFF
--- a/lib/netrc.h
+++ b/lib/netrc.h
@@ -58,7 +58,6 @@ NETRCcode Curl_parsenetrc(struct store_netrc *store, const char *host,
  */
 #else
 /* disabled */
-#define Curl_parsenetrc(a, b, c, d, e, f) 1
 #define Curl_netrc_init(x)
 #define Curl_netrc_cleanup(x)
 #endif


### PR DESCRIPTION
When netrc is disabled, this macro is unused (and wrong).