### PR TITLE
test1275.pl: ignore indented sections in markdowns

### DIFF
--- a/tests/test1275.pl
+++ b/tests/test1275.pl
@@ -72,7 +72,8 @@ sub checkfile {
             next;
         }
         if($line =~ /^    /) {
-            # leading 4-space
+            # leading 4-space; reset previous-line context and skip checks
+            $prevl = '';
             next;
         }
         if($line =~ /^(\`\`\`|\~\~\~)/) {


### PR DESCRIPTION
They are special and should not be checked like this.