### PR TITLE
libssh: fix 64-bit printf mask for mingw-w64 <=6.0.0

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -566,8 +566,10 @@ static int myssh_in_SFTP_QUOTE_STATVFS(struct Curl_easy *data,
   else if(statvfs) {
 #ifdef _MSC_VER
 #define CURL_LIBSSH_VFS_SIZE_MASK "I64u"
-#else
+#elif defined(__MINGW32__) && (__MINGW64_VERSION_MAJOR <= 6)
 #define CURL_LIBSSH_VFS_SIZE_MASK "llu"
+#else
+#define CURL_LIBSSH_VFS_SIZE_MASK PRIu64
 #endif
     CURLcode result = CURLE_OK;
     char *tmp = curl_maprintf("statvfs:\n"


### PR DESCRIPTION
Fixing (dl-mingw, CM 6.4.0-i686 (mingw-w64 5.0.0) schannel !unity):
```
lib/vssh/libssh.c: In function 'myssh_in_SFTP_QUOTE_STATVFS':
lib/vssh/libssh.c:573:31: error: ISO C does not support the 'I' printf flag [-Werror=format=]
     char *tmp = curl_maprintf("statvfs:\n"
                               ^~~~~~~~~~~~
lib/vssh/libssh.c:573:31: error: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'uint64_t {aka long long unsigned int}' [-Werror=format=]
lib/vssh/libssh.c:573:31: error: ISO C does not support the 'I' printf flag [-Werror=format=]
[...]
```
Ref: https://github.com/curl/curl/actions/runs/24002480364/job/70000685821

mingw-w64 <=6.0.0 define `PRIu64` like this:
```
./inttypes.h:#define PRIu64 "I64u"
```

Follow-up to 413a0fedd02c8c6df1d294534b8c6e306fcca7a2 #12346
Cherry-picked from #21227
