### PR TITLE
cmake: add CMake Config-based dependency detection for c-ares, wolfSSL

### DIFF
--- a/CMake/FindCares.cmake
+++ b/CMake/FindCares.cmake
@@ -37,11 +37,15 @@
 
 set(_cares_pc_requires "libcares")
 
-if(CURL_USE_PKGCONFIG AND
-   NOT DEFINED CARES_INCLUDE_DIR AND
+if(NOT DEFINED CARES_INCLUDE_DIR AND
    NOT DEFINED CARES_LIBRARY)
-  find_package(PkgConfig QUIET)
-  pkg_check_modules(_cares ${_cares_pc_requires})
+  if(CURL_USE_PKGCONFIG)
+    find_package(PkgConfig QUIET)
+    pkg_check_modules(_cares ${_cares_pc_requires})
+  endif()
+  if(NOT _cares_FOUND AND CURL_USE_CMAKECONFIG)
+    find_package(c-ares CONFIG QUIET)
+  endif()
 endif()
 
 if(_cares_FOUND)
@@ -55,6 +59,16 @@ if(_cares_FOUND)
     set(_cares_LIBRARIES    "${_cares_STATIC_LIBRARIES}")
   endif()
   message(STATUS "Found Cares (via pkg-config): ${_cares_INCLUDE_DIRS} (found version \"${CARES_VERSION}\")")
+elseif(c-ares_CONFIG)
+  set(Cares_FOUND TRUE)
+  set(CARES_FOUND TRUE)
+  set(CARES_VERSION ${c-ares_VERSION})
+  if(CARES_USE_STATIC_LIBS)
+    set(_cares_LIBRARIES c-ares::cares_static)
+  else()
+    set(_cares_LIBRARIES c-ares::cares)
+  endif()
+  message(STATUS "Found Cares (via CMake Config): ${c-ares_CONFIG} (found version \"${CARES_VERSION}\")")
 else()
   find_path(CARES_INCLUDE_DIR NAMES "ares.h")
   if(CARES_USE_STATIC_LIBS)

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -45,11 +45,15 @@ endif()
 
 set(_wolfssl_pc_requires "wolfssl")
 
-if(CURL_USE_PKGCONFIG AND
-   NOT DEFINED WOLFSSL_INCLUDE_DIR AND
+if(NOT DEFINED WOLFSSL_INCLUDE_DIR AND
    NOT DEFINED WOLFSSL_LIBRARY)
-  find_package(PkgConfig QUIET)
-  pkg_check_modules(_wolfssl ${_wolfssl_pc_requires})
+  if(CURL_USE_PKGCONFIG)
+    find_package(PkgConfig QUIET)
+    pkg_check_modules(_wolfssl ${_wolfssl_pc_requires})
+  endif()
+  if(NOT _wolfssl_FOUND AND CURL_USE_CMAKECONFIG)
+    find_package(wolfssl CONFIG QUIET)
+  endif()
 endif()
 
 if(_wolfssl_FOUND)
@@ -57,6 +61,12 @@ if(_wolfssl_FOUND)
   set(WOLFSSL_FOUND TRUE)
   set(WOLFSSL_VERSION ${_wolfssl_VERSION})
   message(STATUS "Found WolfSSL (via pkg-config): ${_wolfssl_INCLUDE_DIRS} (found version \"${WOLFSSL_VERSION}\")")
+elseif(wolfssl_CONFIG)
+  set(WolfSSL_FOUND TRUE)
+  set(WOLFSSL_FOUND TRUE)
+  set(WOLFSSL_VERSION ${wolfssl_VERSION})
+  set(_wolfssl_LIBRARIES wolfssl::wolfssl)
+  message(STATUS "Found WolfSSL (via CMake Config): ${wolfssl_CONFIG} (found version \"${WOLFSSL_VERSION}\")")
 else()
   find_path(WOLFSSL_INCLUDE_DIR NAMES "wolfssl/ssl.h")
   find_library(WOLFSSL_LIBRARY NAMES "wolfssl")

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -393,9 +393,9 @@ Details via CMake
 - `<PackageName>_DIR`:                      Absolute path to `<PackageName>` CMake Config directory where `*.cmake` files reside.
                                             Used when `CURL_USE_CMAKECONFIG` is enabled.
                                             `<PackageName>` may be:
-                                            `Libssh2`, `MbedTLS`, `NGHTTP2`, `NGHTTP3`,
-                                            `NGTCP2` 1.19.0+ (with non-fork OpenSSL only),
-                                            `Zstd` 1.4.5+.
+                                            `c-ares`, `Libssh2`, `MbedTLS`, `NGHTTP2`, `NGHTTP3`,
+                                            `NGTCP2` for 1.19.0+ (with non-fork OpenSSL only),
+                                            `wolfssl` for 5.2.1+, `Zstd` for 1.4.5+.
 
 ## Dependency options (tools)
 


### PR DESCRIPTION
For wolfSSL it requires v5.2.1+, and with 5.9.0+ it's also supported when
wolfSSL was built with autotools.

Follow-up to 8fce3e17e6cb310cd6dbe38ff14869b8fe5827d2 #20814

---

https://github.com/curl/curl/pull/21098/files?w=1
