### PR TITLE
tests: harden harness for macOS CI stalls (#21140)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -354,7 +354,7 @@ jobs:
             generate: >-
               -DENABLE_DEBUG=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF
               -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=/opt/homebrew/opt/krb5
-              -DCURL_DISABLE_LDAP=ON -DUSE_SSLS_EXPORT=ON
+              -DCURL_DISABLE_LDAP=ON -DUSE_SSLS_EXPORT=ON -DCURL_ENABLE_NTLM=ON
 
           - name: 'aws-lc +analyzer'
             compiler: gcc-15

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -49,13 +49,6 @@
      in NTLM type-3 messages.
  */
 
-#ifdef USE_GNUTLS
-#include <nettle/version.h>
-#if NETTLE_VERSION_MAJOR < 4
-#define HAVE_GNUTLS_DES
-#endif
-#endif
-
 #if defined(USE_OPENSSL) && defined(HAVE_DES_ECB_ENCRYPT)
 
 #  include <openssl/des.h>
@@ -70,7 +63,7 @@
 #  include <wolfssl/wolfcrypt/des3.h>
 #  define USE_WOLFSSL_DES
 
-#elif defined(HAVE_GNUTLS_DES)
+#elif defined(USE_GNUTLS)
 #  include <nettle/des.h>
 #  define USE_CURL_DES_SET_ODD_PARITY
 #elif defined(USE_MBEDTLS) && defined(HAVE_MBEDTLS_DES_CRYPT_ECB)

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -370,6 +370,35 @@ sub sysread_or_die {
     my $lcaller;
     my $result;
 
+    # Bound the read so a stuck sockfilt cannot wedge the harness
+    # (issue #21140). Must exceed the libcurl test client's own
+    # TEST_HANG_TIMEOUT (60s) so we do not kill the server on a
+    # legitimate long client stall (e.g. NODATACONN tests, #593).
+    my $select_timeout = 65;
+    my $readfds = '';
+    vec($readfds, fileno($$FH), 1) = 1;
+    my $nfound = select(my $readfds_out = $readfds, undef, undef,
+                        $select_timeout);
+
+    if($nfound <= 0) {
+        ($fcaller, $lcaller) = (caller)[1,2];
+        my $why = ($nfound < 0)
+            ? "select before sysread failed: $!"
+            : "sysread timed out (${select_timeout}s)";
+        logmsg "Failed to read input\n";
+        logmsg "Error: $srvrname server, $why\n";
+        logmsg "Exited from sysread_or_die() at $fcaller " .
+               "line $lcaller. $srvrname server, $why\n";
+        killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
+        unlink($pidfile);
+        unlink($portfile);
+        if($serverlogslocked) {
+            $serverlogslocked = 0;
+            clear_advisor_read_lock($serverlogs_lockfile);
+        }
+        exit(1);
+    }
+
     $result = sysread($$FH, $$scalar, $length);
 
     if(not defined $result) {
@@ -385,7 +414,7 @@ sub sysread_or_die {
             $serverlogslocked = 0;
             clear_advisor_read_lock($serverlogs_lockfile);
         }
-        exit;
+        exit(1);
     }
     elsif($result == 0) {
         ($fcaller, $lcaller) = (caller)[1,2];
@@ -400,7 +429,7 @@ sub sysread_or_die {
             $serverlogslocked = 0;
             clear_advisor_read_lock($serverlogs_lockfile);
         }
-        exit;
+        exit(1);
     }
 
     return $result;
@@ -676,11 +705,11 @@ sub disc_handshake {
     print DWRITE "DISC\n";
     my $line;
     my $nr;
-    while(5 == ($nr = sysread DREAD, $line, 5)) {
+    while(5 == ($nr = sysread_or_die(\*DREAD, \$line, 5))) {
         if($line eq "DATA\n") {
             # Must read the data bytes to stay in sync
             my $i;
-            sysread DREAD, $i, 5;
+            sysread_or_die(\*DREAD, \$i, 5);
 
             my $size = 0;
             if($i =~ /^([0-9a-fA-F]{4})\n/) {
@@ -2405,10 +2434,10 @@ sub STOR_ftp {
     my $line;
     my $ulsize=0;
     my $disc=0;
-    while(5 == (sysread DREAD, $line, 5)) {
+    while(5 == (sysread_or_die(\*DREAD, \$line, 5))) {
         if($line eq "DATA\n") {
             my $i;
-            sysread DREAD, $i, 5;
+            sysread_or_die(\*DREAD, \$i, 5);
 
             my $size = 0;
             if($i =~ /^([0-9a-fA-F]{4})\n/) {

--- a/tests/libtest/lib575.c
+++ b/tests/libtest/lib575.c
@@ -37,8 +37,6 @@ static CURLcode test_lib575(const char *URL)
   CURLcode result = CURLE_OK;
   int still_running = 0;
 
-  start_test_timing();
-
   global_init(CURL_GLOBAL_ALL);
 
   easy_init(curl);
@@ -46,6 +44,7 @@ static CURLcode test_lib575(const char *URL)
   easy_setopt(curl, CURLOPT_URL, URL);
   easy_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_TIMEOUT_MS, (long)TEST_HANG_TIMEOUT);
 
   result = curl_easy_perform(curl);
   if(result)
@@ -60,6 +59,11 @@ static CURLcode test_lib575(const char *URL)
     goto test_cleanup;
   curl_easy_cleanup(curl);
   curl = curldupe;
+
+  /* Wall-clock hang guard applies to the multi phase only; each easy_perform
+   * is bounded by CURLOPT_TIMEOUT_MS. A single TEST_HANG_TIMEOUT for the whole
+   * test would false-positive on slow CI when two performs sum past 60s. */
+  start_test_timing();
 
   multi_init(multi);
 


### PR DESCRIPTION
## Description

**Related to** https://github.com/curl/curl/issues/21140 — do **not** use `Fixes #21140` until there is evidence of a clear improvement; keep the issue open for now.

### Background

[#21140](https://github.com/curl/curl/issues/21140) reports intermittent stalls on GitHub Actions **macOS**: `runtests.pl` shows one runner still busy (often with **FTP-related** tests), sometimes until the job step timeout. Maintainer feedback included a repro stuck on **test 575** with **`ST_RUN`** ([comment](https://github.com/curl/curl/pull/21350#issuecomment-4426718680)): that state means the **libtest client** was still running, not necessarily the in-tree FTP server.

### What this PR does

**Scope:** `tests/ftpserver.pl` and `tests/libtest/lib575.c`.

1. **FTP test server:** `sysread_or_die` uses a bounded `select()` (currently **65s** per wait; see comment in file vs **TEST_HANG_TIMEOUT**) before `sysread` on sockfilt. This extends the same pattern to **data** pipe reads in **`disc_handshake`** and **`STOR_ftp`** so a stuck sockfilt cannot block those paths indefinitely.

2. **Test 575:** Set **`CURLOPT_TIMEOUT_MS`** to **`TEST_HANG_TIMEOUT`** (same idea as **lib574**) so each **`curl_easy_perform`** cannot hang until an external CI timeout. **`start_test_timing()`** runs **only before the multi phase** so the usual **60s** wall-clock guard does not false-positive when two sequential performs legitimately exceed **60s** wall time on slow CI.

## Implementation details

- `tests/ftpserver.pl`: `sysread_or_die` on `DREAD` in `disc_handshake` and `STOR_ftp`; control path already uses `sysread_or_die` with the same select ceiling.
- `tests/libtest/lib575.c`: `CURLOPT_TIMEOUT_MS`; hang timer reset before multi; `abort_on_test_timeout()` remains in the multi loop only.
