### PR TITLE
openssl: change default file type to provider

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -523,6 +523,7 @@ Features testable here are:
 - `NTLM`
 - `NTLM_WB`
 - `OpenSSL`
+- `OpenSSL-providers` - OpenSSL >= 3.0.0 (providers not available in LibreSSL/BoringSSL/etc.)
 - `override-dns` - this build can use a "fake" DNS server
 - `parsedate`
 - `proxy`

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -825,7 +825,11 @@ static CURLcode ossl_seed(struct Curl_easy *data)
 static int ossl_do_file_type(const char *type)
 {
   if(!type || !type[0])
+#ifdef OPENSSL_HAS_PROVIDERS
+    return SSL_FILETYPE_PROVIDER;
+#else
     return SSL_FILETYPE_PEM;
+#endif
   if(curl_strequal(type, "PEM"))
     return SSL_FILETYPE_PEM;
   if(curl_strequal(type, "DER"))
@@ -1077,6 +1081,10 @@ static int providercheck(struct Curl_easy *data,
                          const char *key_file)
 {
 #ifdef OPENSSL_HAS_PROVIDERS
+  EVP_PKEY *priv_key = NULL;
+  OSSL_STORE_CTX *store = NULL;
+  OSSL_STORE_INFO *info = NULL;
+  UI_METHOD *ui_method = NULL;
   char error_buffer[256];
   /* Implicitly use pkcs11 provider if none was provided and the
    * key_file is a PKCS#11 URI */
@@ -1088,67 +1096,58 @@ static int providercheck(struct Curl_easy *data,
     }
   }
 
-  if(data->state.provider_loaded) {
-    /* Load the private key from the provider */
-    EVP_PKEY *priv_key = NULL;
-    OSSL_STORE_CTX *store = NULL;
-    OSSL_STORE_INFO *info = NULL;
-    UI_METHOD *ui_method = UI_create_method("curl user interface");
-    if(!ui_method) {
-      failf(data, "unable to create " OSSL_PACKAGE " user-interface method");
-      return 0;
-    }
-    UI_method_set_opener(ui_method, UI_method_get_opener(UI_OpenSSL()));
-    UI_method_set_closer(ui_method, UI_method_get_closer(UI_OpenSSL()));
-    UI_method_set_reader(ui_method, ssl_ui_reader);
-    UI_method_set_writer(ui_method, ssl_ui_writer);
-
-    store = OSSL_STORE_open_ex(key_file, data->state.libctx,
-                               data->state.propq, ui_method, NULL, NULL,
-                               NULL, NULL);
-    if(!store) {
-      failf(data, "Failed to open OpenSSL store: %s",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-      UI_destroy_method(ui_method);
-      return 0;
-    }
-    if(OSSL_STORE_expect(store, OSSL_STORE_INFO_PKEY) != 1) {
-      failf(data, "Failed to set store preference. Ignoring the error: %s",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-    }
-
-    info = OSSL_STORE_load(store);
-    if(info) {
-      int ossl_type = OSSL_STORE_INFO_get_type(info);
-
-      if(ossl_type == OSSL_STORE_INFO_PKEY)
-        priv_key = OSSL_STORE_INFO_get1_PKEY(info);
-      OSSL_STORE_INFO_free(info);
-    }
-    OSSL_STORE_close(store);
-    UI_destroy_method(ui_method);
-    if(!priv_key) {
-      failf(data, "No private key found in the openssl store: %s",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-      return 0;
-    }
-
-    if(SSL_CTX_use_PrivateKey(ctx, priv_key) != 1) {
-      failf(data, "unable to set private key [%s]",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-      EVP_PKEY_free(priv_key);
-      return 0;
-    }
-    EVP_PKEY_free(priv_key); /* we do not need the handle any more... */
-  }
-  else {
-    failf(data, "crypto provider not set, cannot load private key");
+  /* Load the private key from the provider */
+  ui_method = UI_create_method("curl user interface");
+  if(!ui_method) {
+    failf(data, "unable to create " OSSL_PACKAGE " user-interface method");
     return 0;
   }
+  UI_method_set_opener(ui_method, UI_method_get_opener(UI_OpenSSL()));
+  UI_method_set_closer(ui_method, UI_method_get_closer(UI_OpenSSL()));
+  UI_method_set_reader(ui_method, ssl_ui_reader);
+  UI_method_set_writer(ui_method, ssl_ui_writer);
+
+  store = OSSL_STORE_open_ex(key_file, data->state.libctx,
+                             data->state.propq, ui_method, NULL, NULL,
+                             NULL, NULL);
+  if(!store) {
+    failf(data, "Failed to open OpenSSL store: %s",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+    UI_destroy_method(ui_method);
+    return 0;
+  }
+  if(OSSL_STORE_expect(store, OSSL_STORE_INFO_PKEY) != 1) {
+    failf(data, "Failed to set store preference. Ignoring the error: %s",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+  }
+
+  info = OSSL_STORE_load(store);
+  if(info) {
+    int ossl_type = OSSL_STORE_INFO_get_type(info);
+
+    if(ossl_type == OSSL_STORE_INFO_PKEY)
+      priv_key = OSSL_STORE_INFO_get1_PKEY(info);
+    OSSL_STORE_INFO_free(info);
+  }
+  OSSL_STORE_close(store);
+  UI_destroy_method(ui_method);
+  if(!priv_key) {
+    failf(data, "No private key found in the openssl store: %s",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+    return 0;
+  }
+
+  if(SSL_CTX_use_PrivateKey(ctx, priv_key) != 1) {
+    failf(data, "unable to set private key [%s]",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+    EVP_PKEY_free(priv_key);
+    return 0;
+  }
+  EVP_PKEY_free(priv_key); /* we do not need the handle any more... */
   return 1;
 #else
   (void)ctx;
@@ -1233,6 +1232,10 @@ static int providerload(struct Curl_easy *data,
                         const char *cert_file)
 {
 #ifdef OPENSSL_HAS_PROVIDERS
+  OSSL_STORE_INFO *info = NULL;
+  X509 *cert = NULL;
+  OSSL_STORE_CTX *store = NULL;
+  int rc;
   char error_buffer[256];
   /* Implicitly use pkcs11 provider if none was provided and the
    * cert_file is a PKCS#11 URI */
@@ -1244,55 +1247,46 @@ static int providerload(struct Curl_easy *data,
     }
   }
 
-  if(data->state.provider_loaded) {
-    /* Load the certificate from the provider */
-    OSSL_STORE_INFO *info = NULL;
-    X509 *cert = NULL;
-    OSSL_STORE_CTX *store =
-      OSSL_STORE_open_ex(cert_file, data->state.libctx,
-                         NULL, NULL, NULL, NULL, NULL, NULL);
-    int rc;
+  /* Load the certificate from the provider */
 
-    if(!store) {
-      failf(data, "Failed to open OpenSSL store: %s",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-      return 0;
-    }
-    if(OSSL_STORE_expect(store, OSSL_STORE_INFO_CERT) != 1) {
-      failf(data, "Failed to set store preference. Ignoring the error: %s",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-    }
+  store = OSSL_STORE_open_ex(cert_file, data->state.libctx,
+                              NULL, NULL, NULL, NULL, NULL, NULL);
 
-    info = OSSL_STORE_load(store);
-    if(info) {
-      int ossl_type = OSSL_STORE_INFO_get_type(info);
-
-      if(ossl_type == OSSL_STORE_INFO_CERT)
-        cert = OSSL_STORE_INFO_get1_CERT(info);
-      OSSL_STORE_INFO_free(info);
-    }
-    OSSL_STORE_close(store);
-    if(!cert) {
-      failf(data, "No cert found in the openssl store: %s",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-      return 0;
-    }
-
-    rc = SSL_CTX_use_certificate(ctx, cert);
-    X509_free(cert); /* we do not need the handle any more... */
-
-    if(rc != 1) {
-      failf(data, "unable to set client certificate [%s]",
-            ossl_strerror(ERR_get_error(), error_buffer,
-                          sizeof(error_buffer)));
-      return 0;
-    }
+  if(!store) {
+    failf(data, "Failed to open OpenSSL store: %s",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+    return 0;
   }
-  else {
-    failf(data, "crypto provider not set, cannot load certificate");
+  if(OSSL_STORE_expect(store, OSSL_STORE_INFO_CERT) != 1) {
+    failf(data, "Failed to set store preference. Ignoring the error: %s",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+  }
+
+  info = OSSL_STORE_load(store);
+  if(info) {
+    int ossl_type = OSSL_STORE_INFO_get_type(info);
+
+    if(ossl_type == OSSL_STORE_INFO_CERT)
+      cert = OSSL_STORE_INFO_get1_CERT(info);
+    OSSL_STORE_INFO_free(info);
+  }
+  OSSL_STORE_close(store);
+  if(!cert) {
+    failf(data, "No cert found in the openssl store: %s",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+    return 0;
+  }
+
+  rc = SSL_CTX_use_certificate(ctx, cert);
+  X509_free(cert); /* we do not need the handle any more... */
+
+  if(rc != 1) {
+    failf(data, "unable to set client certificate [%s]",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
     return 0;
   }
   return 1;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1232,8 +1232,8 @@ static int providerload(struct Curl_easy *data,
                         const char *cert_file)
 {
 #ifdef OPENSSL_HAS_PROVIDERS
-  OSSL_STORE_INFO *info = NULL;
   X509 *cert = NULL;
+  STACK_OF(X509) *cert_chain = NULL;
   OSSL_STORE_CTX *store = NULL;
   int rc;
   char error_buffer[256];
@@ -1264,14 +1264,36 @@ static int providerload(struct Curl_easy *data,
                         sizeof(error_buffer)));
   }
 
-  info = OSSL_STORE_load(store);
-  if(info) {
-    int ossl_type = OSSL_STORE_INFO_get_type(info);
+  while(!OSSL_STORE_eof(store)) {
+    OSSL_STORE_INFO *info = OSSL_STORE_load(store);
+    if(!info) {
+      /* OSSL_STORE_load() returns NULL both on error and when an item type
+       * doesn't match the expected type. Only stop on actual errors to avoid
+       * looping forever if EOF is never reached. */
+      if(OSSL_STORE_error(store)) {
+        break;
+      }
+      continue;
+    }
 
-    if(ossl_type == OSSL_STORE_INFO_CERT)
-      cert = OSSL_STORE_INFO_get1_CERT(info);
+    if(OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_CERT) {
+      /* Only load the first cert hit: when using a cert chain,
+         first one should be the right one.*/
+      if(!cert) {
+        cert = OSSL_STORE_INFO_get1_CERT(info);
+      }
+
+      /* Load all certs found in the chain. */
+      if(!cert_chain) {
+        cert_chain = sk_X509_new_null();
+      }
+      X509_add_cert(cert_chain, OSSL_STORE_INFO_get1_CERT(info),
+        X509_ADD_FLAG_DEFAULT);
+    }
+
     OSSL_STORE_INFO_free(info);
   }
+
   OSSL_STORE_close(store);
   if(!cert) {
     failf(data, "No cert found in the openssl store: %s",
@@ -1285,6 +1307,17 @@ static int providerload(struct Curl_easy *data,
 
   if(rc != 1) {
     failf(data, "unable to set client certificate [%s]",
+          ossl_strerror(ERR_get_error(), error_buffer,
+                        sizeof(error_buffer)));
+    sk_X509_pop_free(cert_chain, X509_free);
+    return 0;
+  }
+
+  rc = (int) SSL_CTX_set1_chain(ctx, cert_chain);
+  sk_X509_pop_free(cert_chain, X509_free);
+
+  if(rc != 1) {
+    failf(data, "unable to set client certificate chain [%s]",
           ossl_strerror(ERR_get_error(), error_buffer,
                         sizeof(error_buffer)));
     return 0;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1078,7 +1078,8 @@ static int enginecheck(struct Curl_easy *data,
 
 static int providercheck(struct Curl_easy *data,
                          SSL_CTX* ctx,
-                         const char *key_file)
+                         const char *key_file,
+                         const char *key_passwd)
 {
 #ifdef OPENSSL_HAS_PROVIDERS
   EVP_PKEY *priv_key = NULL;
@@ -1108,7 +1109,8 @@ static int providercheck(struct Curl_easy *data,
   UI_method_set_writer(ui_method, ssl_ui_writer);
 
   store = OSSL_STORE_open_ex(key_file, data->state.libctx,
-                             data->state.propq, ui_method, NULL, NULL,
+                             data->state.propq, ui_method,
+                             CURL_UNCONST(key_passwd), NULL,
                              NULL, NULL);
   if(!store) {
     failf(data, "Failed to open OpenSSL store: %s",
@@ -1152,6 +1154,7 @@ static int providercheck(struct Curl_easy *data,
 #else
   (void)ctx;
   (void)key_file;
+  (void)key_passwd;
   failf(data, "SSL_FILETYPE_PROVIDER not supported for private key");
   return 0;
 #endif
@@ -1229,12 +1232,14 @@ static int engineload(struct Curl_easy *data,
 
 static int providerload(struct Curl_easy *data,
                         SSL_CTX* ctx,
-                        const char *cert_file)
+                        const char *cert_file,
+                        const char *key_passwd)
 {
 #ifdef OPENSSL_HAS_PROVIDERS
   X509 *cert = NULL;
   STACK_OF(X509) *cert_chain = NULL;
   OSSL_STORE_CTX *store = NULL;
+  UI_METHOD *ui_method = NULL;
   int rc;
   char error_buffer[256];
   /* Implicitly use pkcs11 provider if none was provided and the
@@ -1248,14 +1253,26 @@ static int providerload(struct Curl_easy *data,
   }
 
   /* Load the certificate from the provider */
+  ui_method = UI_create_method("curl user interface");
+  if(!ui_method) {
+    failf(data, "unable to create " OSSL_PACKAGE " user-interface method");
+    return 0;
+  }
+  UI_method_set_opener(ui_method, UI_method_get_opener(UI_OpenSSL()));
+  UI_method_set_closer(ui_method, UI_method_get_closer(UI_OpenSSL()));
+  UI_method_set_reader(ui_method, ssl_ui_reader);
+  UI_method_set_writer(ui_method, ssl_ui_writer);
 
   store = OSSL_STORE_open_ex(cert_file, data->state.libctx,
-                              NULL, NULL, NULL, NULL, NULL, NULL);
+                              data->state.propq, ui_method,
+                              CURL_UNCONST(key_passwd), NULL,
+                              NULL, NULL);
 
   if(!store) {
     failf(data, "Failed to open OpenSSL store: %s",
           ossl_strerror(ERR_get_error(), error_buffer,
                         sizeof(error_buffer)));
+    UI_destroy_method(ui_method);
     return 0;
   }
   if(OSSL_STORE_expect(store, OSSL_STORE_INFO_CERT) != 1) {
@@ -1295,6 +1312,7 @@ static int providerload(struct Curl_easy *data,
   }
 
   OSSL_STORE_close(store);
+  UI_destroy_method(ui_method);
   if(!cert) {
     failf(data, "No cert found in the openssl store: %s",
           ossl_strerror(ERR_get_error(), error_buffer,
@@ -1326,6 +1344,7 @@ static int providerload(struct Curl_easy *data,
 #else
   (void)ctx;
   (void)cert_file;
+  (void)key_passwd;
   failf(data, "SSL_FILETYPE_PROVIDER not supported for certificate");
   return 0;
 #endif
@@ -1518,7 +1537,7 @@ static CURLcode client_cert(struct Curl_easy *data,
       break;
 
     case SSL_FILETYPE_PROVIDER:
-      if(!cert_file || !providerload(data, ctx, cert_file))
+      if(!cert_file || !providerload(data, ctx, cert_file, key_passwd))
         return CURLE_SSL_CERTPROBLEM;
       break;
 
@@ -1559,7 +1578,7 @@ static CURLcode client_cert(struct Curl_easy *data,
       break;
 
     case SSL_FILETYPE_PROVIDER:
-      if(!providercheck(data, ctx, key_file))
+      if(!providercheck(data, ctx, key_file, key_passwd))
         return CURLE_SSL_CERTPROBLEM;
       break;
 

--- a/tests/certs/.gitignore
+++ b/tests/certs/.gitignore
@@ -7,8 +7,8 @@ test-*.csr
 test-*.der
 test-*.key*
 test-*.pem
-test-ca.cacert
-test-ca.cnt*
-test-ca.db*
-test-ca.raw*
-test-ca.srl
+test-*ca.cacert
+test-*ca.cnt*
+test-*ca.db*
+test-*ca.raw*
+test-*ca.srl

--- a/tests/certs/Makefile.inc
+++ b/tests/certs/Makefile.inc
@@ -25,7 +25,8 @@
 
 CERTCONFIG_CA = \
   test-ca.cnf \
-  test-ca.prm
+  test-ca.prm \
+  test-intermediate-ca.prm
 
 CERTCONFIGS = \
   test-client-cert.prm \
@@ -40,27 +41,44 @@ GENERATEDCERTS = \
   test-ca.cacert \
   test-ca.crt \
   test-ca.key \
+  test-intermediate-ca.cacert \
+  test-intermediate-ca.crt \
+  test-intermediate-ca.csr \
+  test-intermediate-ca.key \
+  test-intermediate-ca.srl \
   test-client-cert.crl \
   test-client-cert.crt \
   test-client-cert.key \
+  test-client-cert.chain.crt \
+  test-client-cert.chain.pem \
+  test-client-cert.chain-bundle.pem \
   test-client-cert.pem \
   test-client-cert.pub.der \
   test-client-cert.pub.pem \
   test-client-eku-only.crl \
   test-client-eku-only.crt \
   test-client-eku-only.key \
+  test-client-eku-only.chain.crt \
+  test-client-eku-only.chain.pem \
+  test-client-eku-only.chain-bundle.pem \
   test-client-eku-only.pem \
   test-client-eku-only.pub.der \
   test-client-eku-only.pub.pem \
   test-localhost-san-first.crl \
   test-localhost-san-first.crt \
   test-localhost-san-first.key \
+  test-localhost-san-first.chain.crt \
+  test-localhost-san-first.chain.pem \
+  test-localhost-san-first.chain-bundle.pem \
   test-localhost-san-first.pem \
   test-localhost-san-first.pub.der \
   test-localhost-san-first.pub.pem \
   test-localhost-san-last.crl \
   test-localhost-san-last.crt \
   test-localhost-san-last.key \
+  test-localhost-san-last.chain.crt \
+  test-localhost-san-last.chain.pem \
+  test-localhost-san-last.chain-bundle.pem \
   test-localhost-san-last.pem \
   test-localhost-san-last.pub.der \
   test-localhost-san-last.pub.pem \
@@ -73,12 +91,21 @@ GENERATEDCERTS = \
   test-localhost.nn.pem \
   test-localhost.nn.pub.der \
   test-localhost.nn.pub.pem \
+  test-localhost.nn.chain.crt \
+  test-localhost.nn.chain.pem \
+  test-localhost.nn.chain-bundle.pem \
   test-localhost.pem \
   test-localhost.pub.der \
   test-localhost.pub.pem \
+  test-localhost.chain.crt \
+  test-localhost.chain.pem \
+  test-localhost.chain-bundle.pem \
   test-localhost0h.crl \
   test-localhost0h.crt \
   test-localhost0h.key \
+  test-localhost0h.chain.crt \
+  test-localhost0h.chain.pem \
+  test-localhost0h.chain-bundle.pem \
   test-localhost0h.pem \
   test-localhost0h.pub.der \
   test-localhost0h.pub.pem

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -113,7 +113,7 @@ while(@ARGV) {
 
     # pseudo-secrets
     system($OPENSSL, ('genpkey', '-algorithm', 'EC', '-pkeyopt', "ec_paramgen_curve:$KEYSIZE", '-pkeyopt', 'ec_param_enc:named_curve',
-        '-out', "$PREFIX.keyenc", '-pass', 'pass:secret'));
+        '-aes-256-cbc', '-out', "$PREFIX.keyenc", '-pass', 'pass:secret'));
     redir('2>', $OPENSSL, ('req', '-config', "$SRCDIR/$PREFIX.prm", '-new', '-key', "$PREFIX.keyenc", '-out', "$PREFIX.csr", '-passin', 'pass:secret'));
     system($OPENSSL, ('pkey', '-in', "$PREFIX.keyenc", '-out', "$PREFIX.key", '-passin', 'pass:secret'));
 

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -105,6 +105,20 @@ if(!$CAPREFIX) {
 
 $DURATION = 300;
 
+if(! -f "$CAPREFIX-intermediate-ca.crt" || ! -f "$CAPREFIX-intermediate-ca.key") {
+    system($OPENSSL, ('genpkey', '-algorithm', 'EC', '-pkeyopt', "ec_paramgen_curve:$KEYSIZE",
+        '-pkeyopt', 'ec_param_enc:named_curve', '-out', "$CAPREFIX-intermediate-ca.key"));
+    redir('2>', $OPENSSL, ('req', '-config', "$SRCDIR/test-intermediate-ca.prm", '-new',
+        '-key', "$CAPREFIX-intermediate-ca.key", '-out', "$CAPREFIX-intermediate-ca.csr"));
+    redir(">$CAPREFIX-intermediate-ca.crt", '2>', $OPENSSL, ('x509', '-sha256',
+        '-extfile', "$SRCDIR/test-intermediate-ca.prm", '-days', $DURATION,
+        '-req', '-CA', "$CAPREFIX-ca.cacert", '-CAkey', "$CAPREFIX-ca.key",
+        '-CAcreateserial', '-in', "$CAPREFIX-intermediate-ca.csr"));
+    redir(">$CAPREFIX-intermediate-ca.cacert", $OPENSSL, ('x509', '-in', "$CAPREFIX-intermediate-ca.crt",
+        '-text', '-nameopt', 'multiline'));
+    print "Client intermediate CA generated: $CAPREFIX $DURATION days $KEYSIZE\n";
+}
+
 open($fh, '>>', "$CAPREFIX-ca.db") and close($fh);  # for revoke server cert
 
 while(@ARGV) {
@@ -139,6 +153,28 @@ while(@ARGV) {
     if(open($fh, '>>', "$PREFIX.pem")) {
         my $fi;
         print $fh do { local $/; open $fi, '<', $_ and <$fi> } for("$SRCDIR/$PREFIX.prm", "$PREFIX.key", "$PREFIX.crt");
+        close($fh);
+    }
+
+    # sign with intermediate client CA and create chain bundle
+    redir(">$PREFIX.chain.crt", '2>', $OPENSSL, ('x509', '-sha256',
+        '-extfile', "$SRCDIR/$PREFIX.prm", '-days', $DURATION,
+        '-req', '-CA', "$CAPREFIX-intermediate-ca.cacert", '-CAkey', "$CAPREFIX-intermediate-ca.key",
+        '-CAcreateserial', '-in', "$PREFIX.csr"));
+
+    open($fh, '>', "$PREFIX.chain.pem") and close($fh);
+    chmod 0600, "$PREFIX.chain.pem";
+    if(open($fh, '>>', "$PREFIX.chain.pem")) {
+        my $fi;
+        print $fh do { local $/; open $fi, '<', $_ and <$fi> } for("$PREFIX.chain.crt", "$CAPREFIX-intermediate-ca.crt");
+        close($fh);
+    }
+
+    open($fh, '>', "$PREFIX.chain-bundle.pem") and close($fh);
+    chmod 0600, "$PREFIX.chain-bundle.pem";
+    if(open($fh, '>>', "$PREFIX.chain-bundle.pem")) {
+        my $fi;
+        print $fh do { local $/; open $fi, '<', $_ and <$fi> } for("$PREFIX.chain.pem", "$PREFIX.key");
         close($fh);
     }
 

--- a/tests/certs/test-intermediate-ca.prm
+++ b/tests/certs/test-intermediate-ca.prm
@@ -1,0 +1,32 @@
+extensions = x509v3
+
+[ x509v3 ]
+basicConstraints        = critical,CA:true,pathlen:0
+keyUsage                = critical,keyCertSign,cRLSign
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+authorityInfoAccess     = @issuer_info
+crlDistributionPoints   = @crl_info
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid:always
+authorityInfoAccess     = @issuer_info
+
+[ issuer_info ]
+caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
+
+[ crl_info ]
+URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
+
+[ req ]
+distinguished_name      = req_DN
+default_md              = sha256
+string_mask             = utf8only
+
+[ req_DN ]
+countryName             = "Country Name"
+countryName_value       = NN
+organizationName        = "Organization Name"
+organizationName_value  = Edel curl Arctic Illudium Research Cloud
+commonName              = "Common Name"
+commonName_value        = Northern Nowhere Intermediate Trust Issuer

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -253,6 +253,7 @@ test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 test2093 test2094 test2095 \
+test2096 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
 test2108 test2109 test2110 test2113 test2114 test2115 test2116 test2117 \
 \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -253,7 +253,7 @@ test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 test2093 test2094 test2095 \
-test2096 \
+test2096 test2097 test2098 test2099 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
 test2108 test2109 test2110 test2113 test2114 test2115 test2116 test2117 \
 \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -252,7 +252,7 @@ test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
-test2088 test2089 test2090 test2091 test2092 test2093 test2094 \
+test2088 test2089 test2090 test2091 test2092 test2093 test2094 test2095 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
 test2108 test2109 test2110 test2113 test2114 test2115 test2116 test2117 \
 \

--- a/tests/data/test2095
+++ b/tests/data/test2095
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP GET
+Client Auth
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 7
+
+MooMoo
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+SSL
+!Schannel
+local-http
+</features>
+<server>
+https-mtls
+</server>
+<name>
+HTTPS GET with client authentication using encrypted key
+</name>
+<command>
+--cacert %CERTDIR/certs/test-ca.crt --cert %CERTDIR/certs/test-client-eku-only.crt --pass secret --key %CERTDIR/certs/test-client-eku-only.keyenc https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: localhost:%HTTPS-MTLSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2095
+++ b/tests/data/test2095
@@ -26,6 +26,9 @@ MooMoo
 SSL
 !Schannel
 local-http
+# Wolfssl and rustls backends do not support encrypted private key
+!wolfssl
+!rustls
 </features>
 <server>
 https-mtls

--- a/tests/data/test2096
+++ b/tests/data/test2096
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP GET
+Client Auth
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 7
+
+MooMoo
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+SSL
+!Schannel
+local-http
+</features>
+<server>
+https-mtls
+</server>
+<name>
+HTTPS GET with client authentication using certificate chain
+</name>
+<command>
+--cacert %CERTDIR/certs/test-ca.crt --cert %CERTDIR/certs/test-client-eku-only.chain-bundle.pem https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: localhost:%HTTPS-MTLSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test2097
+++ b/tests/data/test2097
@@ -23,20 +23,18 @@ MooMoo
 # Client-side
 <client>
 <features>
+OpenSSL-providers
 SSL
-!Schannel
 local-http
-# Rustls backend does not support certificate chain
-!rustls
 </features>
 <server>
 https-mtls
 </server>
 <name>
-HTTPS GET with client authentication using certificate chain
+App HTTPS GET with client authentication using Openssl store provider
 </name>
 <command>
---cacert %CERTDIR/certs/test-ca.crt --cert %CERTDIR/certs/test-client-eku-only.chain-bundle.pem --key %CERTDIR/certs/test-client-eku-only.key https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
+--cacert %CERTDIR/certs/test-ca.crt --cert-type PROV --cert %CERTDIR/certs/test-client-eku-only.crt --key-type PROV --key %CERTDIR/certs/test-client-eku-only.key https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2098
+++ b/tests/data/test2098
@@ -23,20 +23,18 @@ MooMoo
 # Client-side
 <client>
 <features>
+OpenSSL-providers
 SSL
-!Schannel
 local-http
-# Rustls backend does not support certificate chain
-!rustls
 </features>
 <server>
 https-mtls
 </server>
 <name>
-HTTPS GET with client authentication using certificate chain
+App HTTPS GET with client authentication using Openssl mix of store provider and PEM
 </name>
 <command>
---cacert %CERTDIR/certs/test-ca.crt --cert %CERTDIR/certs/test-client-eku-only.chain-bundle.pem --key %CERTDIR/certs/test-client-eku-only.key https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
+--cacert %CERTDIR/certs/test-ca.crt --cert-type PEM --cert %CERTDIR/certs/test-client-eku-only.crt --key-type PROV --key %CERTDIR/certs/test-client-eku-only.key https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2099
+++ b/tests/data/test2099
@@ -10,10 +10,11 @@ Client Auth
 
 # Server-side
 <reply>
-<data>
+<data nocheck="yes">
 HTTP/1.1 200 OK
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake
+Content-Type: text/html
 Content-Length: 7
 
 MooMoo
@@ -23,31 +24,28 @@ MooMoo
 # Client-side
 <client>
 <features>
+OpenSSL-providers
 SSL
-!Schannel
 local-http
-# Rustls backend does not support certificate chain
-!rustls
 </features>
 <server>
 https-mtls
 </server>
+<tool>
+lib%TESTNUMBER
+</tool>
 <name>
-HTTPS GET with client authentication using certificate chain
+HTTPS GET with client authentication using Openssl store provider
 </name>
 <command>
---cacert %CERTDIR/certs/test-ca.crt --cert %CERTDIR/certs/test-client-eku-only.chain-bundle.pem --key %CERTDIR/certs/test-client-eku-only.key https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
+https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER %CERTDIR/certs/test-ca.crt %CERTDIR/certs/test-client-eku-only.crt %CERTDIR/certs/test-client-eku-only.key
 </command>
 </client>
 
 # Verify data after the test has been "shot"
 <verify>
-<protocol crlf="headers">
-GET /%TESTNUMBER HTTP/1.1
-Host: localhost:%HTTPS-MTLSPORT
-User-Agent: curl/%VERSION
-Accept: */*
-
-</protocol>
+<stdout>
+MooMoo
+</stdout>
 </verify>
 </testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -116,7 +116,7 @@ TESTS_C = \
   lib1955.c lib1956.c lib1957.c lib1958.c lib1959.c lib1960.c \
   lib1964.c lib1965.c           lib1967.c                     lib1970.c \
   lib1971.c lib1972.c lib1973.c lib1974.c lib1975.c lib1977.c lib1978.c \
-  lib2023.c lib2032.c lib2082.c \
+  lib2023.c lib2032.c lib2082.c lib2099.c \
   lib2301.c lib2302.c lib2304.c           lib2306.c lib2308.c lib2309.c \
   lib2402.c           lib2404.c lib2405.c \
   lib2412.c           lib2414.c \

--- a/tests/libtest/lib2099.c
+++ b/tests/libtest/lib2099.c
@@ -1,0 +1,84 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+/*
+ * OpenSSL-only mTLS test: HTTPS GET using a client certificate and private
+ * key against an mTLS server. Invocation:
+ *   <URL> <ca-cert> <client-cert> <client-key>
+ */
+
+#include "first.h"
+
+#ifdef USE_OPENSSL
+
+static CURLcode test_lib2099(const char *URL)
+{
+  CURL *curl;
+  CURLcode result = TEST_ERR_MAJOR_BAD;
+
+  if(!libtest_arg2 || !libtest_arg3 || !libtest_arg4) {
+    curl_mfprintf(stderr, "lib2099: missing args\n");
+    return CURLE_OBSOLETE20;
+  }
+
+  if(curl_global_sslset(CURLSSLBACKEND_OPENSSL, NULL, NULL) != CURLSSLSET_OK) {
+    curl_mfprintf(stderr, "lib2099: could not select OpenSSL backend\n");
+    return CURLE_OBSOLETE20;
+  }
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  curl = curl_easy_init();
+
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_CAINFO, libtest_arg2);  /* CA cert */
+  easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PROV"); /* client cert type */
+  easy_setopt(curl, CURLOPT_SSLCERT, libtest_arg3); /* client cert */
+  easy_setopt(curl, CURLOPT_SSLKEYTYPE, "PROV"); /* private key type */
+  easy_setopt(curl, CURLOPT_SSLKEY, libtest_arg4);  /* private key */
+
+  result = curl_easy_perform(curl);
+  if(result) {
+    curl_mfprintf(stderr,
+                  "%s:%d curl_easy_perform() failed with code %d (%s)\n",
+                  __FILE__, __LINE__, (int)result,
+                  curl_easy_strerror(result));
+    goto test_cleanup;
+  }
+
+test_cleanup:
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+  return result;
+}
+
+#else
+
+static CURLcode test_lib2099(const char *URL)
+{
+  (void)URL;
+  curl_mfprintf(stderr, "lib2099: requires OpenSSL\n");
+  return CURLE_OK;
+}
+
+#endif

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -578,6 +578,10 @@ sub checksystemfeatures {
             elsif($libcurl =~ /\sopenssl\b/i) {
                 $feature{"OpenSSL"} = 1;
                 $feature{"SSLpinning"} = 1;
+                # OpenSSL providers were introduced in v3.0.0
+                if($libcurl =~ /\sopenssl\/([0-9]+)\./i && $1 >= 3) {
+                    $feature{"OpenSSL-providers"} = 1;
+                }
             }
             elsif($libcurl =~ /\sgnutls\b/i) {
                 $feature{"GnuTLS"} = 1;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -1223,7 +1223,7 @@ sub runhttpsserver {
     unlink($pidfile) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
-    $certfile = 'certs/test-localhost.pem' unless($certfile);
+    $certfile = 'test-localhost.pem' unless($certfile);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
 
     my $flags = "";
@@ -1232,7 +1232,7 @@ sub runhttpsserver {
     $flags .= "--logdir \"$LOGDIR\" ";
     $flags .= "--id $idnum " if($idnum > 1);
     $flags .= "--ipv$ipvnum --proto $proto ";
-    $flags .= "--certfile \"$certfile\" " if($certfile ne 'certs/test-localhost.pem');
+    $flags .= "--certfile \"$certfile\" " if($certfile ne 'test-localhost.pem');
     $flags .= "--stunnel \"$stunnel\" --srcdir \"$srcdir\" ";
     if($proto eq "https-mtls") {
         $flags .= "--mtls ";
@@ -1381,7 +1381,7 @@ sub runsecureserver {
     unlink($pidfile) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
-    $certfile = 'certs/test-localhost.pem' unless($certfile);
+    $certfile = 'test-localhost.pem' unless($certfile);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
 
     my $flags = "";
@@ -1390,7 +1390,7 @@ sub runsecureserver {
     $flags .= "--logdir \"$LOGDIR\" ";
     $flags .= "--id $idnum " if($idnum > 1);
     $flags .= "--ipv$ipvnum --proto $proto ";
-    $flags .= "--certfile \"$certfile\" " if($certfile ne 'certs/test-localhost.pem');
+    $flags .= "--certfile \"$certfile\" " if($certfile ne 'test-localhost.pem');
     $flags .= "--stunnel \"$stunnel\" --srcdir \"$srcdir\" ";
     $flags .= "--connect $clearport";
 
@@ -2243,7 +2243,7 @@ sub startservers {
 
         my $certfile;
         if($what =~ /^(ftp|gopher|http|imap|pop3|smtp)s|https-mtls((\d*)(-ipv6|-unix|))$/) {
-            $certfile = ($whatlist[1]) ? $whatlist[1] : 'certs/test-localhost.pem';
+            $certfile = ($whatlist[1]) ? $whatlist[1] : 'test-localhost.pem';
         }
 
         if(($what eq "pop3") ||

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -445,9 +445,10 @@ sub stopserver {
         push @killservers, "socks${2}";
     }
     if($server eq "http" or $server eq "https") {
-        # since the http2+3 server is a proxy that needs to know about the
-        # dynamic http port it too needs to get restarted when the http server
-        # is killed
+        # since https-mtls, http/2 and http/3 are proxies that need to know
+        # about the dynamic http port they need to get restarted when the http
+        # server is killed
+        push @killservers, "https-mtls";
         push @killservers, "http/2";
         push @killservers, "http/3";
     }


### PR DESCRIPTION
Openssl 3+ encourages using providers for all data storages. This MR changes the default storage type to provider when supported, instead of PEM file. Using providers as default aligns better with the way Openssl apps handle data storage, and removes the need for end users to maintain a storage type: providers should be the go-to way to allow swapping types, by updating the URI (except Openssl engines, which are deprecated).
Note that, this does not change the behavior, since Openssl bundles a base provider, supporting the file storage type, and the file storage type is assumed by Openssl stack when not specified in the URI.

To avoid breaking changes, this MR also adds support for certificate chain loading, using store providers. A single provider URI may return several hits, thus providing several certificates.

The explicit check on a provider being loaded is removed: it conflicts with Openssl stack guessing the right store. If the provider is not available when trying to open it, the Openssl stack will raise an explicit error, which will be returned to the user.

---

https://github.com/curl/curl/pull/21088/files?w=1
