### PR TITLE
GHA: try workaround for slow Azure Ubuntu distro server (cont.)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 60 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 60 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install \
             libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev \
             libnghttp2-dev libldap-dev libkrb5-dev libgnutls28-dev libwolfssl-dev

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -145,9 +145,9 @@ jobs:
     steps:
       - name: 'install packages'
         run: |
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 30 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 30 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -288,9 +288,9 @@ jobs:
             sha256sum pkg.bin && sha256sum pkg.bin | grep -qwF -- "${OLD_CMAKE_SHA256_WIN_INTEL}" && unzip -q pkg.bin && rm -f pkg.bin
             printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-win64-x64/bin/cmake.exe > ~/old-cmake-path.txt
           elif [[ "${MATRIX_IMAGE}" = *'ubuntu'* ]]; then
-            printf '#!/bin/sh
-              while [ $? = 0 ]; do for i in 1 2 3; do timeout 30 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-              dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+            printf "#!/bin/sh
+              while [ \$? = 0 ]; do for i in 1 2 3; do timeout 30 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+              dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
             sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install libpsl-dev libssl-dev
             cd ~
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -208,9 +208,9 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 60 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 60 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf \
             libbrotli-dev libzstd-dev zlib1g-dev \
@@ -556,9 +556,9 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 45 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 45 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libidn2-0-dev libldap-dev libuv1-dev valgrind \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -438,9 +438,9 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo apt-get -o Dpkg::Use-Pty=0 update
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 45 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 45 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf \
             libpsl-dev zlib1g-dev libbrotli-dev libzstd-dev \
@@ -462,9 +462,9 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,microsoft-prod.list,ondrej-ubuntu-php-noble.sources}
           sudo dpkg --add-architecture i386
           sudo apt-get -o Dpkg::Use-Pty=0 update
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 45 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 45 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -349,9 +349,9 @@ jobs:
     steps:
       - name: 'install packages'
         run: |
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 30 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 30 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install libfl2
 
       - name: 'cache compiler (djgpp)'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -741,9 +741,9 @@ jobs:
         env:
           MATRIX_INSTALL_PACKAGES: '${{ matrix.install_packages }}'
         run: |
-          printf '#!/bin/sh
-            while [ $? = 0 ]; do for i in 1 2 3; do timeout 30 "$@" && break 2; echo "Error: slow server, retry $i"; sleep 1
-            dpkg --configure -a; done; false; done' > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
+          printf "#!/bin/sh
+            while [ \$? = 0 ]; do for i in 1 2 3; do timeout 30 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
+            dpkg --configure -a; done; false; done" > "$HOME"/my-apt; chmod +x "$HOME"/my-apt
           sudo "$HOME"/my-apt apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32 ${MATRIX_INSTALL_PACKAGES}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
- fail if all retries failed.
- run `dpkg --configure -a` after an aborted slow attempt.

```
Selecting previously unselected package libsys-hostname-long-perl.
Error: slow server, retry
E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem.
[...]
```

Bug: https://github.com/curl/curl/pull/21107#issuecomment-4163506100
Follow-up to 5172ba5475cffc525c2338dfa63f818e11e80a42 #21107
