### PR TITLE
cleanup UNITTESTs, improve extract-unit-protos and static some more

### DIFF
--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -487,7 +487,7 @@ CURLcode Curl_cf_dns_insert_after(struct Curl_cfilter *cf_at,
 /* Return the resolv result from the first "resolv" filter, starting
  * the given filter `cf` downwards.
  */
-CURLcode Curl_cf_dns_result(struct Curl_cfilter *cf)
+static CURLcode cf_dns_result(struct Curl_cfilter *cf)
 {
   for(; cf; cf = cf->next) {
     if(cf->cft == &Curl_cft_dns) {
@@ -509,7 +509,7 @@ CURLcode Curl_cf_dns_result(struct Curl_cfilter *cf)
  */
 CURLcode Curl_conn_dns_result(struct connectdata *conn, int sockindex)
 {
-  return Curl_cf_dns_result(conn->cfilter[sockindex]);
+  return cf_dns_result(conn->cfilter[sockindex]);
 }
 
 static const struct Curl_addrinfo *cf_dns_get_nth_ai(

--- a/lib/cf-dns.h
+++ b/lib/cf-dns.h
@@ -46,7 +46,6 @@ CURLcode Curl_cf_dns_insert_after(struct Curl_cfilter *cf_at,
                                   bool complete_resolve);
 
 CURLcode Curl_conn_dns_result(struct connectdata *conn, int sockindex);
-CURLcode Curl_cf_dns_result(struct Curl_cfilter *cf);
 
 /* Returns TRUE if any addressinfo is available via
  * `Curl_conn_dns_get_ai()`. */

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -92,10 +92,10 @@ static cf_ip_connect_create *get_cf_create(uint8_t transport)
 }
 
 #ifdef UNITTESTS
-/* used by unit2600.c */
-UNITTEST void Curl_debug_set_transport_provider(
+/* @unittest 2600 */
+UNITTEST void debug_set_transport_provider(
   uint8_t transport, cf_ip_connect_create *cf_create);
-UNITTEST void Curl_debug_set_transport_provider(
+UNITTEST void debug_set_transport_provider(
   uint8_t transport, cf_ip_connect_create *cf_create)
 {
   size_t i;

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -34,11 +34,9 @@
 #include "curlx/strparse.h"
 
 #ifdef UNITTESTS
-/* used by unit2600.c */
-UNITTEST void Curl_cf_def_close(struct Curl_cfilter *cf,
-                                struct Curl_easy *data);
-UNITTEST void Curl_cf_def_close(struct Curl_cfilter *cf,
-                                struct Curl_easy *data)
+/* @unittest 2600 */
+UNITTEST void cf_def_close(struct Curl_cfilter *cf, struct Curl_easy *data);
+UNITTEST void cf_def_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   cf->connected = FALSE;
   if(cf->next)

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -97,14 +97,17 @@ enum alpnid Curl_str2alpnid(const struct Curl_str *cstr)
 #endif
 
 /*
- * Curl_timeleft_ms() returns the amount of milliseconds left allowed for the
+ * timeleft_now_ms() returns the amount of milliseconds left allowed for the
  * transfer/connection. If the value is 0, there is no timeout (ie there is
  * infinite time left). If the value is negative, the timeout time has already
  * elapsed.
- * @unittest: 1303
+ *
+ * @unittest 1303
  */
-timediff_t Curl_timeleft_now_ms(struct Curl_easy *data,
-                                const struct curltime *pnow)
+UNITTEST timediff_t timeleft_now_ms(struct Curl_easy *data,
+                                    const struct curltime *pnow);
+UNITTEST timediff_t timeleft_now_ms(struct Curl_easy *data,
+                                    const struct curltime *pnow)
 {
   timediff_t timeleft_ms = 0;
   timediff_t ctimeleft_ms = 0;
@@ -139,7 +142,7 @@ timediff_t Curl_timeleft_now_ms(struct Curl_easy *data,
 
 timediff_t Curl_timeleft_ms(struct Curl_easy *data)
 {
-  return Curl_timeleft_now_ms(data, Curl_pgrs_now(data));
+  return timeleft_now_ms(data, Curl_pgrs_now(data));
 }
 
 void Curl_shutdown_start(struct Curl_easy *data, int sockindex,

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -25,6 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+#include "hostip.h"
 #include "curlx/timeval.h"
 
 struct Curl_dns_entry;

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -38,8 +38,6 @@ enum alpnid Curl_str2alpnid(const struct Curl_str *cstr);
 /* generic function that returns how much time there is left to run, according
    to the timeouts set */
 timediff_t Curl_timeleft_ms(struct Curl_easy *data);
-timediff_t Curl_timeleft_now_ms(struct Curl_easy *data,
-                                const struct curltime *pnow);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -330,7 +330,7 @@ static int num_addresses(const struct Curl_addrinfo *addr)
 }
 
 /*
- * Curl_shuffle_addr() shuffles the order of addresses in a 'Curl_addrinfo'
+ * dns_shuffle_addr() shuffles the order of addresses in a 'Curl_addrinfo'
  * struct by re-linking its linked list.
  *
  * The addr argument should be the address of a pointer to the head node of a
@@ -339,12 +339,12 @@ static int num_addresses(const struct Curl_addrinfo *addr)
  *
  * Not declared static only to make it easy to use in a unit test!
  *
- * @unittest: 1608
+ * @unittest 1608
  */
-UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
-                                    struct Curl_addrinfo **addr);
-UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
-                                    struct Curl_addrinfo **addr)
+UNITTEST CURLcode dns_shuffle_addr(struct Curl_easy *data,
+                                   struct Curl_addrinfo **addr);
+UNITTEST CURLcode dns_shuffle_addr(struct Curl_easy *data,
+                                   struct Curl_addrinfo **addr)
 {
   CURLcode result = CURLE_OK;
   const int num_addrs = num_addresses(*addr);
@@ -464,7 +464,7 @@ static struct Curl_dns_entry *dnscache_entry_create(
 #ifndef CURL_DISABLE_SHUFFLE_DNS
   /* shuffle addresses if requested */
   if(data->set.dns_shuffle_addresses && dns->addr) {
-    CURLcode result = Curl_shuffle_addr(data, &dns->addr);
+    CURLcode result = dns_shuffle_addr(data, &dns->addr);
     if(result) {
       /* free without lock, we are the sole owner */
       dnscache_entry_free(dns);

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -714,6 +714,7 @@ static DOHcode doh_rdata(const unsigned char *doh,
   return DOH_OK;
 }
 
+/* @unittest 1655 */
 UNITTEST void de_init(struct dohentry *de);
 UNITTEST void de_init(struct dohentry *de)
 {
@@ -724,6 +725,7 @@ UNITTEST void de_init(struct dohentry *de)
     curlx_dyn_init(&de->cname[i], DYN_DOH_CNAME);
 }
 
+/* @unittest 1655 */
 UNITTEST DOHcode doh_resp_decode(const unsigned char *doh,
                                  size_t dohlen,
                                  DNStype dnstype,
@@ -1045,6 +1047,7 @@ static const char *doh_type2name(DNStype dnstype)
 }
 #endif
 
+/* @unittest 1655 */
 UNITTEST void de_cleanup(struct dohentry *d);
 UNITTEST void de_cleanup(struct dohentry *d)
 {
@@ -1177,11 +1180,8 @@ err:
 }
 
 #if defined(DEBUGBUILD) && defined(CURLVERBOSE)
-UNITTEST void doh_print_httpsrr(struct Curl_easy *data,
-                                struct Curl_https_rrinfo *hrr);
-
-UNITTEST void doh_print_httpsrr(struct Curl_easy *data,
-                                struct Curl_https_rrinfo *hrr)
+static void doh_print_httpsrr(struct Curl_easy *data,
+                              struct Curl_https_rrinfo *hrr)
 {
   DEBUGASSERT(hrr);
   infof(data, "HTTPS RR: priority %d, target: %s", hrr->priority, hrr->target);

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -220,33 +220,36 @@ CURLcode Curl_dynhds_h1_cadd_line(struct dynhds *dynhds, const char *line)
 }
 
 #ifdef UNITTESTS
-/* used by unit2602.c */
+/* @unittest 2602 */
 
 /**
  * Return TRUE iff one or more headers with the given name exist.
  */
-UNITTEST bool Curl_dynhds_contains(struct dynhds *dynhds,
-                                   const char *name, size_t namelen);
-UNITTEST bool Curl_dynhds_contains(struct dynhds *dynhds,
-                                   const char *name, size_t namelen)
+UNITTEST bool dynhds_contains(struct dynhds *dynhds,
+                              const char *name, size_t namelen);
+UNITTEST bool dynhds_contains(struct dynhds *dynhds,
+                              const char *name, size_t namelen)
 {
   return !!Curl_dynhds_get(dynhds, name, namelen);
 }
 
-UNITTEST bool Curl_dynhds_ccontains(struct dynhds *dynhds, const char *name);
-UNITTEST bool Curl_dynhds_ccontains(struct dynhds *dynhds, const char *name)
+/* @unittest 2602 */
+UNITTEST bool dynhds_ccontains(struct dynhds *dynhds, const char *name);
+UNITTEST bool dynhds_ccontains(struct dynhds *dynhds, const char *name)
 {
-  return Curl_dynhds_contains(dynhds, name, strlen(name));
+  return dynhds_contains(dynhds, name, strlen(name));
 }
 
 /**
  * Return how often the given name appears in `dynhds`.
  * Names are case-insensitive.
+ *
+ * @unittest 2602
  */
-UNITTEST size_t Curl_dynhds_count_name(struct dynhds *dynhds,
-                                       const char *name, size_t namelen);
-UNITTEST size_t Curl_dynhds_count_name(struct dynhds *dynhds,
-                                       const char *name, size_t namelen)
+UNITTEST size_t dynhds_count_name(struct dynhds *dynhds,
+                                  const char *name, size_t namelen);
+UNITTEST size_t dynhds_count_name(struct dynhds *dynhds,
+                                  const char *name, size_t namelen)
 {
   size_t n = 0;
   if(dynhds->hds_len) {
@@ -263,23 +266,27 @@ UNITTEST size_t Curl_dynhds_count_name(struct dynhds *dynhds,
 /**
  * Return how often the given null-terminated name appears in `dynhds`.
  * Names are case-insensitive.
+ *
+ * @unittest 2602
  */
-UNITTEST size_t Curl_dynhds_ccount_name(struct dynhds *dynhds,
+UNITTEST size_t dynhds_ccount_name(struct dynhds *dynhds,
                                         const char *name);
-UNITTEST size_t Curl_dynhds_ccount_name(struct dynhds *dynhds,
+UNITTEST size_t dynhds_ccount_name(struct dynhds *dynhds,
                                         const char *name)
 {
-  return Curl_dynhds_count_name(dynhds, name, strlen(name));
+  return dynhds_count_name(dynhds, name, strlen(name));
 }
 
 /**
  * Remove all entries with the given name.
  * Returns number of entries removed.
+ *
+ * @unittest 2602
  */
-UNITTEST size_t Curl_dynhds_remove(struct dynhds *dynhds,
-                                   const char *name, size_t namelen);
-UNITTEST size_t Curl_dynhds_remove(struct dynhds *dynhds,
-                                   const char *name, size_t namelen)
+UNITTEST size_t dynhds_remove(struct dynhds *dynhds,
+                              const char *name, size_t namelen);
+UNITTEST size_t dynhds_remove(struct dynhds *dynhds,
+                              const char *name, size_t namelen)
 {
   size_t n = 0;
   if(dynhds->hds_len) {
@@ -308,22 +315,25 @@ UNITTEST size_t Curl_dynhds_remove(struct dynhds *dynhds,
  * Set the give header name and value, replacing any entries with
  * the same name. The header is added at the end of all (remaining)
  * entries.
+ *
+ * @unittest 2602
  */
-UNITTEST CURLcode Curl_dynhds_set(struct dynhds *dynhds,
-                                  const char *name, size_t namelen,
-                                  const char *value, size_t valuelen);
-UNITTEST CURLcode Curl_dynhds_set(struct dynhds *dynhds,
-                                  const char *name, size_t namelen,
-                                  const char *value, size_t valuelen)
+UNITTEST CURLcode dynhds_set(struct dynhds *dynhds,
+                             const char *name, size_t namelen,
+                             const char *value, size_t valuelen);
+UNITTEST CURLcode dynhds_set(struct dynhds *dynhds,
+                             const char *name, size_t namelen,
+                             const char *value, size_t valuelen)
 {
-  Curl_dynhds_remove(dynhds, name, namelen);
+  dynhds_remove(dynhds, name, namelen);
   return Curl_dynhds_add(dynhds, name, namelen, value, valuelen);
 }
 
-UNITTEST size_t Curl_dynhds_cremove(struct dynhds *dynhds, const char *name);
-UNITTEST size_t Curl_dynhds_cremove(struct dynhds *dynhds, const char *name)
+/* @unittest 2602 */
+UNITTEST size_t dynhds_cremove(struct dynhds *dynhds, const char *name);
+UNITTEST size_t dynhds_cremove(struct dynhds *dynhds, const char *name)
 {
-  return Curl_dynhds_remove(dynhds, name, strlen(name));
+  return dynhds_remove(dynhds, name, strlen(name));
 }
 
 #endif /* UNITTESTS */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2505,7 +2505,7 @@ static bool twodigit(const char *p, int *val)
 }
 
 /*
- * Unittest @1668
+ * @unittest 1668
  */
 UNITTEST bool ftp_213_date(const char *p, int *year, int *month, int *day,
                            int *hour, int *minute, int *second);

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -80,8 +80,8 @@
 #ifdef USE_IPV6
 static bool ipv6works(struct Curl_easy *data);
 #else
-#define Curl_probeipv6(x) CURLE_OK
-#define Curl_ipv6works(x) FALSE
+#define probeipv6(x) CURLE_OK
+#define ipv6works(x) FALSE
 #endif
 
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -80,7 +80,6 @@
 #ifdef USE_IPV6
 static bool ipv6works(struct Curl_easy *data);
 #else
-#define probeipv6(x) CURLE_OK
 #define ipv6works(x) FALSE
 #endif
 
@@ -303,7 +302,7 @@ CURLcode Curl_probeipv6(struct Curl_multi *multi)
 }
 
 /*
- * Curl_ipv6works() returns TRUE if IPv6 seems to work.
+ * ipv6works() returns TRUE if IPv6 seems to work.
  */
 static bool ipv6works(struct Curl_easy *data)
 {

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -75,6 +75,17 @@
 #define MAX_DNS_CACHE_SIZE 29999
 
 /*
+ * ipv6works() returns TRUE if IPv6 seems to work.
+ */
+#ifdef USE_IPV6
+static bool ipv6works(struct Curl_easy *data);
+#else
+#define Curl_probeipv6(x) CURLE_OK
+#define Curl_ipv6works(x) FALSE
+#endif
+
+
+/*
  * hostip.c explained
  * ==================
  *
@@ -120,7 +131,7 @@ uint8_t Curl_resolv_dns_queries(struct Curl_easy *data, uint8_t ip_version)
   case CURL_IPRESOLVE_V4:
     return CURL_DNSQ_A;
   default:
-    if(Curl_ipv6works(data))
+    if(ipv6works(data))
       return (CURL_DNSQ_A | CURL_DNSQ_AAAA);
     else
       return CURL_DNSQ_A;
@@ -294,7 +305,7 @@ CURLcode Curl_probeipv6(struct Curl_multi *multi)
 /*
  * Curl_ipv6works() returns TRUE if IPv6 seems to work.
  */
-bool Curl_ipv6works(struct Curl_easy *data)
+static bool ipv6works(struct Curl_easy *data)
 {
   DEBUGASSERT(data);
   DEBUGASSERT(data->multi);
@@ -334,7 +345,7 @@ static bool can_resolve_dns_queries(struct Curl_easy *data,
                                     uint8_t dns_queries)
 {
   (void)data;
-  if((CURL_DNSQ_IP(dns_queries) == CURL_DNSQ_AAAA) && !Curl_ipv6works(data))
+  if((CURL_DNSQ_IP(dns_queries) == CURL_DNSQ_AAAA) && !ipv6works(data))
     return FALSE;
   return TRUE;
 }

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -71,16 +71,8 @@ enum alpnid {
 bool Curl_host_is_ipnum(const char *hostname);
 
 #ifdef USE_IPV6
-
 /* probe if it seems to work */
 CURLcode Curl_probeipv6(struct Curl_multi *multi);
-/*
- * Curl_ipv6works() returns TRUE if IPv6 seems to work.
- */
-bool Curl_ipv6works(struct Curl_easy *data);
-#else
-#define Curl_probeipv6(x) CURLE_OK
-#define Curl_ipv6works(x) FALSE
 #endif
 
 /* IPv4 thread-safe resolve function used for synch and asynch builds */

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -73,6 +73,8 @@ bool Curl_host_is_ipnum(const char *hostname);
 #ifdef USE_IPV6
 /* probe if it seems to work */
 CURLcode Curl_probeipv6(struct Curl_multi *multi);
+#else
+#define Curl_probeipv6(x) CURLE_OK
 #endif
 
 /* IPv4 thread-safe resolve function used for synch and asynch builds */

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -679,6 +679,7 @@ static int compare_func(const void *a, const void *b)
   return compare;
 }
 
+/* @unittest 1979 */
 UNITTEST CURLcode canon_path(const char *q, size_t len,
                              struct dynbuf *new_path,
                              bool do_uri_encode);
@@ -708,6 +709,7 @@ UNITTEST CURLcode canon_path(const char *q, size_t len,
   return result;
 }
 
+/* @unittest 1980 */
 UNITTEST CURLcode canon_query(const char *query, struct dynbuf *dq);
 UNITTEST CURLcode canon_query(const char *query, struct dynbuf *dq)
 {

--- a/lib/llist.c
+++ b/lib/llist.c
@@ -40,7 +40,7 @@ static struct Curl_llist_node *verifynode(struct Curl_llist_node *n)
 #define VERIFYNODE(x) x
 #endif
 /*
- * @unittest: 1300
+ * @unittest 1300
  */
 void Curl_llist_init(struct Curl_llist *l, Curl_llist_dtor dtor)
 {
@@ -62,7 +62,7 @@ void Curl_llist_init(struct Curl_llist *l, Curl_llist_dtor dtor)
  *
  * The 'ne' argument should be a pointer into the object to store.
  *
- * @unittest: 1300
+ * @unittest 1300
  */
 void Curl_llist_insert_next(struct Curl_llist *list,
                             struct Curl_llist_node *e, /* may be NULL */
@@ -112,7 +112,7 @@ void Curl_llist_insert_next(struct Curl_llist *list,
  *
  * The 'ne' argument should be a pointer into the object to store.
  *
- * @unittest: 1300
+ * @unittest 1300
  */
 void Curl_llist_append(struct Curl_llist *list, const void *p,
                        struct Curl_llist_node *ne)
@@ -168,11 +168,7 @@ void *Curl_node_take_elem(struct Curl_llist_node *e)
   return ptr;
 }
 
-/*
- * @unittest: 1300
- */
-UNITTEST void Curl_node_uremove(struct Curl_llist_node *e, void *user);
-UNITTEST void Curl_node_uremove(struct Curl_llist_node *e, void *user)
+static void node_uremove(struct Curl_llist_node *e, void *user)
 {
   struct Curl_llist *list;
   void *ptr;
@@ -190,7 +186,7 @@ UNITTEST void Curl_node_uremove(struct Curl_llist_node *e, void *user)
 
 void Curl_node_remove(struct Curl_llist_node *e)
 {
-  Curl_node_uremove(e, NULL);
+  node_uremove(e, NULL);
 }
 
 void Curl_llist_destroy(struct Curl_llist *list, void *user)
@@ -198,7 +194,7 @@ void Curl_llist_destroy(struct Curl_llist *list, void *user)
   if(list) {
     DEBUGASSERT(list->_init == LLISTINIT);
     while(list->_size > 0)
-      Curl_node_uremove(list->_tail, user);
+      node_uremove(list->_tail, user);
   }
 }
 
@@ -213,9 +209,12 @@ struct Curl_llist_node *Curl_llist_head(struct Curl_llist *list)
 
 #ifdef UNITTESTS
 /* Curl_llist_tail() returns the last 'struct Curl_llist_node *', which
-   might be NULL */
-UNITTEST struct Curl_llist_node *Curl_llist_tail(struct Curl_llist *list);
-UNITTEST struct Curl_llist_node *Curl_llist_tail(struct Curl_llist *list)
+   might be NULL
+
+   @unittest 1300
+*/
+UNITTEST struct Curl_llist_node *llist_tail(struct Curl_llist *list);
+UNITTEST struct Curl_llist_node *llist_tail(struct Curl_llist *list)
 {
   DEBUGASSERT(list);
   DEBUGASSERT(list->_init == LLISTINIT);
@@ -249,10 +248,13 @@ struct Curl_llist_node *Curl_node_next(struct Curl_llist_node *n)
 }
 
 #ifdef UNITTESTS
-/* Curl_node_prev() returns the previous element in a list from a given
-   Curl_llist_node */
-UNITTEST struct Curl_llist_node *Curl_node_prev(struct Curl_llist_node *n);
-UNITTEST struct Curl_llist_node *Curl_node_prev(struct Curl_llist_node *n)
+/* llist_node_prev() returns the previous element in a list from a given
+   Curl_llist_node
+
+   @unittest 1300
+*/
+UNITTEST struct Curl_llist_node *llist_node_prev(struct Curl_llist_node *n);
+UNITTEST struct Curl_llist_node *llist_node_prev(struct Curl_llist_node *n)
 {
   DEBUGASSERT(n);
   DEBUGASSERT(n->_init == NODEINIT);

--- a/lib/llist.c
+++ b/lib/llist.c
@@ -208,8 +208,8 @@ struct Curl_llist_node *Curl_llist_head(struct Curl_llist *list)
 }
 
 #ifdef UNITTESTS
-/* Curl_llist_tail() returns the last 'struct Curl_llist_node *', which
-   might be NULL
+/* llist_tail() returns the last 'struct Curl_llist_node *', which might be
+   NULL
 
    @unittest 1300
 */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -304,10 +304,8 @@ struct Curl_multi *Curl_multi_handle(uint32_t xfer_table_size,
     goto error;
 #endif
 
-#ifdef USE_IPV6
   if(Curl_probeipv6(multi))
     goto error;
-#endif
 
 #ifdef USE_RESOLV_THREADED
   if(xfer_table_size < CURL_XFER_TABLE_SIZE) { /* easy multi */

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -38,15 +38,17 @@
 #endif
 
 /*
- * Curl_cidr4_match() returns TRUE if the given IPv4 address is within the
+ * cidr4_match() returns TRUE if the given IPv4 address is within the
  * specified CIDR address range.
+ *
+ * @unittest 1614
  */
-UNITTEST bool Curl_cidr4_match(const char *ipv4,    /* 1.2.3.4 address */
-                               const char *network, /* 1.2.3.4 address */
-                               unsigned int bits);
-UNITTEST bool Curl_cidr4_match(const char *ipv4,    /* 1.2.3.4 address */
-                               const char *network, /* 1.2.3.4 address */
-                               unsigned int bits)
+UNITTEST bool cidr4_match(const char *ipv4,    /* 1.2.3.4 address */
+                          const char *network, /* 1.2.3.4 address */
+                          unsigned int bits);
+UNITTEST bool cidr4_match(const char *ipv4,    /* 1.2.3.4 address */
+                          const char *network, /* 1.2.3.4 address */
+                          unsigned int bits)
 {
   unsigned int address = 0;
   unsigned int check = 0;
@@ -77,12 +79,11 @@ UNITTEST bool Curl_cidr4_match(const char *ipv4,    /* 1.2.3.4 address */
   return address == check;
 }
 
-UNITTEST bool Curl_cidr6_match(const char *ipv6,
-                               const char *network,
-                               unsigned int bits);
-UNITTEST bool Curl_cidr6_match(const char *ipv6,
-                               const char *network,
-                               unsigned int bits)
+/* @unittest 1614 */
+UNITTEST bool cidr6_match(const char *ipv6, const char *network,
+                          unsigned int bits);
+UNITTEST bool cidr6_match(const char *ipv6, const char *network,
+                          unsigned int bits)
 {
 #ifdef USE_IPV6
   unsigned int bytes;
@@ -176,9 +177,9 @@ static bool match_ip(int type, const char *token, size_t tokenlen,
     *slash = 0; /* null-terminate there */
   }
   if(type == TYPE_IPV6)
-    return Curl_cidr6_match(name, checkip, bits);
+    return cidr6_match(name, checkip, bits);
   else
-    return Curl_cidr4_match(name, checkip, bits);
+    return cidr4_match(name, checkip, bits);
 }
 
 /****************************************************************

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -33,7 +33,7 @@
 #ifndef CURL_DISABLE_PROGRESS_METER
 /* Provide a string that is 7 letters long (plus the zero byte).
 
-   Unit test 1636.
+   @unittest 1636
 */
 UNITTEST void time2str(char *r, size_t rsize, curl_off_t seconds);
 UNITTEST void time2str(char *r, size_t rsize, curl_off_t seconds)
@@ -83,7 +83,7 @@ UNITTEST void time2str(char *r, size_t rsize, curl_off_t seconds)
    but never longer than 6 columns (+ one zero byte).
    Add suffix k, M, G when suitable...
 
-   Unit test 1636
+   @unittest 1636
 */
 UNITTEST char *max6out(curl_off_t bytes, char *max6, size_t mlen);
 UNITTEST char *max6out(curl_off_t bytes, char *max6, size_t mlen)
@@ -127,7 +127,7 @@ static void pgrs_speedinit(struct Curl_easy *data)
 }
 
 /*
- * @unittest: 1606
+ * @unittest 1606
  */
 UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
                                   const struct curltime *pnow);

--- a/lib/uint-bset.c
+++ b/lib/uint-bset.c
@@ -68,8 +68,9 @@ void Curl_uint32_bset_destroy(struct uint32_bset *bset)
 }
 
 #ifdef UNITTESTS
-UNITTEST uint32_t Curl_uint32_bset_capacity(struct uint32_bset *bset);
-UNITTEST uint32_t Curl_uint32_bset_capacity(struct uint32_bset *bset)
+/* @unittest 3211 */
+UNITTEST uint32_t uint32_bset_capacity(struct uint32_bset *bset);
+UNITTEST uint32_t uint32_bset_capacity(struct uint32_bset *bset)
 {
   return bset->nslots * 64;
 }

--- a/lib/uint-hash.c
+++ b/lib/uint-hash.c
@@ -181,6 +181,7 @@ void *Curl_uint32_hash_get(struct uint_hash *h, uint32_t id)
   return NULL;
 }
 
+/* @unittest 1616 */
 UNITTEST void uint_hash_clear(struct uint_hash *h);
 UNITTEST void uint_hash_clear(struct uint_hash *h)
 {

--- a/lib/uint-spbset.c
+++ b/lib/uint-spbset.c
@@ -38,9 +38,12 @@ void Curl_uint32_spbset_init(struct uint32_spbset *bset)
 #endif
 }
 
-/* Clear the bitset, making it empty. */
-UNITTEST void Curl_uint32_spbset_clear(struct uint32_spbset *bset);
-UNITTEST void Curl_uint32_spbset_clear(struct uint32_spbset *bset)
+/* Clear the bitset, making it empty.
+
+   @unittest 3213
+ */
+UNITTEST void uint32_spbset_clear(struct uint32_spbset *bset);
+UNITTEST void uint32_spbset_clear(struct uint32_spbset *bset)
 {
   struct uint32_spbset_chunk *next, *chunk;
 
@@ -54,7 +57,7 @@ UNITTEST void Curl_uint32_spbset_clear(struct uint32_spbset *bset)
 void Curl_uint32_spbset_destroy(struct uint32_spbset *bset)
 {
   DEBUGASSERT(bset->init == CURL_UINT32_SPBSET_MAGIC);
-  Curl_uint32_spbset_clear(bset);
+  uint32_spbset_clear(bset);
 }
 
 uint32_t Curl_uint32_spbset_count(struct uint32_spbset *bset)

--- a/lib/uint-table.c
+++ b/lib/uint-table.c
@@ -79,9 +79,12 @@ CURLcode Curl_uint32_tbl_resize(struct uint32_tbl *tbl, uint32_t nrows)
   return CURLE_OK;
 }
 
-/* Clear the table, making it empty. */
-UNITTEST void Curl_uint32_tbl_clear(struct uint32_tbl *tbl);
-UNITTEST void Curl_uint32_tbl_clear(struct uint32_tbl *tbl)
+/* Clear the table, making it empty.
+
+   @unittest 3212
+ */
+UNITTEST void uint32_tbl_clear(struct uint32_tbl *tbl);
+UNITTEST void uint32_tbl_clear(struct uint32_tbl *tbl)
 {
   DEBUGASSERT(tbl->init == CURL_UINT32_TBL_MAGIC);
   uint32_tbl_clear_rows(tbl, 0, tbl->nrows);
@@ -92,7 +95,7 @@ UNITTEST void Curl_uint32_tbl_clear(struct uint32_tbl *tbl)
 void Curl_uint32_tbl_destroy(struct uint32_tbl *tbl)
 {
   DEBUGASSERT(tbl->init == CURL_UINT32_TBL_MAGIC);
-  Curl_uint32_tbl_clear(tbl);
+  uint32_tbl_clear(tbl);
   curlx_free(tbl->rows);
   memset(tbl, 0, sizeof(*tbl));
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -3418,29 +3418,6 @@ out:
   return result;
 }
 
-/* Curl_setup_conn() is called after the name resolve initiated in
- * create_conn() is all done.
- *
- * Curl_setup_conn() also handles reused connections
- */
-CURLcode Curl_setup_conn(struct Curl_easy *data,
-                         struct Curl_dns_entry *dns,
-                         bool *protocol_done)
-{
-  CURLcode result = CURLE_OK;
-  struct connectdata *conn = data->conn;
-
-  if(!conn->bits.reuse)
-    result = Curl_conn_setup(data, conn, FIRSTSOCKET, dns,
-                             CURL_CF_SSL_DEFAULT);
-  if(!result)
-    result = Curl_headers_init(data);
-
-  /* not sure we need this flag to be passed around any more */
-  *protocol_done = FALSE;
-  return result;
-}
-
 CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
 {
   CURLcode result;
@@ -3474,7 +3451,7 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
                              CURL_CF_SSL_DEFAULT);
     if(!result)
       result = Curl_headers_init(data);
-    CURL_TRC_M(data, "Curl_setup_conn() -> %d", result);
+    CURL_TRC_M(data, "Curl_conn_setup() -> %d", result);
   }
 
 out:

--- a/lib/url.h
+++ b/lib/url.h
@@ -37,9 +37,6 @@ void Curl_freeset(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy **datap); /* opposite of Curl_open() */
 CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected);
-CURLcode Curl_setup_conn(struct Curl_easy *data,
-                         struct Curl_dns_entry *dns,
-                         bool *protocol_done);
 void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn);
 CURLcode Curl_parse_login_details(const char *login, const size_t len,
                                   char **userp, char **passwdp,

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -118,7 +118,7 @@ static const char *find_host_sep(const char *url)
  * 'query' tells if it is a query part or not, or if it is allowed to
  * "transition" into a query part with a question mark.
  *
- * @unittest: 1675
+ * @unittest 1675
  */
 UNITTEST CURLUcode urlencode_str(struct dynbuf *o, const char *url,
                                  size_t len, bool relative,
@@ -341,10 +341,11 @@ out:
   return ures;
 }
 
-UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
-                                   bool has_scheme);
-UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
-                                   bool has_scheme)
+/* @unittest 1653 */
+UNITTEST CURLUcode parse_port(struct Curl_URL *u, struct dynbuf *host,
+                              bool has_scheme);
+UNITTEST CURLUcode parse_port(struct Curl_URL *u, struct dynbuf *host,
+                              bool has_scheme)
 {
   const char *portptr;
   const char *hostname = curlx_dyn_ptr(host);
@@ -400,7 +401,7 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
 /* This function assumes 'hostname' now starts with [. It trims 'hostname' in
  * place and it sets u->zoneid if present.
  *
- * @unittest: 1675
+ * @unittest 1675
  */
 UNITTEST CURLUcode ipv6_parse(struct Curl_URL *u, char *hostname,
                               size_t hlen);
@@ -458,10 +459,8 @@ UNITTEST CURLUcode ipv6_parse(struct Curl_URL *u, char *hostname,
   return CURLUE_OK;
 }
 
-UNITTEST CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
-                                  size_t hlen);
-UNITTEST CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
-                                  size_t hlen) /* length of hostname */
+static CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
+                                size_t hlen) /* length of hostname */
 {
   size_t len;
   DEBUGASSERT(hostname);
@@ -492,7 +491,7 @@ UNITTEST CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
  *
  * Returns the host type.
  *
- * @unittest: 1675
+ * @unittest 1675
  */
 
 UNITTEST int ipv4_normalize(struct dynbuf *host);
@@ -640,7 +639,7 @@ static CURLUcode parse_authority(struct Curl_URL *u,
     goto out;
   }
 
-  uc = Curl_parse_port(u, host, has_scheme);
+  uc = parse_port(u, host, has_scheme);
   if(uc)
     goto out;
 
@@ -716,7 +715,6 @@ static bool is_dot(const char **str, size_t *clen)
 
 /*
  * dedotdotify()
- * @unittest: 1395
  *
  * This function gets a null-terminated path with dot and dotdot sequences
  * passed in and strips them off according to the rules in RFC 3986 section
@@ -727,6 +725,8 @@ static bool is_dot(const char **str, size_t *clen)
  * RETURNS
  *
  * Zero for success and 'out' set to an allocated dedotdotified string.
+ *
+ * @unittest 1395
  */
 UNITTEST int dedotdotify(const char *input, size_t clen, char **outp);
 UNITTEST int dedotdotify(const char *input, size_t clen, char **outp)
@@ -835,7 +835,7 @@ end:
 }
 
 /*
- * @unittest: 1675
+ * @unittest 1675
  */
 UNITTEST CURLUcode parse_file(const char *url, size_t urllen, CURLU *u,
                               const char **pathp, size_t *pathlenp);

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -198,7 +198,7 @@ static const char *getASN1Element_(struct Curl_asn1Element *elem,
 }
 
 /*
- * unit test @1657
+ * @unittest 1657
  */
 UNITTEST const char *getASN1Element(struct Curl_asn1Element *elem,
                                     const char *beg, const char *end);
@@ -490,7 +490,7 @@ static CURLcode OID2str(struct dynbuf *store,
 }
 
 /*
- * Unit test @1656
+ * @unittest 1656
  */
 UNITTEST CURLcode GTime2str(struct dynbuf *store,
                             const char *beg, const char *end);
@@ -617,6 +617,8 @@ static CURLcode UTime2str(struct dynbuf *store,
  * Convert an ASN.1 element to a printable string.
  *
  * Return error
+ *
+ * @unittest 1667
  */
 UNITTEST CURLcode ASN1tostr(struct dynbuf *store,
                             struct Curl_asn1Element *elem);

--- a/scripts/extract-unit-protos
+++ b/scripts/extract-unit-protos
@@ -29,18 +29,43 @@ use warnings;
 my @proto;
 my %func;
 my %inc;
+my %test;
+my %from;
+my $error;
 
 sub scanfile {
     my ($file) = @_;
     open(F, "<$file") || die "$file failed";
     my $unit = 0;
+    my $line = 0;
+    my $unitref = 0;
+    my $unittest = 0;
     while(<F>) {
+        $line++;
+        my $full = $_;
+        if($_ =~ /\@unittest (\d+)/) {
+            $unittest = $1;
+            $unitref = $line; # store line number
+        }
         if($_ =~ /^UNITTEST .*[* ]([a-z0-9_]+)\(/i) {
             my $n = $1;
             if($func{$n}) {
                 # already prototyped, this is now the function itself
             }
             else {
+                if($n =~ /^Curl_/) {
+                    print STDERR "$file:$line:1: warn: $n is Curl_ prefixed?\n";
+                    $error++;
+                }
+                if(($line - $unitref) > 10) {
+                    print STDERR "$file:$line:1: warn: Missing \@unittest reference?\n";
+                    $error++;
+                }
+                else {
+                    $test{$full} = $unittest;
+                    $from{$full} = "$file:$line";
+                }
+
                 $func{$n} = 1;
                 push @proto, $_;
                 $inc{$file} = 1;
@@ -66,6 +91,10 @@ sub scanfile {
 
 foreach my $f (@ARGV) {
     scanfile($f);
+}
+
+if($error) {
+    exit 1;
 }
 
 print <<HEAD
@@ -109,6 +138,10 @@ for my $f (sort keys %inc) {
 }
 
 for my $p (@proto) {
+    if($test{$p}) {
+        printf "\n/* for unit test %d from %s */\n",
+            $test{$p}, $from{$p};
+    }
     print $p;
 }
 

--- a/tests/unit/unit1300.c
+++ b/tests/unit/unit1300.c
@@ -69,7 +69,7 @@ static CURLcode test_unit1300(const char *arg)
               "list initial size should be zero");
   fail_unless(Curl_llist_head(&llist) == NULL,
               "list head should initiate to NULL");
-  fail_unless(Curl_llist_tail(&llist) == NULL,
+  fail_unless(llist_tail(&llist) == NULL,
               "list tail should initiate to NULL");
 
   /**
@@ -91,7 +91,7 @@ static CURLcode test_unit1300(const char *arg)
   fail_unless(Curl_node_elem(Curl_llist_head(&llist)) == &unusedData_case1,
               "head ptr should be first entry");
   /* same goes for the list tail */
-  fail_unless(Curl_llist_tail(&llist) == Curl_llist_head(&llist),
+  fail_unless(llist_tail(&llist) == Curl_llist_head(&llist),
               "tail and head should be the same");
 
   /**
@@ -108,7 +108,7 @@ static CURLcode test_unit1300(const char *arg)
   fail_unless(Curl_node_elem(Curl_node_next(Curl_llist_head(&llist))) ==
                 &unusedData_case3,
               "the node next to head is not getting set correctly");
-  fail_unless(Curl_node_elem(Curl_llist_tail(&llist)) == &unusedData_case3,
+  fail_unless(Curl_node_elem(llist_tail(&llist)) == &unusedData_case3,
               "the list tail is not getting set correctly");
 
   /**
@@ -126,7 +126,7 @@ static CURLcode test_unit1300(const char *arg)
                 &unusedData_case2,
               "the node next to head is not getting set correctly");
   /* better safe than sorry, check that the tail is not corrupted */
-  fail_unless(Curl_node_elem(Curl_llist_tail(&llist)) != &unusedData_case2,
+  fail_unless(Curl_node_elem(llist_tail(&llist)) != &unusedData_case2,
               "the list tail is not getting set correctly");
 
   /* unit tests for Curl_node_remove */
@@ -152,7 +152,7 @@ static CURLcode test_unit1300(const char *arg)
   fail_unless(Curl_llist_head(&llist) == element_next,
               "llist new head not modified properly");
   abort_unless(Curl_llist_head(&llist), "llist.head is NULL");
-  fail_unless(Curl_node_prev(Curl_llist_head(&llist)) == NULL,
+  fail_unless(llist_node_prev(Curl_llist_head(&llist)) == NULL,
               "new head previous not set to null");
 
   /**
@@ -173,12 +173,12 @@ static CURLcode test_unit1300(const char *arg)
   to_remove = Curl_node_next(Curl_llist_head(&llist));
   abort_unless(to_remove, "to_remove is NULL");
   element_next = Curl_node_next(to_remove);
-  element_prev = Curl_node_prev(to_remove);
-  Curl_node_uremove(to_remove, NULL);
+  element_prev = llist_node_prev(to_remove);
+  Curl_node_remove(to_remove);
   fail_unless(Curl_node_next(element_prev) == element_next,
               "element previous->next is not being adjusted");
   abort_unless(element_next, "element_next is NULL");
-  fail_unless(Curl_node_prev(element_next) == element_prev,
+  fail_unless(llist_node_prev(element_next) == element_prev,
               "element next->previous is not being adjusted");
 
   /**
@@ -191,10 +191,10 @@ static CURLcode test_unit1300(const char *arg)
    * 4: list->tail will be tail->previous
    */
 
-  to_remove = Curl_llist_tail(&llist);
-  element_prev = Curl_node_prev(to_remove);
+  to_remove = llist_tail(&llist);
+  element_prev = llist_node_prev(to_remove);
   Curl_node_remove(to_remove);
-  fail_unless(Curl_llist_tail(&llist) == element_prev,
+  fail_unless(llist_tail(&llist) == element_prev,
               "llist tail is not being adjusted when removing tail");
 
   /**
@@ -210,7 +210,7 @@ static CURLcode test_unit1300(const char *arg)
   Curl_node_remove(to_remove);
   fail_unless(Curl_llist_head(&llist) == NULL,
               "llist head is not NULL while the llist is empty");
-  fail_unless(Curl_llist_tail(&llist) == NULL,
+  fail_unless(llist_tail(&llist) == NULL,
               "llist tail is not NULL while the llist is empty");
 
   /**
@@ -228,7 +228,7 @@ static CURLcode test_unit1300(const char *arg)
   fail_unless(Curl_node_elem(Curl_llist_head(&llist)) == &unusedData_case1,
               "head ptr should be first entry");
   /* same goes for the list tail */
-  fail_unless(Curl_llist_tail(&llist) == Curl_llist_head(&llist),
+  fail_unless(llist_tail(&llist) == Curl_llist_head(&llist),
               "tail and head should be the same");
 
   /**
@@ -243,7 +243,7 @@ static CURLcode test_unit1300(const char *arg)
   fail_unless(Curl_node_elem(Curl_node_next(Curl_llist_head(&llist))) ==
                 &unusedData_case2,
               "the node next to head is not getting set correctly");
-  fail_unless(Curl_node_elem(Curl_llist_tail(&llist)) == &unusedData_case2,
+  fail_unless(Curl_node_elem(llist_tail(&llist)) == &unusedData_case2,
               "the list tail is not getting set correctly");
 
   /**
@@ -258,7 +258,7 @@ static CURLcode test_unit1300(const char *arg)
   fail_unless(Curl_node_elem(Curl_node_next(Curl_llist_head(&llist))) ==
                 &unusedData_case2,
               "the node next to head did not stay the same");
-  fail_unless(Curl_node_elem(Curl_llist_tail(&llist)) == &unusedData_case3,
+  fail_unless(Curl_node_elem(llist_tail(&llist)) == &unusedData_case3,
               "the list tail is not getting set correctly");
 
   Curl_llist_destroy(&llist, NULL);

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -148,7 +148,7 @@ static CURLcode test_unit1303(const char *arg)
     TIMEOUTS(run[i].timeout_ms, run[i].connecttimeout_ms);
     easy->progress.now = now;
     easy->mstate = run[i].connecting ? MSTATE_INIT : MSTATE_DO;
-    timeout = Curl_timeleft_now_ms(easy, &now);
+    timeout = timeleft_now_ms(easy, &now);
     if(timeout != run[i].result)
       fail(run[i].comment);
   }

--- a/tests/unit/unit1608.c
+++ b/tests/unit/unit1608.c
@@ -55,7 +55,7 @@ static CURLcode test_unit1608(const char *arg)
 
   /* Shuffle repeatedly and make sure that the list changes */
   for(i = 0; i < 10; i++) {
-    if(CURLE_OK != Curl_shuffle_addr(easy, &addrhead))
+    if(CURLE_OK != dns_shuffle_addr(easy, &addrhead))
       break;
     if(addrhead != addrs)
       break;

--- a/tests/unit/unit1614.c
+++ b/tests/unit/unit1614.c
@@ -156,7 +156,7 @@ static CURLcode test_unit1614(const char *arg)
     { NULL, NULL, FALSE }
   };
   for(i = 0; list4[i].a; i++) {
-    bool match = Curl_cidr4_match(list4[i].a, list4[i].n, list4[i].bits);
+    bool match = cidr4_match(list4[i].a, list4[i].n, list4[i].bits);
     if(match != list4[i].match) {
       curl_mfprintf(stderr, "%s in %s/%u should %smatch\n",
                     list4[i].a, list4[i].n, list4[i].bits,
@@ -166,7 +166,7 @@ static CURLcode test_unit1614(const char *arg)
   }
 #ifdef USE_IPV6
   for(i = 0; list6[i].a; i++) {
-    bool match = Curl_cidr6_match(list6[i].a, list6[i].n, list6[i].bits);
+    bool match = cidr6_match(list6[i].a, list6[i].n, list6[i].bits);
     if(match != list6[i].match) {
       curl_mfprintf(stderr, "%s in %s/%u should %smatch\n",
                     list6[i].a, list6[i].n, list6[i].bits,

--- a/tests/unit/unit1653.c
+++ b/tests/unit/unit1653.c
@@ -26,14 +26,14 @@
 #include "curl/urlapi.h"
 #include "urlapi-int.h"
 
-static CURLUcode parse_port(CURLU *url, const char *h, bool has_scheme)
+static CURLUcode my_parse_port(CURLU *url, const char *h, bool has_scheme)
 {
   struct dynbuf host;
   CURLUcode ret;
   curlx_dyn_init(&host, 10000);
   if(curlx_dyn_add(&host, h))
     return CURLUE_OUT_OF_MEMORY;
-  ret = Curl_parse_port(url, &host, has_scheme);
+  ret = parse_port(url, &host, has_scheme);
   curlx_dyn_free(&host);
   return ret;
 }
@@ -55,7 +55,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15]");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, CURLU_NO_DEFAULT_PORT);
   fail_unless(ret != CURLUE_OK, "curl_url_get portnum returned something");
@@ -69,7 +69,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15|");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "parse_port true on error");
   curlx_safefree(ipv6port);
   curl_url_cleanup(u);
@@ -80,7 +80,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff;fea7:da15]:808");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, 0);
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
@@ -97,7 +97,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15%25eth3]:80");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, 0);
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
@@ -113,7 +113,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15%25eth3]");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   curlx_safefree(ipv6port);
   curl_url_cleanup(u);
@@ -125,7 +125,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15]:81");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, 0);
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
@@ -141,7 +141,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15];81");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "parse_port true on error");
   curlx_safefree(ipv6port);
   curl_url_cleanup(u);
@@ -152,7 +152,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15]80");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret != CURLUE_OK, "parse_port true on error");
   curlx_safefree(ipv6port);
   curl_url_cleanup(u);
@@ -165,7 +165,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15]:");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, TRUE);
+  ret = my_parse_port(u, ipv6port, TRUE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   curlx_safefree(ipv6port);
   curl_url_cleanup(u);
@@ -177,7 +177,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15!25eth3]:180");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   ret = curl_url_get(u, CURLUPART_PORT, &portnum, 0);
   fail_unless(ret == CURLUE_OK, "curl_url_get portnum returned error");
@@ -193,7 +193,7 @@ static CURLcode test_unit1653(const char *arg)
   ipv6port = curlx_strdup("[fe80::250:56ff:fea7:da15%eth3]:80");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_OK, "parse_port returned error");
   curlx_safefree(ipv6port);
   curl_url_cleanup(u);
@@ -207,7 +207,7 @@ static CURLcode test_unit1653(const char *arg)
                           "aaaaaaaaaaaaaaaaaaaaaa:");
   if(!ipv6port)
     goto fail;
-  ret = parse_port(u, ipv6port, FALSE);
+  ret = my_parse_port(u, ipv6port, FALSE);
   fail_unless(ret == CURLUE_BAD_PORT_NUMBER, "parse_port did wrong");
 fail:
   curlx_free(ipv6port);

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -175,7 +175,7 @@ static CURLcode cf_test_create(struct Curl_cfilter **pcf,
     CURL_LOG_LVL_NONE,
     cf_test_destroy,
     cf_test_connect,
-    Curl_cf_def_close,
+    cf_def_close,
     Curl_cf_def_shutdown,
     cf_test_adjust_pollset,
     Curl_cf_def_data_pending,
@@ -315,7 +315,7 @@ static void test_connect(CURL *easy, const struct test_case *tc)
   struct test_result tr;
   struct curl_slist *list = NULL;
 
-  Curl_debug_set_transport_provider(TRNSPRT_TCP, cf_test_create);
+  debug_set_transport_provider(TRNSPRT_TCP, cf_test_create);
   current_tc = tc;
   current_tr = &tr;
 

--- a/tests/unit/unit2602.c
+++ b/tests/unit/unit2602.c
@@ -42,7 +42,7 @@ static CURLcode test_unit2602(const char *arg)
   fail_if(Curl_dynhds_add(&hds, "test2", 5, "456", 3), "add failed");
   /* remove and add without exceeding limits */
   for(i = 0; i < 100; ++i) {
-    if(Curl_dynhds_remove(&hds, "test2", 5) != 1) {
+    if(dynhds_remove(&hds, "test2", 5) != 1) {
       fail_if(TRUE, "should");
       break;
     }
@@ -54,7 +54,7 @@ static CURLcode test_unit2602(const char *arg)
   fail_unless(Curl_dynhds_count(&hds) == 2, "should hold 2");
   /* set, replacing previous entry without exceeding limits */
   for(i = 0; i < 100; ++i) {
-    if(Curl_dynhds_set(&hds, "test2", 5, "456", 3)) {
+    if(dynhds_set(&hds, "test2", 5, "456", 3)) {
       fail_if(TRUE, "add failed");
       break;
     }
@@ -64,16 +64,16 @@ static CURLcode test_unit2602(const char *arg)
   result = Curl_dynhds_add(&hds, "test3", 5, "789", 3);
   fail_unless(result, "add should have failed");
 
-  fail_unless(Curl_dynhds_count_name(&hds, "test", 4) == 0, "false positive");
-  fail_unless(Curl_dynhds_count_name(&hds, "test1", 4) == 0, "false positive");
+  fail_unless(dynhds_count_name(&hds, "test", 4) == 0, "false positive");
+  fail_unless(dynhds_count_name(&hds, "test1", 4) == 0, "false positive");
   fail_if(Curl_dynhds_get(&hds, "test1", 4), "false positive");
   fail_unless(Curl_dynhds_get(&hds, "test1", 5), "false negative");
-  fail_unless(Curl_dynhds_count_name(&hds, "test1", 5) == 1, "should");
-  fail_unless(Curl_dynhds_ccount_name(&hds, "test2") == 1, "should");
+  fail_unless(dynhds_count_name(&hds, "test1", 5) == 1, "should");
+  fail_unless(dynhds_ccount_name(&hds, "test2") == 1, "should");
   fail_unless(Curl_dynhds_cget(&hds, "test2"), "should");
-  fail_unless(Curl_dynhds_ccount_name(&hds, "TEST2") == 1, "should");
-  fail_unless(Curl_dynhds_ccontains(&hds, "TesT2"), "should");
-  fail_unless(Curl_dynhds_contains(&hds, "TeSt2", 5), "should");
+  fail_unless(dynhds_ccount_name(&hds, "TEST2") == 1, "should");
+  fail_unless(dynhds_ccontains(&hds, "TesT2"), "should");
+  fail_unless(dynhds_contains(&hds, "TeSt2", 5), "should");
   Curl_dynhds_free(&hds);
 
   /* add header exceeding max overall length */
@@ -89,14 +89,14 @@ static CURLcode test_unit2602(const char *arg)
   fail_if(Curl_dynhds_add(&hds, "test1", 5, "123", 3), "add failed");
   fail_if(Curl_dynhds_cadd(&hds, "blablabla", "thingies"), "add failed");
   fail_if(Curl_dynhds_h1_cadd_line(&hds, "blablabla: thingies"), "add failed");
-  fail_unless(Curl_dynhds_ccount_name(&hds, "blablabla") == 2, "should");
-  fail_unless(Curl_dynhds_cremove(&hds, "blablabla") == 2, "should");
-  fail_if(Curl_dynhds_ccontains(&hds, "blablabla"), "should not");
+  fail_unless(dynhds_ccount_name(&hds, "blablabla") == 2, "should");
+  fail_unless(dynhds_cremove(&hds, "blablabla") == 2, "should");
+  fail_if(dynhds_ccontains(&hds, "blablabla"), "should not");
 
   result = Curl_dynhds_h1_cadd_line(&hds, "blablabla thingies");
   fail_unless(result, "add should have failed");
   if(!result) {
-    fail_unless(Curl_dynhds_ccount_name(&hds, "bLABlaBlA") == 0, "should");
+    fail_unless(dynhds_ccount_name(&hds, "bLABlaBlA") == 0, "should");
     fail_if(Curl_dynhds_cadd(&hds, "Bla-Bla", "thingies"), "add failed");
 
     curlx_dyn_init(&dbuf, 32 * 1024);

--- a/tests/unit/unit3211.c
+++ b/tests/unit/unit3211.c
@@ -37,7 +37,7 @@ static void check_set(const char *name, uint32_t capacity,
                 name, capacity, slen);
   Curl_uint32_bset_init(&bset);
   fail_unless(!Curl_uint32_bset_resize(&bset, capacity), "bset resize failed");
-  c = Curl_uint32_bset_capacity(&bset);
+  c = uint32_bset_capacity(&bset);
   fail_unless(c == (((capacity + 63) / 64) * 64), "wrong capacity");
 
   Curl_uint32_bset_clear(&bset);
@@ -68,7 +68,7 @@ static void check_set(const char *name, uint32_t capacity,
   }
 
   /* Adding capacity number does not work (0 - capacity-1) */
-  c = Curl_uint32_bset_capacity(&bset);
+  c = uint32_bset_capacity(&bset);
   fail_unless(!Curl_uint32_bset_add(&bset, c), "add out of range worked");
   /* The count it correct */
   c = Curl_uint32_bset_count(&bset);
@@ -109,7 +109,7 @@ static void check_set(const char *name, uint32_t capacity,
   fail_unless(!Curl_uint32_bset_resize(&bset, capacity / 2),
               "resize half failed");
   /* halved the size, what numbers remain in set? */
-  c = Curl_uint32_bset_capacity(&bset);
+  c = uint32_bset_capacity(&bset);
   n = 0;
   for(i = 0; i < slen; ++i) {
     if(s[i] < c)

--- a/tests/unit/unit3212.c
+++ b/tests/unit/unit3212.c
@@ -104,7 +104,7 @@ static CURLcode test_unit3212(const char *arg)
                 "does not contain dummy");
   }
   /* clear */
-  Curl_uint32_tbl_clear(&tbl);
+  uint32_tbl_clear(&tbl);
   fail_unless(!Curl_uint32_tbl_count(&tbl), "count not 0 after clear");
   for(i = 0; i < TBL_SIZE / 2; ++i) {
     fail_unless(!Curl_uint32_tbl_contains(&tbl, i),
@@ -118,7 +118,7 @@ static CURLcode test_unit3212(const char *arg)
   fail_unless(Curl_uint32_tbl_add(&tbl, &dummy, &key), "failed to add");
   fail_unless(key == 1, "unexpected key assigned");
   /* clear, fill, remove one, add, should get the removed key again */
-  Curl_uint32_tbl_clear(&tbl);
+  uint32_tbl_clear(&tbl);
   for(i = 0; i < Curl_uint32_tbl_capacity(&tbl); ++i)
     fail_unless(Curl_uint32_tbl_add(&tbl, &dummy, &key), "failed to add");
   fail_unless(!Curl_uint32_tbl_add(&tbl, &dummy, &key), "add on full");

--- a/tests/unit/unit3213.c
+++ b/tests/unit/unit3213.c
@@ -36,7 +36,7 @@ static void check_spbset(const char *name, const uint32_t *s, size_t slen)
 
   Curl_uint32_spbset_init(&bset);
 
-  Curl_uint32_spbset_clear(&bset);
+  uint32_spbset_clear(&bset);
   c = Curl_uint32_spbset_count(&bset);
   fail_unless(c == 0, "set count is not 0");
 
@@ -75,7 +75,7 @@ static void check_spbset(const char *name, const uint32_t *s, size_t slen)
   c = Curl_uint32_spbset_count(&bset);
   fail_unless(c == slen / 2, "set count is wrong");
 
-  Curl_uint32_spbset_clear(&bset);
+  uint32_spbset_clear(&bset);
   c = Curl_uint32_spbset_count(&bset);
   fail_unless(c == 0, "set count is not 0");
   for(i = 0; i < slen; i++) { /* none present any longer */


### PR DESCRIPTION
- make sure all UNITTEST prototypes mark in which unit test they are used, with `@unittest` markup
- make sure all UNITTEST functions do not use Curl_ prefix, as that is a prefix we use for global private functions and these functions are static and therefore not global and the prefix is wrong
- drop UNITTEST for functions not used in unit tests
- make the extract-unit-protos script highlight the above issues if found
- extract-unit-protos now also outputs the unit test number for all the generated protos in lib/unitprotos.h to aid readers. It also adds the source file and line number where the proto originates from.
- extract-unit-protos now exits with a non-zero value if any of the above warnings are triggered
- make a few private functions static (and drop Curl_ prefix)