### PR TITLE
typos: make the typos script not check source code

### DIFF
--- a/.github/scripts/typos.sh
+++ b/.github/scripts/typos.sh
@@ -7,7 +7,8 @@ set -eu
 
 cd "$(dirname "${0}")"/../..
 
-git ls-files | typos \
+# ignore source code files
+git ls-files || grep -Ev '^(src|include|lib)' | typos \
   --isolated \
   --force-exclude \
   --config '.github/scripts/typos.toml' \


### PR DESCRIPTION
Since we cannot filter it to just check strings and comments, and we already check those with the pyspelling tool, this now ignores the src, lib and include directories.

There are too many false positive errors for this to run unconditionally.