### PR TITLE
url: set default upload flags to CURLULFLAG_SEEN

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -426,6 +426,7 @@ void Curl_init_userdefined(struct Curl_easy *data)
   set->sep_headers = TRUE; /* separated header lists by default */
   set->buffer_size = READBUFFER_SIZE;
   set->upload_buffer_size = UPLOADBUFFER_DEFAULT;
+  set->upload_flags = CURLULFLAG_SEEN;
   set->happy_eyeballs_timeout = CURL_HET_DEFAULT;
   set->upkeep_interval_ms = CURL_UPKEEP_INTERVAL_DEFAULT;
   set->maxconnects = DEFAULT_CONNCACHE_SIZE; /* for easy handles */


### PR DESCRIPTION
As documented. Not doing this was a regression.

Follow-up to 6758aa722ddf5a6db819b753d96

Reported by Codex Security.