### PR TITLE
docs/cmdline-opts: tidy up retry-connrefused

### DIFF
--- a/docs/cmdline-opts/retry-connrefused.md
+++ b/docs/cmdline-opts/retry-connrefused.md
@@ -17,5 +17,5 @@ Example:
 
 In addition to the other conditions, also consider ECONNREFUSED as a transient
 error for --retry. This option is used together with --retry. Normally, a
-confused connection is not considered a transient error and therefore thus not
+refused connection is not considered a transient error and therefore would not
 otherwise trigger a retry.


### PR DESCRIPTION
The current docs for `--retry-connrefused` have a couple of minor typos in them. This revision tweaks the documentation text slightly to improve clarity.