### PR TITLE
GHA/windows: drop building with libssh

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -282,14 +282,10 @@ jobs:
               build: 'cmake'    , sys: 'mingw64'   , env: 'x86_64'       , tflags: '-t --shallow=13 --min=700 951 to 9999',
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON',
               install: 'mingw-w64-x86_64-c-ares mingw-w64-x86_64-libssh2' }
-          # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
-          #          read its configuration from, making it vulnerable to attacks on
-          #          Windows. Do not use this component till there is a fix for these.
-          # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-          - { name: 'gnutls libssh', type: 'Debug',
+          - { name: 'gnutls', type: 'Debug',
               build: 'cmake'    , sys: 'clang64'   , env: 'clang-x86_64' , tflags: ''          ,
-              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
-              install: 'mingw-w64-clang-x86_64-gnutls mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2 mingw-w64-clang-x86_64-libssh' }
+              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_ENABLE_NTLM=ON',
+              install: 'mingw-w64-clang-x86_64-gnutls mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2' }
           - { name: 'schannel R', type: 'Release', image: 'windows-11-arm',
               build: 'cmake'    , sys: 'clangarm64', env: 'clang-aarch64', tflags: 'skiprun'   ,
               config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_DROP_UNUSED=ON',


### PR DESCRIPTION
Bumping `msys2/setup-msys2` from 2.30.0 to 2.31.0 also brought libssh
0.12.0 (after 0.11.3). libssh has been long known for loading OpenSSH
configuration from disk insecurely on Windows. 0.12.0 brings some fixes
to this (CVE-2025-14821), which in turn may be changing its behavior on
the default GH Windows runner to fail all curl SCP/SFTP tests.

Detecting what is the exact root cause, then defining exact runtime 
conditions for it is difficult and fragile. Same for changing these
libssh defaults (if at all possible.)

But, since configuration loading remains insecure and broken on Windows 
even after the mitigations made by 0.12.0 [0], this patch removes libssh
from the Windows CI job using it previously.

If someone figures out how to run in CI, it can be readded, though in
general, using libssh on Windows seems to be less than ideal.

[0] https://github.com/curl/curl-for-win/blob/0e4bd38a5b90f6431b4c145ed094940b4d6b6c0d/libssh.sh#L11-L94

Refs:
https://www.libssh.org/2026/02/10/libssh-0-12-0-and-0-11-4-security-releases/
https://github.com/msys2/MINGW-packages/commit/91382507d5df17d89c074a1469bf3725a9602ff5
#21199 (unsuccessful fix attempts)

Bug: https://github.com/curl/curl/pull/21195#issuecomment-4173085194
Follow-up to fcf946e8461b68840e4afb39711a52c9bf622a10 #21195
