### PR TITLE
multi_wait, fixes after #20832

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -254,6 +254,10 @@ struct Curl_multi *Curl_multi_handle(uint32_t xfer_table_size,
   multi->multiplexing = TRUE;
   multi->max_concurrent_streams = 100;
   multi->last_timeout_ms = -1;
+#ifdef ENABLE_WAKEUP
+  multi->wakeup_pair[0] = CURL_SOCKET_BAD;
+  multi->wakeup_pair[1] = CURL_SOCKET_BAD;
+#endif
 
   if(Curl_mntfy_resize(multi) ||
      Curl_uint32_bset_resize(&multi->process, xfer_table_size) ||
@@ -296,13 +300,10 @@ struct Curl_multi *Curl_multi_handle(uint32_t xfer_table_size,
     goto error;
 #endif
 #ifdef ENABLE_WAKEUP
-  if(Curl_wakeup_init(multi->wakeup_pair, TRUE) < 0) {
-    multi->wakeup_pair[0] = CURL_SOCKET_BAD;
-    multi->wakeup_pair[1] = CURL_SOCKET_BAD;
-    /* When enabled, rely on this to work. We ignore this in previous
-     * versions, but that seems an unnecessary complication. */
+  /* When enabled, rely on this to work. We ignore this in previous
+   * versions, but that seems an unnecessary complication. */
+  if(Curl_wakeup_init(multi->wakeup_pair, TRUE) < 0)
     goto error;
-  }
 #endif
 
 #ifdef USE_IPV6
@@ -322,9 +323,6 @@ error:
 #ifdef USE_SSL
   Curl_ssl_scache_destroy(multi->ssl_scache);
 #endif
-#ifdef ENABLE_WAKEUP
-  Curl_wakeup_destroy(multi->wakeup_pair);
-#endif
   if(multi->admin) {
     Curl_multi_ev_xfer_done(multi, multi->admin);
     multi->admin->multi = NULL;
@@ -337,6 +335,9 @@ error:
   Curl_uint32_bset_destroy(&multi->pending);
   Curl_uint32_bset_destroy(&multi->msgsent);
   Curl_uint32_tbl_destroy(&multi->xfers);
+#ifdef ENABLE_WAKEUP
+  Curl_wakeup_destroy(multi->wakeup_pair);
+#endif
 
   curlx_free(multi);
   return NULL;


### PR DESCRIPTION
The refactoring in #20832 introduced some inconsistencies between windows and posix handling, pointed out by reviews. Fix them:

- rename `wait_on_nop` back to `extrawait` as it was called before
- use multi_timeout() to shorten the user supplied timeout for both windows/posix in the same way
- remove the extra multi_timeout() check in the posix function
- Add the multi's wakeup socket for monitoring only when there are other sockets to poll on or when the caller wants the extra waiting time.
- In `curl_multi_wakeup()` write to the wakeup socket first (if it exists), the possibly call the windows event signal as well. If one of the two succeeds, the call is successful.

Update:
- when `ENABLE_WAKEUP` is defined, fail the multi creation when the socketpair could not be initialized.