### PR TITLE
mk-ca-bundle.pl: drop reproducible timestamp feature

### DIFF
--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -37,7 +37,7 @@ use Getopt::Std;
 use MIME::Base64;
 use strict;
 use warnings;
-use vars qw($opt_b $opt_d $opt_f $opt_h $opt_i $opt_k $opt_l $opt_m $opt_n $opt_p $opt_q $opt_r $opt_s $opt_t $opt_u $opt_v $opt_w);
+use vars qw($opt_b $opt_d $opt_f $opt_h $opt_i $opt_k $opt_l $opt_m $opt_n $opt_p $opt_q $opt_s $opt_t $opt_u $opt_v $opt_w);
 use List::Util;
 use Text::Wrap;
 use Time::Local;
@@ -110,7 +110,7 @@ my @valid_signature_algorithms = (
 
 $0 =~ s@.*(/|\\)@@;
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
-getopts('bd:fhiklmnp:qrs:tuvw:');
+getopts('bd:fhiklmnp:qs:tuvw:');
 
 if(!defined($opt_d)) {
     # to make plain "-d" use not cause warnings, and actually still work
@@ -181,7 +181,6 @@ sub HELP_MESSAGE() {
     print "\t\t  Valid levels are:\n";
     print wrap("\t\t    ","\t\t    ", join(", ", "ALL", @valid_mozilla_trust_levels)), "\n";
     print "\t-q\tbe really quiet (no progress output at all)\n";
-    print "\t-r\treproducible output\n";
     print wrap("\t","\t\t", "-s\tcomma separated list of certificate signatures/hashes to output in plain text mode. (default: $default_signature_algorithms)\n");
     print "\t\t  Valid signature algorithms are:\n";
     print wrap("\t\t    ","\t\t    ", join(", ", "ALL", @valid_signature_algorithms)), "\n";
@@ -308,29 +307,6 @@ my $filedate_iso = '';
 
 if(!$opt_n) {
     report "Using URL: $url";
-
-    if($opt_r && $opt_d ne 'ref') {
-        report "Determining latest commit and timestamp for the remote file ...";
-
-        my $out = '';
-        # https://raw.githubusercontent.com/mozilla-firefox/firefox/refs/heads/autoland/security/nss/lib/ckfw/builtins/certdata.txt
-        if($url =~ /^https:\/\/raw.githubusercontent.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)\/(refs\/heads\/[a-z]+)(\/.+)$/) {
-            my $slug = $1;
-            my $refs = "&sha=$2";
-            my $path = $3;
-            if(open(my $fh, '-|', 'curl', '-A', 'curl', '-H', 'X-GitHub-Api-Version: 2022-11-28',
-                                          "https://api.github.com/repos/mozilla-firefox/firefox/commits?path=$path$refs")) {
-                $out = do { local $/; <$fh> };
-                close $fh;
-            }
-            if($out) {
-                use JSON::PP;
-                my $json = decode_json($out);
-                $filedate_iso = $json->[0]->{commit}->{committer}->{date};
-            }
-        }
-    }
-
     report "Downloading $txt ...";
 
     # If we have an HTTPS URL then use curl


### PR DESCRIPTION
Mozilla may push to its repo much later than the commit date, which can
be a source of confusion when using the reproducible timestamp (which is
determined by the commit date) by default. Example:

https://curl.se/ca/cacert-2026-03-19.pem vs.
https://github.com/mozilla-firefox/firefox/commits/1a84aee6387d2f9c9531c655edeea4a80aa0fcfa/security/nss/lib/ckfw/builtins/certdata.txt

This feature had no actual user (or a planned one) from within curl at
the moment, and not requested by curl users. curl-for-win does this on
its own, which is the more practical way there since everything (not
just the CA bundle) needs to be reproducible anyway. I surmise this may
be true for most if not all reproducible use-cases.

Another limitation was that it could bump into GitHub's rate limiting,
needing further updates.

Also: code had some unintented leftovers.

Reported-by: Daniel Stenberg
Bug: https://github.com/curl/curl/pull/20528#issuecomment-4140610008
Follow-up to ca92e20123928e4788d27135cdafdd084d3833d4 #20528

---

An alternative is to just delete this capability. 

Another limitation of this feature is that it may bump into GitHub's
rate limiting, unless adding support to forward a token to the API call.
(I run into this in CI in context of curl-for-win just yesterday.)
