### PR TITLE
url same origin tests

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -718,9 +718,9 @@ static struct Curl_easy *h2_duphandle(struct Curl_cfilter *cf,
   return second;
 }
 
-static int set_transfer_url(struct Curl_easy *data,
+static int set_transfer_url(struct Curl_easy *newhandle,
                             struct curl_pushheaders *hp,
-                            struct Curl_easy *orig_data)
+                            struct Curl_easy *data)
 {
   const char *v;
   CURLUcode uc;
@@ -760,7 +760,7 @@ static int set_transfer_url(struct Curl_easy *data,
 
   /* We can only allow PUSH of resource from the same origin, e.g.
    * scheme + hostname + port */
-  if(!Curl_url_same_origin(orig_data->state.uh, u)) {
+  if(!Curl_url_same_origin(data->state.uh, u)) {
     rc = 1;
     goto fail;
   }
@@ -773,7 +773,7 @@ fail:
   if(rc)
     return rc;
 
-  Curl_bufref_set(&data->state.url, url, 0, curl_free);
+  Curl_bufref_set(&newhandle->state.url, url, 0, curl_free);
   return 0;
 }
 

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -718,8 +718,9 @@ static struct Curl_easy *h2_duphandle(struct Curl_cfilter *cf,
   return second;
 }
 
-static int set_transfer_url(struct Curl_easy *data, bool via_ssl_conn,
-                            struct curl_pushheaders *hp)
+static int set_transfer_url(struct Curl_easy *data,
+                            struct curl_pushheaders *hp,
+                            struct Curl_easy *orig_data)
 {
   const char *v;
   CURLUcode uc;
@@ -732,14 +733,6 @@ static int set_transfer_url(struct Curl_easy *data, bool via_ssl_conn,
 
   v = curl_pushheader_byname(hp, HTTP_PSEUDO_SCHEME);
   if(v) {
-    if(!via_ssl_conn) {
-      /* PUSH over an insecure connection, accept only insecure schemes. */
-      const struct Curl_scheme *scheme = Curl_get_scheme(v);
-      if(!scheme || (scheme->flags & PROTOPT_SSL)) {
-        rc = 1;
-        goto fail;
-      }
-    }
     uc = curl_url_set(u, CURLUPART_SCHEME, v, 0);
     if(uc) {
       rc = 1;
@@ -763,6 +756,13 @@ static int set_transfer_url(struct Curl_easy *data, bool via_ssl_conn,
       rc = 3;
       goto fail;
     }
+  }
+
+  /* We can only allow PUSH of resource from the same origin, e.g.
+   * scheme + hostname + port */
+  if(!curl_url_same_origin(orig_data->state.uh, u)) {
+    rc = 1;
+    goto fail;
   }
 
   uc = curl_url_get(u, CURLUPART_URL, &url, 0);
@@ -819,8 +819,7 @@ static int push_promise(struct Curl_cfilter *cf,
     heads.stream = stream;
     heads.frame = frame;
 
-    rv = set_transfer_url(newhandle,
-                          Curl_conn_is_ssl(cf->conn, cf->sockindex), &heads);
+    rv = set_transfer_url(newhandle, &heads, data);
     if(rv) {
       CURL_TRC_CF(data, cf, "[%d] PUSH_PROMISE, failed to set URL -> %d",
                   frame->promised_stream_id, rv);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -760,7 +760,7 @@ static int set_transfer_url(struct Curl_easy *data,
 
   /* We can only allow PUSH of resource from the same origin, e.g.
    * scheme + hostname + port */
-  if(!curl_url_same_origin(orig_data->state.uh, u)) {
+  if(!Curl_url_same_origin(orig_data->state.uh, u)) {
     rc = 1;
     goto fail;
   }

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -63,6 +63,6 @@ CURLUcode Curl_junkscan(const char *url, size_t *urllen, bool allowspace);
 #define U_CURLU_URLDECODE  (unsigned int)CURLU_URLDECODE
 #define U_CURLU_PATH_AS_IS (unsigned int)CURLU_PATH_AS_IS
 
-bool curl_url_same_origin(CURLU *base, CURLU *href);
+bool Curl_url_same_origin(CURLU *base, CURLU *href);
 
 #endif /* HEADER_CURL_URLAPI_INT_H */

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -63,4 +63,6 @@ CURLUcode Curl_junkscan(const char *url, size_t *urllen, bool allowspace);
 #define U_CURLU_URLDECODE  (unsigned int)CURLU_URLDECODE
 #define U_CURLU_PATH_AS_IS (unsigned int)CURLU_PATH_AS_IS
 
+bool curl_url_same_origin(CURLU *base, CURLU *href);
+
 #endif /* HEADER_CURL_URLAPI_INT_H */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -2006,7 +2006,7 @@ bool Curl_url_same_origin(CURLU *base, CURLU *href)
       return FALSE;
     if(!curl_strequal(base->port, href->port)) {
       /* This may still match if only one has an explicit port
-       * and it is the defaukt for the scheme. */
+       * and it is the default for the scheme. */
       if(base->port && href->port)
         return FALSE;
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1992,7 +1992,7 @@ nomem:
   return CURLUE_OK;
 }
 
-bool curl_url_same_origin(CURLU *base, CURLU *href)
+bool Curl_url_same_origin(CURLU *base, CURLU *href)
 {
   const struct Curl_scheme *s = NULL;
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1991,3 +1991,36 @@ nomem:
   }
   return CURLUE_OK;
 }
+
+bool curl_url_same_origin(CURLU *base, CURLU *href)
+{
+  const struct Curl_scheme *s = NULL;
+
+  /* base must be an absolute URL */
+  if(!base->scheme || !base->host)
+    return FALSE;
+  if(href->scheme && !curl_strequal(base->scheme, href->scheme))
+    return FALSE;
+  if(href->host) {
+    if(!curl_strequal(base->host, href->host))
+      return FALSE;
+    if(!curl_strequal(base->port, href->port)) {
+      /* This may still match if only one has an explicit port
+       * and it is the defaukt for the scheme. */
+      if(base->port && href->port)
+        return FALSE;
+
+      s = Curl_get_scheme(base->scheme);
+      if(!s) /* Cannot match default port for unkown scheme */
+        return FALSE;
+
+      /* The port which is set must be the default one */
+      if((base->port && (base->portnum != s->defport)) ||
+         (href->port && (href->portnum != s->defport)))
+        return FALSE;
+    }
+  }
+  else if(href->port) /* no host in href, then there must be no port */
+    return FALSE;
+  return TRUE;
+}

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -2011,7 +2011,7 @@ bool Curl_url_same_origin(CURLU *base, CURLU *href)
         return FALSE;
 
       s = Curl_get_scheme(base->scheme);
-      if(!s) /* Cannot match default port for unkown scheme */
+      if(!s) /* Cannot match default port for unknown scheme */
         return FALSE;
 
       /* The port which is set must be the default one */

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -57,6 +57,7 @@ my %wl = (
     'curlx_base64_encode' => 'internal api',
     'curlx_base64url_encode' => 'internal api',
     'Curl_multi_clear_dirty' => 'internal api',
+    'curl_url_same_origin' => 'internal api',
 );
 
 my %api = (

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -57,7 +57,6 @@ my %wl = (
     'curlx_base64_encode' => 'internal api',
     'curlx_base64url_encode' => 'internal api',
     'Curl_multi_clear_dirty' => 'internal api',
-    'curl_url_same_origin' => 'internal api',
 );
 
 my %api = (

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -301,5 +301,76 @@ static CURLcode test_unit1675(const char *arg)
     abort_if(fails, "parse_file tests failed");
   }
 
+  /* Test same origin check */
+  {
+    CURLU *base, *href;
+    int fails = 0;
+    unsigned int i;
+    bool match;
+    struct origin_test {
+      const char *base;
+      const char *scheme;
+      const char *host;
+      const char *port;
+      const char *path;
+      bool expect_match;
+    };
+    const struct origin_test tests[] = {
+      {"http://host:123/x", "http", "host", "123", "/y", TRUE},
+      {"http://host:123/x", NULL, "host", "123", "/y", TRUE},
+      {"http://host:123/x", NULL, NULL, NULL, "/y", TRUE},
+      {"http://host:80/x", "http", "host", "123", "/y", FALSE},
+      {"http://host:80/x", "http", "host", NULL, "/y", TRUE},
+      {"http://host/x", "http", "host", "80", "/y", TRUE},
+      {"http://host:123/x", "https", "host", "123", "/y", FALSE},
+      {"https://host/x", "http", "host", "443", "/y", FALSE},
+      {"https://host/x", "https", "host", "443", "/y", TRUE},
+    };
+
+    for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
+      CURLUcode uc;
+      base = curl_url();
+      href = curl_url();
+      if(!base || !href)
+        return CURLE_OUT_OF_MEMORY;
+      uc = curl_url_set(base, CURLUPART_URL, tests[i].base, 0);
+      if(uc) {
+        curl_mfprintf(stderr, "failed to parse %d base %s -> %d\n", i,
+                      tests[i].base, uc);
+        fails++;
+        goto loop_end;
+      }
+      if(tests[i].scheme)
+        uc = curl_url_set(href, CURLUPART_SCHEME, tests[i].scheme, 0);
+      if(!uc && tests[i].host)
+        uc = curl_url_set(href, CURLUPART_HOST, tests[i].host, 0);
+      if(!uc && tests[i].port)
+        uc = curl_url_set(href, CURLUPART_PORT, tests[i].port, 0);
+      if(!uc && tests[i].path)
+        uc = curl_url_set(href, CURLUPART_PATH, tests[i].path, 0);
+      if(uc) {
+        curl_mfprintf(stderr, "failed to parse %d href %s://%s:%s%s -> %d\n",
+                      i, tests[i].scheme, tests[i].host, tests[i].port,
+                      tests[i].path, uc);
+        fails++;
+        goto loop_end;
+      }
+
+      match = curl_url_same_origin(base, href);
+      if(match != tests[i].expect_match) {
+        curl_mfprintf(stderr, "ERROR: %d base %s and href %s://%s:%s%s %s\n",
+                      i, tests[i].base, tests[i].scheme, tests[i].host,
+                      tests[i].port, tests[i].path,
+                      match ? "matched" : "did not match");
+        fails++;
+      }
+
+loop_end:
+      curl_url_cleanup(base);
+      curl_url_cleanup(href);
+    }
+    abort_if(fails, "same_origin tests failed");
+  }
+
   UNITTEST_END_SIMPLE
 }

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -331,8 +331,11 @@ static CURLcode test_unit1675(const char *arg)
       CURLUcode uc;
       base = curl_url();
       href = curl_url();
-      if(!base || !href)
-        return CURLE_OUT_OF_MEMORY;
+      if(!base || !href) {
+        curl_mfprintf(stderr, "%d: failed to allocate memory\n", i);
+        fails++;
+        goto loop_end;
+      }
       uc = curl_url_set(base, CURLUPART_URL, tests[i].base, 0);
       if(uc) {
         curl_mfprintf(stderr, "failed to parse %d base %s -> %d\n", i,
@@ -356,7 +359,7 @@ static CURLcode test_unit1675(const char *arg)
         goto loop_end;
       }
 
-      match = curl_url_same_origin(base, href);
+      match = Curl_url_same_origin(base, href);
       if(match != tests[i].expect_match) {
         curl_mfprintf(stderr, "ERROR: %d base %s and href %s://%s:%s%s %s\n",
                       i, tests[i].base, tests[i].scheme, tests[i].host,

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -301,7 +301,9 @@ static CURLcode test_unit1675(const char *arg)
     abort_if(fails, "parse_file tests failed");
   }
 
-  /* Test same origin check */
+  /* Test same origin check. For now, we can only do that when
+   * schemes are supported by libcurl. */
+#ifndef CURL_DISABLE_HTTP
   {
     CURLU *base, *href;
     int fails = 0;
@@ -322,9 +324,11 @@ static CURLcode test_unit1675(const char *arg)
       {"http://host:80/x", "http", "host", "123", "/y", FALSE},
       {"http://host:80/x", "http", "host", NULL, "/y", TRUE},
       {"http://host/x", "http", "host", "80", "/y", TRUE},
+#ifdef USE_SSL
       {"http://host:123/x", "https", "host", "123", "/y", FALSE},
       {"https://host/x", "http", "host", "443", "/y", FALSE},
       {"https://host/x", "https", "host", "443", "/y", TRUE},
+#endif
     };
 
     for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
@@ -374,6 +378,7 @@ loop_end:
     }
     abort_if(fails, "same_origin tests failed");
   }
+#endif /* !CURL_DISABLE_HTTP */
 
   UNITTEST_END_SIMPLE
 }


### PR DESCRIPTION
Add new internal `curl_url_same_origin()` to check if a href has the same origin as a base URL. Add test cases in test1675 and use this in http2 push handling.