### PR TITLE
rustls: handle EOF during initial handshake

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1138,6 +1138,7 @@ static CURLcode cr_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
   CURLcode result;
   bool wants_read;
   bool wants_write;
+  ssize_t nread;
 
   DEBUGASSERT(backend);
 
@@ -1280,7 +1281,13 @@ static CURLcode cr_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
 
     if(wants_read) {
       CURL_TRC_CF(data, cf, "rustls_connection wants us to read_tls.");
-      if(tls_recv_more(cf, data, &tmperr) < 0) {
+      nread = tls_recv_more(cf, data, &tmperr);
+      if(nread == 0) {
+        connssl->peer_closed = TRUE;
+        failf(data, "TLS connect error: Connection closed abruptly");
+        return CURLE_SSL_CONNECT_ERROR;
+      }
+      if(nread < 0) {
         if(tmperr == CURLE_AGAIN) {
           CURL_TRC_CF(data, cf, "reading would block");
           connssl->io_need = CURL_SSL_IO_NEED_RECV;

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -26,6 +26,8 @@
 #
 import logging
 import os
+import socket
+import threading
 
 import pytest
 from testenv import CurlClient, Env
@@ -179,3 +181,35 @@ class TestErrors:
         r.check_response(http_status=401)
         # No retries on a 401
         assert r.stats[0]['num_retries'] == 0, f'{r}'
+
+    # Server closes the connection immediately after accept,
+    def test_05_09_handshake_eof(self, env: Env, httpd, nghttpx):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server.bind(('127.0.0.1', 0))
+            server.listen(1)
+            port = server.getsockname()[1]
+
+            # accept one connection and immediately close it
+            def accept_and_close():
+                try:
+                    conn, _ = server.accept()
+                    conn.close()
+                except Exception:
+                    pass
+
+            t = threading.Thread(target=accept_and_close)
+            t.start()
+
+            curl = CurlClient(env=env, timeout=5)
+            url = f'https://127.0.0.1:{port}/'
+            r = curl.run_direct(args=[url, '--insecure'])
+
+            t.join(timeout=2)
+
+        # We expect an error code, not success (0) and not timeout (-1)
+        # Different TLS backends may return different codes:
+        # - CURLE_SSL_CONNECT_ERROR (35) - common for handshake failures
+        # - CURLE_RECV_ERROR (56) - rustls with the fix returns this
+        assert r.exit_code in [35, 56], \
+            f'Expected error 35 or 56, got {r.exit_code}\n{r.dump_logs()}'

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -208,8 +208,7 @@ class TestErrors:
             t.join(timeout=2)
 
         # We expect an error code, not success (0) and not timeout (-1)
-        # Different TLS backends may return different codes:
+        # Expected error code is:
         # - CURLE_SSL_CONNECT_ERROR (35) - common for handshake failures
-        # - CURLE_RECV_ERROR (56) - rustls with the fix returns this
-        assert r.exit_code in [35, 56], \
-            f'Expected error 35 or 56, got {r.exit_code}\n{r.dump_logs()}'
+        assert r.exit_code == 35, \
+            f'Expected error 35, got {r.exit_code}\n{r.dump_logs()}'


### PR DESCRIPTION
I noticed curl built with vtls-rustls gets stuck if the server closes the connection immediately without writing anything.

This adds a check if `rustls_connection_read_tls` had returned 0, which is also interpreted as EOF in the demo client:

https://github.com/rustls/rustls-ffi/blob/3f6476095541972da158226746a5d73e70842056/librustls/tests/client.c#L747-L752

Things I'm not sure about regarding this patch:

- [ ] Should I set `peer_closed` in this case or leave it unmodified?
- [ ] Is there a style guide for "check `== 0` or `< 0` first"?
- [X] Is "Connection closed abruptly" the correct/best error message for this situation?
    - Changed to `TLS connect error: Connection closed abruptly`
- [X] Is `CURLE_RECV_ERROR` the best error code for this?
    - Changed to `CURLE_SSL_CONNECT_ERROR`

Also happy to add a unit/integration test for this when pointed in the right direction.

cc: @cpu

## Steps to reproduce

```
socat TCP-LISTEN:4443,fork /dev/null
```

## Before this patch
```
% curl -v https://localhost:4443      
* Host localhost:4443 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4443...
* connect to ::1 port 4443 from ::1 port 37120 failed: Connection refused
*   Trying 127.0.0.1:4443...
* ALPN: curl offers h2,http/1.1
```
[hangs]

## With this patch
```
% ./src/curl -v https://localhost:4443
* Host localhost:4443 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4443...
* connect to ::1 port 4443 from ::1 port 35140 failed: Connection refused
*   Trying 127.0.0.1:4443...
* ALPN: curl offers h2,http/1.1
* Connection closed abruptly
* closing connection #0
curl: (56) Connection closed abruptly
%
```