### PR TITLE
guard NULL state.up.hostname checks in protocol host handling

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2096,8 +2096,9 @@ static CURLcode http_set_aptr_host(struct Curl_easy *data)
   }
   else {
     /* Use the hostname as present in the URL if it was IPv6. */
-    char *host = (data->state.up.hostname[0] == '[') ?
-       data->state.up.hostname : conn->host.name;
+    char *host = (data->state.up.hostname &&
+                  data->state.up.hostname[0] == '[') ?
+      data->state.up.hostname : conn->host.name;
 
     if(((conn->given->protocol & (CURLPROTO_HTTPS | CURLPROTO_WSS)) &&
         (conn->remote_port == PORT_HTTPS)) ||

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -616,7 +616,8 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
 
   hosturl = curl_maprintf("%s://%s:%d",
                           conn->scheme->name,
-                          (data->state.up.hostname[0] == '[') ?
+                          (data->state.up.hostname &&
+                           data->state.up.hostname[0] == '[') ?
                           data->state.up.hostname : conn->host.name,
                           conn->remote_port);
   if(!hosturl) {

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2550,7 +2550,8 @@ static CURLcode myssh_connect(struct Curl_easy *data, bool *done)
   }
 
   rc = ssh_options_set(sshc->ssh_session, SSH_OPTIONS_HOST,
-                       (data->state.up.hostname[0] == '[') ?
+                       (data->state.up.hostname &&
+                        data->state.up.hostname[0] == '[') ?
                        data->state.up.hostname : conn->host.name);
 
   if(rc != SSH_OK) {


### PR DESCRIPTION
## Summary
- guard `data->state.up.hostname` before checking for bracketed IPv6 literals
- keep the existing fallback to `conn->host.name` when the URL hostname is unavailable
- harden HTTP, OpenLDAP, and libssh host handling against NULL dereferences

## Why
A recent IPv6 hostname handling refactor introduced direct `data->state.up.hostname[0]` access in a few protocol paths. If `state.up.hostname` is unset, those paths can dereference NULL during host/header setup.

## Files changed
- `lib/http.c`
- `lib/openldap.c`
- `lib/vssh/libssh.c`

## Testing
- `git diff --check`