### PR TITLE
libssh: fix `-Wsign-compare` in 32-bit builds

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1661,7 +1661,7 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       myssh_quote_error(data, sshc, NULL);
       return SSH_NO_ERROR;
     }
-    if(date > UINT_MAX)
+    if(date > (time_t)UINT_MAX)
       /* because the liubssh API cannot deal with a larger value */
       date = UINT_MAX;
     if(!strncmp(cmd, "atime", 5))


### PR DESCRIPTION
Seen with mingw-w64 i686 gcc 15.2.0 (mingw32):
```
D:/a/curl/curl/lib/vssh/libssh.c: In function 'myssh_in_SFTP_QUOTE_STAT':
D:/a/curl/curl/lib/vssh/libssh.c:1664:13: error: comparison of integer expressions of different signedness: 'time_t' {aka 'long int'} and 'unsigned int' [-Werror=sign-compare]
 1664 |     if(date > UINT_MAX)
      |             ^
cc1.exe: all warnings being treated as errors
```
Ref: https://github.com/curl/curl/actions/runs/23966805891/job/69908216152

Cherry-picked from #21199