### PR TITLE
buildconf: remove

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: curl
 
-buildconf eol=lf
 configure.ac eol=lf
 *.m4 eol=lf
 *.in eol=lf

--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -11,7 +11,6 @@ set -eu
 gitonly=".git*
 ^.*
 ^appveyor.*
-^buildconf
 ^GIT-INFO.md
 ^README.md
 ^renovate.json

--- a/buildconf
+++ b/buildconf
@@ -1,8 +1,0 @@
-#!/bin/sh
-#
-# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
-#
-# SPDX-License-Identifier: curl
-
-echo "*** Do not use buildconf. Instead, just use: autoreconf -fi" >&2
-exec ${AUTORECONF:-autoreconf} -fi "${@}"


### PR DESCRIPTION
Not used since 85868537d6d5b (Aug 2020)

Removed from the release tarballs since 91fcbc5d1a489c (Aug 2024)