### PR TITLE
http: clear the proxy credentials as well on port or scheme change

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1289,6 +1289,13 @@ CURLcode Curl_http_follow(struct Curl_easy *data, const char *newurl,
     }
   }
   DEBUGASSERT(follow_url);
+  {
+    CURLcode result = Curl_reset_proxypwd(data);
+    if(result) {
+      curlx_free(follow_url);
+      return result;
+    }
+  }
 
   if(type == FOLLOW_FAKE) {
     /* we are only figuring out the new URL if we would have followed locations

--- a/lib/http.c
+++ b/lib/http.c
@@ -1278,6 +1278,11 @@ CURLcode Curl_http_follow(struct Curl_easy *data, const char *newurl,
         curlx_free(scheme);
       }
       if(clear) {
+        CURLcode result = Curl_reset_userpwd(data);
+        if(result) {
+          curlx_free(follow_url);
+          return result;
+        }
         curlx_safefree(data->state.aptr.user);
         curlx_safefree(data->state.aptr.passwd);
       }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -451,15 +451,25 @@ CURLcode Curl_reset_userpwd(struct Curl_easy *data)
   if(!result)
     result = Curl_setstropt(&data->state.aptr.passwd,
                             data->set.str[STRING_PASSWORD]);
+  return result;
+}
+
+/*
+ * Restore the proxy credentials to those set in options.
+ */
+CURLcode Curl_reset_proxypwd(struct Curl_easy *data)
+{
 #ifndef CURL_DISABLE_PROXY
-  if(!result)
-    result = Curl_setstropt(&data->state.aptr.proxyuser,
-                            data->set.str[STRING_PROXYUSERNAME]);
+  CURLcode result = Curl_setstropt(&data->state.aptr.proxyuser,
+                                   data->set.str[STRING_PROXYUSERNAME]);
   if(!result)
     result = Curl_setstropt(&data->state.aptr.proxypasswd,
                             data->set.str[STRING_PROXYPASSWORD]);
-#endif
   return result;
+#else
+  (void)data;
+  return CURLE_OK;
+#endif
 }
 
 /*
@@ -612,6 +622,8 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 
   if(!result)
     result = Curl_reset_userpwd(data);
+  if(!result)
+    result = Curl_reset_proxypwd(data);
 
   data->req.headerbytecount = 0;
   Curl_headers_cleanup(data);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -439,6 +439,30 @@ void Curl_init_CONNECT(struct Curl_easy *data)
 }
 
 /*
+ * Restore the user and proxy credentials to those set in options.
+ */
+CURLcode Curl_reset_userpwd(struct Curl_easy *data)
+{
+  CURLcode result;
+  if(data->set.str[STRING_USERNAME] || data->set.str[STRING_PASSWORD])
+    data->state.creds_from = CREDS_OPTION;
+  result = Curl_setstropt(&data->state.aptr.user,
+                          data->set.str[STRING_USERNAME]);
+  if(!result)
+    result = Curl_setstropt(&data->state.aptr.passwd,
+                            data->set.str[STRING_PASSWORD]);
+#ifndef CURL_DISABLE_PROXY
+  if(!result)
+    result = Curl_setstropt(&data->state.aptr.proxyuser,
+                            data->set.str[STRING_PROXYUSERNAME]);
+  if(!result)
+    result = Curl_setstropt(&data->state.aptr.proxypasswd,
+                            data->set.str[STRING_PROXYPASSWORD]);
+#endif
+  return result;
+}
+
+/*
  * Curl_pretransfer() is called immediately before a transfer starts, and only
  * once for one transfer no matter if it has redirects or do multi-pass
  * authentication etc.
@@ -586,23 +610,8 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
       return CURLE_OUT_OF_MEMORY;
   }
 
-  if(data->set.str[STRING_USERNAME] ||
-     data->set.str[STRING_PASSWORD])
-    data->state.creds_from = CREDS_OPTION;
   if(!result)
-    result = Curl_setstropt(&data->state.aptr.user,
-                            data->set.str[STRING_USERNAME]);
-  if(!result)
-    result = Curl_setstropt(&data->state.aptr.passwd,
-                            data->set.str[STRING_PASSWORD]);
-#ifndef CURL_DISABLE_PROXY
-  if(!result)
-    result = Curl_setstropt(&data->state.aptr.proxyuser,
-                            data->set.str[STRING_PROXYUSERNAME]);
-  if(!result)
-    result = Curl_setstropt(&data->state.aptr.proxypasswd,
-                            data->set.str[STRING_PROXYPASSWORD]);
-#endif
+    result = Curl_reset_userpwd(data);
 
   data->req.headerbytecount = 0;
   Curl_headers_cleanup(data);

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -31,6 +31,7 @@ char *Curl_checkheaders(const struct Curl_easy *data,
 
 void Curl_init_CONNECT(struct Curl_easy *data);
 
+CURLcode Curl_reset_userpwd(struct Curl_easy *data);
 CURLcode Curl_pretransfer(struct Curl_easy *data);
 
 CURLcode Curl_sendrecv(struct Curl_easy *data);

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -32,6 +32,7 @@ char *Curl_checkheaders(const struct Curl_easy *data,
 void Curl_init_CONNECT(struct Curl_easy *data);
 
 CURLcode Curl_reset_userpwd(struct Curl_easy *data);
+CURLcode Curl_reset_proxypwd(struct Curl_easy *data);
 CURLcode Curl_pretransfer(struct Curl_easy *data);
 
 CURLcode Curl_sendrecv(struct Curl_easy *data);

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -244,7 +244,7 @@ test1970 test1971 test1972 test1973 test1974 test1975 test1976 test1977 \
 test1978 test1979 test1980 test1981 test1982 test1983 test1984 \
 \
 test2000 test2001 test2002 test2003 test2004 test2005 test2006 test2007 \
-test2008 \
+test2008 test2009 test2010 \
 \
                                                                test2023 \
 test2024 test2025 test2026 test2027 test2028 test2029 test2030 test2031 \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -244,7 +244,7 @@ test1970 test1971 test1972 test1973 test1974 test1975 test1976 test1977 \
 test1978 test1979 test1980 test1981 test1982 test1983 test1984 \
 \
 test2000 test2001 test2002 test2003 test2004 test2005 test2006 test2007 \
-test2008 test2009 test2010 \
+test2008 test2009 test2010 test2011 \
 \
                                                                test2023 \
 test2024 test2025 test2026 test2027 test2028 test2029 test2030 test2031 \

--- a/tests/data/test2009
+++ b/tests/data/test2009
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+http_proxy
+</keywords>
+</info>
+# Server-side
+<reply>
+<connect>
+HTTP/1.1 407 Denied
+
+</connect>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 redirect
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+Location: https://another.example/%TESTNUMBER0002
+
+boo
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+proxy
+</features>
+<server>
+http
+https
+</server>
+<name>
+proxy credentials via env variables, redirect from http to https
+</name>
+
+<setenv>
+http_proxy=http://user:secret@%HOSTIP:%HTTPPORT
+https_proxy=https://%HOSTIP:%HTTPSPORT/
+</setenv>
+<command>
+http://somewhere.example/ --follow --proxy-insecure
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://somewhere.example/ HTTP/1.1
+Host: somewhere.example
+Proxy-Authorization: Basic %b64[user:secret]b64%
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+CONNECT another.example:443 HTTP/1.1
+Host: another.example:443
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+</protocol>
+<errorcode>
+7
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test2010
+++ b/tests/data/test2010
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+http_proxy
+</keywords>
+</info>
+# Server-side
+<reply>
+<connect>
+HTTP/1.1 407 Denied
+
+</connect>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 redirect
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+Location: https://another.example/%TESTNUMBER0002
+
+boo
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+proxy
+</features>
+<server>
+http
+https
+</server>
+<name>
+proxy credentials via options for two proxies, redirect from http to https
+</name>
+
+<setenv>
+http_proxy=http://%HOSTIP:%HTTPPORT
+https_proxy=https://%HOSTIP:%HTTPSPORT/
+</setenv>
+<command>
+--proxy-user batman:robin http://somewhere.example/ --follow --proxy-insecure
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://somewhere.example/ HTTP/1.1
+Host: somewhere.example
+Proxy-Authorization: Basic %b64[batman:robin]b64%
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+CONNECT another.example:443 HTTP/1.1
+Host: another.example:443
+Proxy-Authorization: Basic %b64[batman:robin]b64%
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+</protocol>
+<errorcode>
+7
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test2011
+++ b/tests/data/test2011
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+http_proxy
+</keywords>
+</info>
+# Server-side
+<reply>
+<connect>
+HTTP/1.1 407 Denied
+
+</connect>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 redirect
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/html
+Location: https://another.example/%TESTNUMBER0002
+
+boo
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+proxy
+</features>
+<server>
+http
+https
+</server>
+<name>
+proxy creds via env, cross-scheme redirect, --location-trusted
+</name>
+
+<setenv>
+http_proxy=http://user:secret@%HOSTIP:%HTTPPORT
+https_proxy=https://%HOSTIP:%HTTPSPORT/
+</setenv>
+<command>
+http://somewhere.example/ --location-trusted --proxy-insecure
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://somewhere.example/ HTTP/1.1
+Host: somewhere.example
+Proxy-Authorization: Basic %b64[user:secret]b64%
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+CONNECT another.example:443 HTTP/1.1
+Host: another.example:443
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+</protocol>
+<errorcode>
+7
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Add test 2009 to verify switching between proxies with credentials when the switch is driven by a redirect

Reported-by: Dwij Mehta