### PR TITLE
vtls_scache: include cert_blob independently of verifypeer

### DIFF
--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -741,7 +741,7 @@ static CURLcode cf_ssl_add_peer(struct Curl_easy *data,
     username = conn_config ? conn_config->username : NULL;
     password = conn_config ? conn_config->password : NULL;
 #endif
-    if(!ccert && conn_config->cert_blob) {
+    if(!ccert && conn_config && conn_config->cert_blob) {
       /* when using a client cert blob, create a name for it */
       curl_msnprintf(buffer, sizeof(buffer),
                      "cert-%p", conn_config->cert_blob->data);


### PR DESCRIPTION
The making of the TLS session cache key should use the cert blob independently of verifypeer on/off.

Follow-up to fa0ccd9f1fbbbd77bf50b2

Spotted by Codex Security