### PR TITLE
build: drop redundant `HAVE_PTHREAD_H` guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,7 +646,6 @@ endif()
 if(NOT WIN32)
   find_package(Threads)
   set(HAVE_THREADS_POSIX ${CMAKE_USE_PTHREADS_INIT})
-  set(HAVE_PTHREAD_H ${CMAKE_USE_PTHREADS_INIT})
   list(APPEND CURL_NETWORK_AND_TIME_LIBS ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
@@ -2032,7 +2031,7 @@ curl_add_if("HTTPS-proxy"   NOT CURL_DISABLE_PROXY AND _ssl_enabled AND (USE_OPE
                             OR USE_SCHANNEL OR USE_RUSTLS OR USE_MBEDTLS OR
                             (USE_WOLFSSL AND HAVE_WOLFSSL_BIO_NEW)))
 curl_add_if("Unicode"       ENABLE_UNICODE)
-curl_add_if("threadsafe"    HAVE_ATOMIC OR (HAVE_THREADS_POSIX AND HAVE_PTHREAD_H) OR WIN32)
+curl_add_if("threadsafe"    HAVE_ATOMIC OR HAVE_THREADS_POSIX OR WIN32)
 curl_add_if("Debug"         ENABLE_DEBUG)
 curl_add_if("ECH"           _ssl_enabled AND HAVE_ECH)
 curl_add_if("HTTPSRR"       _ssl_enabled AND USE_HTTPSRR)

--- a/configure.ac
+++ b/configure.ac
@@ -4193,7 +4193,7 @@ fi
 dnl detect pthreads
 if test "$curl_cv_native_windows" != "yes"; then
   AC_CHECK_HEADER(pthread.h,
-    [ AC_DEFINE(HAVE_PTHREAD_H, 1, [if you have <pthread.h>])
+    [
       save_CFLAGS="$CFLAGS"
       dnl When statically linking against BoringSSL, -lpthread is added to LIBS.
       dnl Make sure to that this does not pass the check below, we really want

--- a/docs/examples/threaded.c
+++ b/docs/examples/threaded.c
@@ -35,7 +35,7 @@
  * https://github.com/curl/curl/blob/curl-7_88_1/docs/examples/threaded-ssl.c
  */
 
-/* Requires: HAVE_PTHREAD_H */
+/* Requires: HAVE_THREADS_POSIX */
 /* Also requires TLS support to run */
 
 #include <stdio.h>

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -135,9 +135,6 @@
 /* Define to 1 if you have the 'pipe' function. */
 #define HAVE_PIPE               1
 
-/* if you have <pthread.h> */
-#define HAVE_PTHREAD_H          1
-
 /* Define to 1 if you have the <pwd.h> header file. */
 #define HAVE_PWD_H              1
 

--- a/lib/curl_config-cmake.h.in
+++ b/lib/curl_config-cmake.h.in
@@ -442,9 +442,6 @@
 /* Define to 1 if you have a working POSIX-style strerror_r function. */
 #cmakedefine HAVE_POSIX_STRERROR_R 1
 
-/* Define to 1 if you have the <pthread.h> header file */
-#cmakedefine HAVE_PTHREAD_H 1
-
 /* Define to 1 if you have the <pwd.h> header file. */
 #cmakedefine HAVE_PWD_H 1
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -220,7 +220,7 @@
 /* ================================================================ */
 
 /* Give calloc a chance to be dragging in early, so we do not redefine */
-#if defined(HAVE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
+#ifdef HAVE_THREADS_POSIX
 #  include <pthread.h>
 #endif
 

--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -84,7 +84,7 @@ static CURL_INLINE void curl_simple_lock_unlock(curl_simple_lock *lock)
   atomic_store_explicit(lock, false, memory_order_release);
 }
 
-#elif defined(HAVE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
+#elif defined(HAVE_THREADS_POSIX)
 
 #define curl_simple_lock           pthread_mutex_t
 #define CURL_SIMPLE_LOCK_INIT      PTHREAD_MUTEX_INITIALIZER

--- a/tests/libtest/lib1565.c
+++ b/tests/libtest/lib1565.c
@@ -23,7 +23,7 @@
  ***************************************************************************/
 #include "first.h"
 
-#ifdef HAVE_PTHREAD_H
+#ifdef HAVE_THREADS_POSIX
 
 #define CONN_NUM                3
 #define TIME_BETWEEN_START_SECS 2

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -84,7 +84,7 @@ cleanup:
   return result;
 }
 
-#elif defined(HAVE_PTHREAD_H)
+#elif defined(HAVE_THREADS_POSIX)
 
 static void *t3026_run_thread(void *ptr)
 {


### PR DESCRIPTION
Prior to this patch code used either `HAVE_PTHREAD_H`, or
`HAVE_THREADS_POSIX`, or both, to decide if POSIX Threads support is
present. In effect requiring both to be defined for a consistent build.

Drop detecting and guarding for `pthread.h`, and assume it present when
`HAVE_THREADS_POSIX` is set.

OS/400 had `HAVE_PTHREAD_H` set, but not `HAVE_THREADS_POSIX`, which
possibly left threading disabled in most sources.

Ref: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/pthread.h.html
Ref: 930f2e822715d4602326d549e5a8085ee8c3ec11 #21144
