### PR TITLE
lib: move request specific allocations to the request struct

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -172,7 +172,7 @@ static void h1_tunnel_go_state(struct Curl_cfilter *cf,
     /* If a proxy-authorization header was used for the proxy, then we should
        make sure that it is not accidentally used for the document request
        after we have connected. Let's thus free and clear it here. */
-    curlx_safefree(data->state.aptr.proxyuserpwd);
+    curlx_safefree(data->req.proxyuserpwd);
     break;
   }
 }
@@ -449,7 +449,7 @@ static CURLcode recv_CONNECT_resp(struct Curl_cfilter *cf,
 
     if(!nread) {
       if(data->set.proxyauth && data->state.authproxy.avail &&
-         data->state.aptr.proxyuserpwd) {
+         data->req.proxyuserpwd) {
         /* proxy auth was requested and there was proxy auth available,
            then deem this as "mere" proxy disconnect */
         ts->close_connection = TRUE;
@@ -690,7 +690,7 @@ static CURLcode cf_h1_proxy_connect(struct Curl_cfilter *cf,
   result = H1_CONNECT(cf, data, ts);
   if(result)
     goto out;
-  curlx_safefree(data->state.aptr.proxyuserpwd);
+  curlx_safefree(data->req.proxyuserpwd);
 
 out:
   *done = (result == CURLE_OK) && tunnel_is_established(cf->ctx);

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -158,7 +158,7 @@ static void h2_tunnel_go_state(struct Curl_cfilter *cf,
     /* If a proxy-authorization header was used for the proxy, then we should
        make sure that it is not accidentally used for the document request
        after we have connected. Let's thus free and clear it here. */
-    curlx_safefree(data->state.aptr.proxyuserpwd);
+    curlx_safefree(data->req.proxyuserpwd);
     break;
   }
 }

--- a/lib/http.c
+++ b/lib/http.c
@@ -3122,12 +3122,6 @@ out:
   if(result == CURLE_TOO_LARGE)
     failf(data, "HTTP request too large");
 
-  /* clear userpwd and proxyuserpwd to avoid reusing old credentials
-   * from reused connections */
-  curlx_safefree(data->req.userpwd);
-#ifndef CURL_DISABLE_PROXY
-  curlx_safefree(data->req.proxyuserpwd);
-#endif
   curlx_dyn_free(&req);
   return result;
 }

--- a/lib/http.c
+++ b/lib/http.c
@@ -256,7 +256,7 @@ static CURLcode http_output_basic(struct Curl_easy *data, bool proxy)
      connection */
   if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-    userp = &data->state.aptr.proxyuserpwd;
+    userp = &data->req.proxyuserpwd;
     user = data->state.aptr.proxyuser;
     pwd = data->state.aptr.proxypasswd;
 #else
@@ -264,7 +264,7 @@ static CURLcode http_output_basic(struct Curl_easy *data, bool proxy)
 #endif
   }
   else {
-    userp = &data->state.aptr.userpwd;
+    userp = &data->req.userpwd;
     user = data->state.aptr.user;
     pwd = data->state.aptr.passwd;
   }
@@ -312,7 +312,7 @@ static CURLcode http_output_bearer(struct Curl_easy *data)
   char **userp;
   CURLcode result = CURLE_OK;
 
-  userp = &data->state.aptr.userpwd;
+  userp = &data->req.userpwd;
   curlx_free(*userp);
   *userp = curl_maprintf("Authorization: Bearer %s\r\n",
                          data->set.str[STRING_BEARER]);
@@ -2904,14 +2904,14 @@ static CURLcode http_add_hd(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_PROXY
   case H1_HD_PROXY_AUTH:
-    if(data->state.aptr.proxyuserpwd)
-      result = curlx_dyn_add(req, data->state.aptr.proxyuserpwd);
+    if(data->req.proxyuserpwd)
+      result = curlx_dyn_add(req, data->req.proxyuserpwd);
     break;
 #endif
 
   case H1_HD_USER_AUTH:
-    if(data->state.aptr.userpwd)
-      result = curlx_dyn_add(req, data->state.aptr.userpwd);
+    if(data->req.userpwd)
+      result = curlx_dyn_add(req, data->req.userpwd);
     break;
 
   case H1_HD_RANGE:
@@ -3124,9 +3124,9 @@ out:
 
   /* clear userpwd and proxyuserpwd to avoid reusing old credentials
    * from reused connections */
-  curlx_safefree(data->state.aptr.userpwd);
+  curlx_safefree(data->req.userpwd);
 #ifndef CURL_DISABLE_PROXY
-  curlx_safefree(data->state.aptr.proxyuserpwd);
+  curlx_safefree(data->req.proxyuserpwd);
 #endif
   curlx_dyn_free(&req);
   return result;

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -1110,8 +1110,8 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
   Curl_strntoupper(&auth_headers[sizeof("Authorization: ") - 1],
                    curlx_str(&provider0), curlx_strlen(&provider0));
 
-  curlx_free(data->state.aptr.userpwd);
-  data->state.aptr.userpwd = auth_headers;
+  curlx_free(data->req.userpwd);
+  data->req.userpwd = auth_headers;
   data->state.authhost.done = TRUE;
   result = CURLE_OK;
 

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -1110,7 +1110,6 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
   Curl_strntoupper(&auth_headers[sizeof("Authorization: ") - 1],
                    curlx_str(&provider0), curlx_strlen(&provider0));
 
-  curlx_free(data->req.userpwd);
   data->req.userpwd = auth_headers;
   data->state.authhost.done = TRUE;
   result = CURLE_OK;

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -1110,6 +1110,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
   Curl_strntoupper(&auth_headers[sizeof("Authorization: ") - 1],
                    curlx_str(&provider0), curlx_strlen(&provider0));
 
+  curlx_free(data->req.userpwd);
   data->req.userpwd = auth_headers;
   data->state.authhost.done = TRUE;
   result = CURLE_OK;

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -91,7 +91,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
     return CURLE_NOT_BUILT_IN;
 #else
     digest = &data->state.proxydigest;
-    allocuserpwd = &data->state.aptr.proxyuserpwd;
+    allocuserpwd = &data->req.proxyuserpwd;
     userp = data->state.aptr.proxyuser;
     passwdp = data->state.aptr.proxypasswd;
     authp = &data->state.authproxy;
@@ -99,7 +99,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   }
   else {
     digest = &data->state.digest;
-    allocuserpwd = &data->state.aptr.userpwd;
+    allocuserpwd = &data->req.userpwd;
     userp = data->state.aptr.user;
     passwdp = data->state.aptr.passwd;
     authp = &data->state.authhost;

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -217,13 +217,13 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
 
     if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-      curlx_free(data->state.aptr.proxyuserpwd);
-      data->state.aptr.proxyuserpwd = userp;
+      curlx_free(data->req.proxyuserpwd);
+      data->req.proxyuserpwd = userp;
 #endif
     }
     else {
-      curlx_free(data->state.aptr.userpwd);
-      data->state.aptr.userpwd = userp;
+      curlx_free(data->req.userpwd);
+      data->req.userpwd = userp;
     }
 
     curlx_free(base64);

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -139,7 +139,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 
   if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-    allocuserpwd = &data->state.aptr.proxyuserpwd;
+    allocuserpwd = &data->req.proxyuserpwd;
     userp = data->state.aptr.proxyuser;
     passwdp = data->state.aptr.proxypasswd;
     service = data->set.str[STRING_PROXY_SERVICE_NAME] ?
@@ -152,7 +152,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 #endif
   }
   else {
-    allocuserpwd = &data->state.aptr.userpwd;
+    allocuserpwd = &data->req.userpwd;
     userp = data->state.aptr.user;
     passwdp = data->state.aptr.passwd;
     service = data->set.str[STRING_SERVICE_NAME] ?

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -233,9 +233,9 @@ CURLcode Curl_http_proxy_create_CONNECT(struct httpreq **preq,
       goto out;
   }
 
-  if(data->state.aptr.proxyuserpwd) {
+  if(data->req.proxyuserpwd) {
     result = Curl_dynhds_h1_cadd_line(&req->headers,
-                                      data->state.aptr.proxyuserpwd);
+                                      data->req.proxyuserpwd);
     if(result)
       goto out;
   }

--- a/lib/request.c
+++ b/lib/request.c
@@ -110,6 +110,10 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   struct curltime t0 = { 0, 0 };
 
   curlx_safefree(req->newurl);
+  curlx_safefree(req->userpwd);
+#ifndef CURL_DISABLE_PROXY
+  curlx_safefree(req->proxyuserpwd);
+#endif
   Curl_client_reset(data);
   if(req->sendbuf_init)
     Curl_bufq_reset(&req->sendbuf);
@@ -163,6 +167,10 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
 void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
 {
   curlx_safefree(req->newurl);
+  curlx_safefree(req->userpwd);
+#ifndef CURL_DISABLE_PROXY
+  curlx_safefree(req->proxyuserpwd);
+#endif
   if(req->sendbuf_init)
     Curl_bufq_free(&req->sendbuf);
   Curl_client_cleanup(data);

--- a/lib/request.h
+++ b/lib/request.h
@@ -113,6 +113,10 @@ struct SingleRequest {
                        wanted */
   uint8_t io_flags; /* REQ_IO_RECV | REQ_IO_SEND */
 
+  char *userpwd;      /* auth header */
+#ifndef CURL_DISABLE_PROXY
+  char *proxyuserpwd; /* proxy auth header */
+#endif
 #ifndef CURL_DISABLE_COOKIES
   unsigned char setcookies;
 #endif

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -538,12 +538,6 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                           p_proxyuserpwd ? p_proxyuserpwd : "",
                           p_userpwd ? p_userpwd : "");
 
-  /*
-   * Free userpwd now --- cannot reuse this for Negotiate and possibly NTLM
-   * with basic and digest, it will be freed anyway by the next request
-   */
-  curlx_safefree(data->req.userpwd);
-
   if(result)
     goto out;
 

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -453,9 +453,9 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     goto out;
 
 #ifndef CURL_DISABLE_PROXY
-  p_proxyuserpwd = data->state.aptr.proxyuserpwd;
+  p_proxyuserpwd = data->req.proxyuserpwd;
 #endif
-  p_userpwd = data->state.aptr.userpwd;
+  p_userpwd = data->req.userpwd;
 
   /* Referrer */
   curlx_safefree(data->state.aptr.ref);
@@ -542,7 +542,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
    * Free userpwd now --- cannot reuse this for Negotiate and possibly NTLM
    * with basic and digest, it will be freed anyway by the next request
    */
-  curlx_safefree(data->state.aptr.userpwd);
+  curlx_safefree(data->req.userpwd);
 
   if(result)
     goto out;

--- a/lib/url.c
+++ b/lib/url.c
@@ -284,10 +284,6 @@ CURLcode Curl_close(struct Curl_easy **datap)
     DEBUGASSERT(0);
 
   Curl_hash_destroy(&data->meta_hash);
-#ifndef CURL_DISABLE_PROXY
-  curlx_safefree(data->req.proxyuserpwd);
-#endif
-  curlx_safefree(data->req.userpwd);
   curlx_safefree(data->state.aptr.uagent);
   curlx_safefree(data->state.aptr.accept_encoding);
   curlx_safefree(data->state.aptr.rangeline);

--- a/lib/url.c
+++ b/lib/url.c
@@ -285,10 +285,10 @@ CURLcode Curl_close(struct Curl_easy **datap)
 
   Curl_hash_destroy(&data->meta_hash);
 #ifndef CURL_DISABLE_PROXY
-  curlx_safefree(data->state.aptr.proxyuserpwd);
+  curlx_safefree(data->req.proxyuserpwd);
 #endif
+  curlx_safefree(data->req.userpwd);
   curlx_safefree(data->state.aptr.uagent);
-  curlx_safefree(data->state.aptr.userpwd);
   curlx_safefree(data->state.aptr.accept_encoding);
   curlx_safefree(data->state.aptr.rangeline);
   curlx_safefree(data->state.aptr.ref);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -801,7 +801,6 @@ struct UrlState {
   struct dynamically_allocated_data {
     char *uagent;
     char *accept_encoding;
-    char *userpwd;
     char *rangeline;
     char *ref;
     char *host;
@@ -816,7 +815,6 @@ struct UrlState {
     char *user;
     char *passwd;
 #ifndef CURL_DISABLE_PROXY
-    char *proxyuserpwd;
     char *proxyuser;
     char *proxypasswd;
 #endif


### PR DESCRIPTION
To make it clearer that they are ephemeral.