### PR TITLE
libssh2: split ssh_statemachine into more sub functions

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2640,7 +2640,7 @@ static CURLcode ssh_state_sftp_trans_init(struct Curl_easy *data,
     myssh_to(data, sshc, SSH_SFTP_UPLOAD_INIT);
   else if(sshp) {
     size_t plen = strlen(sshp->path);
-    if(plen && (sshp->path[strlen(sshp->path) - 1] == '/'))
+    if(plen && (sshp->path[plen - 1] == '/'))
       myssh_to(data, sshc, SSH_SFTP_READDIR_INIT);
     else
       myssh_to(data, sshc, SSH_SFTP_DOWNLOAD_INIT);


### PR DESCRIPTION
The pieces of the state machine that were not separate functions before, now are.

Also removed the use of ternary operators in the function calls.

Follow-up to f0bf43e20936cf4aa2665