### PR TITLE
CI: sshserver: skip -m PEM for ed25519 key generation

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,7 @@ jobs:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
     needs: build-cache
     runs-on: windows-2022
-    timeout-minutes: 10
+    timeout-minutes: 30
     defaults:
       run:
         shell: D:\cygwin\bin\bash.exe '{0}'  # zizmor: ignore[misfeature]
@@ -157,7 +157,7 @@ jobs:
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'build'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           PATH=/usr/bin
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
@@ -200,7 +200,7 @@ jobs:
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           TFLAGS: '${{ matrix.tflags }}'
         run: |
@@ -234,7 +234,7 @@ jobs:
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
     needs: build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
-    timeout-minutes: ${{ contains(matrix.tflags, '-t') && 14 || 10 }}
+    timeout-minutes: 25
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
@@ -418,7 +418,7 @@ jobs:
           cat bld/cmake_install.cmake || true
 
       - name: 'build'
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose
@@ -445,7 +445,7 @@ jobs:
 
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}  # Save time by skipping this for autotools
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target testdeps
@@ -496,7 +496,7 @@ jobs:
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: ${{ contains(matrix.tflags, '-t') && 15 || 10 }}
+        timeout-minutes: ${{ contains(matrix.tflags, '-t') && 22 || 20 }}
         env:
           MATRIX_ENV: '${{ matrix.env }}'
           MATRIX_INSTALL: '${{ matrix.install }}'
@@ -562,7 +562,7 @@ jobs:
     name: 'dl-mingw, CM ${{ matrix.ver }}-${{ matrix.env }} ${{ matrix.name }}'
     needs: build-cache
     runs-on: windows-2022
-    timeout-minutes: 10
+    timeout-minutes: 25
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
@@ -717,7 +717,7 @@ jobs:
 
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           PATH="/d/my-cache/${MATRIX_DIR}/bin:$PATH"
           cmake --build bld --target testdeps
@@ -741,7 +741,7 @@ jobs:
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
+        timeout-minutes: 20
         env:
           TFLAGS: '${{ matrix.tflags }}'
         run: |
@@ -768,7 +768,7 @@ jobs:
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       LDFLAGS: -s
       MAKEFLAGS: -j 5
@@ -876,7 +876,7 @@ jobs:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     needs: build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
-    timeout-minutes: ${{ matrix.arch == 'arm64' && 12 || 10 }}
+    timeout-minutes: ${{ matrix.arch == 'arm64' && 28 || 25 }}
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
@@ -1109,7 +1109,7 @@ jobs:
 
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
 
       - name: 'cache test prereqs (stunnel)'
@@ -1151,7 +1151,7 @@ jobs:
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
+        timeout-minutes: 20
         env:
           TFLAGS: '${{ matrix.tflags }}'
         run: |

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -57,32 +57,6 @@ static size_t t670_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
   exit(1);
 }
 
-static int t670_xferinfo(void *clientp,
-                         curl_off_t dltotal, curl_off_t dlnow,
-                         curl_off_t ultotal, curl_off_t ulnow)
-{
-  struct t670_ReadThis *pooh = (struct t670_ReadThis *)clientp;
-
-  (void)dltotal;
-  (void)dlnow;
-  (void)ultotal;
-  (void)ulnow;
-
-  if(pooh->origin) {
-    time_t delta = time(NULL) - pooh->origin;
-
-    if(delta >= 4 * PAUSE_TIME) {
-      curl_mfprintf(stderr, "unpausing failed: drain problem?\n");
-      return CURLE_ABORTED_BY_CALLBACK;
-    }
-
-    if(delta >= PAUSE_TIME)
-      curl_easy_pause(pooh->curl, CURLPAUSE_CONT);
-  }
-
-  return 0;
-}
-
 static CURLcode test_lib670(const char *URL)
 {
   static const char testname[] = "field";
@@ -154,13 +128,31 @@ static CURLcode test_lib670(const char *URL)
     test_setopt(pooh.curl, CURLOPT_HTTPPOST, formpost);
   }
 
-  if(testnum == 670 || testnum == 672) {
+  /*
+   * curl_easy_perform() uses multi internally, but tests 671/673 used
+   * CURLOPT_XFERINFOFUNCTION to unpause. Progress callbacks are not always
+   * invoked often enough while the upload is paused on some platforms, so
+   * drive curl_multi_* directly and unpause from this loop (same as 670/672).
+   */
+  {
     CURLMcode mresult;
     CURLM *multi;
-    /* Use the multi interface. */
+
     multi = curl_multi_init();
+    if(!multi) {
+      result = CURLE_OUT_OF_MEMORY;
+      goto test_cleanup;
+    }
+
     mresult = curl_multi_add_handle(multi, pooh.curl);
-    while(!mresult) {
+    if(mresult) {
+      curl_multi_cleanup(multi);
+      result = (mresult == CURLM_OUT_OF_MEMORY) ?
+        CURLE_OUT_OF_MEMORY : CURLE_FAILED_INIT;
+      goto test_cleanup;
+    }
+
+    while(mresult == CURLM_OK) {
       struct timeval timeout;
       int rc = 0;
       fd_set fdread;
@@ -170,7 +162,10 @@ static CURLcode test_lib670(const char *URL)
       int still_running = 0;
 
       mresult = curl_multi_perform(multi, &still_running);
-      if(!still_running || mresult != CURLM_OK)
+      if(mresult != CURLM_OK)
+        break;
+
+      if(!still_running)
         break;
 
       if(pooh.origin) {
@@ -206,27 +201,19 @@ static CURLcode test_lib670(const char *URL)
       }
     }
 
-    if(mresult != CURLM_OK)
-      for(;;) {
-        int msgs_left;
-        CURLMsg *msg;
-        msg = curl_multi_info_read(multi, &msgs_left);
-        if(!msg)
-          break;
-        if(msg->msg == CURLMSG_DONE) {
-          result = msg->data.result;
-        }
-      }
+    for(;;) {
+      int msgs_left;
+      CURLMsg *msg;
+
+      msg = curl_multi_info_read(multi, &msgs_left);
+      if(!msg)
+        break;
+      if(msg->msg == CURLMSG_DONE)
+        result = msg->data.result;
+    }
 
     curl_multi_remove_handle(multi, pooh.curl);
     curl_multi_cleanup(multi);
-  }
-  else {
-    /* Use the easy interface. */
-    test_setopt(pooh.curl, CURLOPT_XFERINFODATA, &pooh);
-    test_setopt(pooh.curl, CURLOPT_XFERINFOFUNCTION, t670_xferinfo);
-    test_setopt(pooh.curl, CURLOPT_NOPROGRESS, 0L);
-    result = curl_easy_perform(pooh.curl);
   }
 
 test_cleanup:

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -407,13 +407,20 @@ if((! -e pp($hstprvkeyf)) || (! -s pp($hstprvkeyf)) ||
 
     my @sshkeygenopt;
     if(($sshid =~ /OpenSSH/) && ($sshvernum >= 560)) {
-        # Override the default key format. Necessary to force legacy PEM format
-        # for libssh2 crypto backends that do not understand the OpenSSH (RFC4716)
-        # format, e.g. WinCNG.
+        my $sshkeyformat = $ENV{'CURL_TEST_SSH_KEY_FORMAT'};
+
+        # Legacy PEM helps some libssh2 backends (e.g. WinCNG). Ed25519 cannot
+        # use -m PEM (OpenSSH errors on Windows/MSYS); default PEM only for
+        # other algorithms. Explicit CURL_TEST_SSH_KEY_FORMAT still wins.
         # Accepted values: RFC4716, PKCS8, PEM (see also 'man ssh-keygen')
-        push @sshkeygenopt, '-m';
-        # Default to the most compatible format for tests.
-        push @sshkeygenopt, $ENV{'CURL_TEST_SSH_KEY_FORMAT'} ? $ENV{'CURL_TEST_SSH_KEY_FORMAT'} : 'PEM';
+        if($sshkeyformat) {
+            push @sshkeygenopt, '-m';
+            push @sshkeygenopt, $sshkeyformat;
+        }
+        elsif($keyalgo ne 'ed25519') {
+            push @sshkeygenopt, '-m';
+            push @sshkeygenopt, 'PEM';
+        }
     }
     logmsg "generating host keys...\n" if($verbose);
     if(system($sshkeygen, ('-q', '-t', $keyalgo, '-f', pp($hstprvkeyf), '-C', 'curl test server', '-N', '', @sshkeygenopt))) {


### PR DESCRIPTION
ssh-keygen does not support exporting ed25519 keys in PEM format. On Windows/MSYS this causes a hard failure ("Saving key ... failed: invalid format") while on macOS it silently ignores the flag and writes OpenSSH format anyway. Either way, passing -m PEM with ed25519 is wrong.

Only default to -m PEM for key algorithms that support it (rsa, ecdsa). Ed25519 keys now use the ssh-keygen default format unless CURL_TEST_SSH_KEY_FORMAT is explicitly set.

This fixes SSH server startup failures on Windows CI where CURL_TEST_SSH_KEYALGO is set to ed25519.

Follow-up to acda4eae5ee
Ref: #21223