### PR TITLE
parsedate: bsearch the time zones

### DIFF
--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -243,8 +243,7 @@ static int checktz(const char *check, size_t len)
     const struct tzinfo *what;
     struct tzinfo find;
     curlx_strcopy(find.name, sizeof(find.name), check, len);
-    what = bsearch(&find, tz, CURL_ARRAYSIZE(tz), sizeof(struct tzinfo *),
-                   tzcompare);
+    what = bsearch(&find, tz, CURL_ARRAYSIZE(tz), sizeof(tz[0]), tzcompare);
     if(what)
       return what->offset * 60;
   }

--- a/tests/libtest/lib517.c
+++ b/tests/libtest/lib517.c
@@ -52,6 +52,9 @@ static CURLcode test_lib517(const char *URL)
     { "1994.Nov.6", 784080000 },
     { "Sun/Nov/6/94/GMT", 784080000 },
     { "Sun, 06 Nov 1994 08:49:37 CET", 784108177 },
+    { "Sun, 06 Nov 1994 08:49:37 cet", -1 }, /* lowercase time zone */
+    { "Sun, 06 Nov 1994 08:49:37 utc", -1 }, /* lowercase time zone */
+    { "Sun, 06 Nov 1994 08:49:37 gmt", -1 }, /* lowercase time zone */
     { "06 Nov 1994 08:49:37 EST", 784129777 },
     { "Sun, 06 Nov 1994 08:49:37 UT", 784111777 },
     { "Sun, 12 Sep 2004 15:05:58 -0700", 1095026758 },


### PR DESCRIPTION
There are 69 entries, bsearch is faster than linear search for random access.

This now also makes the matching case sensitive (zone names always in uppercase). No docs said otherwise and all tests assumed uppercase.