### PR TITLE
m4/curl-wolfssl.m4: fix build with older wolfSSL

### DIFF
--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -127,6 +127,9 @@ if test "$OPT_WOLFSSL" != "no"; then
       AC_MSG_NOTICE([detected wolfSSL])
       check_for_ca_bundle=1
 
+      dnl wolfssl/wolfcrypt/types.h needs SIZEOF_LONG_LONG defined!
+      CURL_SIZEOF(long long)
+
       LIBS="$addlib $LIBS"
 
       dnl is this wolfSSL providing the original QUIC API?


### PR DESCRIPTION
Commit 0159100f4f78 ("lib: use (u)int64_t instead of long long") removed definition of SIZEOF_LONG_LONG for wolfSSL. This breaks autotools build for wolfSSL version 5.7.2 at least:

In file included from .../arm-buildroot-linux-gnueabi/sysroot/usr/include/wolfssl/wolfcrypt/hash.h:29,
                 from .../arm-buildroot-linux-gnueabi/sysroot/usr/include/wolfssl/openssl/md5.h:32,
                 from md5.c:76:
.../arm-buildroot-linux-gnueabi/sysroot/usr/include/wolfssl/wolfcrypt/types.h:1289:10: error: #error "bad math long / long long settings"
 1289 |         #error "bad math long / long long settings"
      |          ^~~~~
.../arm-buildroot-linux-gnueabi/sysroot/usr/include/wolfssl/wolfcrypt/types.h:1291:5: error: empty enum is invalid
 1291 |     };
      |     ^
make[3]: *** [Makefile:2966: libcurl_la-md5.lo] Error 1

Restore SIZEOF_LONG_LONG macro definition to fix the build.