### PR TITLE
pytest: check retries

### DIFF
--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -184,4 +184,3 @@ class TestErrors:
         r.check_response(http_status=401)
         # No retries on a 401
         assert r.stats[0]['num_retries'] == 0, f'{r}'
-


### PR DESCRIPTION
For issue #20669, check that curl's --retry behaviour works
- test 502 in serial, works
- test 502 in parallel, hangs forever, test skipped by default
- test 401, no retries done, ok?