### PR TITLE
tool: add a retry delay for all transfers to the same host on http error 429

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -855,6 +855,7 @@ static CURLcode post_close_output(struct per_transfer *per,
   /* Close the outs file */
   if(outs->fopened && outs->stream) {
     rc = curlx_fclose(outs->stream);
+    outs->stream = NULL;
     if(!result && rc) {
       /* something went wrong in the writing process */
       result = CURLE_WRITE_ERROR;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -186,82 +186,77 @@ static curl_off_t VmsSpecialSize(const char *name,
 
 /* linked-list structure for the 429 delay */
 struct curl_429_list {
-  char *hostname;
+  char *origin;
   time_t startat;
   struct curl_429_list *next;
 };
 
-/* a list of hosts and their delay timer for 429 errors */
+/* a list of origins and their delay timer for 429 errors */
 static struct curl_429_list *http_429_list = NULL;
 
 /*
- * Set the delay for new transfers for a given host.
- * If the host is not found, a new item is appended to the list.
+ * Set the delay for new transfers for a given origin.
+ * If the origin is not found, a new item is appended to the list.
  * If the list is NULL a new list will be created.
  * On error the function returns NULL, otherwise the list is returned.
  */
 static struct curl_429_list *curl_429_delay_set(struct curl_429_list *list,
-                                                const char *host,
+                                                const char *origin,
                                                 uint32_t delayms)
 {
-  struct curl_429_list *item;
-  struct curl_429_list *last_item;
-  struct curl_429_list *new_item;
-  time_t startat = time(NULL) + (delayms / 1000);
+  struct curl_429_list *item = NULL;
+  struct curl_429_list *last_item = NULL;
+  struct curl_429_list *new_item = NULL;
+  time_t startat = delayms ? time(NULL) + (delayms / 1000) : 0;
 
-  /* if there is no list yet we create a new list */
-  if(!list) {
-    new_item = curlx_malloc(sizeof(struct curl_429_list));
-    if(!new_item)
-      return NULL;
-
-    new_item->hostname = curlx_strdup(host);
-    new_item->startat = startat;
-    new_item->next = NULL;
-    return new_item;
+  /* try to find the origin in the existing list and update it's timer */
+  if(list) {
+    item = list;
+    do {
+      if(curl_strequal(item->origin, origin)) {
+        item->startat = startat;
+        return list;
+      }
+      last_item = item;
+      item = item->next;
+    } while(item);
   }
 
-  /* loop through the list to check if we already got this host */
-  item = list;
-  do {
-    if(curl_strequal(item->hostname, host)) {
-      item->startat = startat;
-      return list;
-    }
-    last_item = item;
-    item = item->next;
-  } while(item);
-
-  /* host was not found so we create a new item and append it to the list */
+  /* origin not found, so we create a new item */
   new_item = curlx_malloc(sizeof(struct curl_429_list));
   if(!new_item)
     return NULL;
-
-  new_item->hostname = curlx_strdup(host);
+  new_item->origin = curlx_strdup(origin);
+  if(!new_item->origin) {
+    curlx_free(new_item);
+    return NULL;
+  }
   new_item->startat = startat;
   new_item->next = NULL;
+  if(!list)
+    return new_item; /* the new item is the newly created list */
   last_item->next = new_item;
   return list;
 }
 
 /*
- * Check the list if it contains the given host and return it.
- * Returns NULL if the host was not found in the list.
+ * Check the list if it contains the given origin and return it.
+ * Returns NULL if the origin was not found in the list.
  */
 static struct curl_429_list *curl_429_delay_get(struct curl_429_list *list,
-                                                const char *host)
+                                                const char *origin)
 {
   struct curl_429_list *item = list;
 
-  /* loop through the list to find this host */
+  /* loop through the list to find this origin */
   while(item) {
-    if(curl_strequal(item->hostname, host)) {
+    if(curl_strequal(item->origin, origin)) {
       return item;
     }
     item = item->next;
   }
 
-  return NULL; /* host not found */
+  return NULL; /* origin not found */
 }
 
 /* Free all the elements and their data. */
@@ -276,10 +271,68 @@ static void curl_429_delay_free_all(struct curl_429_list *list)
   item = list;
   do {
     next = item->next;
-    curlx_safefree(item->hostname);
+    curlx_safefree(item->origin);
     curlx_free(item);
     item = next;
   } while(next);
+}
+
+/*
+ * extract the host, port and scheme from the URL and write it to porigin
+ * porigin needs to be freed by the user of this function
+ * if the URL is invalid origin is set to "-/-/-"
+ */
+static CURLcode set_per_transfer_origin(const char *url, char **porigin)
+{
+  char *host = NULL;
+  char *port = NULL;
+  char *scheme = NULL;
+  char *origin = NULL;
+  size_t len_origin = 0;
+  CURLcode err = CURLE_OK;
+  CURLUcode uerr = CURLUE_OK;
+  CURLU *uh = curl_url();
+
+  uerr = curl_url_set(uh, CURLUPART_URL, url, CURLU_GUESS_SCHEME);
+  if(uerr)
+    goto urlerr;
+  uerr = curl_url_get(uh, CURLUPART_HOST, &host, CURLU_URLDECODE);
+  if(uerr)
+    goto urlerr;
+  uerr = curl_url_get(uh, CURLUPART_PORT, &port, CURLU_DEFAULT_PORT);
+  if(uerr)
+    goto urlerr;
+  uerr = curl_url_get(uh, CURLUPART_SCHEME, &scheme, CURLU_DEFAULT_SCHEME);
+  if(uerr)
+    goto urlerr;
+
+  len_origin = strlen(host) + strlen(port) + strlen(scheme) + 3;
+  origin = curlx_malloc(len_origin);
+  if(!origin) {
+    err = CURLE_OUT_OF_MEMORY;
+    goto clean;
+  }
+  curl_msnprintf(origin, len_origin, "%s/%s/%s", host, port, scheme);
+  *porigin = origin;
+  err = CURLE_OK;
+  goto clean;
+
+urlerr:
+  origin = curlx_strdup("-/-/-");
+  if(!origin) {
+    err = CURLE_OUT_OF_MEMORY;
+    goto clean;
+  }
+  *porigin = origin;
+  err = CURLE_OK;
+  goto clean;
+
+clean:
+  curl_free(host);
+  curl_free(port);
+  curl_free(scheme);
+  curl_url_cleanup(uh);
+  return err;
 }
 
 struct per_transfer *transfers; /* first node */
@@ -335,6 +388,7 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
   curlx_free(per->uploadfile);
   curlx_free(per->outfile);
   curlx_free(per->url);
+  curlx_free(per->origin);
   curl_easy_cleanup(per->curl);
   curlx_free(per);
 
@@ -534,7 +588,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
                            bool *retryp,
                            uint32_t *delayms)
 {
-  bool is_http_429_error = FALSE;
+  long http_error = 0;
   CURL *curl = per->curl;
   struct OutStruct *outs = &per->outs;
   enum retryreason reason = RETRY_NO;
@@ -563,11 +617,11 @@ static CURLcode retrycheck(struct OperationConfig *config,
       /* This was HTTP(S) */
       long response = 0;
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
+      http_error = response;
 
       switch(response) {
       case 408: /* Request Timeout */
       case 429: /* Too Many Requests (RFC6585) */
-        is_http_429_error = TRUE;
       case 500: /* Internal Server Error */
       case 502: /* Bad Gateway */
       case 503: /* Service Unavailable */
@@ -627,15 +681,11 @@ static CURLcode retrycheck(struct OperationConfig *config,
 
     /* The retry delay for 429 applies to all requests to the same host.
        Update the global 429 delay list for this host. */
-    if(is_http_429_error) {
-      char *host = NULL;
-      CURLU *hurl = curl_url();
-      curl_url_set(hurl, CURLUPART_URL, per->url, CURLU_GUESS_SCHEME);
-      curl_url_get(hurl, CURLUPART_HOST, &host, CURLU_URLDECODE);
-      http_429_list = curl_429_delay_set(http_429_list, host, *delayms);
+    if(http_error == 429) {
+      http_429_list = curl_429_delay_set(http_429_list,
+                                         per->origin, *delayms);
       if(!http_429_list)
         return CURLE_OUT_OF_MEMORY;
-      curl_url_cleanup(hurl);
     }
 
     /* Skip truncation of outfile if auto-resume is enabled for download and
@@ -1543,6 +1593,11 @@ static CURLcode create_single(struct OperationConfig *config,
     if(!per->url)
       break;
 
+    /* store the origin in the per transfer struct for 429 delay checks */
+    result = set_per_transfer_origin(per->url, &per->origin);
+    if(result)
+      return result;
+
     result = setup_outfile(config, per, u, outs, skipped);
     if(result)
       return result;
@@ -1684,12 +1739,8 @@ static CURLcode add_parallel_transfers(CURLM *multi, CURLSH *share,
       continue;
     }
     if(http_429_list) {
-      char *host = NULL;
-      CURLU *hurl = curl_url();
-      curl_url_set(hurl, CURLUPART_URL, per->url, CURLU_GUESS_SCHEME);
-      curl_url_get(hurl, CURLUPART_HOST, &host, CURLU_URLDECODE);
-      struct curl_429_list *item = curl_429_delay_get(http_429_list, host);
-      curl_url_cleanup(hurl);
+      struct curl_429_list *item;
+      item = curl_429_delay_get(http_429_list, per->origin);
       if(item && (time(NULL) < item->startat)) {
         per->startat = item->startat;
         per->added = FALSE;
@@ -2120,8 +2171,6 @@ static CURLcode parallel_transfers(CURLSH *share)
                                   &s->more_transfers, &s->added_transfers);
   if(result) {
     curl_multi_cleanup(s->multi);
-    curl_429_delay_free_all(http_429_list);
-    http_429_list = NULL;
     return result;
   }
 
@@ -2182,8 +2231,6 @@ static CURLcode parallel_transfers(CURLSH *share)
   }
 
   curl_multi_cleanup(s->multi);
-  curl_429_delay_free_all(http_429_list);
-  http_429_list = NULL;
 
   return result;
 }
@@ -2483,6 +2530,9 @@ static CURLcode run_all_transfers(CURLSH *share,
   /* Reset the global config variables */
   global->noprogress = orig_noprogress;
   global->isatty = orig_isatty;
+
+  curl_429_delay_free_all(http_429_list);
+  http_429_list = NULL;
 
   return result;
 }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -184,6 +184,104 @@ static curl_off_t VmsSpecialSize(const char *name,
 }
 #endif /* __VMS */
 
+/* linked-list structure for the 429 delay */
+struct curl_429_list {
+  char *hostname;
+  time_t startat;
+  struct curl_429_list *next;
+};
+
+/* a list of hosts and their delay timer for 429 errors */
+static struct curl_429_list *http_429_list = NULL;
+
+/*
+ * Set the delay for new transfers for a given host.
+ * If the host is not found, a new item is appended to the list.
+ * If the list is NULL a new list will be created.
+ * On error the function returns NULL, otherwise the list is returned.
+ */
+static struct curl_429_list *curl_429_delay_set(struct curl_429_list *list,
+                                                const char *host,
+                                                uint32_t delayms)
+{
+  struct curl_429_list *item;
+  struct curl_429_list *last_item;
+  struct curl_429_list *new_item;
+  time_t startat = time(NULL) + (delayms / 1000);
+
+  /* if there is no list yet we create a new list */
+  if(!list) {
+    new_item = curlx_malloc(sizeof(struct curl_429_list));
+    if(!new_item)
+      return NULL;
+
+    new_item->hostname = curlx_strdup(host);
+    new_item->startat = startat;
+    new_item->next = NULL;
+    return new_item;
+  }
+
+  /* loop through the list to check if we already got this host */
+  item = list;
+  do {
+    if(curl_strequal(item->hostname, host)) {
+      item->startat = startat;
+      return list;
+    }
+    last_item = item;
+    item = item->next;
+  } while(item);
+
+  /* host was not found so we create a new item and append it to the list */
+  new_item = curlx_malloc(sizeof(struct curl_429_list));
+  if(!new_item)
+    return NULL;
+
+  new_item->hostname = curlx_strdup(host);
+  new_item->startat = startat;
+  new_item->next = NULL;
+  last_item->next = new_item;
+  return list;
+}
+
+/*
+ * Check the list if it contains the given host and return it.
+ * Returns NULL if the host was not found in the list.
+ */
+static struct curl_429_list *curl_429_delay_get(struct curl_429_list *list,
+                                                const char *host)
+{
+  struct curl_429_list *item = list;
+
+  /* loop through the list to find this host */
+  while(item) {
+    if(curl_strequal(item->hostname, host)) {
+      return item;
+    }
+    item = item->next;
+  }
+
+  return NULL; /* host not found */
+}
+
+/* Free all the elements and their data. */
+static void curl_429_delay_free_all(struct curl_429_list *list)
+{
+  struct curl_429_list *next;
+  struct curl_429_list *item;
+
+  if(!list)
+    return;
+
+  item = list;
+  do {
+    next = item->next;
+    curlx_safefree(item->hostname);
+    curlx_free(item);
+    item = next;
+  } while(next);
+}
+
 struct per_transfer *transfers; /* first node */
 static struct per_transfer *transfersl; /* last node */
 
@@ -436,6 +534,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
                            bool *retryp,
                            uint32_t *delayms)
 {
+  bool is_http_429_error = FALSE;
   CURL *curl = per->curl;
   struct OutStruct *outs = &per->outs;
   enum retryreason reason = RETRY_NO;
@@ -468,6 +567,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
       switch(response) {
       case 408: /* Request Timeout */
       case 429: /* Too Many Requests (RFC6585) */
+        is_http_429_error = TRUE;
       case 500: /* Internal Server Error */
       case 502: /* Bad Gateway */
       case 503: /* Service Unavailable */
@@ -522,6 +622,21 @@ static CURLcode retrycheck(struct OperationConfig *config,
       /* no retry */
       return CURLE_OK;
     per->retry_remaining--;
+    per->num_retries++;
+    *delayms = sleeptime;
+
+    /* The retry delay for 429 applies to all requests to the same host.
+       Update the global 429 delay list for this host. */
+    if(is_http_429_error) {
+      char *host = NULL;
+      CURLU *hurl = curl_url();
+      curl_url_set(hurl, CURLUPART_URL, per->url, CURLU_GUESS_SCHEME);
+      curl_url_get(hurl, CURLUPART_HOST, &host, CURLU_URLDECODE);
+      http_429_list = curl_429_delay_set(http_429_list, host, *delayms);
+      if(!http_429_list)
+        return CURLE_OUT_OF_MEMORY;
+      curl_url_cleanup(hurl);
+    }
 
     /* Skip truncation of outfile if auto-resume is enabled for download and
        the partially received data is good. Only for HTTP GET requests in
@@ -594,8 +709,6 @@ static CURLcode retrycheck(struct OperationConfig *config,
         outs->bytes = 0; /* clear for next round */
       }
     }
-    per->num_retries++;
-    *delayms = sleeptime;
     result = CURLE_OK;
   }
   return result;
@@ -1570,6 +1683,20 @@ static CURLcode add_parallel_transfers(CURLM *multi, CURLSH *share,
       sleeping = TRUE;
       continue;
     }
+    if(http_429_list) {
+      char *host = NULL;
+      CURLU *hurl = curl_url();
+      curl_url_set(hurl, CURLUPART_URL, per->url, CURLU_GUESS_SCHEME);
+      curl_url_get(hurl, CURLUPART_HOST, &host, CURLU_URLDECODE);
+      struct curl_429_list *item = curl_429_delay_get(http_429_list, host);
+      curl_url_cleanup(hurl);
+      if(item && (time(NULL) < item->startat)) {
+        per->startat = item->startat;
+        per->added = FALSE;
+        sleeping = TRUE;
+        continue;
+      }
+    }
     per->added = TRUE;
 
     result = pre_transfer(per);
@@ -1993,6 +2120,8 @@ static CURLcode parallel_transfers(CURLSH *share)
                                   &s->more_transfers, &s->added_transfers);
   if(result) {
     curl_multi_cleanup(s->multi);
+    curl_429_delay_free_all(http_429_list);
+    http_429_list = NULL;
     return result;
   }
 
@@ -2053,6 +2182,8 @@ static CURLcode parallel_transfers(CURLSH *share)
   }
 
   curl_multi_cleanup(s->multi);
+  curl_429_delay_free_all(http_429_list);
+  http_429_list = NULL;
 
   return result;
 }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -209,7 +209,7 @@ static struct curl_429_list *curl_429_delay_set(struct curl_429_list *list,
   struct curl_429_list *new_item = NULL;
   time_t startat = delayms ? time(NULL) + (delayms / 1000) : 0;
 
-  /* try to find the origin in the existing list and update it's timer */
+  /* try to find the origin in the existing list and update its timer */
   if(list) {
     item = list;
     do {
@@ -288,7 +288,6 @@ static CURLcode set_per_transfer_origin(const char *url, char **porigin)
   char *port = NULL;
   char *scheme = NULL;
   char *origin = NULL;
-  size_t len_origin = 0;
   CURLcode err = CURLE_OK;
   CURLUcode uerr = CURLUE_OK;
   CURLU *uh = curl_url();
@@ -306,13 +305,11 @@ static CURLcode set_per_transfer_origin(const char *url, char **porigin)
   if(uerr)
     goto urlerr;
 
-  len_origin = strlen(host) + strlen(port) + strlen(scheme) + 3;
-  origin = curlx_malloc(len_origin);
+  origin = curl_maprintf("%s/%s/%s", host, port, scheme);
   if(!origin) {
     err = CURLE_OUT_OF_MEMORY;
     goto clean;
   }
-  curl_msnprintf(origin, len_origin, "%s/%s/%s", host, port, scheme);
   *porigin = origin;
   err = CURLE_OK;
   goto clean;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -201,7 +201,7 @@ static struct curl_429_list *http_429_list = NULL;
  * On error the function returns NULL, otherwise the list is returned.
  */
 static struct curl_429_list *curl_429_delay_set(struct curl_429_list *list,
-                                                const char *origin,
+                                                char *origin,
                                                 uint32_t delayms)
 {
   struct curl_429_list *item = NULL;
@@ -226,7 +226,7 @@ static struct curl_429_list *curl_429_delay_set(struct curl_429_list *list,
   new_item = curlx_malloc(sizeof(struct curl_429_list));
   if(!new_item)
     return NULL;
-  new_item->origin = curlx_strdup(origin);
+  new_item->origin = origin;
   if(!new_item->origin) {
     curlx_free(new_item);
     return NULL;
@@ -271,7 +271,6 @@ static void curl_429_delay_free_all(struct curl_429_list *list)
   item = list;
   do {
     next = item->next;
-    curlx_safefree(item->origin);
     curlx_free(item);
     item = next;
   } while(next);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -226,7 +226,7 @@ static struct curl_429_list *curl_429_delay_set(struct curl_429_list *list,
   new_item = curlx_malloc(sizeof(struct curl_429_list));
   if(!new_item)
     return NULL;
-  new_item->origin = origin;
+  new_item->origin = curlx_strdup(origin);
   if(!new_item->origin) {
     curlx_free(new_item);
     return NULL;
@@ -271,6 +271,7 @@ static void curl_429_delay_free_all(struct curl_429_list *list)
   item = list;
   do {
     next = item->next;
+    curlx_free(item->origin);
     curlx_free(item);
     item = next;
   } while(next);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -280,7 +280,6 @@ static void curl_429_delay_free_all(struct curl_429_list *list)
 /*
  * extract the host, port and scheme from the URL and write it to porigin
  * porigin needs to be freed by the user of this function
- * if the URL is invalid origin is set to "-/-/-"
  */
 static CURLcode set_per_transfer_origin(const char *url, char **porigin)
 {
@@ -315,13 +314,7 @@ static CURLcode set_per_transfer_origin(const char *url, char **porigin)
   goto clean;
 
 urlerr:
-  origin = curlx_strdup("-/-/-");
-  if(!origin) {
-    err = CURLE_OUT_OF_MEMORY;
-    goto clean;
-  }
-  *porigin = origin;
-  err = CURLE_OK;
+  err = urlerr_cvt(uerr);
   goto clean;
 
 clean:
@@ -676,9 +669,14 @@ static CURLcode retrycheck(struct OperationConfig *config,
     per->num_retries++;
     *delayms = sleeptime;
 
-    /* The retry delay for 429 applies to all requests to the same host.
-       Update the global 429 delay list for this host. */
+    /* The retry delay for 429 applies to all requests to the same origin.
+       Update the global 429 delay list for this origin. */
     if(http_error == 429) {
+      if(!per->origin) {
+        CURLcode err = set_per_transfer_origin(per->url, &per->origin);
+        if(err)
+          return err;
+      }
       http_429_list = curl_429_delay_set(http_429_list,
                                          per->origin, *delayms);
       if(!http_429_list)
@@ -1590,11 +1588,6 @@ static CURLcode create_single(struct OperationConfig *config,
       return result;
     if(!per->url)
       break;
-
-    /* store the origin in the per transfer struct for 429 delay checks */
-    result = set_per_transfer_origin(per->url, &per->origin);
-    if(result)
-      return result;
 
     result = setup_outfile(config, per, u, outs, skipped);
     if(result)

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -44,6 +44,7 @@ struct per_transfer {
   struct curltime start; /* start of this transfer */
   struct curltime retrystart;
   char *url;
+  char *origin;
   curl_off_t urlnum; /* the index of the given URL */
   char *outfile;
   int infd;

--- a/tests/data/test142
+++ b/tests/data/test142
@@ -188,7 +188,7 @@ RETR %TESTNUMBER
 QUIT
 </protocol>
 <limits>
-Allocations: 180
+Allocations: 190
 Maximum allocated: 150000
 </limits>
 </verify>

--- a/tests/data/test440
+++ b/tests/data/test440
@@ -75,7 +75,7 @@ https://this.hsts.example./%TESTNUMBER
 7
 </errorcode>
 <limits>
-Allocations: 160
+Allocations: 170
 </limits>
 </verify>
 </testcase>

--- a/tests/data/test445
+++ b/tests/data/test445
@@ -55,7 +55,7 @@ Refuse tunneling protocols through HTTP proxy
 7
 </errorcode>
 <limits>
-Allocations: 1500
+Allocations: 1580
 </limits>
 </verify>
 </testcase>

--- a/tests/data/test767
+++ b/tests/data/test767
@@ -49,7 +49,7 @@ Accept: */*
 
 </protocol>
 <limits>
-Allocations: 135
+Allocations: 140
 Maximum allocated: 136000
 </limits>
 </verify>


### PR DESCRIPTION
Don't start new transfers to the same host if this host has returned a 429 error.

The --retry-delay setting is used for all transfers to the same host on error 429.