### PR TITLE
urldata: move cookiehost to struct SingleRequest

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2081,8 +2081,8 @@ static CURLcode http_set_aptr_host(struct Curl_easy *data)
         if(colon)
           *colon = 0; /* The host must not include an embedded port number */
       }
-      curlx_free(aptr->cookiehost);
-      aptr->cookiehost = cookiehost;
+      curlx_free(data->req.cookiehost);
+      data->req.cookiehost = cookiehost;
     }
 #endif
 
@@ -2577,8 +2577,8 @@ static CURLcode http_cookies(struct Curl_easy *data,
 
     if(data->cookies && data->state.cookie_engine) {
       bool okay;
-      const char *host = data->state.aptr.cookiehost ?
-        data->state.aptr.cookiehost : data->conn->host.name;
+      const char *host = data->req.cookiehost ?
+        data->req.cookiehost : data->conn->host.name;
       Curl_share_lock(data, CURL_LOCK_DATA_COOKIE, CURL_LOCK_ACCESS_SINGLE);
       result = Curl_cookie_getlist(data, data->conn, &okay, host, &list);
       if(!result && okay) {
@@ -3578,8 +3578,8 @@ static CURLcode http_header_s(struct Curl_easy *data,
   if(v) {
     /* If there is a custom-set Host: name, use it here, or else use
      * real peer hostname. */
-    const char *host = data->state.aptr.cookiehost ?
-      data->state.aptr.cookiehost : conn->host.name;
+    const char *host = data->req.cookiehost ?
+      data->req.cookiehost : conn->host.name;
     const bool secure_context = Curl_secure_context(conn, host);
     CURLcode result;
     Curl_share_lock(data, CURL_LOCK_DATA_COOKIE, CURL_LOCK_ACCESS_SINGLE);

--- a/lib/http.c
+++ b/lib/http.c
@@ -2046,6 +2046,9 @@ static CURLcode http_set_aptr_host(struct Curl_easy *data)
     data->state.first_remote_protocol = conn->scheme->protocol;
   }
   curlx_safefree(aptr->host);
+#ifndef CURL_DISABLE_COOKIES
+  curlx_safefree(data->req.cookiehost);
+#endif
 
   ptr = Curl_checkheaders(data, STRCONST("Host"));
   if(ptr && (!data->state.this_is_a_follow ||
@@ -2081,7 +2084,6 @@ static CURLcode http_set_aptr_host(struct Curl_easy *data)
         if(colon)
           *colon = 0; /* The host must not include an embedded port number */
       }
-      curlx_free(data->req.cookiehost);
       data->req.cookiehost = cookiehost;
     }
 #endif

--- a/lib/request.c
+++ b/lib/request.c
@@ -119,6 +119,9 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
 #ifndef CURL_DISABLE_PROXY
   curlx_safefree(req->proxyuserpwd);
 #endif
+#ifndef CURL_DISABLE_COOKIES
+  curlx_safefree(req->cookiehost);
+#endif
   Curl_client_reset(data);
   if(req->sendbuf_init)
     Curl_bufq_reset(&req->sendbuf);

--- a/lib/request.h
+++ b/lib/request.h
@@ -119,6 +119,9 @@ struct SingleRequest {
   char *proxyuserpwd; /* proxy auth header */
 #endif
 #ifndef CURL_DISABLE_COOKIES
+  char *cookiehost;
+#endif
+#ifndef CURL_DISABLE_COOKIES
   unsigned char setcookies;
 #endif
   BIT(header);        /* incoming data has HTTP header */

--- a/lib/url.c
+++ b/lib/url.c
@@ -290,7 +290,7 @@ CURLcode Curl_close(struct Curl_easy **datap)
   curlx_safefree(data->state.aptr.ref);
   curlx_safefree(data->state.aptr.host);
 #ifndef CURL_DISABLE_COOKIES
-  curlx_safefree(data->state.aptr.cookiehost);
+  curlx_safefree(data->req.cookiehost);
 #endif
 #ifndef CURL_DISABLE_RTSP
   curlx_safefree(data->state.aptr.rtsp_transport);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -804,9 +804,6 @@ struct UrlState {
     char *rangeline;
     char *ref;
     char *host;
-#ifndef CURL_DISABLE_COOKIES
-    char *cookiehost;
-#endif
 #ifndef CURL_DISABLE_RTSP
     char *rtsp_transport;
 #endif

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -265,7 +265,7 @@ test2309 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 test2407 \
 \
-test2500 test2501 test2502 test2503 \
+test2500 test2501 test2502 test2503 test2504 \
 \
 test2600 test2601 test2602 test2603 test2604 test2605 \
 \

--- a/tests/data/test2504
+++ b/tests/data/test2504
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+cookies
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: server.example.com
+Content-Length: 47
+Set-Cookie: sid=SECRET123; Path=/
+
+file contents should appear once for each file
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<tool>
+lib%TESTNUMBER
+</tool>
+<name>
+custom Host with cookie, handle reuse, no custom Host:
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET / HTTP/1.1
+Host: victim.internal
+Accept: */*
+
+GET / HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -112,7 +112,7 @@ TESTS_C = \
   lib2023.c lib2032.c lib2082.c \
   lib2301.c lib2302.c lib2304.c           lib2306.c lib2308.c lib2309.c \
   lib2402.c           lib2404.c lib2405.c \
-  lib2502.c \
+  lib2502.c lib2504.c \
   lib2700.c \
   lib3010.c lib3025.c lib3026.c lib3027.c lib3033.c lib3034.c \
   lib3100.c lib3101.c lib3102.c lib3103.c lib3104.c lib3105.c \

--- a/tests/libtest/lib2504.c
+++ b/tests/libtest/lib2504.c
@@ -67,22 +67,23 @@ static CURLcode test_lib2504(const char *URL)
   }
 
   hdrs = curl_slist_append(hdrs, "Host: victim.internal");
+  if(hdrs) {
+    test_setopt(curl, CURLOPT_WRITEFUNCTION, sink2504);
+    test_setopt(curl, CURLOPT_COOKIEFILE, "");
+    test_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+    test_setopt(curl, CURLOPT_URL, URL);
 
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, sink2504);
-  test_setopt(curl, CURLOPT_COOKIEFILE, "");
-  test_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
-  test_setopt(curl, CURLOPT_URL, URL);
+    result = curl_easy_perform(curl);
+    curl_mprintf("req1=%d\n", (int)result);
+    dump_cookies2504(curl, "after request 1");
 
-  result = curl_easy_perform(curl);
-  curl_mprintf("req1=%d\n", (int)result);
-  dump_cookies2504(curl, "after request 1");
+    test_setopt(curl, CURLOPT_HTTPHEADER, NULL);
+    test_setopt(curl, CURLOPT_URL, URL);
 
-  test_setopt(curl, CURLOPT_HTTPHEADER, NULL);
-  test_setopt(curl, CURLOPT_URL, URL);
-
-  result = curl_easy_perform(curl);
-  curl_mprintf("req2=%d\n", (int)result);
-  dump_cookies2504(curl, "after request 2");
+    result = curl_easy_perform(curl);
+    curl_mprintf("req2=%d\n", (int)result);
+    dump_cookies2504(curl, "after request 2");
+  }
 test_cleanup:
   curl_slist_free_all(hdrs);
   curl_easy_cleanup(curl);

--- a/tests/libtest/lib2504.c
+++ b/tests/libtest/lib2504.c
@@ -51,7 +51,7 @@ static void dump_cookies2504(CURL *h, const char *tag)
 static CURLcode test_lib2504(const char *URL)
 {
   CURL *curl;
-  CURLcode result;
+  CURLcode result = CURLE_OUT_OF_MEMORY;
   struct curl_slist *hdrs = NULL;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {

--- a/tests/libtest/lib2504.c
+++ b/tests/libtest/lib2504.c
@@ -1,0 +1,92 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Linus Nielsen Feltzing <linus@haxx.se>
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+#include "testtrace.h"
+
+static size_t sink2504(char *ptr, size_t size, size_t nmemb, void *ud)
+{
+  (void)ptr;
+  (void)ud;
+  return size * nmemb;
+}
+
+static void dump_cookies2504(CURL *h, const char *tag)
+{
+  struct curl_slist *cookies = NULL;
+  struct curl_slist *nc;
+  CURLcode rc = curl_easy_getinfo(h, CURLINFO_COOKIELIST, &cookies);
+
+  curl_mprintf("== %s ==\n", tag);
+  if(rc) {
+    curl_mprintf("getinfo error: %d\n", (int)rc);
+    return;
+  }
+  for(nc = cookies; nc; nc = nc->next)
+    puts(nc->data);
+  curl_slist_free_all(cookies);
+}
+
+static CURLcode test_lib2504(const char *URL)
+{
+  CURL *curl;
+  CURLcode result;
+  struct curl_slist *hdrs = NULL;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    curl_mfprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    curl_mfprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  hdrs = curl_slist_append(hdrs, "Host: victim.internal");
+
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, sink2504);
+  test_setopt(curl, CURLOPT_COOKIEFILE, "");
+  test_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+  test_setopt(curl, CURLOPT_URL, URL);
+
+  result = curl_easy_perform(curl);
+  curl_mprintf("req1=%d\n", (int)result);
+  dump_cookies2504(curl, "after request 1");
+
+  test_setopt(curl, CURLOPT_HTTPHEADER, NULL);
+  test_setopt(curl, CURLOPT_URL, URL);
+
+  result = curl_easy_perform(curl);
+  curl_mprintf("req2=%d\n", (int)result);
+  dump_cookies2504(curl, "after request 2");
+test_cleanup:
+  curl_slist_free_all(hdrs);
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return result;
+}


### PR DESCRIPTION
To make it scoped for the single request appropriately.

Reported-by: Muhamad Arga Reksapati

Verify with libtest 2504: a custom Host *disabled* on reused handle