### PR TITLE
libssh: split myssh_statemach_act into sub functions and rename

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2045,6 +2045,8 @@ static int myssh_in_SFTP_CREATE_DIRS_MKDIR(struct Curl_easy *data,
 
   rc = sftp_mkdir(sshc->sftp_session, sshp->path,
                   (mode_t)data->set.new_directory_perms);
+  if(rc == SSH_AGAIN)
+    return rc;
   *sshc->slash_pos = '/';
   ++sshc->slash_pos;
   if(rc < 0) {


### PR DESCRIPTION
Follow-up to bd3b2a626a33434a1e9e83a

- rename it to myssh_statemachine

- remove the use of ternary operators in the switch

- fix the error handling for if 'sshp' actually ever is NULL