### PR TITLE
GHA/curl-for-win: pass GH token to the containers

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -32,6 +32,7 @@ concurrency:
 permissions: {}
 
 env:
+  GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
   CW_NOGET: 'curl trurl'
   CW_MAP: '0'
   CW_JOBS: '5'


### PR DESCRIPTION
To avoid rate limits when accessing GH APIs during the build.

Aiming to avoid (while trying to retrieve a file timestamp):
```
++ [[ 2026-02-11-1a84aee6387d2f9c9531c655edeea4a80aa0fcfa =~ (.+)-([a-f0-9]{40,}) ]]
++ ver=2026-02-11
++ commit=1a84aee6387d2f9c9531c655edeea4a80aa0fcfa
++ set +x
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
curl: (22) The requested URL returned error: 403
[...]
```
Ref: https://github.com/curl/curl/actions/runs/23598912140/job/68723120977?pr=21104

Follow-up to:
https://github.com/curl/curl-for-win/commit/a26898fe489e2721b709d1eebc3b5e95c7332417
https://github.com/curl/curl-for-win/commit/17f2fb3ead747d375ea1d6c08e649efd17017c8b
https://github.com/curl/curl-for-win/commit/6dd6e47e9876ffe615544977ff6cfd684e6d421b
https://github.com/curl/curl-for-win/commit/b461404b5a800bcfebe34d524d9c6a32bc08b9a5
