### PR TITLE
curl_setup.h: drop stray/unused `USE_OPENSSL_QUIC` guard

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1522,9 +1522,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define USE_HTTP2
 #endif
 
-#if (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || \
-  (defined(USE_OPENSSL_QUIC) && defined(USE_NGHTTP3)) || \
-  defined(USE_QUICHE)
+#if (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || defined(USE_QUICHE)
 
 #ifdef CURL_WITH_MULTI_SSL
 #error "MultiSSL combined with QUIC is not supported"


### PR DESCRIPTION
Follow-up to 6aaac9dd388a64d0f511544496608693e1105d13 #20226