### PR TITLE
test2405: require wakeup

### DIFF
--- a/tests/data/test2405
+++ b/tests/data/test2405
@@ -29,6 +29,9 @@ Funny-head: yesyes
 
 # Client-side
 <client>
+<features>
+wakeup
+</features>
 <server>
 http
 </server>


### PR DESCRIPTION
To get the correct file descriptor count

Reported-by: Marcel Raad
Fixes #21069