### PR TITLE
configure: remove superfluous experimental warning for HTTP/3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3655,7 +3655,6 @@ dnl **********************************************************************
 
 if test "$USE_NGTCP2" = "1" && test "$USE_NGHTTP3" = "1"; then
   USE_NGTCP2_H3=1
-  AC_MSG_NOTICE([HTTP3 support is experimental])
   curl_h3_msg="enabled (ngtcp2 + nghttp3)"
 fi
 


### PR DESCRIPTION
This warning was created at a time when all backends for HTTP/3 were experimental. Since there are now non-experimental backends this warning is incorrect in some cases and was already handled by backends that were added to the experimental list.

Follow-up to 0535f6ec71cf950d7ad412b19ed706fcc7e4a7a9