### PR TITLE
socks: add assertion for hostname length in SOCKS5 connect

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -808,6 +808,10 @@ static CURLproxycode socks5_req1_init(struct socks_state *sx,
   }
   else {
     const size_t hostname_len = strlen(sx->hostname);
+    /* socks5_req0_init() already rejects hostnames longer than 255 bytes,
+       so this cast to unsigned char is safe. Assert to guard against future
+       refactoring that might remove or reorder that earlier check. */
+    DEBUGASSERT(hostname_len <= 255);
     desttype = 3;
     destination = (const unsigned char *)sx->hostname;
     destlen = (unsigned char)hostname_len; /* one byte length */


### PR DESCRIPTION
The hostname length is validated against 255 in `socks5_req0_init()` (line 607) before `socks5_req1_init()` casts it to `unsigned char` (line 813). The cast is safe because of the earlier check, but there is no     
  local indication of this dependency.                                                                                                                                                                                   
   
  Add a `DEBUGASSERT(hostname_len <= 255)` to document the invariant and catch any future refactoring that might remove the earlier check.                                                                               
                                                                  
  Ref: HackerOne report [3636044](https://hackerone.com/reports/3636044)