### PR TITLE
sendf: fix CR detection if no LF is in the chunk

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1009,6 +1009,8 @@ static CURLcode cr_lc_read(struct Curl_easy *data,
 
     if(!nread || !memchr(buf, '\n', nread)) {
       /* nothing to convert, return this right away */
+      if(nread)
+        ctx->prev_cr = (buf[nread - 1] == '\r');
       if(ctx->read_eos)
         ctx->eos = TRUE;
       *pnread = nread;


### PR DESCRIPTION
When doing line ending conversions, and a chunk contains no '\n', the function returned early without updating prev_cr to reflect the last byte. It could then lead to CRLFs sequences not get converted when occuring right on the boundary border.

Found by Codex Security