### PR TITLE
ci: update RUSTLS_VERSION 0.15.1 -> 0.15.2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,7 @@ env:
   # renovate: datasource=github-releases depName=openssl/openssl versioning=semver extractVersion=^openssl-(?<version>.+)$ registryUrl=https://github.com
   OPENSSL_VERSION: 3.6.2
   # renovate: datasource=github-tags depName=rustls/rustls-ffi versioning=semver registryUrl=https://github.com
-  RUSTLS_VERSION: 0.15.1
+  RUSTLS_VERSION: 0.15.2
   # handled in renovate.json
   OPENLDAP_VERSION: 2.6.10
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com


### PR DESCRIPTION
Updates the `rustls-ffi` vTLS backend from 0.15.1 to [0.15.2](https://github.com/rustls/rustls-ffi/releases/tag/v0.15.2).