### PR TITLE
socks: reject zero-length GSSAPI/SSPI tokens from proxy

### DIFF
--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -266,6 +266,13 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     memcpy(&us_length, socksreq + 2, sizeof(short));
     us_length = ntohs(us_length);
 
+    if(!us_length) {
+      failf(data, "Invalid zero-length GSS-API authentication token.");
+      gss_release_name(&gss_status, &server);
+      Curl_gss_delete_sec_context(&gss_status, &gss_context, NULL);
+      return CURLE_COULDNT_CONNECT;
+    }
+
     gss_recv_token.length = us_length;
     gss_recv_token.value = curlx_malloc(gss_recv_token.length);
     if(!gss_recv_token.value) {
@@ -452,6 +459,12 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
 
   memcpy(&us_length, socksreq + 2, sizeof(short));
   us_length = ntohs(us_length);
+
+  if(!us_length) {
+    failf(data, "Invalid zero-length GSS-API encryption token.");
+    Curl_gss_delete_sec_context(&gss_status, &gss_context, NULL);
+    return CURLE_COULDNT_CONNECT;
+  }
 
   gss_recv_token.length = us_length;
   gss_recv_token.value = curlx_malloc(gss_recv_token.length);

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -223,6 +223,11 @@ static CURLcode socks5_sspi_loop(struct Curl_cfilter *cf,
     memcpy(&us_length, socksreq + 2, sizeof(short));
     us_length = ntohs(us_length);
 
+    if(!us_length) {
+      failf(data, "Invalid zero-length SSPI authentication token.");
+      return CURLE_COULDNT_CONNECT;
+    }
+
     sspi_recv_token.cbBuffer = us_length;
     sspi_recv_token.pvBuffer = curlx_malloc(us_length);
 
@@ -399,6 +404,11 @@ static CURLcode socks5_sspi_encrypt(struct Curl_cfilter *cf,
 
   memcpy(&us_length, socksreq + 2, sizeof(short));
   us_length = ntohs(us_length);
+
+  if(!us_length) {
+    failf(data, "Invalid zero-length SSPI encryption token.");
+    return CURLE_COULDNT_CONNECT;
+  }
 
   sspi_w_token[0].cbBuffer = us_length;
   sspi_w_token[0].pvBuffer = curlx_malloc(us_length);


### PR DESCRIPTION
A "broken" SOCKS5 proxy can send an invalid length of the encryption token, which could cause malloc(0) to be called, which is a "platform can do what it wants" potential problem.

Resolve this by explicitly checking the length and rejecting the invalid token before ever attempting to allocate any memory.