### PR TITLE
build: fix `-Wformat-signedness` by adjusting printf masks

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -294,7 +294,7 @@ static CURLcode altsvc_out(struct altsvc *as, FILE *fp)
                 "%s %s%s%s %u "
                 "\"%d%02d%02d "
                 "%02d:%02d:%02d\" "
-                "%u 0\n", /* prio still always zero */
+                "%d 0\n", /* prio still always zero */
                 Curl_alpnid2str(as->src.alpnid),
                 src6_pre, as->src.host, src6_post,
                 as->src.port,

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -627,7 +627,7 @@ static ssize_t tunnel_send_callback(nghttp2_session *session,
   if(ts->closed && Curl_bufq_is_empty(&ts->sendbuf))
     *data_flags = NGHTTP2_DATA_FLAG_EOF;
 
-  CURL_TRC_CF(data, cf, "[%d] tunnel_send_callback -> %zd",
+  CURL_TRC_CF(data, cf, "[%d] tunnel_send_callback -> %zu",
               ts->stream_id, nread);
   return (nread  > SSIZE_MAX) ?
     NGHTTP2_ERR_CALLBACK_FAILURE : (ssize_t)nread;
@@ -675,7 +675,7 @@ static int proxy_h2_on_stream_close(nghttp2_session *session,
   if(stream_id != ctx->tunnel.stream_id)
     return 0;
 
-  CURL_TRC_CF(data, cf, "[%d] proxy_h2_on_stream_close, %s (err %d)",
+  CURL_TRC_CF(data, cf, "[%d] proxy_h2_on_stream_close, %s (err %u)",
               stream_id, nghttp2_http2_strerror(error_code), error_code);
   ctx->tunnel.closed = TRUE;
   ctx->tunnel.error = error_code;
@@ -1159,7 +1159,7 @@ static CURLcode h2_handle_tunnel_close(struct Curl_cfilter *cf,
 
   *pnread = 0;
   if(ctx->tunnel.error) {
-    failf(data, "HTTP/2 stream %u reset by %s (error 0x%x %s)",
+    failf(data, "HTTP/2 stream %d reset by %s (error 0x%x %s)",
           ctx->tunnel.stream_id, ctx->tunnel.reset ? "server" : "curl",
           ctx->tunnel.error, nghttp2_http2_strerror(ctx->tunnel.error));
     return CURLE_RECV_ERROR;
@@ -1269,7 +1269,7 @@ static CURLcode cf_h2_proxy_send(struct Curl_cfilter *cf,
   }
 
   result = Curl_bufq_write(&ctx->tunnel.sendbuf, buf, len, pnwritten);
-  CURL_TRC_CF(data, cf, "cf_send(), bufq_write %d, %zd", result, *pnwritten);
+  CURL_TRC_CF(data, cf, "cf_send(), bufq_write %d, %zu", result, *pnwritten);
   if(result && (result != CURLE_AGAIN))
     goto out;
 

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -625,7 +625,7 @@ static CURLcode cf_hc_adjust_pollset(struct Curl_cfilter *cf,
         continue;
       result = Curl_conn_cf_adjust_pollset(b->cf, data, ps);
     }
-    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %d socks", result, ps->n);
+    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %u socks", result, ps->n);
   }
   return result;
 }

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -403,7 +403,7 @@ evaluate:
   }
   if(bs->running)
     CURL_TRC_CF(data, cf, "checked connect attempts: "
-                "%d ongoing, %d inconclusive", ongoing, inconclusive);
+                "%u ongoing, %u inconclusive", ongoing, inconclusive);
 
   /* no attempt connected yet, start another one? */
   if(!ongoing) {
@@ -700,7 +700,7 @@ static CURLcode is_connected(struct Curl_cfilter *cf,
         port = conn->conn_to_port;
       else
         port = conn->remote_port;
-      curl_msnprintf(viamsg, sizeof(viamsg), "port %u", port);
+      curl_msnprintf(viamsg, sizeof(viamsg), "port %d", port);
     }
 
     failf(data, "Failed to connect to %s %s %s%s%safter "
@@ -786,7 +786,7 @@ static CURLcode cf_ip_happy_adjust_pollset(struct Curl_cfilter *cf,
 
   if(!cf->connected) {
     result = cf_ip_ballers_pollset(&ctx->ballers, data, ps);
-    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %d socks", result, ps->n);
+    CURL_TRC_CF(data, cf, "adjust_pollset -> %d, %u socks", result, ps->n);
   }
   return result;
 }

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -751,7 +751,7 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       }
 
       if(Curl_cwriter_count(data, phase) + 1 >= MAX_ENCODE_STACK) {
-        failf(data, "Reject response due to more than %u content encodings",
+        failf(data, "Reject response due to more than %d content encodings",
               MAX_ENCODE_STACK);
         return CURLE_BAD_CONTENT_ENCODING;
       }

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -211,7 +211,7 @@ static CURLcode cw_out_cb_write(struct cw_out_ctx *ctx,
   }
   else if(nwritten != blen) {
     failf(data, "Failure writing output to destination, "
-          "passed %zu returned %zd", blen, nwritten);
+          "passed %zu returned %zu", blen, nwritten);
     return CURLE_WRITE_ERROR;
   }
   *pnwritten = nwritten;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -732,7 +732,7 @@ static CURLcode getftpresponse(struct Curl_easy *data,
   } /* while there is buffer left and loop is requested */
 
   pp->pending_resp = FALSE;
-  CURL_TRC_FTP(data, "getftpresponse -> result=%d, nread=%zd, ftpcode=%d",
+  CURL_TRC_FTP(data, "getftpresponse -> result=%d, nread=%zu, ftpcode=%d",
                result, *nreadp, *ftpcodep);
 
   return result;

--- a/lib/http.c
+++ b/lib/http.c
@@ -1256,7 +1256,7 @@ CURLcode Curl_http_follow(struct Curl_easy *data, const char *newurl,
         curlx_free(portnum);
       }
       if(port != data->info.conn_remote_port) {
-        infof(data, "Clear auth, redirects to port from %u to %u",
+        infof(data, "Clear auth, redirects to port from %d to %d",
               data->info.conn_remote_port, port);
         clear = TRUE;
       }
@@ -3761,13 +3761,13 @@ static CURLcode http_statusline(struct Curl_easy *data,
     /* no major version switch mid-connection */
     if(k->httpversion_sent &&
        (k->httpversion / 10 != k->httpversion_sent / 10)) {
-      failf(data, "Version mismatch (from HTTP/%u to HTTP/%u)",
+      failf(data, "Version mismatch (from HTTP/%d to HTTP/%d)",
             k->httpversion_sent / 10, k->httpversion / 10);
       return CURLE_WEIRD_SERVER_REPLY;
     }
     break;
   default:
-    failf(data, "Unsupported HTTP version (%u.%d) in response",
+    failf(data, "Unsupported HTTP version (%d.%d) in response",
           k->httpversion / 10, k->httpversion % 10);
     return CURLE_UNSUPPORTED_PROTOCOL;
   }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -877,7 +877,7 @@ static int push_promise(struct Curl_cfilter *cf,
                                               newstream->id,
                                               newhandle);
     if(rv) {
-      infof(data, "failed to set user_data for stream %u",
+      infof(data, "failed to set user_data for stream %d",
             newstream->id);
       DEBUGASSERT(0);
       discard_newhandle(cf, newhandle);
@@ -1113,7 +1113,7 @@ int Curl_nghttp2_fr_print(const nghttp2_frame *frame, char *buffer,
       memcpy(scratch, frame->goaway.opaque_data, len);
     scratch[len] = '\0';
     return curl_msnprintf(buffer, blen,
-                          "FRAME[GOAWAY, error=%d, reason='%s', "
+                          "FRAME[GOAWAY, error=%u, reason='%s', "
                           "last_stream=%d]", frame->goaway.error_code,
                           scratch, frame->goaway.last_stream_id);
   }
@@ -1148,7 +1148,7 @@ static int on_frame_send(nghttp2_session *session, const nghttp2_frame *frame,
   if((frame->hd.type == NGHTTP2_GOAWAY) && !ctx->sent_goaway) {
     /* A GOAWAY not initiated by us, but by nghttp2 itself on detecting
      * a protocol error on the connection */
-    failf(data, "nghttp2 shuts down connection with error %d: %s",
+    failf(data, "nghttp2 shuts down connection with error %u: %s",
           frame->goaway.error_code,
           nghttp2_http2_strerror(frame->goaway.error_code));
   }
@@ -1186,7 +1186,7 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
           session, NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS);
         ctx->enable_push = nghttp2_session_get_remote_settings(
           session, NGHTTP2_SETTINGS_ENABLE_PUSH) != 0;
-        CURL_TRC_CF(data, cf, "[0] MAX_CONCURRENT_STREAMS: %d",
+        CURL_TRC_CF(data, cf, "[0] MAX_CONCURRENT_STREAMS: %u",
                     ctx->max_concurrent_streams);
         CURL_TRC_CF(data, cf, "[0] ENABLE_PUSH: %s",
                     ctx->enable_push ? "TRUE" : "false");
@@ -1211,7 +1211,7 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
       ctx->goaway_error = frame->goaway.error_code;
       ctx->remote_max_sid = frame->goaway.last_stream_id;
       if(data) {
-        infof(data, "received GOAWAY, error=%u, last_stream=%u",
+        infof(data, "received GOAWAY, error=%u, last_stream=%d",
               ctx->goaway_error, ctx->remote_max_sid);
         Curl_multi_connchanged(data->multi);
       }
@@ -1341,7 +1341,7 @@ static int on_stream_close(nghttp2_session *session, int32_t stream_id,
     stream->reset = TRUE;
 
   if(stream->error)
-    CURL_TRC_CF(data_s, cf, "[%d] RESET: %s (err %d)",
+    CURL_TRC_CF(data_s, cf, "[%d] RESET: %s (err %u)",
               stream_id, nghttp2_http2_strerror(error_code), error_code);
   else
     CURL_TRC_CF(data_s, cf, "[%d] CLOSED", stream_id);
@@ -1350,7 +1350,7 @@ static int on_stream_close(nghttp2_session *session, int32_t stream_id,
   /* remove `data_s` from the nghttp2 stream */
   rv = nghttp2_session_set_stream_user_data(session, stream_id, 0);
   if(rv) {
-    infof(data_s, "http/2: failed to clear user_data for stream %u",
+    infof(data_s, "http/2: failed to clear user_data for stream %d",
           stream_id);
     DEBUGASSERT(0);
   }
@@ -1522,7 +1522,7 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
       cf_h2_header_error(cf, data_s, stream, result);
       return NGHTTP2_ERR_CALLBACK_FAILURE;
     }
-    hlen = curl_msnprintf(buffer, sizeof(buffer), HTTP_PSEUDO_STATUS ":%u\r",
+    hlen = curl_msnprintf(buffer, sizeof(buffer), HTTP_PSEUDO_STATUS ":%d\r",
                           stream->status_code);
     result = Curl_headers_push(data_s, buffer, hlen, CURLH_PSEUDO);
     if(result) {
@@ -1709,7 +1709,7 @@ static CURLcode http2_handle_stream_close(struct Curl_cfilter *cf,
         stream->close_handled = TRUE;
         return CURLE_OK;
     }
-    failf(data, "HTTP/2 stream %u reset by %s (error 0x%x %s)",
+    failf(data, "HTTP/2 stream %d reset by %s (error 0x%x %s)",
           stream->id, stream->reset_by_server ? "server" : "curl",
           stream->error, nghttp2_http2_strerror(stream->error));
     return stream->error ? CURLE_HTTP2_STREAM :
@@ -2053,7 +2053,7 @@ static CURLcode cf_h2_body_send(struct Curl_cfilter *cf,
       return CURLE_OK;
     }
     /* Server closed before we got a response, this is an error */
-    infof(data, "stream %u closed", stream->id);
+    infof(data, "stream %d closed", stream->id);
     return CURLE_SEND_ERROR;
   }
 
@@ -2153,7 +2153,7 @@ static CURLcode h2_submit(struct h2_stream_ctx **pstream,
   }
 
   if(stream_id < 0) {
-    CURL_TRC_CF(data, cf, "send: nghttp2_submit_request error (%s)%u",
+    CURL_TRC_CF(data, cf, "send: nghttp2_submit_request error (%s)%d",
                 nghttp2_strerror(stream_id), stream_id);
     result = CURLE_SEND_ERROR;
     goto out;
@@ -2253,7 +2253,7 @@ static CURLcode cf_h2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   /* if the stream has been closed in egress handling (nghttp2 does that
    * when it does not like the headers, for example */
   if(stream && stream->closed) {
-    infof(data, "stream %u closed", stream->id);
+    infof(data, "stream %d closed", stream->id);
     result = CURLE_SEND_ERROR;
     goto out;
   }
@@ -2462,7 +2462,7 @@ static CURLcode cf_h2_ctx_open(struct Curl_cfilter *cf,
     rc = nghttp2_session_set_stream_user_data(ctx->h2, stream->id,
                                               data);
     if(rc) {
-      infof(data, "http/2: failed to set user_data for stream %u",
+      infof(data, "http/2: failed to set user_data for stream %d",
             stream->id);
       DEBUGASSERT(0);
     }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1452,8 +1452,8 @@ static CURLcode imap_state_fetch_resp(struct Curl_easy *data,
       if(result)
         return result;
 
-      infof(data, "Written %zu bytes, %" FMT_OFF_TU
-            " bytes are left for transfer", chunk, size - chunk);
+      infof(data, "Written %zu bytes, %" FMT_OFF_T
+            " bytes are left for transfer", chunk, (curl_off_t)(size - chunk));
 
       /* Have we used the entire overflow or part of it?*/
       if(pp->overflow > chunk) {

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1930,7 +1930,7 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
   else
     nread = Curl_mime_read(buf, 1, blen, ctx->part);
 
-  CURL_TRC_READ(data, "cr_mime_read(len=%zu), mime_read() -> %zd",
+  CURL_TRC_READ(data, "cr_mime_read(len=%zu), mime_read() -> %zu",
                 blen, nread);
 
   switch(nread) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1622,7 +1622,7 @@ static CURLMcode multi_wait(struct Curl_multi *multi,
     timeout_ms = (int)timeout_internal;
 
   if(data)
-    CURL_TRC_M(data, "multi_wait(fds=%d, timeout=%d) tinternal=%ld",
+    CURL_TRC_M(data, "multi_wait(fds=%u, timeout=%d) tinternal=%ld",
                cpfds.n, timeout_ms, timeout_internal);
 
 #ifdef USE_WINSOCK

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -253,7 +253,7 @@ static CURLMcode mev_sh_entry_update(struct Curl_multi *multi,
   DEBUGASSERT(entry->writers + entry->readers);
 
   CURL_TRC_M(data, "ev update fd=%" FMT_SOCKET_T ", action '%s%s' -> '%s%s'"
-             " (%d/%d r/w)", s,
+             " (%u/%u r/w)", s,
              (last_action & CURL_POLL_IN) ? "IN" : "",
              (last_action & CURL_POLL_OUT) ? "OUT" : "",
              (cur_action & CURL_POLL_IN) ? "IN" : "",

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -674,7 +674,7 @@ static CURLcode rtsp_filter_rtp(struct Curl_easy *data,
             /* This could be the next response, no consume and return */
             if(*pconsumed) {
               DEBUGF(infof(data, "RTP rtsp_filter_rtp[SKIP] RTSP/ prefix, "
-                           "skipping %zd bytes of junk", *pconsumed));
+                           "skipping %zu bytes of junk", *pconsumed));
             }
             rtspc->state = RTP_PARSE_SKIP;
             rtspc->in_header = TRUE;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -431,7 +431,7 @@ static CURLcode cr_eob_read(struct Curl_easy *data,
     ctx->eos = TRUE;
   }
   *peos = (bool)ctx->eos;
-  DEBUGF(infof(data, "cr_eob_read(%zu) -> %d, %zd, %d",
+  DEBUGF(infof(data, "cr_eob_read(%zu) -> %d, %zu, %d",
                blen, result, *pnread, *peos));
   return result;
 }

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1273,7 +1273,7 @@ static CURLcode socks_proxy_cf_connect(struct Curl_cfilter *cf,
     struct ip_quadruple ipquad;
     bool is_ipv6;
     if(!Curl_conn_cf_get_ip_info(cf->next, data, &is_ipv6, &ipquad))
-      infof(data, "Opened %sSOCKS connection from %s port %u to %s port %u "
+      infof(data, "Opened %sSOCKS connection from %s port %d to %s port %d "
             "(via %s port %u)",
             (sockindex == SECONDARYSOCKET) ? "2nd " : "",
             ipquad.local_ip, ipquad.local_port,

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -300,8 +300,8 @@ static CURLcode tftp_parse_option_ack(struct tftp_conn *state,
         return CURLE_TFTP_ILLEGAL;
       }
 
-      state->blksize = (int)blksize;
-      infof(data, "blksize parsed from OACK (%d) requested (%d)",
+      state->blksize = (unsigned int)blksize;
+      infof(data, "blksize parsed from OACK (%u) requested (%u)",
             state->blksize, state->requested_blksize);
     }
     else if(checkprefix(TFTP_OPTION_TSIZE, option)) {
@@ -717,7 +717,7 @@ static CURLcode tftp_send_first(struct tftp_conn *state,
         result = tftp_option_add(state, &sbytes, sbytes, buf);
 
       /* add blksize option */
-      curl_msnprintf(buf, sizeof(buf), "%d", state->requested_blksize);
+      curl_msnprintf(buf, sizeof(buf), "%u", state->requested_blksize);
       if(result == CURLE_OK)
         result = tftp_option_add(state, &sbytes, sbytes, TFTP_OPTION_BLKSIZE);
       if(result == CURLE_OK)

--- a/lib/url.c
+++ b/lib/url.c
@@ -1815,7 +1815,7 @@ static CURLcode setup_connection_internals(struct Curl_easy *data,
   /* IPv6 addresses with a scope_id (0 is default == global) have a
    * printable representation with a '%<scope_id>' suffix. */
   if(conn->scope_id)
-    conn->destination = curl_maprintf("[%s:%u]%%%d", hostname, port,
+    conn->destination = curl_maprintf("[%s:%u]%%%u", hostname, port,
                                       conn->scope_id);
   else
 #endif

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1141,7 +1141,7 @@ static int cb_h3_recv_data(nghttp3_conn *conn, int64_t stream3_id,
   if(stream->rx_offset_max < stream->rx_offset)
     stream->rx_offset_max = stream->rx_offset;
 
-  CURL_TRC_CF(data, cf, "[%" PRId64 "] DATA len=%zu, rx win=%" PRId64,
+  CURL_TRC_CF(data, cf, "[%" PRId64 "] DATA len=%zu, rx win=%" PRIu64,
               stream->id, blen, stream->rx_offset_max - stream->rx_offset);
   cf_ngtcp2_upd_rx_win(cf, data, stream);
   return 0;
@@ -1587,7 +1587,7 @@ static nghttp3_ssize cb_h3_read_req_body(nghttp3_conn *conn, int64_t stream_id,
   }
 
   CURL_TRC_CF(data, cf, "[%" PRId64 "] read req body -> "
-              "%d vecs%s with %zu (buffered=%zu, left=%" FMT_OFF_T ")",
+              "%d vecs%s with %zd (buffered=%zu, left=%" FMT_OFF_T ")",
               stream->id, (int)nvecs,
               *pflags == NGHTTP3_DATA_FLAG_EOF ? " EOF" : "",
               nwritten, Curl_bufq_len(&stream->sendbuf),
@@ -2244,8 +2244,8 @@ static CURLcode cf_ngtcp2_shutdown(struct Curl_cfilter *cf,
       (uint8_t *)buffer, sizeof(buffer),
       &ctx->last_error, pktx.ts);
     CURL_TRC_CF(data, cf, "start shutdown(err_type=%d, err_code=%"
-                PRIu64 ") -> %d", ctx->last_error.type,
-                ctx->last_error.error_code, (int)nwritten);
+                PRIu64 ") -> %zd", ctx->last_error.type,
+                ctx->last_error.error_code, (ssize_t)nwritten);
     /* there are cases listed in ngtcp2 documentation where this call
      * may fail. Since we are doing a connection shutdown as graceful
      * as we can, such an error is ignored here. */
@@ -2412,7 +2412,7 @@ static int quic_gtls_handshake_cb(gnutls_session_t session, unsigned int htype,
     DEBUGASSERT(data);
     if(!data)
       return 0;
-    CURL_TRC_CF(data, cf, "SSL message: %s %s [%d]",
+    CURL_TRC_CF(data, cf, "SSL message: %s %s [%u]",
                 incoming ? "<-" : "->", gtls_hs_msg_name(htype), htype);
     switch(htype) {
     case GNUTLS_HANDSHAKE_NEW_SESSION_TICKET: {

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1051,7 +1051,7 @@ static CURLcode h3_open_stream(struct Curl_cfilter *cf,
       goto out;
     }
     else {
-      CURL_TRC_CF(data, cf, "send_request(%s) -> %" PRIu64,
+      CURL_TRC_CF(data, cf, "send_request(%s) -> %" PRId64,
                   Curl_bufref_ptr(&data->state.url), rv);
     }
     result = CURLE_SEND_ERROR;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -127,7 +127,7 @@ static ssize_t gtls_pull(void *s, void *buf, size_t blen)
   }
 
   result = Curl_conn_cf_recv(cf->next, data, buf, blen, &nread);
-  CURL_TRC_CF(data, cf, "glts_pull(len=%zu) -> %d, %zd", blen, result, nread);
+  CURL_TRC_CF(data, cf, "glts_pull(len=%zu) -> %d, %zu", blen, result, nread);
   backend->gtls.io_result = result;
   if(result) {
     /* !checksrc! disable ERRNOVAR 1 */
@@ -793,7 +793,7 @@ static int gtls_handshake_cb(gnutls_session_t session, unsigned int htype,
   if(when) { /* after message has been processed */
     struct Curl_easy *data = CF_DATA_CURRENT(cf);
     if(data) {
-      CURL_TRC_CF(data, cf, "handshake: %s message type %d",
+      CURL_TRC_CF(data, cf, "handshake: %s message type %u",
                   incoming ? "incoming" : "outgoing", htype);
       switch(htype) {
       case GNUTLS_HANDSHAKE_NEW_SESSION_TICKET: {
@@ -1619,7 +1619,7 @@ CURLcode Curl_gtls_verifyserver(struct Curl_cfilter *cf,
 
   if(data->set.ssl.certinfo && chain.certs) {
     if(chain.num_certs > MAX_ALLOWED_CERT_AMOUNT) {
-      failf(data, "%u certificates is more than allowed (%u)",
+      failf(data, "%u certificates is more than allowed (%d)",
             chain.num_certs, MAX_ALLOWED_CERT_AMOUNT);
       result = CURLE_SSL_CONNECT_ERROR;
       goto out;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -425,7 +425,7 @@ static void mbed_extract_certinfo(struct Curl_easy *data,
     cert_count++;
 
   if(cert_count > MAX_ALLOWED_CERT_AMOUNT) {
-    infof(data, "Certificates is more than allowed (%u), skipping certinfo",
+    infof(data, "Certificates is more than allowed (%d), skipping certinfo",
           MAX_ALLOWED_CERT_AMOUNT);
     return;
   }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -279,7 +279,7 @@ static CURLcode get_pkey_rsa(struct Curl_easy *data,
 #else
   RSA_get0_key(rsa, &n, &e, NULL);
 #endif /* HAVE_EVP_PKEY_GET_PARAMS */
-  BIO_printf(mem, "%d", n ? BN_num_bits(n) : 0);
+  BIO_printf(mem, "%d", (int)(n ? BN_num_bits(n) : 0));
   result = push_certinfo(data, mem, "RSA Public Key", i);
   if(!result) {
     result = print_pubkey_BN(rsa, n, i);
@@ -384,7 +384,7 @@ static CURLcode ossl_certchain(struct Curl_easy *data, SSL *ssl)
 
   numcerts = sk_X509_num(sk);
   if(numcerts > MAX_ALLOWED_CERT_AMOUNT) {
-    failf(data, "%d certificates is more than allowed (%u)", (int)numcerts,
+    failf(data, "%d certificates is more than allowed (%d)", (int)numcerts,
           MAX_ALLOWED_CERT_AMOUNT);
     return CURLE_SSL_CONNECT_ERROR;
   }

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -373,7 +373,7 @@ static CURLcode cr_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     *pnwritten += (ssize_t)plainwritten;
 
 out:
-  CURL_TRC_CF(data, cf, "rustls_send(len=%zu) -> %d, %zd",
+  CURL_TRC_CF(data, cf, "rustls_send(len=%zu) -> %d, %zu",
               plainlen, result, *pnwritten);
   return result;
 }
@@ -1217,7 +1217,7 @@ static CURLcode cr_connect(struct Curl_cfilter *cf, struct Curl_easy *data,
         while(rustls_connection_get_peer_certificate(rconn, num_certs)) {
           num_certs++;
           if(num_certs > MAX_ALLOWED_CERT_AMOUNT) {
-            failf(data, "%zu certificates is more than allowed (%u)",
+            failf(data, "%zu certificates is more than allowed (%d)",
                   num_certs, MAX_ALLOWED_CERT_AMOUNT);
             return CURLE_SSL_CONNECT_ERROR;
           }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1670,7 +1670,7 @@ static CURLcode schannel_connect_step3(struct Curl_cfilter *cf,
 
     traverse_cert_store(ccert_context, cert_counter_callback, &certs_count);
     if(certs_count > MAX_ALLOWED_CERT_AMOUNT) {
-      failf(data, "%d certificates is more than allowed (%u)",
+      failf(data, "%d certificates is more than allowed (%d)",
             certs_count, MAX_ALLOWED_CERT_AMOUNT);
       CertFreeCertificateContext(ccert_context);
       return CURLE_SSL_CONNECT_ERROR;

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -290,7 +290,7 @@ static CURLcode add_certs_file_to_store(HCERTSTORE trust_store,
   }
 
   if(file_size.QuadPart > MAX_CAFILE_SIZE) {
-    failf(data, "schannel: CA file exceeds max size of %u bytes",
+    failf(data, "schannel: CA file exceeds max size of %d bytes",
           MAX_CAFILE_SIZE);
     result = CURLE_SSL_CACERT_BADFILE;
     goto cleanup;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1393,7 +1393,7 @@ static CURLcode ssl_cf_set_earlydata(struct Curl_cfilter *cf,
     if(blen > connssl->earlydata_max)
       blen = connssl->earlydata_max;
     result = Curl_bufq_write(&connssl->earlydata, buf, blen, &nwritten);
-    CURL_TRC_CF(data, cf, "ssl_cf_set_earlydata(len=%zu) -> %zd",
+    CURL_TRC_CF(data, cf, "ssl_cf_set_earlydata(len=%zu) -> %zu",
                 blen, nwritten);
     if(result)
       return result;

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -200,7 +200,7 @@ CURLcode Curl_ssl_peer_key_make(struct Curl_cfilter *cf,
   }
 
   if(ssl->version || ssl->version_max) {
-    r = curlx_dyn_addf(&buf, ":TLSVER-%d-%d", ssl->version,
+    r = curlx_dyn_addf(&buf, ":TLSVER-%d-%u", ssl->version,
                        (ssl->version_max >> 16));
     if(r)
       goto out;

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -607,7 +607,7 @@ static CURLcode UTime2str(struct dynbuf *store,
   }
 
   tzl = end - tzp;
-  return curlx_dyn_addf(store, "%u%.2s-%.2s-%.2s %.2s:%.2s:%.2s %.*s",
+  return curlx_dyn_addf(store, "%d%.2s-%.2s-%.2s %.2s:%.2s:%.2s %.*s",
                         20 - (*beg >= '5'), beg, beg + 2, beg + 4,
                         beg + 6, beg + 8, sec,
                         (int)tzl, tzp);

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -758,7 +758,7 @@ static CURLcode ws_cw_write(struct Curl_easy *data,
   }
 
   if((type & CLIENTWRITE_EOS) && !Curl_bufq_is_empty(&ctx->buf)) {
-    failf(data, "[WS] decode ending with %zd frame bytes remaining",
+    failf(data, "[WS] decode ending with %zu frame bytes remaining",
           Curl_bufq_len(&ctx->buf));
     return CURLE_RECV_ERROR;
   }
@@ -1049,9 +1049,9 @@ static CURLcode ws_enc_send(struct Curl_easy *data,
     if((curl_off_t)buflen >
        (ws->enc.payload_remain + (curl_off_t)ws->sendbuf_payload)) {
       /* too large buflen beyond payload length of frame */
-      failf(data, "[WS] unaligned frame size (sending %zu instead of %"
-                  FMT_OFF_T ")",
-            buflen, ws->enc.payload_remain + ws->sendbuf_payload);
+      failf(data, "[WS] unaligned frame size (sending %zu instead of "
+            "%" FMT_OFF_T ")", buflen,
+            (curl_off_t)(ws->enc.payload_remain + ws->sendbuf_payload));
       return CURLE_BAD_FUNCTION_ARGUMENT;
     }
   }

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -519,7 +519,7 @@ static CURLcode cookie_setopts(struct OperationConfig *config, CURL *curl)
                                 ISBLANK(cl->data[0]) ? "" : " ", cl->data);
       if(result) {
         warnf("skipped provided cookie, the cookie header "
-              "would go over %u bytes", MAX_COOKIE_LINE);
+              "would go over %d bytes", MAX_COOKIE_LINE);
         return result;
       }
     }

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2255,7 +2255,7 @@ static ParameterError opt_file(struct OperationConfig *config,
     break;
   case C_CONFIG: /* --config */
     if(--max_recursive < 0) {
-      errorf("Max config file recursion level reached (%u)",
+      errorf("Max config file recursion level reached (%d)",
              CONFIG_MAX_LEVELS);
       err = PARAM_BAD_USE;
     }

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -67,8 +67,8 @@ static int writeTime(FILE *stream, const struct writeoutvar *wovar,
     if(use_json)
       curl_mfprintf(stream, "\"%s\":", wovar->name);
 
-    curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_TU
-                  ".%06" CURL_FORMAT_CURL_OFF_TU, secs, us);
+    curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T
+                  ".%06" CURL_FORMAT_CURL_OFF_T, secs, us);
   }
   else {
     if(use_json)

--- a/src/var.c
+++ b/src/var.c
@@ -394,7 +394,7 @@ ParameterError setvariable(const char *input)
     line++;
   nlen = line - name;
   if(!nlen || (nlen >= MAX_VAR_LEN)) {
-    warnf("Bad variable name length (%zd), skipping", nlen);
+    warnf("Bad variable name length (%zu), skipping", nlen);
     return PARAM_OK;
   }
   if(import) {

--- a/tests/libtest/cli_h2_upgrade_extreme.c
+++ b/tests/libtest/cli_h2_upgrade_extreme.c
@@ -79,8 +79,8 @@ static CURLcode test_cli_h2_upgrade_extreme(const char *URL)
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, NULL);
       curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
       curl_msnprintf(range, sizeof(range),
-                     "%" CURL_FORMAT_CURL_OFF_TU "-"
-                     "%" CURL_FORMAT_CURL_OFF_TU,
+                     "%" CURL_FORMAT_CURL_OFF_T "-"
+                     "%" CURL_FORMAT_CURL_OFF_T,
                      (curl_off_t)0,
                      (curl_off_t)16384);
       curl_easy_setopt(curl, CURLOPT_RANGE, range);

--- a/tests/libtest/cli_ws_data.c
+++ b/tests/libtest/cli_ws_data.c
@@ -104,7 +104,7 @@ static CURLcode test_ws_data_m2_echo(const char *url,
   curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
   result = curl_easy_perform(curl);
-  curl_mfprintf(stderr, "curl_easy_perform() returned %u\n", result);
+  curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", result);
   if(result != CURLE_OK)
     goto out;
 

--- a/tests/libtest/cli_ws_pingpong.c
+++ b/tests/libtest/cli_ws_pingpong.c
@@ -78,7 +78,7 @@ static CURLcode test_cli_ws_pingpong(const char *URL)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
     result = curl_easy_perform(curl);
-    curl_mfprintf(stderr, "curl_easy_perform() returned %u\n", result);
+    curl_mfprintf(stderr, "curl_easy_perform() returned %d\n", result);
     if(result == CURLE_OK)
       result = pingpong(curl, payload);
 

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -163,7 +163,7 @@ CURLcode ws_send_ping(CURL *curl, const char *send_payload)
   size_t sent;
   CURLcode result = curl_ws_send(curl, send_payload, strlen(send_payload),
                                  &sent, 0, CURLWS_PING);
-  curl_mfprintf(stderr, "ws: curl_ws_send returned %u, sent %zu\n",
+  curl_mfprintf(stderr, "ws: curl_ws_send returned %d, sent %zu\n",
                 result, sent);
   return result;
 }
@@ -175,7 +175,7 @@ CURLcode ws_recv_pong(CURL *curl, const char *expected_payload)
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
   if(result) {
-    curl_mfprintf(stderr, "ws: curl_ws_recv returned %u, received %zu\n",
+    curl_mfprintf(stderr, "ws: curl_ws_recv returned %d, received %zu\n",
                   result, rlen);
     return result;
   }
@@ -201,7 +201,7 @@ void ws_close(CURL *curl)
 {
   size_t sent;
   CURLcode result = curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
-  curl_mfprintf(stderr, "ws: curl_ws_send returned %u, sent %zu\n",
+  curl_mfprintf(stderr, "ws: curl_ws_send returned %d, sent %zu\n",
                 result, sent);
 }
 #endif /* CURL_DISABLE_WEBSOCKETS */

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1914,41 +1914,41 @@ static int get_nothing(void)
 
     rc = curl_url_get(u, CURLUPART_SCHEME, &p, 0);
     if(rc != CURLUE_NO_SCHEME)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_HOST, &p, 0);
     if(rc != CURLUE_NO_HOST)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_USER, &p, 0);
     if(rc != CURLUE_NO_USER)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_PASSWORD, &p, 0);
     if(rc != CURLUE_NO_PASSWORD)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_OPTIONS, &p, 0);
     if(rc != CURLUE_NO_OPTIONS)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_PATH, &p, 0);
     if(rc != CURLUE_OK)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
     else
       curl_free(p);
 
     rc = curl_url_get(u, CURLUPART_QUERY, &p, 0);
     if(rc != CURLUE_NO_QUERY)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_FRAGMENT, &p, 0);
     if(rc != CURLUE_NO_FRAGMENT)
-      curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+      curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
     rc = curl_url_get(u, CURLUPART_ZONEID, &p, 0);
     if(rc != CURLUE_NO_ZONEID)
-      curl_mfprintf(stderr, "unexpected return code %u on line %u\n", rc,
+      curl_mfprintf(stderr, "unexpected return code %d on line %d\n", rc,
                     __LINE__);
 
     curl_url_cleanup(u);
@@ -1981,17 +1981,17 @@ static int clear_url(void)
     for(i = 0; clear_url_list[i].in && !error; i++) {
       rc = curl_url_set(u, clear_url_list[i].part, clear_url_list[i].in, 0);
       if(rc != CURLUE_OK)
-        curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+        curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
       rc = curl_url_set(u, CURLUPART_URL, NULL, 0);
       if(rc != CURLUE_OK)
-        curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+        curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
 
       rc = curl_url_get(u, clear_url_list[i].part, &p, 0);
       if(rc != clear_url_list[i].ucode ||
          (clear_url_list[i].out && strcmp(p, clear_url_list[i].out) != 0)) {
 
-        curl_mfprintf(stderr, "unexpected return code line %u\n", __LINE__);
+        curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
         error++;
       }
       if(rc == CURLUE_OK)
@@ -2046,7 +2046,7 @@ static int huge(void)
     rc = curl_url_set(urlp, CURLUPART_URL, total, CURLU_NON_SUPPORT_SCHEME);
     if((!i && (rc != CURLUE_BAD_SCHEME)) ||
        (i && rc)) {
-      curl_mprintf("URL %u: failed to parse [%s]\n", i, total);
+      curl_mprintf("URL %d: failed to parse [%s]\n", i, total);
       error++;
     }
 
@@ -2054,7 +2054,7 @@ static int huge(void)
     if(!rc) {
       curl_url_get(urlp, part[i], &partp, 0);
       if(!partp || strcmp(partp, &bigpart[1 - (i == 4)])) {
-        curl_mprintf("URL %u part %u: failure\n", i, part[i]);
+        curl_mprintf("URL %d part %u: failure\n", i, part[i]);
         error++;
       }
       curl_free(partp);

--- a/tests/libtest/lib1565.c
+++ b/tests/libtest/lib1565.c
@@ -129,7 +129,7 @@ static CURLcode test_lib1565(const char *URL)
       }
       else {
         curl_mfprintf(stderr,
-                      "%s:%d Got an unexpected message from curl: %i\n",
+                      "%s:%d Got an unexpected message from curl: %d\n",
                       __FILE__, __LINE__, message->msg);
         result = TEST_ERR_MAJOR_BAD;
         goto test_cleanup;

--- a/tests/libtest/lib1597.c
+++ b/tests/libtest/lib1597.c
@@ -100,7 +100,7 @@ static CURLcode test_lib1597(const char *URL)
       break;
     }
   }
-  curl_mprintf("Tested %u strings\n", i);
+  curl_mprintf("Tested %d strings\n", i);
 
 test_cleanup:
   curl_easy_cleanup(curl);

--- a/tests/libtest/lib1947.c
+++ b/tests/libtest/lib1947.c
@@ -63,7 +63,7 @@ static CURLcode test_lib1947(const char *URL)
     if(h)
       count++;
   } while(h);
-  curl_mprintf("count = %u\n", count);
+  curl_mprintf("count = %d\n", count);
 
   /* perform another request - without redirect */
   easy_setopt(curl, CURLOPT_URL, libtest_arg2);
@@ -81,7 +81,7 @@ static CURLcode test_lib1947(const char *URL)
     if(h)
       count++;
   } while(h);
-  curl_mprintf("count = %u\n", count);
+  curl_mprintf("count = %d\n", count);
 
 test_cleanup:
   curl_easy_cleanup(curl);

--- a/tests/libtest/lib2405.c
+++ b/tests/libtest/lib2405.c
@@ -332,7 +332,7 @@ static CURLcode empty_multi_test(void)
   }
   else if(fd_count > 0) {
     curl_mfprintf(stderr, "curl_multi_waitfds(), empty, returned non-zero "
-                  "count of waitfds: %d.\n", fd_count);
+                  "count of waitfds: %u.\n", fd_count);
     result = TEST_ERR_FAILURE;
     goto test_cleanup;
   }
@@ -354,7 +354,7 @@ static CURLcode empty_multi_test(void)
   }
   else if(fd_count > 1) {
     curl_mfprintf(stderr, "curl_multi_waitfds() returned > 1 count of "
-                  "waitfds: %d.\n", fd_count);
+                  "waitfds: %u.\n", fd_count);
     result = TEST_ERR_FAILURE;
     goto test_cleanup;
   }
@@ -381,15 +381,15 @@ static CURLcode test_lib2405(const char *URL)
 
   if(testnum == 2405) {
     /* HTTP1, expected 3 waitfds - one for each transfer  + wakeup */
-    test_run_check(TEST_USE_HTTP1, 3);
+    test_run_check(TEST_USE_HTTP1, 3U);
   }
 #ifdef USE_HTTP2
   else { /* 2407 */
     /* HTTP2, expected 3 waitfds - one for each transfer + wakeup */
-    test_run_check(TEST_USE_HTTP2, 3);
+    test_run_check(TEST_USE_HTTP2, 3U);
 
     /* HTTP2 with multiplexing, expected 2 waitfds - transfers + wakeup */
-    test_run_check(TEST_USE_HTTP2_MPLEX, 2);
+    test_run_check(TEST_USE_HTTP2_MPLEX, 2U);
   }
 #endif
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -155,7 +155,7 @@ static void logprotocol(mqttdir dir,
   }
   fprintf(output, "%s %s %x %s\n",
           dir == FROM_CLIENT ? "client" : "server",
-          prefix, remlen, data);
+          prefix, (unsigned int)remlen, data);
 }
 
 /* return 0 on success */

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -155,7 +155,7 @@ static void logprotocol(mqttdir dir,
   }
   fprintf(output, "%s %s %x %s\n",
           dir == FROM_CLIENT ? "client" : "server",
-          prefix, (int)remlen, data);
+          prefix, remlen, data);
 }
 
 /* return 0 on success */

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1130,7 +1130,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
                     sizeof(req->reqbuf) - 1 - req->offset);
         if(got > 0) {
           req->offset += got;
-          logmsg("Got %zu bytes from client", got);
+          logmsg("Got %zd bytes from client", got);
         }
 
         if((got == -1) &&

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -436,7 +436,7 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
       break;
     }
     if(signum) {
-      logmsg("main_window_proc: %d -> %d", uMsg, signum);
+      logmsg("main_window_proc: %u -> %d", uMsg, signum);
       raise(signum);
     }
   }
@@ -671,7 +671,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
   memset(sau, 0, sizeof(struct sockaddr_un));
   sau->sun_family = AF_UNIX;
   if(len >= sizeof(sau->sun_path) - 1) {
-    logmsg("Too long unix socket domain path (%zd)", len);
+    logmsg("Too long unix socket domain path (%zu)", len);
     return -1;
   }
   curlx_strcopy(sau->sun_path, sizeof(sau->sun_path), unix_socket, len);

--- a/tests/tunit/tool1621.c
+++ b/tests/tunit/tool1621.c
@@ -71,7 +71,7 @@ static CURLcode test_tool1621(const char *arg)
     const char *url = tests[i].input;
     char *stripped = stripcredentials(url);
     const char *strippedstr = stripped ? stripped : "(null)";
-    curl_mprintf("Test %u got input \"%s\", output: \"%s\", "
+    curl_mprintf("Test %d got input \"%s\", output: \"%s\", "
                  "expected: \"%s\"\n",
                  i, tests[i].input, strippedstr, tests[i].output);
 

--- a/tests/unit/unit1323.c
+++ b/tests/unit/unit1323.c
@@ -45,7 +45,7 @@ static CURLcode test_unit1323(const char *arg)
   for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
     timediff_t result = curlx_timediff_ms(tests[i].first, tests[i].second);
     if(result != tests[i].result) {
-      curl_mprintf("%ld.%06u to %ld.%06u got %" FMT_TIMEDIFF_T
+      curl_mprintf("%ld.%06d to %ld.%06d got %" FMT_TIMEDIFF_T
                    ", but expected %" FMT_TIMEDIFF_T "\n",
                    (long)tests[i].first.tv_sec,
                    tests[i].first.tv_usec,

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -102,7 +102,7 @@ static CURLcode test_unit1652(const char *arg)
   fail_unless(verify(output, input) == 0, "Simple string test");
 
   /* Injecting a few different variables with a format */
-  Curl_infof(easy, "%s %u testing %lu", input, 42, 43L);
+  Curl_infof(easy, "%s %d testing %ld", input, 42, 43L);
   fail_unless(verify(output, "Simple Test 42 testing 43\n") == 0,
               "Format string");
 

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -132,7 +132,7 @@ static CURLcode test_unit1660(const char *arg)
         continue;
       }
       else if(result) {
-        curl_mprintf("Input %u: error %d\n", i, (int)result);
+        curl_mprintf("Input %d: error %d\n", i, (int)result);
         continue;
       }
     }

--- a/tests/unit/unit1664.c
+++ b/tests/unit/unit1664.c
@@ -61,7 +61,7 @@ static CURLcode test_unit1664(const char *arg)
     const char *line = wordparse[i];
     const char *orgline = line;
     int rc = curlx_str_word(&line, &out, 7);
-    curl_mprintf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
+    curl_mprintf("%d: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
                  i, orgline, rc, (int)out.len, out.str, (int)out.len,
                  (int)(line - orgline));
   }
@@ -72,7 +72,7 @@ static CURLcode test_unit1664(const char *arg)
     const char *line = wordparse[i];
     const char *orgline = line;
     int rc = curlx_str_until(&line, &out, 7, 'd');
-    curl_mprintf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
+    curl_mprintf("%d: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
                  i, orgline, rc, (int)out.len, out.str, (int)out.len,
                  (int)(line - orgline));
   }
@@ -105,7 +105,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = qwords[i];
       const char *orgline = line;
       int rc = curlx_str_quotedword(&line, &out, 7);
-      curl_mprintf("%u: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, \"%.*s\" [%d], line %d\n",
                    i, orgline, rc, (int)out.len, out.str, (int)out.len,
                    (int)(line - orgline));
     }
@@ -127,7 +127,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = single[i];
       const char *orgline = line;
       int rc = curlx_str_single(&line, 'a');
-      curl_mprintf("%u: (\"%s\") %d, line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, line %d\n",
                    i, orgline, rc, (int)(line - orgline));
     }
   }
@@ -150,7 +150,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = single[i];
       const char *orgline = line;
       int rc = curlx_str_singlespace(&line);
-      curl_mprintf("%u: (\"%s\") %d, line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, line %d\n",
                    i, orgline, rc, (int)(line - orgline));
     }
   }
@@ -171,7 +171,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = single[i];
       const char *orgline = line;
       int rc = curlx_str_single(&line, 'a');
-      curl_mprintf("%u: (\"%s\") %d, line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, line %d\n",
                    i, orgline, rc, (int)(line - orgline));
     }
   }
@@ -198,7 +198,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i];
       const char *orgline = line;
       int rc = curlx_str_number(&line, &num, 1235);
-      curl_mprintf("%u: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
                    i, orgline, rc, num, (int)(line - orgline));
     }
   }
@@ -230,7 +230,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i].str;
       const char *orgline = line;
       int rc = curlx_str_number(&line, &num, nums[i].max);
-      curl_mprintf("%u: (\"%s\") max %" CURL_FORMAT_CURL_OFF_T
+      curl_mprintf("%d: (\"%s\") max %" CURL_FORMAT_CURL_OFF_T
                    " == %d, [%" CURL_FORMAT_CURL_OFF_T "]\n",
                    i, orgline, nums[i].max, rc, num);
     }
@@ -270,7 +270,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i].str;
       const char *orgline = line;
       int rc = curlx_str_hex(&line, &num, nums[i].max);
-      curl_mprintf("%u: (\"%s\") max %" CURL_FORMAT_CURL_OFF_T
+      curl_mprintf("%d: (\"%s\") max %" CURL_FORMAT_CURL_OFF_T
                    " == %d, [%" CURL_FORMAT_CURL_OFF_T "]\n",
                    i, orgline, nums[i].max, rc, num);
     }
@@ -305,7 +305,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i].str;
       const char *orgline = line;
       int rc = curlx_str_octal(&line, &num, nums[i].max);
-      curl_mprintf("%u: (\"%s\") max %" CURL_FORMAT_CURL_OFF_T
+      curl_mprintf("%d: (\"%s\") max %" CURL_FORMAT_CURL_OFF_T
                    " == %d, [%" CURL_FORMAT_CURL_OFF_T "]\n",
                    i, orgline, nums[i].max, rc, num);
     }
@@ -341,7 +341,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i];
       const char *orgline = line;
       int rc = curlx_str_number(&line, &num, CURL_OFF_T_MAX);
-      curl_mprintf("%u: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
                    i, orgline, rc, num, (int)(line - orgline));
     }
   }
@@ -366,7 +366,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = newl[i];
       const char *orgline = line;
       int rc = curlx_str_newline(&line);
-      curl_mprintf("%u: (%%%02x) %d, line %d\n",
+      curl_mprintf("%d: (%%%02x) %d, line %d\n",
                    i, *orgline, rc, (int)(line - orgline));
     }
   }
@@ -393,7 +393,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i];
       const char *orgline = line;
       int rc = curlx_str_hex(&line, &num, 0x1235);
-      curl_mprintf("%u: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
                    i, orgline, rc, num, (int)(line - orgline));
     }
   }
@@ -420,7 +420,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i];
       const char *orgline = line;
       int rc = curlx_str_octal(&line, &num, 01235);
-      curl_mprintf("%u: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
                    i, orgline, rc, num, (int)(line - orgline));
     }
   }
@@ -444,7 +444,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i];
       const char *orgline = line;
       int rc = curlx_str_octal(&line, &num, CURL_OFF_T_MAX);
-      curl_mprintf("%u: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
                    i, orgline, rc, num, (int)(line - orgline));
     }
   }
@@ -480,7 +480,7 @@ static CURLcode test_unit1664(const char *arg)
       const char *line = nums[i];
       const char *orgline = line;
       int rc = curlx_str_hex(&line, &num, CURL_OFF_T_MAX);
-      curl_mprintf("%u: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
+      curl_mprintf("%d: (\"%s\") %d, [%" CURL_FORMAT_CURL_OFF_T "] line %d\n",
                    i, orgline, rc, num, (int)(line - orgline));
     }
   }

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -185,7 +185,7 @@ static CURLcode test_unit1675(const char *arg)
       uc = urlencode_str(&out, tests[i].in, strlen(tests[i].in),
                          tests[i].relative, tests[i].query);
       if(uc || strcmp(curlx_dyn_ptr(&out), tests[i].out)) {
-        curl_mfprintf(stderr, "urlencode_str('%s', query=%d) failed:"
+        curl_mfprintf(stderr, "urlencode_str('%s', query=%u) failed:"
                       " expected '%s', got '%s'\n",
                       tests[i].in, tests[i].query, tests[i].out,
                       uc ? "error" : curlx_dyn_ptr(&out));

--- a/tests/unit/unit2603.c
+++ b/tests/unit/unit2603.c
@@ -82,7 +82,7 @@ static void parse_success(const struct tcase *t)
     in_consumed += nread;
     if(nread != buflen) {
       if(!p.done) {
-        curl_mfprintf(stderr, "only %zd/%zu consumed for: '%s'\n",
+        curl_mfprintf(stderr, "only %zu/%zu consumed for: '%s'\n",
                       nread, buflen, buf);
         fail("not all consumed");
       }

--- a/tests/unit/unit2604.c
+++ b/tests/unit/unit2604.c
@@ -86,7 +86,7 @@ static CURLcode test_unit2604(const char *arg)
     char *path;
     const char *cp = i == 0 ? cp0 : list[i].cp;
     CURLcode result = Curl_get_pathname(&cp, &path, list[i].home);
-    curl_mprintf("%u - Curl_get_pathname(\"%s\", ... \"%s\") == %u\n", i,
+    curl_mprintf("%d - Curl_get_pathname(\"%s\", ... \"%s\") == %d\n", i,
                  list[i].cp, list[i].home, list[i].result);
     if(result != list[i].result) {
       curl_mprintf("... returned %d\n", result);

--- a/tests/unit/unit2605.c
+++ b/tests/unit/unit2605.c
@@ -78,7 +78,7 @@ static CURLcode test_unit2605(const char *arg)
       curl_off_t start;
       curl_off_t size;
       CURLcode result;
-      curl_mprintf("%u: '%s' (file size: %" FMT_OFF_T ")\n", i, list[i].r,
+      curl_mprintf("%d: '%s' (file size: %" FMT_OFF_T ")\n", i, list[i].r,
                    list[i].filesize);
       result = Curl_ssh_range(curl, list[i].r, list[i].filesize, &start,
                               &size);

--- a/tests/unit/unit3200.c
+++ b/tests/unit/unit3200.c
@@ -92,7 +92,7 @@ static CURLcode test_unit3200(const char *arg)
     fp = curlx_fopen(arg, "rb");
     abort_unless(fp != NULL, "Cannot open testfile");
 
-    curl_mfprintf(stderr, "Test %zd...", i);
+    curl_mfprintf(stderr, "Test %zu...", i);
     switch(i) {
     case 0:
       result = Curl_get_line(&buf, fp, &eof);


### PR DESCRIPTION
- sync printf masks with the passed value.
- fix a couple of casts.

Cherry-picked from #20848
