### PR TITLE
tool_getparam: use correct free function for libcurl memory

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -727,7 +727,11 @@ static ParameterError data_urlencode(const char *nextarg,
         size = curlx_dyn_len(&dyn);
       }
       else {
-        n = enc;
+        /* make sure we return "our memory" */
+        n = curlx_strdup(enc);
+        curl_free(enc);
+        if(!n)
+          return PARAM_NO_MEM;
         size = strlen(n);
       }
       postdata = n;


### PR DESCRIPTION
Memory returned from curl_easy_escape() should be fred with curl_free() to avoid surprises.

Follow-up to f37840a46e5eddaf109c16fa7

Spotted by Codex Security