### PR TITLE
CURLOPT_RTSP_SESSION_ID.md: clarify reuse "dangers"

### DIFF
--- a/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.md
@@ -39,6 +39,9 @@ option.
 Using this option multiple times makes the last set string override the
 previous ones. Set it to NULL to disable its use again.
 
+**WARNING:** when changing the URL's origin in a reused easy handle, you might
+want to set or clear the Session ID to avoid reuse across different hosts.
+
 # DEFAULT
 
 NULL


### PR DESCRIPTION
When re-using easy handles the session id stays, unless you do something about it.