### PR TITLE
url: allow credential upgrade for Negotiate auth

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1005,6 +1005,14 @@ static bool url_match_auth(struct connectdata *conn,
        Curl_timestrcmp(m->needle->passwd, conn->passwd) ||
        Curl_timestrcmp(m->needle->sasl_authzid, conn->sasl_authzid) ||
        Curl_timestrcmp(m->needle->oauth_bearer, conn->oauth_bearer)) {
+#ifdef USE_SPNEGO
+      /* Allow credential changes if Negotiate auth hasn't started yet */
+      if((m->needle->scheme->protocol & PROTO_FAMILY_HTTP) &&
+         (conn->http_negotiate_state == GSS_AUTHNONE)) {
+        /* Negotiate auth not started, credentials can be added */
+        return TRUE;
+      }
+#endif
       /* one of them was different */
       return FALSE;
     }
@@ -1156,6 +1164,11 @@ static bool url_match_auth_nego(struct connectdata *conn,
      already authenticating with the right credentials. If not, keep looking
      so that we can reuse Negotiate connections if possible. */
   if(m->want_nego_http) {
+    /* If auth hasn't started yet, we can add credentials to this connection */
+    if(conn->http_negotiate_state == GSS_AUTHNONE) {
+      return TRUE;  /* Auth not started - safe to reuse and add credentials */
+    }
+    /* Auth has started, so credentials must match */
     if(Curl_timestrcmp(m->needle->user, conn->user) ||
        Curl_timestrcmp(m->needle->passwd, conn->passwd))
       return FALSE;
@@ -1202,7 +1215,7 @@ static bool url_match_auth_nego(struct connectdata *conn,
   return TRUE;
 }
 #else
-#define url_match_auth_nego(c, m) ((void)(c), (void)(m), TRUE)
+#define url_match_auth_nego(c, m) ((void)c, (void)m, TRUE)
 #endif
 
 static bool url_match_conn(struct connectdata *conn, void *userdata)

--- a/lib/url.c
+++ b/lib/url.c
@@ -1215,7 +1215,7 @@ static bool url_match_auth_nego(struct connectdata *conn,
   return TRUE;
 }
 #else
-#define url_match_auth_nego(c, m) ((void)c, (void)m, TRUE)
+#define url_match_auth_nego(c, m) ((void)(c), (void)(m), TRUE)
 #endif
 
 static bool url_match_conn(struct connectdata *conn, void *userdata)


### PR DESCRIPTION
# Connection Reuse Regression with Negotiate Auth After CVE-2026-1965

## Summary

When curl is built with GSSAPI support due to a connection reuse regression introduced by the CVE-2026-1965 security fix. The fix added credential checking to `url_match_auth_nego()` but doesn't allow "upgrading" connections from no-auth to with-auth, which is a legitimate use case.

This issue is masked in 8.19 by a separate test server issue (commit 510fdad64d prevents logging multiple disconnects with `--next`).

## Steps to Reproduce

1. Build curl with GSSAPI support:
   ```bash
   ./configure --with-gssapi --enable-debug
   make
   cd tests && make
   ```

2. Run test 338:
   ```bash
   ./runtests.pl 338 -v
   ```

3. 
Test fails on > curl-8.19 with 2 disconnects instead of 1
Test passes on curl-8.19 due to masking, logs show 2 connections/disconnects.

## Expected vs Actual Behavior

**Test 338 uses `--next` to make two requests:**
```bash
curl http://host/338 --next http://host/338 --anyauth -u foo:moo
```

- Request 1: No credentials (`user=NULL, passwd=NULL`)
- Request 2: With credentials (`user="foo", passwd="moo"`)

**Expected:** Connection reused → 1 disconnect  
**Actual:** New connection created → 2 disconnects

## Root Cause

After CVE-2026-1965, `url_match_auth_nego()` strictly compares credentials:

```c
if(Curl_timestrcmp(m->needle->user, conn->user) ||
   Curl_timestrcmp(m->needle->passwd, conn->passwd))
  return FALSE;
```

This prevents reusing a connection with `NULL` credentials when credentials are added in a subsequent request (`NULL` vs `"foo:moo"`).

## Why This Only Affects GSSAPI Builds

When built with GSSAPI, `--anyauth` includes `CURLAUTH_NEGOTIATE`:
```c
#define CURLAUTH_ANY  ((~CURLAUTH_DIGEST_IE) & 0xffffffff)
```

Without GSSAPI, Negotiate auth isn't available, so this credential upgrade scenario doesn't occur.

## Proposed Fix

Allow "upgrading" connections that haven't started Negotiate authentication yet, similar to how NTLM handles this:

This preserves CVE-2026-1965 security (credentials must match once auth starts) while allowing the legitimate upgrade case (NULL → with-creds before auth starts).

## Environment

- **curl version:** 8.19.0
- **Affects:** Any version with CVE-2026-1965 patch when built with GSSAPI
- **OS:** Linux (Amazon Linux, Ubuntu)
- **GSSAPI:** MIT Kerberos 1.15+

## Additional Notes

**Thank you for your time!**

**Discovered by:** Samuel Dainard <sdainard>, Amazon Linux team  
**Related:** Issue #4499 (original test 338 creation), CVE-2026-1965
**Fixes** Issue #21307 Connection Reuse Regression with Negotiate Auth
