### PR TITLE
boringssl: fix more coexist cases with Schannel/WinCrypt

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -29,39 +29,6 @@
 
 #if defined(USE_QUICHE) || defined(USE_OPENSSL)
 
-#ifdef USE_WIN32_CRYPTO
-#include <wincrypt.h>
-/* If <wincrypt.h> is included directly, or indirectly via <schannel.h>,
- * <winldap.h>, <iphlpapi.h>, or something else, <wincrypt.h> does this:
- *   #define X509_NAME  ((LPCSTR)7)
- *
- * In BoringSSL/AWC-LC's <openssl/base.h> there is:
- *  typedef struct X509_name_st X509_NAME;
- *  etc.
- *
- * The redefined symbols break these OpenSSL headers when included after
- * <wincrypt.h>.
- * The workaround is to undefine those defines here (and only here).
- *
- * For unity builds it may need to be repeated elsewhere too, e.g. in ldap.c,
- * to apply to other sources using OpenSSL includes. Each compilation unit
- * needs undefine them between the first <wincrypt.h> include and the first
- * OpenSSL include.
- *
- * OpenSSL does this in <openssl/ssl.h> and <openssl/x509v3.h>, but it
- * also does the #undef by including <openssl/ossl_typ.h>. <3.1.0 only does
- * it on the first include.
- *
- * LibreSSL automatically undefines these symbols before using them.
- */
-#undef X509_NAME
-#undef X509_EXTENSIONS
-#undef PKCS7_ISSUER_AND_SERIAL
-#undef PKCS7_SIGNER_INFO
-#undef OCSP_REQUEST
-#undef OCSP_RESPONSE
-#endif
-
 #include "urldata.h"
 #include "curl_trc.h"
 #include "httpsrr.h"

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -26,6 +26,40 @@
 #include "curl_setup.h"
 
 #ifdef USE_OPENSSL
+
+#ifdef USE_WIN32_CRYPTO
+#include <wincrypt.h>
+/* If <wincrypt.h> is included directly, or indirectly via <schannel.h>,
+ * <winldap.h>, <iphlpapi.h>, or something else, <wincrypt.h> does this:
+ *   #define X509_NAME  ((LPCSTR)7)
+ *
+ * In BoringSSL/AWC-LC's <openssl/base.h> there is:
+ *  typedef struct X509_name_st X509_NAME;
+ *  etc.
+ *
+ * The redefined symbols break these OpenSSL headers when included after
+ * <wincrypt.h>.
+ * The workaround is to undefine those defines here (and only here).
+ *
+ * For unity builds it may need to be repeated elsewhere too, e.g. in ldap.c,
+ * to apply to other sources using OpenSSL includes. Each compilation unit
+ * needs undefine them between the first <wincrypt.h> include and the first
+ * OpenSSL include.
+ *
+ * OpenSSL does this in <openssl/ssl.h> and <openssl/x509v3.h>, but it
+ * also does the #undef by including <openssl/ossl_typ.h>. <3.1.0 only does
+ * it on the first include.
+ *
+ * LibreSSL automatically undefines these symbols before using them.
+ */
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef PKCS7_SIGNER_INFO
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+#endif /* USE_WIN32_CRYPTO */
+
 /*
  * This header should only be needed to get included by vtls.c, openssl.c
  * and ngtcp2.c


### PR DESCRIPTION
By moving the coexist workaround from vtls/openssl.c to vtls/openssl.h.
This way it also applies to vtls.c (and possibly other sources including
`vtls/openssl.h`), which may need it in unity builds before BoringSSL 
header `openssl/ssl.h` pulling in the conflicting symbols and causing
conflicts otherwise.

Seen with build config:
```
-DCURL_USE_SCHANNEL=ON -DCURL_USE_OPENSSL=ON
-DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=30
```

Fixing:
```
In file included from _cm-win-boringssl/lib/CMakeFiles/libcurl_object.dir/Unity/unity_5_c.c:7:
In file included from lib/vtls/vtls.c:54:
In file included from lib/vtls/openssl.h:33:
In file included from /path/to/boringssl/_x64-win-ucrt/usr/include/openssl/opensslv.h:18:
In file included from /path/to/boringssl/_x64-win-ucrt/usr/include/openssl/crypto.h:18:
/path/to/boringssl/_x64-win-ucrt/usr/include/openssl/base.h:293:29: error: expected ')'
  293 | typedef struct X509_name_st X509_NAME;
      |                             ^
/path/to/llvm-mingw/x86_64-w64-mingw32/include/wincrypt.h:1515:29: note: expanded from macro 'X509_NAME'
 1515 | #define X509_NAME ((LPCSTR) 7)
      |                             ^
[...]
```

Ref: 2a92c39a218713635768364f801fa13831a019e0 #20567
