### PR TITLE
GHA/curl-for-win: drop certdata dependency and `GITHUB_TOKEN` with it

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-prefill-zero-osnotls-osnoidn-nohttp-nocurltool-linux-x64-gcc'
+          export CW_CONFIG='-main-werror-unitybatch-nocertdata-prefill-zero-osnotls-osnoidn-nohttp-nocurltool-linux-x64-gcc'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default


### PR DESCRIPTION
`certdata` dependency requires accessing api.github.com for
a reproducible timestamp, which in turn requires a GitHub token to avoid
errors due to rate limiting. Avoid all this by omitting this dependency,
which isn't necessary for these build tests anyway.

The `zero` job already did not use `certdata`, but disable explicitly
anyway just in case.

Reported-by: James Fuller

Follow-up to https://github.com/curl/curl-for-win/commit/9514184977347dbfcd7a4f48daeda7bdb8222458
Follow-up to 128c252975423856d1403c42267a8a1f1b97433f #21105
