### PR TITLE
keylog.h: replace literal number with macro in declaration

### DIFF
--- a/lib/vtls/keylog.h
+++ b/lib/vtls/keylog.h
@@ -57,8 +57,8 @@ bool Curl_tls_keylog_enabled(void);
  * Returns true iff the key log file is open and a valid entry was provided.
  */
 bool Curl_tls_keylog_write(const char *label,
-                           const unsigned char client_random[32],
-                           const unsigned char *secret, size_t secretlen);
+                         const unsigned char client_random[CLIENT_RANDOM_SIZE],
+                         const unsigned char *secret, size_t secretlen);
 
 /*
  * Appends a line to the key log file, ensure it is terminated by an LF.


### PR DESCRIPTION
Also syncing with the defintion already doing this.