### PR TITLE
http2: return error on OOM in push headers

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1488,8 +1488,10 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
       stream->push_headers = headp;
     }
     h = curl_maprintf("%s:%s", name, value);
-    if(!h)
+    if(!h) {
+      free_push_headers(stream);
       return NGHTTP2_ERR_CALLBACK_FAILURE;
+    }
     stream->push_headers[stream->push_headers_used++] = h;
     return 0;
   }


### PR DESCRIPTION
Reported-by: M42kL33 on hackerone
Bug: https://hackerone.com/reports/3636044