### PR TITLE
libssh: fix `-Wsign-compare` in 32-bit builds by dropping a redundant check

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -295,6 +295,10 @@ jobs:
               build: 'cmake'    , sys: 'clang64'   , env: 'clang-x86_64' , tflags: ''          ,
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
               install: 'mingw-w64-clang-x86_64-gnutls mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2 mingw-w64-clang-x86_64-libssh unzip' }
+          - { name: 'gnutls libssh', type: 'Debug',
+              build: 'cmake'    , sys: 'mingw32'   , env: 'i686'         , tflags: ''          ,
+              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
+              install: 'mingw-w64-i686-gnutls mingw-w64-i686-nghttp3 mingw-w64-i686-ngtcp2 mingw-w64-i686-libssh' }
           - { name: 'schannel R', type: 'Release', image: 'windows-11-arm',
               build: 'cmake'    , sys: 'clangarm64', env: 'clang-aarch64', tflags: 'skiprun'   ,
               config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_DROP_UNUSED=ON',
@@ -317,8 +321,8 @@ jobs:
               install: 'mingw-w64-x86_64-libssh2' }
           - { name: 'schannel R', type: 'Release',
               build: 'cmake'    , sys: 'mingw32'   , env: 'i686'         , tflags: 'skiprun'   ,
-              config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=ON',
-              install: 'mingw-w64-i686-openssl mingw-w64-i686-libssh2' }
+              config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON',
+              install: 'mingw-w64-i686-libssh2' }
       fail-fast: false
     steps:
       - uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
@@ -611,8 +615,7 @@ jobs:
             ver: '6.4.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             SHA256: 12d2c62ad4527ec8a52275ea8485678dcbe20bec4716a3c7ba274f225d696085
-            config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
-            install: mingw-w64-i686-libssh
+            config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
             type: 'Debug'
             tflags: 'skiprun'
           - name: 'schannel !examples'  # mingw-w64 3.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -295,10 +295,6 @@ jobs:
               build: 'cmake'    , sys: 'clang64'   , env: 'clang-x86_64' , tflags: ''          ,
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
               install: 'mingw-w64-clang-x86_64-gnutls mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2 mingw-w64-clang-x86_64-libssh unzip' }
-          - { name: 'gnutls libssh', type: 'Debug',
-              build: 'cmake'    , sys: 'mingw32'   , env: 'i686'         , tflags: ''          ,
-              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
-              install: 'mingw-w64-i686-gnutls mingw-w64-i686-nghttp3 mingw-w64-i686-ngtcp2 mingw-w64-i686-libssh' }
           - { name: 'schannel R', type: 'Release', image: 'windows-11-arm',
               build: 'cmake'    , sys: 'clangarm64', env: 'clang-aarch64', tflags: 'skiprun'   ,
               config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_DROP_UNUSED=ON',

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -295,6 +295,10 @@ jobs:
               build: 'cmake'    , sys: 'clang64'   , env: 'clang-x86_64' , tflags: ''          ,
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
               install: 'mingw-w64-clang-x86_64-gnutls mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2 mingw-w64-clang-x86_64-libssh unzip' }
+          - { name: 'gnutls libssh', type: 'Debug',
+              build: 'cmake'    , sys: 'mingw32'   , env: 'i686'         , tflags: ''          ,
+              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
+              install: 'mingw-w64-i686-gnutls mingw-w64-i686-nghttp3 mingw-w64-i686-ngtcp2 mingw-w64-i686-libssh' }
           - { name: 'schannel R', type: 'Release', image: 'windows-11-arm',
               build: 'cmake'    , sys: 'clangarm64', env: 'clang-aarch64', tflags: 'skiprun'   ,
               config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_DROP_UNUSED=ON',

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -295,10 +295,6 @@ jobs:
               build: 'cmake'    , sys: 'clang64'   , env: 'clang-x86_64' , tflags: ''          ,
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
               install: 'mingw-w64-clang-x86_64-gnutls mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2 mingw-w64-clang-x86_64-libssh unzip' }
-          - { name: 'gnutls libssh', type: 'Debug',
-              build: 'cmake'    , sys: 'mingw32'   , env: 'i686'         , tflags: ''          ,
-              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_GNUTLS=ON -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_ENABLE_NTLM=ON',
-              install: 'mingw-w64-i686-gnutls mingw-w64-i686-nghttp3 mingw-w64-i686-ngtcp2 mingw-w64-i686-libssh' }
           - { name: 'schannel R', type: 'Release', image: 'windows-11-arm',
               build: 'cmake'    , sys: 'clangarm64', env: 'clang-aarch64', tflags: 'skiprun'   ,
               config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_DROP_UNUSED=ON',
@@ -321,8 +317,8 @@ jobs:
               install: 'mingw-w64-x86_64-libssh2' }
           - { name: 'schannel R', type: 'Release',
               build: 'cmake'    , sys: 'mingw32'   , env: 'i686'         , tflags: 'skiprun'   ,
-              config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON',
-              install: 'mingw-w64-i686-libssh2' }
+              config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=ON',
+              install: 'mingw-w64-i686-openssl mingw-w64-i686-libssh2' }
       fail-fast: false
     steps:
       - uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
@@ -615,7 +611,8 @@ jobs:
             ver: '6.4.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             SHA256: 12d2c62ad4527ec8a52275ea8485678dcbe20bec4716a3c7ba274f225d696085
-            config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
+            config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
+            install: mingw-w64-i686-libssh
             type: 'Debug'
             tflags: 'skiprun'
           - name: 'schannel !examples'  # mingw-w64 3.0

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1661,7 +1661,7 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       myssh_quote_error(data, sshc, NULL);
       return SSH_NO_ERROR;
     }
-    if(date > (time_t)UINT_MAX)
+    if(date > UINT_MAX)
       /* because the liubssh API cannot deal with a larger value */
       date = UINT_MAX;
     if(!strncmp(cmd, "atime", 5))

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1661,11 +1661,9 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       myssh_quote_error(data, sshc, NULL);
       return SSH_NO_ERROR;
     }
-#if SIZEOF_TIME_T > 4
     if(date >= 0 && (curl_off_t)date > (curl_off_t)UINT_MAX)
       /* because the libssh API cannot deal with a larger value */
       date = (time_t)UINT_MAX;
-#endif
     if(!strncmp(cmd, "atime", 5))
       sshc->quote_attrs->atime = (uint32_t)date;
     else /* mtime */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1661,6 +1661,9 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       myssh_quote_error(data, sshc, NULL);
       return SSH_NO_ERROR;
     }
+    if(date > UINT_MAX)
+      /* because the liubssh API cannot deal with a larger value */
+      date = UINT_MAX;
     if(!strncmp(cmd, "atime", 5))
       sshc->quote_attrs->atime = (uint32_t)date;
     else /* mtime */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1661,9 +1661,6 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       myssh_quote_error(data, sshc, NULL);
       return SSH_NO_ERROR;
     }
-    if(date > UINT_MAX)
-      /* because the liubssh API cannot deal with a larger value */
-      date = UINT_MAX;
     if(!strncmp(cmd, "atime", 5))
       sshc->quote_attrs->atime = (uint32_t)date;
     else /* mtime */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1661,9 +1661,6 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       myssh_quote_error(data, sshc, NULL);
       return SSH_NO_ERROR;
     }
-    if(date >= 0 && (curl_off_t)date > (curl_off_t)UINT_MAX)
-      /* because the libssh API cannot deal with a larger value */
-      date = (time_t)UINT_MAX;
     if(!strncmp(cmd, "atime", 5))
       sshc->quote_attrs->atime = (uint32_t)date;
     else /* mtime */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1661,9 +1661,11 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
       myssh_quote_error(data, sshc, NULL);
       return SSH_NO_ERROR;
     }
-    if(date > UINT_MAX)
-      /* because the liubssh API cannot deal with a larger value */
-      date = UINT_MAX;
+#if SIZEOF_TIME_T > 4
+    if(date >= 0 && (curl_off_t)date > (curl_off_t)UINT_MAX)
+      /* because the libssh API cannot deal with a larger value */
+      date = (time_t)UINT_MAX;
+#endif
     if(!strncmp(cmd, "atime", 5))
       sshc->quote_attrs->atime = (uint32_t)date;
     else /* mtime */


### PR DESCRIPTION
Follow-up to 8c8eeba5225599a1f5750ece1d15751a8bfce0bb #21214 (wrong silencing)
Follow-up to c049c37acd074a61bbd07eebe25fdf32af575a2a #18989 (add redundant check)
Follow-up to c988ec9f41060144e175b519f9017c569ac8d3db #9328 (make check fail)
Follow-up to 44a02d2532c4e6dabb8f2a074d52d5e99ff533be #9324 (add original check)
