### PR TITLE
Use the correct CURLOPT_WRITEFUNCTION signature

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1187,7 +1187,7 @@ function that is passed a pointer to the class:
 
 ~~~c++
 // f is the pointer to your object.
-static size_t YourClass::func(void *buffer, size_t sz, size_t n, void *f)
+static size_t YourClass::func(char *buffer, size_t sz, size_t n, void *f)
 {
   // Call non-static member function.
   static_cast<YourClass*>(f)->nonStaticFunction();

--- a/docs/examples/cacertinmem.c
+++ b/docs/examples/cacertinmem.c
@@ -40,7 +40,7 @@ typedef size_t ossl_valsize_t;
 typedef int ossl_valsize_t;
 #endif
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   fwrite(ptr, size, nmemb, (FILE *)stream);
   return nmemb * size;

--- a/docs/examples/certinfo.c
+++ b/docs/examples/certinfo.c
@@ -29,7 +29,7 @@
 
 #include <curl/curl.h>
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   (void)stream;
   (void)ptr;

--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -57,7 +57,7 @@
 
 #define CHKSPEED_VERSION "1.0"
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *data)
 {
   /* we are not interested in the downloaded bytes itself,
      so we only return the size we would have saved ... */

--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -62,7 +62,7 @@ struct memory {
   size_t size;
 };
 
-static size_t write_cb(void *contents, size_t sz, size_t nmemb, void *ctx)
+static size_t write_cb(char *contents, size_t sz, size_t nmemb, void *ctx)
 {
   size_t realsize = sz * nmemb;
   struct memory *mem = (struct memory *)ctx;

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -325,7 +325,7 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 }
 
 /* CURLOPT_WRITEFUNCTION */
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *data)
 {
   (void)ptr;
   (void)data;

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -292,7 +292,7 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 }
 
 /* CURLOPT_WRITEFUNCTION */
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *data)
 {
   size_t realsize = size * nmemb;
   struct ConnInfo *conn = (struct ConnInfo *)data;

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -60,7 +60,7 @@
 #define INADDR_NONE 0xffffffff
 #endif
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
   return written;

--- a/docs/examples/ftp-delete.c
+++ b/docs/examples/ftp-delete.c
@@ -29,7 +29,7 @@
 
 #include <curl/curl.h>
 
-static size_t write_cb(void *buffer, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *buffer, size_t size, size_t nmemb, void *stream)
 {
   (void)buffer;
   (void)stream;

--- a/docs/examples/ftpget.c
+++ b/docs/examples/ftpget.c
@@ -40,7 +40,7 @@ struct FtpFile {
   FILE *stream;
 };
 
-static size_t write_cb(void *buffer, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *buffer, size_t size, size_t nmemb, void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
   if(!out->stream) {

--- a/docs/examples/ftpsget.c
+++ b/docs/examples/ftpsget.c
@@ -40,7 +40,7 @@ struct FtpFile {
   FILE *stream;
 };
 
-static size_t write_cb(void *buffer, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *buffer, size_t size, size_t nmemb, void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
   if(!out->stream) {

--- a/docs/examples/ftpuploadresume.c
+++ b/docs/examples/ftpuploadresume.c
@@ -51,7 +51,7 @@ static size_t getcontentlengthfunc(void *ptr, size_t size, size_t nmemb,
 }
 
 /* discard downloaded data */
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   (void)ptr;
   (void)stream;

--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -37,7 +37,7 @@ struct MemoryStruct {
   size_t size;
 };
 
-static size_t write_cb(void *contents, size_t size, size_t nmemb, void *userp)
+static size_t write_cb(char *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -281,7 +281,7 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 }
 
 /* CURLOPT_WRITEFUNCTION */
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *data)
 {
   size_t realsize = size * nmemb;
   struct ConnInfo *conn = (struct ConnInfo *)data;

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -292,7 +292,7 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 }
 
 /* CURLOPT_WRITEFUNCTION */
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *data)
 {
   (void)ptr;
   (void)data;

--- a/docs/examples/http2-pushinmemory.c
+++ b/docs/examples/http2-pushinmemory.c
@@ -36,7 +36,7 @@ struct Memory {
   size_t size;
 };
 
-static size_t write_cb(void *contents, size_t size, size_t nmemb, void *userp)
+static size_t write_cb(char *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct Memory *mem = (struct Memory *)userp;

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -36,7 +36,7 @@ struct MemoryStruct {
   size_t size;
 };
 
-static size_t write_cb(void *contents, size_t size, size_t nmemb, void *userp)
+static size_t write_cb(char *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;

--- a/docs/examples/sepheaders.c
+++ b/docs/examples/sepheaders.c
@@ -36,7 +36,7 @@
 
 #include <curl/curl.h>
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
   return written;

--- a/docs/examples/sessioninfo.c
+++ b/docs/examples/sessioninfo.c
@@ -44,7 +44,7 @@
 
 static CURL *curl;
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   const struct curl_tlssessioninfo *info;
   CURLcode result;

--- a/docs/examples/sftpget.c
+++ b/docs/examples/sftpget.c
@@ -50,7 +50,7 @@ struct FtpFile {
   FILE *stream;
 };
 
-static size_t write_cb(void *buffer, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *buffer, size_t size, size_t nmemb, void *stream)
 {
   struct FtpFile *out = (struct FtpFile *)stream;
   if(!out->stream) {

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -108,7 +108,7 @@ static const char *MthStr[] = {
 };
 #endif
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   fwrite(ptr, size, nmemb, stream);
   return nmemb * size;

--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -36,7 +36,7 @@
 
 #include <curl/curl.h>
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t written = fwrite(ptr, size, nmemb, (FILE *)stream);
   return written;

--- a/docs/examples/usercertinmem.c
+++ b/docs/examples/usercertinmem.c
@@ -40,7 +40,7 @@
 
 #include <curl/curl.h>
 
-static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   fwrite(ptr, size, nmemb, (FILE *)stream);
   return nmemb * size;

--- a/docs/libcurl/libcurl-tutorial.md
+++ b/docs/libcurl/libcurl-tutorial.md
@@ -203,7 +203,7 @@ that needs this transfer, I assume that you would like to get the data passed
 to you directly instead of getting it passed to stdout. You write your
 own function that matches this prototype:
 ~~~c
-    size_t write_data(void *buffer, size_t size, size_t nmemb, void *userp);
+    size_t write_data(char *buffer, size_t size, size_t nmemb, void *userp);
 ~~~
 
 You tell libcurl to pass all data to this function by issuing a function
@@ -807,7 +807,7 @@ Example C++ code:
 
 ~~~c
     class AClass {
-      static size_t write_data(void *ptr, size_t size, size_t nmemb,
+      static size_t write_data(char *ptr, size_t size, size_t nmemb,
                                void *ourpointer)
       {
         /* do what you want with the data */

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -128,7 +128,7 @@ https://github.com/curl/curl/issues/685
 #include <openssl/ssl.h>
 
 CURL *curl;
-static size_t wf(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t wf(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   const struct curl_tlssessioninfo *info = NULL;
   CURLcode result = curl_easy_getinfo(curl, CURLINFO_TLS_SSL_PTR, &info);

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -80,7 +80,7 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
   return true;
 }
 
-static size_t wrfu(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t wrfu(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   (void)stream;
   (void)ptr;


### PR DESCRIPTION
In order to not encourage users to use incompatible function pointers, change the callback function definitions to use `char *` instead of `void *` for the first argument.

Triggered by https://stackoverflow.com/questions/79921871/curl-c-c-library-based-application-produces-erronious-response-for-http-post-r#comment141032037_79921871 :
"The code was mostly modified from [this example code](https://curl.se/libcurl/c/postinmemory.html), honestly I never knew this is wrong. Thanks for pointing it out."