### PR TITLE
test threaded resolver, check

### DIFF
--- a/src/curlinfo.c
+++ b/src/curlinfo.c
@@ -34,7 +34,7 @@
 #include "multihandle.h" /* for ENABLE_WAKEUP */
 #include "tool_xattr.h" /* for USE_XATTR */
 #include "curl_sha512_256.h" /* for CURL_HAVE_SHA512_256 */
-#include "asyn.h" /* for USE_RESOLV_ARES */
+#include "asyn.h" /* for USE_RESOLV_ARES, USE_RESOLV_THREADED */
 #include "fake_addrinfo.h" /* for USE_FAKE_GETADDRINFO */
 
 #include <stdio.h>
@@ -140,6 +140,13 @@ static const char *disabled[] = {
   ,
   "shuffle-dns: "
 #ifdef CURL_DISABLE_SHUFFLE_DNS
+  "OFF"
+#else
+  "ON"
+#endif
+  ,
+  "resolv-threaded: "
+#ifndef USE_RESOLV_THREADED
   "OFF"
 #else
   "ON"

--- a/tests/http/test_21_resolve.py
+++ b/tests/http/test_21_resolve.py
@@ -109,7 +109,7 @@ class TestResolve:
         assert os.path.exists(dfiles[1])
 
     # use .invalid host name, parallel, single resolve thread
-    @pytest.mark.skipif(condition=Env.curl_uses_lib('c-ares'), reason="c-ares resolver skipped")
+    @pytest.mark.skipif(condition=not Env.curl_resolv_threaded(), reason="no threaded resolver")
     def test_21_05_resolv_single_thread(self, env: Env, httpd, nghttpx):
         count = 10
         delay_ms = 50

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -165,6 +165,7 @@ class EnvConfig:
         self.curl_is_verbose = 'verbose-strings: ON' in p.stdout
         self.curl_can_cert_status = 'cert-status: ON' in p.stdout
         self.curl_override_dns = 'override-dns: ON' in p.stdout
+        self.curl_resolv_threaded = 'resolv-threaded: ON' in p.stdout
 
         self.ports = {}
 
@@ -514,6 +515,10 @@ class Env:
     @staticmethod
     def curl_override_dns() -> bool:
         return Env.CONFIG.curl_override_dns
+
+    @staticmethod
+    def curl_resolv_threaded() -> bool:
+        return Env.CONFIG.curl_resolv_threaded
 
     @staticmethod
     def curl_can_early_data() -> bool:


### PR DESCRIPTION
Add `resolv-threaded` to curlinfo to detect use of the threaded resolver correctly even with c-ares linked to https-rr.

Run test_21_05 exactly when threaded resolver is built.