### PR TITLE
protocol: disable connection reuse for SMB(S)

### DIFF
--- a/lib/protocol.c
+++ b/lib/protocol.c
@@ -316,7 +316,7 @@ const struct Curl_scheme Curl_scheme_smb = {
 #endif
   CURLPROTO_SMB,                        /* protocol */
   CURLPROTO_SMB,                        /* family */
-  0,                                    /* flags */
+  PROTOPT_NONE,                         /* flags */
   PORT_SMB,                             /* defport */
 };
 


### PR DESCRIPTION
Connections should only be reused when using the same "share" (and perhaps some additional conditions), but instead of fixing this flaw, this change completely disables connection reuse for SMB. This protocol is about to get dropped soon anyway.

Reported-by: Osama Hamad