### PR TITLE
libssh: propagate error back in SFTP function

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -519,8 +519,10 @@ static int myssh_in_SFTP_READDIR_BOTTOM(struct Curl_easy *data,
   ssh_string_free_char(sshc->readdir_tmp);
   sshc->readdir_tmp = NULL;
 
-  if(result)
+  if(result) {
     myssh_to(data, sshc, SSH_STOP);
+    sshc->actualcode = result;
+  }
   else
     myssh_to(data, sshc, SSH_SFTP_READDIR);
   return SSH_NO_ERROR;


### PR DESCRIPTION
The myssh_in_SFTP_READDIR_BOTTOM() function would not store the error code correctly thus it could be ignored and missed when an error was returned at that particular moment.

Follow-up to 3c26e6a896247ccf872d3f1

Found by Codex Security