### PR TITLE
cmake: silence bad library `Threads::Threads` warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2154,7 +2154,7 @@ if(NOT CURL_DISABLE_INSTALL)
       curl_collect_target_link_options("${_lib}")  # look into the target recursively
       list(APPEND _explicit_libdirs ${_libdirs})
       list(APPEND _explicit_libs ${_libs})
-      if(NOT _libs AND NOT _libdirs)
+      if(NOT _libs AND NOT _libdirs AND NOT _lib STREQUAL Threads::Threads)
         message(WARNING "Bad lib in library list: ${_lib}")
       endif()
       if(_lib STREQUAL OpenSSL::SSL AND NOT HAVE_BORINGSSL)  # BoringSSL does not provide openssl.pc


### PR DESCRIPTION
Seen on macOS:
```
CMake Warning at CMakeLists.txt:2158 (message):
  Bad lib in library list: Threads::Threads
```

Follow-up to 2d546d239ecd455b6459e68b85ef8d4b045c0a00 #21163
