### PR TITLE
sha256, sha512_256: switch to wolfCrypt API

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -193,7 +193,7 @@ typedef struct wc_Sha512 Curl_sha512_256_ctx;
 
 static CURLcode Curl_sha512_256_init(void *ctx)
 {
-  if(wc_InitSha512_256((Curl_sha512_256_ctx *)ctx))
+  if(wc_InitSha512_256(ctx))
     return CURLE_FAILED_INIT;
   return CURLE_OK;
 }
@@ -202,14 +202,14 @@ static CURLcode Curl_sha512_256_update(void *ctx,
                                        const unsigned char *data,
                                        size_t length)
 {
-  if(wc_Sha512_256Update((Curl_sha512_256_ctx *)ctx, data, (word32)length))
+  if(wc_Sha512_256Update(ctx, data, (word32)length))
     return CURLE_SSL_CIPHER;
   return CURLE_OK;
 }
 
 static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *ctx)
 {
-  if(wc_Sha512_256Final((Curl_sha512_256_ctx *)ctx, digest))
+  if(wc_Sha512_256Final(ctx, digest))
     return CURLE_SSL_CIPHER;
   return CURLE_OK;
 }

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -95,7 +95,7 @@ typedef struct wc_Sha256 my_sha256_ctx;
 
 static CURLcode my_sha256_init(void *in)
 {
-  if(wc_InitSha256((my_sha256_ctx *)in))
+  if(wc_InitSha256(in))
     return CURLE_FAILED_INIT;
   return CURLE_OK;
 }
@@ -104,12 +104,12 @@ static void my_sha256_update(void *in,
                              const unsigned char *data,
                              unsigned int length)
 {
-  (void)wc_Sha256Update((my_sha256_ctx *)in, data, (word32)length);
+  (void)wc_Sha256Update(in, data, (word32)length);
 }
 
 static void my_sha256_final(unsigned char *digest, void *in)
 {
-  (void)wc_Sha256Final((my_sha256_ctx *)in, digest);
+  (void)wc_Sha256Final(in, digest);
 }
 
 #elif defined(USE_GNUTLS)


### PR DESCRIPTION
Replacing the OpenSSL-like compatibility interface, and syncing with
existing API use within lib/wolfssl.c for SHA-256.

Ref: https://www.wolfssl.com/documentation/manuals/wolfssl/group__SHA.html

Follow-up to 28f0932073bfbcb977e2638e137e2519cb2b14e2 #21077
Follow-up to 988b352f917151452c4f1483214ba7012299b1e2 #21078
