### PR TITLE
request: reset resp_trailer in new requests

### DIFF
--- a/lib/request.c
+++ b/lib/request.c
@@ -153,6 +153,7 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->ignorebody = FALSE;
   req->http_bodyless = FALSE;
   req->chunk = FALSE;
+  req->resp_trailer = FALSE;
   req->ignore_cl = FALSE;
   req->upload_chunky = FALSE;
   req->no_body = data->set.opt_no_body;


### PR DESCRIPTION
Otherwise the trailer state lingers on into subsequent requests.

Follow-up to 29610e5f3d0c9f2643e09

Spotted by Codex Security