### PR TITLE
cf-https-connect: silence `-Wimplicit-int-enum-cast` with HTTPS-RR + clang 21 (reapply)

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -350,7 +350,7 @@ static CURLcode cf_hc_resolv(struct Curl_cfilter *cf,
         rr->port == cf->conn->remote_port)) {
       for(i = 0; i < CURL_ARRAYSIZE(rr->alpns) &&
                  alpn_count < CURL_ARRAYSIZE(alpn_ids); ++i) {
-        enum alpnid alpn = rr->alpns[i];
+        enum alpnid alpn = (enum alpnid)rr->alpns[i];
         if(cf_https_alpns_contain(alpn, alpn_ids, alpn_count))
           continue;
         switch(alpn) {


### PR DESCRIPTION
Reapply: e09a7b83d67c56bcb65ef6d0d3c9ba517942fa6d #21057

Also:
- enable HTTPS-RR by default in curl-for-win to test it with clang 21.
  Ref: https://github.com/curl/curl-for-win/commit/dc65c449f313a16279dde7eb243367b77986ddf1

Follow-up to 335dc0e3c59688270140115c9f84ea5c929870d8 #21027

---

Issue reproduced in curl CI: https://github.com/curl/curl/actions/runs/23775957316/job/69277779588?pr=21167
