### PR TITLE
http: always ignore custom method on 303 redirects

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1103,7 +1103,7 @@ static void http_switch_to_get(struct Curl_easy *data, int code)
   const char *req = data->set.str[STRING_CUSTOMREQUEST];
 
   if((req || data->state.httpreq != HTTPREQ_GET) &&
-     (data->set.http_follow_mode == CURLFOLLOW_OBEYCODE)) {
+     (data->set.http_follow_mode == CURLFOLLOW_OBEYCODE || code == 303)) {
     NOVERBOSE((void)code);
     infof(data, "Switch to GET because of %d response", code);
     data->state.http_ignorecustom = TRUE;


### PR DESCRIPTION
For 303 (See Other) redirects, HTTP specifies that the follow-up request should use GET/HEAD regardless of the original request method.

Previously, `http_switch_to_get()` would only set `http_ignorecustom=TRUE` when `http_follow_mode==CURLFOLLOW_OBEYCODE`. This meant that using `--request <VERB> --follow` would not properly switch to GET on 303 redirects when using the default follow mode (CURLFOLLOW_ALL).

Fix by adding `|| code == 303` to the condition so that 303 redirects always ignore the custom request method and switch to GET.

**Steps to reproduce:**
```
curl --request DELETE --follow http://some/url/that/returns/303
```

**Expected:** curl follows the redirect using GET
**Actual:** curl follows the redirect using DELETE (the original method)

Fixes #20715