### PR TITLE
GHA/windows: switch back to the canonical Cygwin mirror

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,8 +97,7 @@ jobs:
           work-vol: 'D:'
           # https://cygwin.com/mirrors.html
           # Main mirror status: https://archlinux.org/mirrors/kernel.org/
-          # site: https://mirrors.kernel.org/sourceware/cygwin/
-          site: https://cygwin.mirror.gtcomm.net/
+          site: https://mirrors.kernel.org/sourceware/cygwin/
           # https://cygwin.com/cgi-bin2/package-grep.cgi
           packages: >-
             ${{ matrix.build == 'autotools' && 'autoconf automake libtool make' || 'cmake ninja' }}


### PR DESCRIPTION
The spare one is at the time of this patch inaccessible.

Follow-up to fb5541c28bdc7761c50423335f44b698d36caef1 #20583
