### PR TITLE
libssh2: allocate libssh2-friendly memory in kbd_callback

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -148,9 +148,9 @@ static void kbd_callback(const char *name, int name_len,
 #endif /* CURL_LIBSSH2_DEBUG */
   if(num_prompts == 1) {
     struct connectdata *conn = data->conn;
-    /* this function must allocate memory that can be free()ed by
-       libssh2 */
-    responses[0].text = (strdup)(conn->passwd);
+    /* this function must allocate memory that can be free()ed by libssh2,
+       which calls LIBSSH2_FREE_FUNC on free. */
+    responses[0].text = Curl_cstrdup(conn->passwd);
     responses[0].length =
       responses[0].text == NULL ? 0 : curlx_uztoui(strlen(conn->passwd));
   }

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -148,7 +148,9 @@ static void kbd_callback(const char *name, int name_len,
 #endif /* CURL_LIBSSH2_DEBUG */
   if(num_prompts == 1) {
     struct connectdata *conn = data->conn;
-    responses[0].text = curlx_strdup(conn->passwd);
+    /* this function must allocate memory that can be free()ed by
+       libssh2 */
+    responses[0].text = (strdup)(conn->passwd);
     responses[0].length =
       responses[0].text == NULL ? 0 : curlx_uztoui(strlen(conn->passwd));
   }


### PR DESCRIPTION
The function libssh2_userauth_keyboard_interactive_ex() calls the callback and is documented to call free() on the memory returned to libssh2 from the callback. libcurl can therefore not use the regular curlx_strdup() for this, as that is not compatible in debug builds or when curl_global_init_mem() is used.

Fixes #21336