### PR TITLE
tool_operate: actually apply the --parallel-max-host limit

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1881,6 +1881,8 @@ static CURLcode parallel_transfers(CURLSH *share)
 #endif
   (void)curl_multi_setopt(s->multi, CURLMOPT_NOTIFYFUNCTION, mnotify);
   (void)curl_multi_setopt(s->multi, CURLMOPT_NOTIFYDATA, s);
+  (void)curl_multi_setopt(s->multi, CURLMOPT_MAX_HOST_CONNECTIONS, (long)
+                          global->parallel_host);
   (void)curl_multi_notify_enable(s->multi, CURLMNOTIFY_INFO_READ);
 
   result = add_parallel_transfers(s->multi, s->share,


### PR DESCRIPTION
It was wrongly previously only used in debug code for event based transfer and not in the "normal" parallel transfer case.

Follow-up to 4654493fedfccbae18bd9c