### PR TITLE
asyn-thrdd: item cleanup using resolv_id

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -264,7 +264,7 @@ struct async_thrdd_match_ctx {
 
 static bool async_thrdd_match_item(void *qitem, void *match_data)
 {
-  struct async_thrdd_match_ctx *ctx  = match_data;
+  const struct async_thrdd_match_ctx *ctx = match_data;
   struct async_thrdd_item *item = qitem;
   return (item->mid == ctx->mid) && (item->resolv_id == ctx->resolv_id);
 }


### PR DESCRIPTION
Now that we support multiple async operations at the same transfer, fix the thread queue cleanup to match not only the mid but also the resolv_id.

found-by: codex