### PR TITLE
cfilters: fix Curl_pollset_poll() return code mixup

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -832,12 +832,19 @@ CURLcode Curl_conn_adjust_pollset(struct Curl_easy *data,
   return result;
 }
 
+/*
+ * Return values:
+ *   -1 = error
+ *    0 = timeout
+ *    N = number of structures with non zero revent fields
+ */
 int Curl_conn_cf_poll(struct Curl_cfilter *cf,
                       struct Curl_easy *data,
                       timediff_t timeout_ms)
 {
   struct easy_pollset ps;
-  int result;
+  int rc;
+  CURLcode result;
 
   DEBUGASSERT(cf);
   DEBUGASSERT(data);
@@ -846,9 +853,11 @@ int Curl_conn_cf_poll(struct Curl_cfilter *cf,
 
   result = Curl_conn_cf_adjust_pollset(cf, data, &ps);
   if(!result)
-    result = Curl_pollset_poll(data, &ps, timeout_ms);
+    rc = Curl_pollset_poll(data, &ps, timeout_ms);
+  else
+    rc = -1;
   Curl_pollset_cleanup(&ps);
-  return result;
+  return rc;
 }
 
 void Curl_conn_get_current_host(struct Curl_easy *data, int sockindex,

--- a/lib/select.c
+++ b/lib/select.c
@@ -642,13 +642,19 @@ CURLcode Curl_pollset_set(struct Curl_easy *data,
                              (!do_out ? CURL_POLL_OUT : 0));
 }
 
+/*
+ * Return values:
+ *   -1 = system call error or fd >= FD_SETSIZE
+ *    0 = timeout
+ *    N = number of structures with non zero revent fields
+ */
 int Curl_pollset_poll(struct Curl_easy *data,
                       struct easy_pollset *ps,
                       timediff_t timeout_ms)
 {
   struct pollfd *pfds;
   unsigned int i, npfds;
-  int result;
+  int rc;
 
   (void)data;
   DEBUGASSERT(data);
@@ -677,9 +683,9 @@ int Curl_pollset_poll(struct Curl_easy *data,
     }
   }
 
-  result = Curl_poll(pfds, npfds, timeout_ms);
+  rc = Curl_poll(pfds, npfds, timeout_ms);
   curlx_free(pfds);
-  return result;
+  return rc;
 }
 
 void Curl_pollset_check(struct Curl_easy *data,


### PR DESCRIPTION
Curl_conn_cf_poll did not map adjust_pollset failures to poll-style errors properly, so error codes were treated as ready events.

Found by Codex Security