### PR TITLE
hsts: accept 10K entries in the list

### DIFF
--- a/docs/HSTS.md
+++ b/docs/HSTS.md
@@ -19,6 +19,9 @@ libcurl features an in-memory cache for HSTS hosts, so that subsequent
 HTTP-only requests to a hostname present in the cache gets internally
 "redirected" to the HTTPS version.
 
+Since curl 8.20.0, libcurl keeps no more than the most recently added 10,000
+unique HSTS hostnames.
+
 ## `curl_easy_setopt()` options:
 
 - `CURLOPT_HSTS_CTRL` - enable HSTS for this easy handle

--- a/docs/cmdline-opts/hsts.md
+++ b/docs/cmdline-opts/hsts.md
@@ -33,3 +33,6 @@ to access the created file.
 
 If this option is used several times, curl loads contents from all the
 files but the last one is used for saving.
+
+Since curl 8.20.0, curl keeps no more than the most recently added 10,000
+unique HSTS hostnames.

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -27,18 +27,21 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HSTS, char *filename);
 
 # DESCRIPTION
 
-Make the *filename* point to a filename to load an existing HSTS cache
-from, and to store the cache in when the easy handle is closed. Setting a file
-name with this option also enables HSTS for this handle (the equivalent of
-setting *CURLHSTS_ENABLE* with CURLOPT_HSTS_CTRL(3)).
+Make the *filename* point to a filename to load an existing HSTS cache from,
+and to store the cache in when the easy handle is closed. Setting a filename
+with this option also enables HSTS for this handle (the equivalent of setting
+*CURLHSTS_ENABLE* with CURLOPT_HSTS_CTRL(3)).
 
 If the given file does not exist or contains no HSTS entries at startup, the
-HSTS cache starts empty. Setting the filename to NULL allows HSTS
-without reading from or writing to any file. NULL also makes libcurl clear the
-list of files to read HSTS data from, if any such were previously set.
+HSTS cache starts empty. Setting the filename to NULL allows HSTS without
+reading from or writing to any file. NULL also makes libcurl clear the list of
+files to read HSTS data from, if any such were previously set.
 
 If this option is set multiple times, libcurl loads cache entries from each
 given file but only stores the last used name for later writing.
+
+Since libcurl 8.20.0, each in-memory HSTS cache (per easy handle or shared
+cache) holds no more than the most recently added 10,000 HSTS hostnames.
 
 # FILE FORMAT
 
@@ -62,6 +65,9 @@ currently no length or size limit.
 NULL, no filename
 
 # SECURITY CONCERNS
+
+We strongly urge users to stick to `HTTPS://` URLs, which makes this option
+unnecessary.
 
 libcurl cannot fully protect against attacks where an attacker has write
 access to the same directory where it is directed to save files. This is

--- a/lib/hsts.h
+++ b/lib/hsts.h
@@ -28,7 +28,7 @@
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_HSTS)
 #include "llist.h"
 
-#define MAX_HSTS_ENTRIES 1000
+#define MAX_HSTS_ENTRIES 10000
 
 #if defined(DEBUGBUILD) || defined(UNITTESTS)
 extern time_t deltatime;

--- a/tests/data/test1674
+++ b/tests/data/test1674
@@ -18,7 +18,7 @@ HSTS
 CURL_TIME=1548369261
 </setenv>
 <name>
-HSTS load more than 1,000 entries from file
+HSTS load more than 10k entries from file
 </name>
 
 # test 1674 renders the input file itself, then reads it
@@ -29,10 +29,10 @@ HSTS load more than 1,000 entries from file
 
 <verify>
 <stdout>
-Number of entries: 1000
+OK
 </stdout>
 <limits>
-Allocations: 1100
+Allocations: 11000a
 </limits>
 </verify>
 </testcase>

--- a/tests/unit/unit1674.c
+++ b/tests/unit/unit1674.c
@@ -63,7 +63,10 @@ static CURLcode test_unit1674(const char *arg)
 
   Curl_hsts_loadfile(easy, h, arg);
 
-  curl_mprintf("Number of entries: %zu\n", Curl_llist_count(&h->list));
+  if(Curl_llist_count(&h->list) == MAX_HSTS_ENTRIES)
+    curl_mprintf("OK\n");
+  else
+    curl_mprintf("Number of entries: %zu\n", Curl_llist_count(&h->list));
 
   curl_msnprintf(savename, sizeof(savename), "%s.save", arg);
   (void)Curl_hsts_save(easy, h, savename);


### PR DESCRIPTION
Up from 1K.

Reduces the risk that someone could flush the list by tricking a user to do many transfers to new hostnames.

Document the limit.

Follow-up to 03a792b186da7fdfbe4b85b022d7