### PR TITLE
Flag test 766 as timing-dependent

### DIFF
--- a/tests/data/test766
+++ b/tests/data/test766
@@ -5,6 +5,7 @@
 FTP
 PORT
 CURLOPT_SOCKOPTFUNCTION
+timing-dependent
 </keywords>
 </info>
 


### PR DESCRIPTION
 We have noticed this test as failing when run in parallel in Fedora and
 Amazon Linux:
 https://src.fedoraproject.org/rpms/curl/c/389f1409549178f639afa49f478c544fdaa87be2?branch=rawhide

 Debian did not have issues but given there are other FTP tests flagged
 as timing-dependent, it makes sense to flag this one too if we notice
 failures in other OSes.