### PR TITLE
openssl: fix build with 4.0.0-beta1 no-deprecated

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4234,8 +4234,12 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
       reason = ERR_GET_REASON(errdetail);
 
       if((lib == ERR_LIB_SSL) &&
-         ((reason == SSL_R_CERTIFICATE_VERIFY_FAILED) ||
-          (reason == SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED))) {
+         ((reason == SSL_R_CERTIFICATE_VERIFY_FAILED)
+/* Missing from OpenSSL 4+ OPENSSL_NO_DEPRECATED_3_0 builds */
+#ifdef SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED
+          || (reason == SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED)
+#endif
+         )) {
         result = CURLE_PEER_FAILED_VERIFICATION;
 
         lerr = SSL_get_verify_result(octx->ssl);


### PR DESCRIPTION
```
lib/vtls/openssl.c:4238:22: error: ‘SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED’ undeclared (first use in this function); did you mean ‘SSL_R_TLS_ALERT_CERTIFICATE_EXPIRED’?
 4238 |           (reason == SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED))) {
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                      SSL_R_TLS_ALERT_CERTIFICATE_EXPIRED
lib/vtls/openssl.c:4238:22: note: each undeclared identifier is reported only once for each function it appears in
```
Ref: https://github.com/curl/curl/actions/runs/23641366299/job/68863072427#step:24:189

Cherry-picked from #21118
