### PR TITLE
curl_sha512_256: support delegating to wolfSSL API

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -136,8 +136,7 @@ static CURLcode Curl_sha512_256_init(void *context)
   if(wolfSSL_EVP_DigestInit_ex(*ctx, wolfSSL_EVP_sha512_256(), NULL)) {
     /* Check whether the header and this file use the same numbers */
     DEBUGASSERT(wolfSSL_EVP_MD_CTX_size(*ctx) == CURL_SHA512_256_DIGEST_SIZE);
-    /* wolfSSL_EVP_MD_CTX_block_size() returns zero as of 2026-03 wolfSSL
-       master */
+    /* wolfSSL_EVP_MD_CTX_block_size() returns zero as of v5.9.0 */
 #endif
 
     return CURLE_OK; /* Success */


### PR DESCRIPTION
Offered by wolfSSL v5.0.0+ (2021-11-01).

---

- [x] use the native wolfcrypt API instead? following lib/vtls/wolfssl.c? [FUTURE] → #21090