### PR TITLE
cmake: improve passing build options to `try_compile()`

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -40,20 +40,12 @@ set(CURL_TEST_DEFINES "")  # Initialize global variable
 # Return result in variable: CURL_TEST_OUTPUT
 macro(curl_internal_test _curl_test)
   if(NOT DEFINED "${_curl_test}")
-    string(REPLACE ";" " " _cmake_required_definitions "${CMAKE_REQUIRED_DEFINITIONS}")
-    set(_curl_test_add_libraries "")
-    if(CMAKE_REQUIRED_LIBRARIES)
-      set(_curl_test_add_libraries
-        "-DLINK_LIBRARIES:STRING=${CMAKE_REQUIRED_LIBRARIES}")
-    endif()
-
     message(STATUS "Performing Test ${_curl_test}")
     try_compile(${_curl_test}
       ${PROJECT_BINARY_DIR}
       "${CMAKE_CURRENT_SOURCE_DIR}/CMake/CurlTests.c"
-      CMAKE_FLAGS
-        "-DCOMPILE_DEFINITIONS:STRING=-D${_curl_test} ${CURL_TEST_DEFINES} ${CMAKE_REQUIRED_FLAGS} ${_cmake_required_definitions}"
-        "${_curl_test_add_libraries}"
+      COMPILE_DEFINITIONS "-D${_curl_test}" ${CURL_TEST_DEFINES} ${CMAKE_REQUIRED_FLAGS} ${CMAKE_REQUIRED_DEFINITIONS}
+      LINK_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}"
       OUTPUT_VARIABLE CURL_TEST_OUTPUT)
     if(${_curl_test})
       set(${_curl_test} 1 CACHE INTERNAL "curl test")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1557,7 +1557,7 @@ foreach(_variable IN ITEMS
     HAVE_UNISTD_H
 )
   if(${_variable})
-    string(APPEND CURL_TEST_DEFINES " -D${_variable}")
+    list(APPEND CURL_TEST_DEFINES "-D${_variable}")
   endif()
 endforeach()
 


### PR DESCRIPTION
Pass build options directly via `COMPILE_DEFINTIONS` and
`LINK_LIBRARIES`, instead of "tunneling" them through `CMAKE_FLAGS`.
The latter method breaks when passing `Threads::Threads` as library via
`CMAKE_REQUIRED_LIBRARIES`, while also being complex and fragile.

Example:
```
-- Performing Test HAVE_FSETXATTR_5
CMake Error at bld/CMakeFiles/CMakeTmp/CMakeLists.txt:27 (target_link_libraries):
  Target "cmTC_3386e" links to:

    Threads::Threads

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

CMake Error at CMake/Macros.cmake:51 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  CMakeLists.txt:1684 (curl_internal_test)
```
Ref: https://github.com/curl/curl/actions/runs/23792043930/job/69329796592?pr=21168#step:38:318

Note: a side-effect is no longer passing C compiler flags (e.g.
`CMAKE_REQUIRED_FLAGS`) to the _linker_. This should not be an issue,
though CMake is passing them during its built-in detections.

Ref: https://cmake.org/cmake/help/v3.18/command/try_compile.html
