### PR TITLE
GHA/windows: restore libssh, fix to pass tests with 0.12.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -519,8 +519,7 @@ jobs:
           fi
           if [ -n "${MATRIX_OPENSSH}" ]; then  # OpenSSH-Windows
             TFLAGS+=' ~601 ~603 ~617 ~619 ~621 ~641 ~665 ~2004'  # SCP
-            if [[ "${MATRIX_INSTALL_MSYS2} " = *'libssh '* || \
-                  "${MATRIX_INSTALL_VCPKG} " = *'libssh '* ]]; then
+            if [[ "${MATRIX_INSTALL} " = *'libssh '* ]]; then
               TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
             else
               TFLAGS+=' ~3022'  # 'SCP correct sha256 host key' SCP, server sha256 key check


### PR DESCRIPTION
libssh 0.12.0 on Windows 64-bit Intel fails to connect to sshd (with SSH
state 30) when using the mlkem768x25519-sha256 KEX. (32-bit Intel, ARM64
and tested non-Windows platforms work fine.) Fix by disabling this KEX
for the libssh job.

I do not recommend libssh on Windows due to bugs an insecure behavior.

Also:
- fix libssh TFLAGS condition for mingw-w64.

Follow-up to e127f8ce843e1c070c0ca2074c10dcc01081a395 #21204
Follow-up to fcf946e8461b68840e4afb39711a52c9bf622a10 #21195
