### PR TITLE
multi: fix connection retry for non-http

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1955,6 +1955,12 @@ static CURLcode multi_follow(struct Curl_easy *data,
 {
   if(handler && handler->run->follow)
     return handler->run->follow(data, newurl, type);
+
+  if(type == FOLLOW_RETRY)
+    /* Retries are generic and do not require protocol-specific redirect
+       handling. */
+    return CURLE_OK;
+
   return CURLE_TOO_MANY_REDIRECTS;
 }
 


### PR DESCRIPTION
non-HTTP protocols no longer retry after connection reuse failures because multi_follow() now requires a handler->follow callback that is NULL for those protocols. Provide a fallback for plain retries.

Follow-up to 1213c312722f93b7856d2

Spotted by Codex Security