### PR TITLE
fix: pin 1 unpinned action(s)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,4 +40,4 @@ permissions: {}
 
 jobs:
   Fuzzing:
-    uses: curl/curl-fuzzer/.github/workflows/ci.yml@master  # zizmor: ignore[unpinned-uses]
+    uses: curl/curl-fuzzer/.github/workflows/ci.yml@55dc0406831781ba06e68f75839a1f9bd326252c # master # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning GitHub Actions to immutable commit SHAs and extracting unsafe expressions from `run:` blocks into `env:` mappings.

| RGS-007 | medium | `fuzz.yml` | Pinned 1 action(s) to commit SHA |


**1 additional advisory findings** (not auto-fixed, flagged for review). These are patterns like step output interpolations (RGS-019) and other items that require manual review to determine risk.

## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` — original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

We've had 22 merges so far including next.js, keras, webpack, svelte, apache/superset, and excalidraw. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))