### PR TITLE
tool_util: fix the ftruncate use for DJGPP

### DIFF
--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -105,7 +105,8 @@ int msdos_ftruncate(int fd, curl_off_t where)
   if(where > INT_MAX)
     return -1;
 
-  return ftruncate(fd, (off_t) where);
+  /* avoid using the macro for this */
+  return (ftruncate)(fd, (off_t) where);
 }
 #endif /* USE_MSDOS_FTRUNCATE */
 


### PR DESCRIPTION
Follow-up to 6041b9b11b904c64305eb6c3f4

Since we define ftruncate as a macro, we can't use the macro within the function!