### PR TITLE
delta: harden external command invocations

### DIFF
--- a/scripts/delta
+++ b/scripts/delta
@@ -49,6 +49,17 @@ elsif($start eq "") {
     chomp $start;
 }
 
+sub redir {
+    my @out;
+    my $as_string = shift if($_[0] eq '$');
+    my $hideerr = shift if($_[0] =~ /^2>/);
+    my $pid = open3(my $in, my $out, my $err = gensym, @_);
+    if(!$hideerr) { while(<$err>) { print STDERR $_; }; }
+    push @out, <$out>;
+    waitpid($pid, 0);
+    return $as_string ? join('', @out) : @out;
+}
+
 my $commits = `git log --oneline $start.. | wc -l`;
 my $committers = `git shortlog -s $start.. | wc -l`;
 my $bcommitters = `git shortlog -s $start | wc -l`;
@@ -62,21 +73,9 @@ my $ncommitters = $acommitters - $bcommitters;
 # number of contributors right now
 my $acontribs = `./scripts/contrithanks.sh stdout | wc -l`;
 # number when the tag was set
-my $bcontribs = `git show $start:docs/THANKS | grep -c '^[^ ]'`;
+my $bcontribs = redir('$', 'git', 'grep', '-h', '-c', '^[^ ]', "$start:docs/THANKS");
 # delta
 my $contribs = $acontribs - $bcontribs;
-
-sub redir {
-    my @out;
-    my $outfn = shift if($_[0] =~ /^>/);
-    my $hideerr = shift if($_[0] =~ /^2>/);
-    open(my $outfd, $outfn) || die if($outfn);
-    my $pid = open3(my $in, my $out, my $err = gensym, @_);
-    if(!$hideerr) { while(<$err>) { print STDERR $_; }; }
-    push @out, <$out>;
-    waitpid($pid, 0);
-    return @out;
-}
 
 # number of setops:
 sub setopts {
@@ -100,9 +99,9 @@ my $bsetopts = setopts('-|', 'git', 'show', "$start:include/curl/curl.h");
 my $nsetopts = $asetopts - $bsetopts;
 
 # Number of command line options:
-my $aoptions=`grep -c '{ *"....--' src/tool_listhelp.c`;
-my $boptions=`git grep -h -c '{ *"....--' $start:src/tool_listhelp.c 2>/dev/null`;
-my $noptions=$aoptions - $boptions;
+my $aoptions = redir('$', '2>', 'grep', '-c', '{ *"....--', 'src/tool_listhelp.c');
+my $boptions = redir('$', '2>', 'git', 'grep', '-h', '-c', '{ *"....--', "$start:src/tool_listhelp.c");
+my $noptions = $aoptions - $boptions;
 
 # current local branch
 my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
@@ -122,8 +121,8 @@ my $total=$now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
 my $totalhttpget=$now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
 
 # Number of public functions in libcurl
-my $apublic=`git grep ^CURL_EXTERN -- include/curl | wc -l`;
-my $bpublic=`git grep ^CURL_EXTERN $start -- include/curl | wc -l`;
+my $apublic = scalar(redir('git', 'grep', '^CURL_EXTERN', '--', 'include/curl'));
+my $bpublic = scalar(redir('git', 'grep', '^CURL_EXTERN', $start, '--', 'include/curl'));
 my $public = $apublic - $bpublic;
 
 # diffstat

--- a/scripts/delta
+++ b/scripts/delta
@@ -139,7 +139,7 @@ my ($fileschanged, $insertions, $deletions);
 my @diffstat = cmd('2>', 'git', 'diff', '--stat', "$start..");
 my $diffstat = $diffstat[-1];
 if($diffstat =~ /^ *(\d+) files changed, (\d+) insertions\(\+\), (\d+)/) {
-    ($fileschanged, $insertions, $deletions)=($1, $2, $3);
+    ($fileschanged, $insertions, $deletions) = ($1, $2, $3);
 }
 
 # Changes/bug-fixes currently logged
@@ -150,16 +150,16 @@ open(F, "<RELEASE-NOTES");
 my $mode = 0;
 while(<F>) {
     if($_ =~ /following changes:/) {
-        $mode=1;
+        $mode = 1;
     }
     elsif($_ =~ /following bugfixes:/) {
-        $mode=2;
+        $mode = 2;
     }
     elsif($_ =~ /known bugs:/) {
-        $mode=3;
+        $mode = 3;
     }
     elsif($_ =~ /like these:/) {
-        $mode=4;
+        $mode = 4;
     }
     if($_ =~ /^ o /) {
         if($mode == 1) {

--- a/scripts/delta
+++ b/scripts/delta
@@ -64,6 +64,14 @@ my $bcontribs = `git show $start:docs/THANKS | grep -c '^[^ ]'`;
 # delta
 my $contribs = $acontribs - $bcontribs;
 
+sub runstdout {
+    my $command = shift;
+    open(my $fh, '-|', $command, @_) or die;
+    my $content = do { local $/; <$fh> };
+    close($fh);
+    return $content;
+}
+
 # number of setops:
 sub setopts {
     my ($f)=@_;

--- a/scripts/delta
+++ b/scripts/delta
@@ -49,7 +49,7 @@ elsif($start eq "") {
     chomp $start;
 }
 
-sub redir {
+sub cmd {
     my @out;
     my $as_string = shift if($_[0] eq '$');
     my $hideerr = shift if($_[0] =~ /^2>/);
@@ -60,9 +60,9 @@ sub redir {
     return $as_string ? join('', @out) : @out;
 }
 
-my $commits = scalar(redir('git', 'log', '--oneline', "$start.."));
-my $committers = scalar(redir('git', 'shortlog', '-s', "$start.."));
-my $bcommitters = scalar(redir('git', 'shortlog', '-s', $start));
+my $commits = scalar(cmd('git', 'log', '--oneline', "$start.."));
+my $committers = scalar(cmd('git', 'shortlog', '-s', "$start.."));
+my $bcommitters = scalar(cmd('git', 'shortlog', '-s', $start));
 
 my $acommits = `git log --oneline | wc -l`;
 my $acommitters = `git shortlog -s | wc -l`;
@@ -73,7 +73,7 @@ my $ncommitters = $acommitters - $bcommitters;
 # number of contributors right now
 my $acontribs = `./scripts/contrithanks.sh stdout | wc -l`;
 # number when the tag was set
-my $bcontribs = redir('$', 'git', 'grep', '-h', '-c', '^[^ ]', "$start:docs/THANKS");
+my $bcontribs = cmd('$', 'git', 'grep', '-h', '-c', '^[^ ]', "$start:docs/THANKS");
 # delta
 my $contribs = $acontribs - $bcontribs;
 
@@ -99,8 +99,8 @@ my $bsetopts = setopts('-|', 'git', 'show', "$start:include/curl/curl.h");
 my $nsetopts = $asetopts - $bsetopts;
 
 # Number of command line options:
-my $aoptions = redir('$', '2>', 'grep', '-c', '{ *"....--', 'src/tool_listhelp.c');
-my $boptions = redir('$', '2>', 'git', 'grep', '-h', '-c', '{ *"....--', "$start:src/tool_listhelp.c");
+my $aoptions = cmd('$', '2>', 'grep', '-c', '{ *"....--', 'src/tool_listhelp.c');
+my $boptions = cmd('$', '2>', 'git', 'grep', '-h', '-c', '{ *"....--', "$start:src/tool_listhelp.c");
 my $noptions = $aoptions - $boptions;
 
 # current local branch
@@ -108,8 +108,8 @@ my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
 chomp $branch;
 # Number of files in git
 my $afiles=`git ls-files | wc -l`;
-my $deletes = scalar(redir('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
-my $creates = scalar(redir('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
+my $deletes = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
+my $creates = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 
 # Time since that tag
 sub tagstamp {
@@ -122,7 +122,7 @@ sub tagstamp {
         }
     }
 }
-my @tagged = redir('git', 'for-each-ref', '--format=%(refname:short) | %(taggerdate:unix) | %(creatordate)', 'refs/tags/*');
+my @tagged = cmd('git', 'for-each-ref', '--format=%(refname:short) | %(taggerdate:unix) | %(creatordate)', 'refs/tags/*');
 my $tagged = tagstamp(2, @tagged); # Unix timestamp
 my $taggednice = tagstamp(3, @tagged); # human readable time
 chomp $taggednice;
@@ -132,13 +132,13 @@ my $total=$now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
 my $totalhttpget=$now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
 
 # Number of public functions in libcurl
-my $apublic = scalar(redir('git', 'grep', '^CURL_EXTERN', '--', 'include/curl'));
-my $bpublic = scalar(redir('git', 'grep', '^CURL_EXTERN', $start, '--', 'include/curl'));
+my $apublic = scalar(cmd('git', 'grep', '^CURL_EXTERN', '--', 'include/curl'));
+my $bpublic = scalar(cmd('git', 'grep', '^CURL_EXTERN', $start, '--', 'include/curl'));
 my $public = $apublic - $bpublic;
 
 # diffstat
 my ($fileschanged, $insertions, $deletions);
-my @diffstat = redir('2>', 'git', 'diff', '--stat', "$start..");
+my @diffstat = cmd('2>', 'git', 'diff', '--stat', "$start..");
 my $diffstat = $diffstat[-1];
 if($diffstat =~ /^ *(\d+) files changed, (\d+) insertions\(\+\), (\d+)/) {
     ($fileschanged, $insertions, $deletions)=($1, $2, $3);

--- a/scripts/delta
+++ b/scripts/delta
@@ -112,8 +112,19 @@ my $deletes = scalar(redir('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '-
 my $creates = scalar(redir('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 
 # Time since that tag
-my $tagged=`git for-each-ref --format="%(refname:short) | %(taggerdate:unix)" refs/tags/* | grep ^$start | cut '-d|' -f2`; # Unix timestamp
-my $taggednice=`git for-each-ref --format="%(refname:short) | %(creatordate)" refs/tags/* | grep ^$start | cut '-d|' -f2`; # human readable time
+sub tagstamp {
+    my $col = shift;
+    my $q = qr/^$start /;
+    foreach my $line (@_) {
+        if($line =~ /$q/) {
+            my @cols = split(/\|/, $line);
+            return $cols[$col - 1];
+        }
+    }
+}
+my @tagged = redir('git', 'for-each-ref', '--format=%(refname:short) | %(taggerdate:unix) | %(creatordate)', 'refs/tags/*');
+my $tagged = tagstamp(2, @tagged); # Unix timestamp
+my $taggednice = tagstamp(3, @tagged); # human readable time
 chomp $taggednice;
 my $now=POSIX::strftime("%s", localtime());
 my $elapsed=$now - $tagged; # number of seconds since tag

--- a/scripts/delta
+++ b/scripts/delta
@@ -75,12 +75,11 @@ sub redir {
     if(!$hideerr) { while(<$err>) { print STDERR $_; }; }
     push @out, <$out>;
     waitpid($pid, 0);
+print "------------------\n";
+print join("\n", @out);
+print "------------------\n";
+exit 10;
     return $out;
-}
-
-sub wc_l {
-    my ($content) = @_;
-    return scalar(split /\n/, $content);
 }
 
 # number of setops:
@@ -110,8 +109,8 @@ my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
 chomp $branch;
 # Number of files in git
 my $afiles=`git ls-files | wc -l`;
-my $deletes = wc_l(redir('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
-my $creates = wc_l(redir('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
+my $deletes = length(redir('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
+my $creates = length(redir('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 
 # Time since that tag
 my $tagged=`git for-each-ref --format="%(refname:short) | %(taggerdate:unix)" refs/tags/* | grep ^$start | cut '-d|' -f2`; # Unix timestamp

--- a/scripts/delta
+++ b/scripts/delta
@@ -127,7 +127,8 @@ my $public = $apublic - $bpublic;
 
 # diffstat
 my ($fileschanged, $insertions, $deletions);
-my $diffstat=`git diff --stat $start.. | tail -1`;
+my @diffstat = redir('git', 'diff', '--stat', "$start..");
+my $diffstat = $diffstat[-1];
 if($diffstat =~ /^ *(\d+) files changed, (\d+) insertions\(\+\), (\d+)/) {
     ($fileschanged, $insertions, $deletions)=($1, $2, $3);
 }

--- a/scripts/delta
+++ b/scripts/delta
@@ -75,11 +75,7 @@ sub redir {
     if(!$hideerr) { while(<$err>) { print STDERR $_; }; }
     push @out, <$out>;
     waitpid($pid, 0);
-print "------------------\n";
-print join("\n", @out);
-print "------------------\n";
-exit 10;
-    return $out;
+    return @out;
 }
 
 # number of setops:
@@ -109,8 +105,8 @@ my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
 chomp $branch;
 # Number of files in git
 my $afiles=`git ls-files | wc -l`;
-my $deletes = length(redir('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
-my $creates = length(redir('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
+my $deletes = scalar(redir('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
+my $creates = scalar(redir('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 
 # Time since that tag
 my $tagged=`git for-each-ref --format="%(refname:short) | %(taggerdate:unix)" refs/tags/* | grep ^$start | cut '-d|' -f2`; # Unix timestamp

--- a/scripts/delta
+++ b/scripts/delta
@@ -64,7 +64,7 @@ my $commits = cmd('$', 'git', 'rev-list', '--count', "$start..");
 my $committers = scalar(cmd('git', 'shortlog', '-s', "$start.."));
 my $bcommitters = scalar(cmd('git', 'shortlog', '-s', $start));
 
-my $acommits = `git log --oneline | wc -l`;
+my $acommits = cmd('$', 'git', 'rev-list', '--count', 'HEAD');
 my $acommitters = `git shortlog -s | wc -l`;
 
 # delta from now compared to before

--- a/scripts/delta
+++ b/scripts/delta
@@ -60,7 +60,7 @@ sub cmd {
     return $as_string ? join('', @out) : @out;
 }
 
-my $commits = scalar(cmd('git', 'log', '--oneline', "$start.."));
+my $commits = cmd('$', 'git', 'rev-list', '--count', "$start..");
 my $committers = scalar(cmd('git', 'shortlog', '-s', "$start.."));
 my $bcommitters = scalar(cmd('git', 'shortlog', '-s', $start));
 

--- a/scripts/delta
+++ b/scripts/delta
@@ -102,7 +102,7 @@ sub setopts {
     close(H);
     return $opts;
 }
-my $asetopts = setopts('<', 'include/curl/curl.h');
+my $asetopts = setopts("<include/curl/curl.h");
 my $bsetopts = setopts('-|', 'git', 'show', "$start:include/curl/curl.h");
 my $nsetopts = $asetopts - $bsetopts;
 

--- a/scripts/delta
+++ b/scripts/delta
@@ -99,7 +99,7 @@ my $bsetopts = setopts('-|', 'git', 'show', "$start:include/curl/curl.h");
 my $nsetopts = $asetopts - $bsetopts;
 
 # Number of command line options:
-my $aoptions = cmd('$', '2>', 'grep', '-c', '{ *"....--', 'src/tool_listhelp.c');
+my $aoptions = cmd('$', '2>', 'git', 'grep', '-h', '-c', '{ *"....--', 'src/tool_listhelp.c');
 my $boptions = cmd('$', '2>', 'git', 'grep', '-h', '-c', '{ *"....--', "$start:src/tool_listhelp.c");
 my $noptions = $aoptions - $boptions;
 

--- a/scripts/delta
+++ b/scripts/delta
@@ -61,17 +61,17 @@ elsif($start eq "") {
 }
 
 my $commits = cmd('$', 'git', 'rev-list', '--count', "$start..");
-my $committers = scalar(cmd('git', 'shortlog', '-s', "$start.."));
-my $bcommitters = scalar(cmd('git', 'shortlog', '-s', $start));
+my $committers = cmd('git', 'shortlog', '-s', "$start..");
+my $bcommitters = cmd('git', 'shortlog', '-s', $start);
 
 my $acommits = cmd('$', 'git', 'rev-list', '--count', 'HEAD');
-my $acommitters = scalar(cmd('git', 'shortlog', '-s', 'HEAD'));
+my $acommitters = cmd('git', 'shortlog', '-s', 'HEAD');
 
 # delta from now compared to before
 my $ncommitters = $acommitters - $bcommitters;
 
 # number of contributors right now
-my $acontribs = scalar(cmd('./scripts/contrithanks.sh', 'stdout'));
+my $acontribs = cmd('./scripts/contrithanks.sh', 'stdout');
 # number when the tag was set
 my $bcontribs = cmd('$', 'git', 'grep', '-h', '-c', '^[^ ]', "$start:docs/THANKS");
 # delta
@@ -107,9 +107,9 @@ my $noptions = $aoptions - $boptions;
 my $branch = cmd('$', '2>', 'git', 'rev-parse', '--abbrev-ref', 'HEAD');
 chomp $branch;
 # Number of files in git
-my $afiles = scalar(cmd('git', 'ls-files'));
-my $deletes = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
-my $creates = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
+my $afiles = cmd('git', 'ls-files');
+my $deletes = cmd('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start);
+my $creates = cmd('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start);
 
 # Time since that tag
 sub tagstamp {
@@ -131,8 +131,8 @@ my $total = $now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
 my $totalhttpget = $now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
 
 # Number of public functions in libcurl
-my $apublic = scalar(cmd('git', 'grep', '^CURL_EXTERN', '--', 'include/curl'));
-my $bpublic = scalar(cmd('git', 'grep', '^CURL_EXTERN', $start, '--', 'include/curl'));
+my $apublic = cmd('git', 'grep', '^CURL_EXTERN', '--', 'include/curl');
+my $bpublic = cmd('git', 'grep', '^CURL_EXTERN', $start, '--', 'include/curl');
 my $public = $apublic - $bpublic;
 
 # diffstat

--- a/scripts/delta
+++ b/scripts/delta
@@ -39,8 +39,8 @@ use Time::Piece;
 
 sub cmd {
     my @out;
-    my $as_string = shift if($_[0] eq '$');
-    my $hideerr = shift if($_[0] eq '2>');
+    my $as_string = shift if($_[0] eq '$');  # return as string (vs. list of lines)
+    my $hideerr = shift if($_[0] eq '2>');  # 2>/dev/null
     my $pid = open3(my $in, my $out, $hideerr ? '>/dev/null' : '>&STDERR', @_);
     close $in;
     push @out, <$out>;

--- a/scripts/delta
+++ b/scripts/delta
@@ -80,8 +80,9 @@ sub redir {
 
 # number of setops:
 sub setopts {
+    my ($f)=@_;
     my $opts = 0;
-    if(open(H, @_)) {
+    if(open(H, $f)) {
         while(<H>) {
             if(/^  CURLOPT(|DEPRECATED)\(/ && ($_ !~ /OBSOLETE/)) {
                 $opts++;

--- a/scripts/delta
+++ b/scripts/delta
@@ -35,7 +35,6 @@ use warnings;
 
 use POSIX;
 use IPC::Open3;
-use Symbol 'gensym';
 use Time::Piece;
 
 my $start = $ARGV[0] || '';
@@ -53,8 +52,8 @@ sub cmd {
     my @out;
     my $as_string = shift if($_[0] eq '$');
     my $hideerr = shift if($_[0] =~ /^2>/);
-    my $pid = open3(my $in, my $out, my $err = gensym, @_);
-    if(!$hideerr) { while(<$err>) { print STDERR $_; }; }
+    my $pid = open3(my $in, my $out, $hideerr ? '>/dev/null' : '>&STDERR', @_);
+    close $in;
     push @out, <$out>;
     waitpid($pid, 0);
     return $as_string ? join('', @out) : @out;

--- a/scripts/delta
+++ b/scripts/delta
@@ -64,12 +64,21 @@ my $bcontribs = `git show $start:docs/THANKS | grep -c '^[^ ]'`;
 # delta
 my $contribs = $acontribs - $bcontribs;
 
-sub runstdout {
+sub run_stdout {
     my $command = shift;
     open(my $fh, '-|', $command, @_) or die;
-    my $content = do { local $/; <$fh> };
+    my $stdout = do { local $/; <$fh> };
     close($fh);
-    return $content;
+    return $stdout;
+}
+
+sub run_stdout_noerr {
+    my $command = shift;
+    my $stdout = '';
+    open(NULL, '>', File::Spec->devnull);
+    my $pid = open3($stdout, \*PH, '>&NULL', $command, @_);
+    while(<PH>) {}
+    waitpid($pid, 0);
 }
 
 # number of setops:
@@ -85,6 +94,12 @@ sub setopts {
     close(H);
     return $opts;
 }
+
+sub wc_l {
+    my ($content) = @_;
+    return scalar(split /\n/, $content);
+}
+
 my $asetopts = setopts("<include/curl/curl.h");
 my $bsetopts = setopts("git show $start:include/curl/curl.h|");
 my $nsetopts = $asetopts - $bsetopts;
@@ -99,8 +114,8 @@ my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
 chomp $branch;
 # Number of files in git
 my $afiles=`git ls-files | wc -l`;
-my $deletes=`git diff-tree --diff-filter=A -r --summary origin/$branch $start 2>/dev/null | wc -l`;
-my $creates=`git diff-tree --diff-filter=D -r --summary origin/$branch $start 2>/dev/null | wc -l`;
+my $deletes = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", "$start"));
+my $creates = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", "$start"));
 
 # Time since that tag
 my $tagged=`git for-each-ref --format="%(refname:short) | %(taggerdate:unix)" refs/tags/* | grep ^$start | cut '-d|' -f2`; # Unix timestamp

--- a/scripts/delta
+++ b/scripts/delta
@@ -37,17 +37,6 @@ use POSIX;
 use IPC::Open3;
 use Time::Piece;
 
-my $start = $ARGV[0] || '';
-
-if($start eq "-h") {
-    print "Usage: summary [tag]\n";
-    exit;
-}
-elsif($start eq "") {
-    $start = `git tag --sort=taggerdate | grep "^curl-" | tail -1`;
-    chomp $start;
-}
-
 sub cmd {
     my @out;
     my $as_string = shift if($_[0] eq '$');
@@ -57,6 +46,17 @@ sub cmd {
     push @out, <$out>;
     waitpid($pid, 0);
     return $as_string ? join('', @out) : @out;
+}
+
+my $start = $ARGV[0] || '';
+
+if($start eq "-h") {
+    print "Usage: summary [tag]\n";
+    exit;
+}
+elsif($start eq "") {
+    $start = `git tag --sort=taggerdate | grep "^curl-" | tail -1`;
+    chomp $start;
 }
 
 my $commits = cmd('$', 'git', 'rev-list', '--count', "$start..");

--- a/scripts/delta
+++ b/scripts/delta
@@ -55,7 +55,8 @@ if($start eq "-h") {
     exit;
 }
 elsif($start eq "") {
-    $start = `git tag --sort=taggerdate | grep "^curl-" | tail -1`;
+    my @tags = cmd('git', 'tag', '--sort=taggerdate', '--no-column', '--list', 'curl-*');
+    $start = $tags[-1];
     chomp $start;
 }
 

--- a/scripts/delta
+++ b/scripts/delta
@@ -138,7 +138,7 @@ my $public = $apublic - $bpublic;
 
 # diffstat
 my ($fileschanged, $insertions, $deletions);
-my @diffstat = redir('git', 'diff', '--stat', "$start..");
+my @diffstat = redir('2>', 'git', 'diff', '--stat', "$start..");
 my $diffstat = $diffstat[-1];
 if($diffstat =~ /^ *(\d+) files changed, (\d+) insertions\(\+\), (\d+)/) {
     ($fileschanged, $insertions, $deletions)=($1, $2, $3);

--- a/scripts/delta
+++ b/scripts/delta
@@ -108,7 +108,7 @@ my $nsetopts = $asetopts - $bsetopts;
 
 # Number of command line options:
 my $aoptions=`grep -c '{ *"....--' src/tool_listhelp.c`;
-my $boptions=`git show $start:src/tool_listhelp.c 2>/dev/null | grep -c '{ *"....--'`;
+my $boptions=`git grep -c '{ *"....--' $start:src/tool_listhelp.c 2>/dev/null`;
 my $noptions=$aoptions - $boptions;
 
 # current local branch

--- a/scripts/delta
+++ b/scripts/delta
@@ -35,7 +35,7 @@ use warnings;
 
 use POSIX;
 use IPC::Open3;
-use File::Spec;
+use Symbol 'gensym';
 use Time::Piece;
 
 my $start = $ARGV[0] || '';
@@ -66,22 +66,16 @@ my $bcontribs = `git show $start:docs/THANKS | grep -c '^[^ ]'`;
 # delta
 my $contribs = $acontribs - $bcontribs;
 
-open(NULL, '>', File::Spec->devnull);
-
-sub run_stdout {
-    my $command = shift;
-    open(my $fh, '-|', $command, @_) or die;
-    my $stdout = do { local $/; <$fh> };
-    close($fh);
-    return $stdout;
-}
-
-sub run_stdout_noerr {
-    my $command = shift;
-    my $in = '';
-    my $pid = open3($in, \*FH, '>&NULL', $command, @_);
-    my $stdout = do { local $/; <FH> };
+sub redir {
+    my @out;
+    my $outfn = shift if($_[0] =~ /^>/);
+    my $hideerr = shift if($_[0] =~ /^2>/);
+    open(my $outfd, $outfn) || die if($outfn);
+    my $pid = open3(my $in, my $out, my $err = gensym, @_);
+    if(!$hideerr) { while(<$err>) { print STDERR $_; }; }
+    push @out, <$out>;
     waitpid($pid, 0);
+    return $out;
 }
 
 sub wc_l {
@@ -91,15 +85,15 @@ sub wc_l {
 
 # number of setops:
 sub setopts {
-    my ($f)=@_;
-    open(H, $f);
-    my $opts;
-    while(<H>) {
-        if(/^  CURLOPT(|DEPRECATED)\(/ && ($_ !~ /OBSOLETE/)) {
-            $opts++;
+    my $opts = 0;
+    if(open(H, @_)) {
+        while(<H>) {
+            if(/^  CURLOPT(|DEPRECATED)\(/ && ($_ !~ /OBSOLETE/)) {
+                $opts++;
+            }
         }
+        close(H);
     }
-    close(H);
     return $opts;
 }
 my $asetopts = setopts("<include/curl/curl.h");
@@ -108,7 +102,7 @@ my $nsetopts = $asetopts - $bsetopts;
 
 # Number of command line options:
 my $aoptions=`grep -c '{ *"....--' src/tool_listhelp.c`;
-my $boptions=`git grep -c '{ *"....--' $start:src/tool_listhelp.c 2>/dev/null`;
+my $boptions=`git grep -h -c '{ *"....--' $start:src/tool_listhelp.c 2>/dev/null`;
 my $noptions=$aoptions - $boptions;
 
 # current local branch
@@ -116,8 +110,8 @@ my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
 chomp $branch;
 # Number of files in git
 my $afiles=`git ls-files | wc -l`;
-my $deletes = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
-my $creates = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
+my $deletes = wc_l(redir('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
+my $creates = wc_l(redir('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 
 # Time since that tag
 my $tagged=`git for-each-ref --format="%(refname:short) | %(taggerdate:unix)" refs/tags/* | grep ^$start | cut '-d|' -f2`; # Unix timestamp

--- a/scripts/delta
+++ b/scripts/delta
@@ -34,6 +34,8 @@ use strict;
 use warnings;
 
 use POSIX;
+use IPC::Open3;
+use File::Spec;
 use Time::Piece;
 
 my $start = $ARGV[0] || '';
@@ -64,6 +66,8 @@ my $bcontribs = `git show $start:docs/THANKS | grep -c '^[^ ]'`;
 # delta
 my $contribs = $acontribs - $bcontribs;
 
+open(NULL, '>', File::Spec->devnull);
+
 sub run_stdout {
     my $command = shift;
     open(my $fh, '-|', $command, @_) or die;
@@ -74,11 +78,15 @@ sub run_stdout {
 
 sub run_stdout_noerr {
     my $command = shift;
-    my $stdout = '';
-    open(NULL, '>', File::Spec->devnull);
-    my $pid = open3($stdout, \*PH, '>&NULL', $command, @_);
-    while(<PH>) {}
+    my $in = '';
+    my $pid = open3($in, \*FH, '>&NULL', $command, @_);
+    my $stdout = do { local $/; <FH> };
     waitpid($pid, 0);
+}
+
+sub wc_l {
+    my ($content) = @_;
+    return scalar(split /\n/, $content);
 }
 
 # number of setops:
@@ -94,12 +102,6 @@ sub setopts {
     close(H);
     return $opts;
 }
-
-sub wc_l {
-    my ($content) = @_;
-    return scalar(split /\n/, $content);
-}
-
 my $asetopts = setopts("<include/curl/curl.h");
 my $bsetopts = setopts("git show $start:include/curl/curl.h|");
 my $nsetopts = $asetopts - $bsetopts;

--- a/scripts/delta
+++ b/scripts/delta
@@ -102,8 +102,8 @@ sub setopts {
     close(H);
     return $opts;
 }
-my $asetopts = setopts("<include/curl/curl.h");
-my $bsetopts = setopts("git show $start:include/curl/curl.h|");
+my $asetopts = setopts('<', 'include/curl/curl.h');
+my $bsetopts = setopts('-|', 'git', 'show', "$start:include/curl/curl.h");
 my $nsetopts = $asetopts - $bsetopts;
 
 # Number of command line options:

--- a/scripts/delta
+++ b/scripts/delta
@@ -51,7 +51,7 @@ elsif($start eq "") {
 sub cmd {
     my @out;
     my $as_string = shift if($_[0] eq '$');
-    my $hideerr = shift if($_[0] =~ /^2>/);
+    my $hideerr = shift if($_[0] eq '2>');
     my $pid = open3(my $in, my $out, $hideerr ? '>/dev/null' : '>&STDERR', @_);
     close $in;
     push @out, <$out>;

--- a/scripts/delta
+++ b/scripts/delta
@@ -56,7 +56,7 @@ if($start eq "-h") {
 }
 elsif($start eq "") {
     my @tags = cmd('git', 'tag', '--sort=taggerdate', '--no-column', '--list', 'curl-*');
-    $start = $tags[-1];
+    $start = $tags[-1];  # latest tag
     chomp $start;
 }
 

--- a/scripts/delta
+++ b/scripts/delta
@@ -114,9 +114,8 @@ my $creates = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--s
 # Time since that tag
 sub tagstamp {
     my $col = shift;
-    my $q = qr/^$start /;
     foreach my $line (@_) {
-        if($line =~ /$q/) {
+        if(index($line, "$start ") == 0) {
             my @cols = split(/\|/, $line);
             return $cols[$col - 1];
         }

--- a/scripts/delta
+++ b/scripts/delta
@@ -116,8 +116,8 @@ my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
 chomp $branch;
 # Number of files in git
 my $afiles=`git ls-files | wc -l`;
-my $deletes = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", "$start"));
-my $creates = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", "$start"));
+my $deletes = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
+my $creates = wc_l(run_stdout_noerr('git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 
 # Time since that tag
 my $tagged=`git for-each-ref --format="%(refname:short) | %(taggerdate:unix)" refs/tags/* | grep ^$start | cut '-d|' -f2`; # Unix timestamp

--- a/scripts/delta
+++ b/scripts/delta
@@ -104,10 +104,10 @@ my $boptions = cmd('$', '2>', 'git', 'grep', '-h', '-c', '{ *"....--', "$start:s
 my $noptions = $aoptions - $boptions;
 
 # current local branch
-my $branch=`git rev-parse --abbrev-ref HEAD 2>/dev/null`;
+my $branch = `git rev-parse --abbrev-ref HEAD 2>/dev/null`;
 chomp $branch;
 # Number of files in git
-my $afiles=`git ls-files | wc -l`;
+my $afiles = `git ls-files | wc -l`;
 my $deletes = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
 my $creates = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 
@@ -125,10 +125,10 @@ my @tagged = cmd('git', 'for-each-ref', '--format=%(refname:short) | %(taggerdat
 my $tagged = tagstamp(2, @tagged); # Unix timestamp
 my $taggednice = tagstamp(3, @tagged); # human readable time
 chomp $taggednice;
-my $now=POSIX::strftime("%s", localtime());
-my $elapsed=$now - $tagged; # number of seconds since tag
-my $total=$now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
-my $totalhttpget=$now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
+my $now = POSIX::strftime("%s", localtime());
+my $elapsed = $now - $tagged; # number of seconds since tag
+my $total = $now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
+my $totalhttpget = $now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
 
 # Number of public functions in libcurl
 my $apublic = scalar(cmd('git', 'grep', '^CURL_EXTERN', '--', 'include/curl'));

--- a/scripts/delta
+++ b/scripts/delta
@@ -65,13 +65,13 @@ my $committers = scalar(cmd('git', 'shortlog', '-s', "$start.."));
 my $bcommitters = scalar(cmd('git', 'shortlog', '-s', $start));
 
 my $acommits = cmd('$', 'git', 'rev-list', '--count', 'HEAD');
-my $acommitters = `git shortlog -s | wc -l`;
+my $acommitters = cmd('git', 'shortlog', '-s', 'HEAD');
 
 # delta from now compared to before
 my $ncommitters = $acommitters - $bcommitters;
 
 # number of contributors right now
-my $acontribs = `./scripts/contrithanks.sh stdout | wc -l`;
+my $acontribs = scalar(cmd('./scripts/contrithanks.sh', 'stdout'));
 # number when the tag was set
 my $bcontribs = cmd('$', 'git', 'grep', '-h', '-c', '^[^ ]', "$start:docs/THANKS");
 # delta
@@ -104,10 +104,10 @@ my $boptions = cmd('$', '2>', 'git', 'grep', '-h', '-c', '{ *"....--', "$start:s
 my $noptions = $aoptions - $boptions;
 
 # current local branch
-my $branch = `git rev-parse --abbrev-ref HEAD 2>/dev/null`;
+my $branch = cmd('$', '2>', 'git', 'rev-parse', '--abbrev-ref', 'HEAD');
 chomp $branch;
 # Number of files in git
-my $afiles = `git ls-files | wc -l`;
+my $afiles = scalar(cmd('git', 'ls-files'));
 my $deletes = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=A', '-r', '--summary', "origin/$branch", $start));
 my $creates = scalar(cmd('2>', 'git', 'diff-tree', '--diff-filter=D', '-r', '--summary', "origin/$branch", $start));
 

--- a/scripts/delta
+++ b/scripts/delta
@@ -80,9 +80,9 @@ sub redir {
 
 # number of setops:
 sub setopts {
-    my ($f)=@_;
+    my $mode = shift;
     my $opts = 0;
-    if(open(H, $f)) {
+    if(open(H, $mode, @_)) {
         while(<H>) {
             if(/^  CURLOPT(|DEPRECATED)\(/ && ($_ !~ /OBSOLETE/)) {
                 $opts++;
@@ -90,9 +90,12 @@ sub setopts {
         }
         close(H);
     }
+    else {
+        die join(' ', @_) . ": $!\n";
+    }
     return $opts;
 }
-my $asetopts = setopts("<include/curl/curl.h");
+my $asetopts = setopts('<', 'include/curl/curl.h');
 my $bsetopts = setopts('-|', 'git', 'show', "$start:include/curl/curl.h");
 my $nsetopts = $asetopts - $bsetopts;
 

--- a/scripts/delta
+++ b/scripts/delta
@@ -65,7 +65,7 @@ my $committers = scalar(cmd('git', 'shortlog', '-s', "$start.."));
 my $bcommitters = scalar(cmd('git', 'shortlog', '-s', $start));
 
 my $acommits = cmd('$', 'git', 'rev-list', '--count', 'HEAD');
-my $acommitters = cmd('git', 'shortlog', '-s', 'HEAD');
+my $acommitters = scalar(cmd('git', 'shortlog', '-s', 'HEAD'));
 
 # delta from now compared to before
 my $ncommitters = $acommitters - $bcommitters;

--- a/scripts/delta
+++ b/scripts/delta
@@ -60,9 +60,9 @@ sub redir {
     return $as_string ? join('', @out) : @out;
 }
 
-my $commits = `git log --oneline $start.. | wc -l`;
-my $committers = `git shortlog -s $start.. | wc -l`;
-my $bcommitters = `git shortlog -s $start | wc -l`;
+my $commits = scalar(redir('git', 'log', '--oneline', "$start.."));
+my $committers = scalar(redir('git', 'shortlog', '-s', "$start.."));
+my $bcommitters = scalar(redir('git', 'shortlog', '-s', $start));
 
 my $acommits = `git log --oneline | wc -l`;
 my $acommitters = `git shortlog -s | wc -l`;


### PR DESCRIPTION
By moving operations Perl-native (from shell and external commands), and
passing arguments individually to external commands.

Pointed out by Codex Security

---

https://github.com/curl/curl/pull/21104/files?w=1

- [x] figure out why Open3() hangs while reading stdout if it exceeds 64KiB.
  (not an issue in commands using it, but still.)
  https://metacpan.org/pod/IPC::Open3
