### PR TITLE
docs/libcurl: improve easy setopt examples

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.md
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.md
@@ -54,11 +54,13 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_ABSTRACT_UNIX_SOCKET, "/tmp/foo.sock");
     curl_easy_setopt(curl, CURLOPT_URL, "http://localhost/");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.md
@@ -48,12 +48,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/path/file");
 
     /* wait no more than 5 seconds for the FTP server to connect */
     curl_easy_setopt(curl, CURLOPT_ACCEPTTIMEOUT_MS, 5000L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
@@ -106,13 +106,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* enable all supported built-in compressions */
     curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -64,9 +64,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, CURLALTSVC_H1);
     curl_easy_setopt(curl, CURLOPT_ALTSVC, "altsvc-cache.txt");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -84,9 +84,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, CURLALTSVC_H1);
     curl_easy_setopt(curl, CURLOPT_ALTSVC, "altsvc-cache.txt");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_APPEND.md
+++ b/docs/libcurl/opts/CURLOPT_APPEND.md
@@ -44,12 +44,13 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
-
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/dir/to/newfile");
     curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
     curl_easy_setopt(curl, CURLOPT_APPEND, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
+++ b/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
@@ -88,6 +88,7 @@ int main(void)
   CURL *curl = curl_easy_init();
 
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL,
                     "https://service.region.example.com/uri");
     curl_easy_setopt(curl, CURLOPT_AWS_SIGV4, "provider1:provider2");
@@ -98,7 +99,8 @@ int main(void)
                      "provider1:provider2:region:service");
 
     curl_easy_setopt(curl, CURLOPT_USERPWD, "MY_ACCESS_KEY:MY_SECRET_KEY");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.md
@@ -69,9 +69,10 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     curl_easy_setopt(curl, CURLOPT_CAINFO, "/etc/certs/cabundle.pem");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
@@ -60,17 +60,17 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
-    CURLcode res;
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
     /* only reuse certificate stores for a short time */
     curl_easy_setopt(curl, CURLOPT_CA_CACHE_TIMEOUT, 60L);
 
-    res = curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* in this second request, the cache is not used if more than
        sixty seconds passed since the previous connection */
-    res = curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     curl_easy_cleanup(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
@@ -62,13 +62,15 @@ int main(void)
 {
   struct priv myown;
   CURL *curl = curl_easy_init();
+  if(curl) {
+    CURLcode result;
+    /* call this function to close sockets */
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket);
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETDATA, &myown);
 
-  /* call this function to close sockets */
-  curl_easy_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket);
-  curl_easy_setopt(curl, CURLOPT_CLOSESOCKETDATA, &myown);
-
-  curl_easy_perform(curl);
-  curl_easy_cleanup(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
+  }
 }
 ~~~
 

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -73,13 +73,15 @@ int main(void)
 {
   struct priv myown;
   CURL *curl = curl_easy_init();
+  if(curl) {
+    CURLcode result;
+    /* call this function to close sockets */
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket);
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETDATA, &myown);
 
-  /* call this function to close sockets */
-  curl_easy_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket);
-  curl_easy_setopt(curl, CURLOPT_CLOSESOCKETDATA, &myown);
-
-  curl_easy_perform(curl);
-  curl_easy_cleanup(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
+  }
 }
 ~~~
 

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.md
@@ -69,12 +69,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* complete connection within 10 seconds */
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.md
@@ -70,12 +70,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* complete connection within 10000 milliseconds */
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 10000L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.md
@@ -96,10 +96,11 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_COOKIE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.md
@@ -76,11 +76,13 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_COOKIE, "tool=curl; fun=yes;");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.md
@@ -92,6 +92,7 @@ int main(void)
 
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* my_cookie is imported immediately via CURLOPT_COOKIELIST. */
     curl_easy_setopt(curl, CURLOPT_COOKIELIST, my_cookie);
 
@@ -109,7 +110,7 @@ int main(void)
     */
     curl_easy_setopt(curl, CURLOPT_COOKIEJAR, "cookies.txt");  /* export */
 
-    curl_easy_perform(curl);  /* cookies imported from cookies.txt */
+    result = curl_easy_perform(curl); /* cookies imported from cookies.txt */
 
     curl_easy_cleanup(curl);  /* cookies exported to cookies.txt */
   }

--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
@@ -62,6 +62,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     char local_buffer[1024]="data to send";
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
@@ -71,7 +72,8 @@ int main(void)
     /* send data from the local stack */
     curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, local_buffer);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.md
+++ b/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.md
@@ -68,6 +68,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* set a URL without a scheme */
     curl_easy_setopt(curl, CURLOPT_URL, "example.com");
 
@@ -75,7 +76,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_DEFAULT_PROTOCOL, "https");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
@@ -48,11 +48,12 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
-
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_DISALLOW_USERNAME_IN_URL, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_DNS_SHUFFLE_ADDRESSES.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_SHUFFLE_ADDRESSES.md
@@ -56,10 +56,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_DNS_SHUFFLE_ADDRESSES, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
@@ -69,6 +69,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_DOH_URL,
@@ -77,7 +78,8 @@ int main(void)
     /* Disable hostname verification of the DoH server */
     curl_easy_setopt(curl, CURLOPT_DOH_SSL_VERIFYHOST, 0L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
@@ -81,6 +81,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_DOH_URL,
@@ -89,7 +90,8 @@ int main(void)
     /* Disable certificate verification of the DoH server */
     curl_easy_setopt(curl, CURLOPT_DOH_SSL_VERIFYPEER, 0L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
@@ -56,6 +56,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_DOH_URL,
@@ -64,7 +65,8 @@ int main(void)
     /* Ask for OCSP stapling when verifying the DoH server */
     curl_easy_setopt(curl, CURLOPT_DOH_SSL_VERIFYSTATUS, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.md
@@ -79,9 +79,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_DOH_URL, "https://dns.example.com");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_ECH.md
+++ b/docs/libcurl/opts/CURLOPT_ECH.md
@@ -96,8 +96,10 @@ int main(void)
     "ecl:AED+DQA87wAgACB/RuzUCsW3uBbSFI7mzD63TUXpI8sGDTnFTbFCDpa+" \
     "CAAEAAEAAQANY292ZXIuZGVmby5pZQAA";
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_ECH, config);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.md
@@ -46,12 +46,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* wait 3 seconds for 100-continue */
     curl_easy_setopt(curl, CURLOPT_EXPECT_100_TIMEOUT_MS, 3000L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.md
@@ -62,12 +62,14 @@ int main(void)
   struct local_stuff local_data;
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://ftp.example.com/file*");
     curl_easy_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
     curl_easy_setopt(curl, CURLOPT_FNMATCH_FUNCTION, my_fnmatch);
     curl_easy_setopt(curl, CURLOPT_FNMATCH_DATA, &local_data);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.md
@@ -71,11 +71,13 @@ int main(void)
   struct local_stuff local_data;
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://ftp.example.com/file*");
     curl_easy_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
     curl_easy_setopt(curl, CURLOPT_FNMATCH_FUNCTION, my_fnmatch);
     curl_easy_setopt(curl, CURLOPT_FNMATCH_DATA, &local_data);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
@@ -138,12 +138,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* example.com is redirected, so we tell libcurl to follow redirection */
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
@@ -50,12 +50,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
+    CURLcode result2;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* this second transfer may not reuse the same connection */
-    curl_easy_perform(curl);
+    result2 = curl_easy_perform(curl);
 
     curl_easy_cleanup(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.md
+++ b/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.md
@@ -52,10 +52,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1L);
     /* this transfer must use a new connection, not reuse an existing */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
@@ -106,10 +106,13 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
+
+    /* Set the timeout to 300 milliseconds */
     curl_easy_setopt(curl, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS, 300L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_HEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HEADER.md
@@ -63,11 +63,13 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HEADERDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERDATA.md
@@ -68,6 +68,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     struct my_info my = { 10, "the cookies are in the cupboard" };
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
@@ -76,7 +77,9 @@ int main(void)
     /* pass in custom data to the callback */
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, &my);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
@@ -118,11 +118,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -86,8 +86,10 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_HSTS, "/home/user/.hsts-cache");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -87,6 +87,7 @@ int main(void)
   CURL *curl = curl_easy_init();
   if(curl) {
     CURLcode result;
+    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_HSTS, "/home/user/.hsts-cache");
     result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_HSTSREADDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADDATA.md
@@ -48,6 +48,13 @@ struct MyData {
   void *custom;
 };
 
+static CURLSTScode hsts_cb(CURL *easy, struct curl_hstsentry *sts,
+                           void *clientp)
+{
+  /* populate the struct as documented */
+  return CURLSTS_OK;
+}
+
 int main(void)
 {
   CURL *curl = curl_easy_init();

--- a/docs/libcurl/opts/CURLOPT_HSTSREADDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADDATA.md
@@ -53,13 +53,17 @@ int main(void)
   CURL *curl = curl_easy_init();
   struct MyData this;
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
 
     /* pass pointer that gets passed in to the
        CURLOPT_HSTSREADFUNCTION callback */
     curl_easy_setopt(curl, CURLOPT_HSTSREADDATA, &this);
+    /* set HSTS read callback */
+    curl_easy_setopt(curl, CURLOPT_HSTSREADFUNCTION, hsts_cb);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.md
@@ -90,6 +90,8 @@ int main(void)
     struct priv my_stuff;
     CURLcode result;
 
+    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
+
     /* set HSTS read callback */
     curl_easy_setopt(curl, CURLOPT_HSTSREADFUNCTION, hsts_cb);
 

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.md
@@ -53,13 +53,15 @@ int main(void)
   CURL *curl = curl_easy_init();
   struct MyData this;
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "http://example.com");
 
     /* pass pointer that gets passed in to the
        CURLOPT_HSTSWRITEFUNCTION callback */
     curl_easy_setopt(curl, CURLOPT_HSTSWRITEDATA, &this);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
@@ -64,8 +64,13 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
+    /* enable HSTS */
     curl_easy_setopt(curl, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);
-    curl_easy_perform(curl);
+    /* specify where to store the HSTS cache */
+    curl_easy_setopt(curl, CURLOPT_HSTS, "/home/user/.hsts-cache");
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.md
@@ -61,14 +61,16 @@ int main(void)
   CURL *curl = curl_easy_init();
   if(curl) {
     struct curl_slist *list;
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     list = curl_slist_append(NULL, "ICY 200 OK");
     list = curl_slist_append(list, "WEIRDO 99 FINE");
 
     curl_easy_setopt(curl, CURLOPT_HTTP200ALIASES, list);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
     curl_slist_free_all(list); /* free the list again */
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HTTPGET.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPGET.md
@@ -52,13 +52,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* use a GET to fetch this */
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -169,6 +169,7 @@ int main(void)
   struct curl_slist *list = NULL;
 
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* add this header */
@@ -182,9 +183,10 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     curl_slist_free_all(list); /* free the list */
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_HTTPPOST.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPPOST.md
@@ -84,8 +84,9 @@ int main(void)
 
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
   curl_formfree(formpost);

--- a/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.md
@@ -59,10 +59,12 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/file.txt");
     curl_easy_setopt(curl, CURLOPT_PROXY, "http://127.0.0.1:80");
     curl_easy_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.md
+++ b/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.md
@@ -55,12 +55,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* we know the server is silly, ignore content-length */
     curl_easy_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE.md
@@ -63,6 +63,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     long uploadsize = FILE_SIZE;
 
     curl_easy_setopt(curl, CURLOPT_URL,
@@ -72,7 +73,8 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_INFILESIZE, uploadsize);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.md
@@ -59,6 +59,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_off_t uploadsize = FILE_SIZE;
 
     curl_easy_setopt(curl, CURLOPT_URL,
@@ -68,7 +69,8 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, uploadsize);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.md
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.md
@@ -56,10 +56,12 @@ int main(void)
   struct local rtp_data;
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_INTERLEAVEFUNCTION, rtp_write);
     curl_easy_setopt(curl, CURLOPT_INTERLEAVEDATA, &rtp_data);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.md
+++ b/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.md
@@ -53,12 +53,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* only allow 30 seconds idle time */
     curl_easy_setopt(curl, CURLOPT_MAXAGE_CONN, 30L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
+++ b/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
@@ -57,12 +57,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* only allow each connection to be reused for 30 seconds */
     curl_easy_setopt(curl, CURLOPT_MAXLIFETIME_CONN, 30L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_MAXREDIRS.md
+++ b/docs/libcurl/opts/CURLOPT_MAXREDIRS.md
@@ -50,6 +50,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
 
     /* enable redirect following */
@@ -59,7 +60,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_MIMEPOST.md
+++ b/docs/libcurl/opts/CURLOPT_MIMEPOST.md
@@ -55,6 +55,7 @@ int main(void)
   if(curl) {
     curl_mime *multipart = curl_mime_init(curl);
     if(multipart) {
+      CURLcode result;
       curl_mimepart *part = curl_mime_addpart(multipart);
       curl_mime_name(part, "name");
       curl_mime_data(part, "daniel", CURL_ZERO_TERMINATED);
@@ -68,9 +69,10 @@ int main(void)
       /* Set the form info */
       curl_easy_setopt(curl, CURLOPT_MIMEPOST, multipart);
 
-      curl_easy_perform(curl); /* post away */
+      result = curl_easy_perform(curl); /* post away */
       curl_mime_free(multipart); /* free the post data */
     }
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
@@ -68,6 +68,7 @@ int main(void)
   curl_mime *form = NULL;
 
   if(curl) {
+    CURLcode result = CURLE_OK;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_MIME_OPTIONS, CURLMIMEOPT_FORMESCAPE);
 
@@ -81,7 +82,7 @@ int main(void)
         curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
 
         /* Perform the request */
-        curl_easy_perform(curl);
+        result = curl_easy_perform(curl);
       }
     }
 

--- a/docs/libcurl/opts/CURLOPT_NOBODY.md
+++ b/docs/libcurl/opts/CURLOPT_NOBODY.md
@@ -59,13 +59,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* get us the resource without a body - use HEAD */
     curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_NOPROGRESS.md
+++ b/docs/libcurl/opts/CURLOPT_NOPROGRESS.md
@@ -46,13 +46,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* enable progress meter */
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.md
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.md
@@ -76,13 +76,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* accept various URLs */
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     /* use this proxy */
     curl_easy_setopt(curl, CURLOPT_PROXY, "http://proxy.example:80");
     /* ... but make sure this hostname is not proxied */
     curl_easy_setopt(curl, CURLOPT_NOPROXY, "www.example.com");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
@@ -60,12 +60,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL,
                      "https://example.com/../../etc/password");
 
     curl_easy_setopt(curl, CURLOPT_PATH_AS_IS, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
@@ -66,6 +66,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_PINNEDPUBLICKEY, "/etc/publickey.der");
     /* OR
@@ -76,7 +77,8 @@ int main(void)
     */
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDS.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDS.md
@@ -84,6 +84,7 @@ NULL
 /* send an application/x-www-form-urlencoded POST */
 int main(void)
 {
+  CURLcode result = CURLE_OK;
   CURL *curl = curl_easy_init();
   if(curl) {
     const char *data = "data to send";
@@ -96,7 +97,8 @@ int main(void)
     /* pass in a pointer to the data - libcurl does not copy */
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 
   /* send an application/json POST */
@@ -115,7 +117,8 @@ int main(void)
     /* pass in a pointer to the data - libcurl does not copy */
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
@@ -51,6 +51,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     const char *data = "data to send";
 
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
@@ -60,7 +61,8 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.md
@@ -51,6 +51,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     const char *data = large_chunk;
     curl_off_t length_of_data = 12345; /* set somehow */
 
@@ -61,7 +62,8 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -61,6 +61,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* a silly POST example */
@@ -70,7 +71,8 @@ int main(void)
        302 and 303 HTTP response codes */
     curl_easy_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PREREQDATA.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQDATA.md
@@ -58,9 +58,11 @@ int main(void)
   struct priv prereq_data;
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_PREREQFUNCTION, prereq_callback);
     curl_easy_setopt(curl, CURLOPT_PREREQDATA, &prereq_data);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
@@ -111,9 +111,11 @@ int main(void)
   struct priv prereq_data;
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_PREREQFUNCTION, prereq_callback);
     curl_easy_setopt(curl, CURLOPT_PREREQDATA, &prereq_data);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.md
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.md
@@ -70,10 +70,12 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/file.txt");
     curl_easy_setopt(curl, CURLOPT_PRE_PROXY, "socks4://socks-proxy:1080");
     curl_easy_setopt(curl, CURLOPT_PROXY, "http://proxy:80");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PRIVATE.md
+++ b/docs/libcurl/opts/CURLOPT_PRIVATE.md
@@ -50,16 +50,19 @@ int main(void)
   CURL *curl = curl_easy_init();
   struct private secrets;
   if(curl) {
+    CURLcode result;
     struct private *extracted;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* store a pointer to our private struct */
     curl_easy_setopt(curl, CURLOPT_PRIVATE, &secrets);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* we can extract the private pointer again too */
     curl_easy_getinfo(curl, CURLINFO_PRIVATE, &extracted);
+
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
@@ -61,13 +61,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     struct progress data;
 
     /* pass struct to callback */
     curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &data);
     curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
@@ -109,11 +109,13 @@ int main(void)
 
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* pass struct to callback */
     curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &data);
     curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
@@ -86,6 +86,7 @@ int main(int argc, char **argv)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* pass in the URL from an external source */
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
 
@@ -94,7 +95,8 @@ int main(int argc, char **argv)
                      CURLPROTO_HTTP | CURLPROTO_TFTP | CURLPROTO_SFTP);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.md
@@ -69,6 +69,7 @@ int main(int argc, char **argv)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* pass in the URL from an external source */
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
 
@@ -76,7 +77,8 @@ int main(int argc, char **argv)
     curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,tftp,sftp");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROXY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY.md
@@ -136,9 +136,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/file.txt");
     curl_easy_setopt(curl, CURLOPT_PROXY, "http://proxy.example:80");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROXYHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYHEADER.md
@@ -61,6 +61,7 @@ int main(void)
   struct curl_slist *list;
 
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_PROXY, "http://proxy.example.com:80");
 
@@ -69,9 +70,10 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_PROXYHEADER, list);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     curl_slist_free_all(list); /* free the list again */
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
@@ -66,6 +66,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_PROXY, "https://proxy.example:443");
     curl_easy_setopt(curl, CURLOPT_PROXY_PINNEDPUBLICKEY,
@@ -74,7 +75,8 @@ int main(void)
                      "Gxa2eg7fRbEgoChTociMee9wno=");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -102,13 +102,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* ask libcurl to use TLS version 1.0 or later */
     curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
@@ -74,12 +74,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* Set the default value: strict name check please */
     curl_easy_setopt(curl, CURLOPT_PROXY_SSL_VERIFYHOST, 2L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
@@ -76,12 +76,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* Set the default value: strict certificate check please */
     curl_easy_setopt(curl, CURLOPT_PROXY_SSL_VERIFYPEER, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PUT.md
+++ b/docs/libcurl/opts/CURLOPT_PUT.md
@@ -57,7 +57,7 @@ int main(void)
 {
   CURL *curl;
   FILE *src = fopen("local-file", "r");
-  if(!rc)
+  if(!src)
     return 1;
   curl = curl_easy_init();
   if(curl) {

--- a/docs/libcurl/opts/CURLOPT_PUT.md
+++ b/docs/libcurl/opts/CURLOPT_PUT.md
@@ -57,6 +57,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     FILE *src = fopen("local-file", "r");
     curl_off_t fsize = 123456; /* set this to the size of the input file */
 
@@ -76,7 +77,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsize);
 
     /* Now run off and do what you have been told */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_PUT.md
+++ b/docs/libcurl/opts/CURLOPT_PUT.md
@@ -55,10 +55,13 @@ static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 int main(void)
 {
-  CURL *curl = curl_easy_init();
+  CURL *curl;
+  FILE *src = fopen("local-file", "r");
+  if(!rc)
+    return 1;
+  curl = curl_easy_init();
   if(curl) {
     CURLcode result;
-    FILE *src = fopen("local-file", "r");
     curl_off_t fsize = 123456; /* set this to the size of the input file */
 
     /* we want to use our own read function */
@@ -80,6 +83,7 @@ int main(void)
     result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
+  fclose(src);
 }
 ~~~
 

--- a/docs/libcurl/opts/CURLOPT_RANGE.md
+++ b/docs/libcurl/opts/CURLOPT_RANGE.md
@@ -73,13 +73,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* get the first 200 bytes */
     curl_easy_setopt(curl, CURLOPT_RANGE, "0-199");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_READDATA.md
+++ b/docs/libcurl/opts/CURLOPT_READDATA.md
@@ -57,13 +57,15 @@ int main(void)
   CURL *curl = curl_easy_init();
   struct MyData this;
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* pass pointer that gets passed in to the
        CURLOPT_READFUNCTION callback */
     curl_easy_setopt(curl, CURLOPT_READDATA, &this);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
@@ -91,6 +91,7 @@ int main(int argc, char **argv)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* pass in the URL from an external source */
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
 
@@ -99,7 +100,8 @@ int main(int argc, char **argv)
                      CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.md
@@ -75,6 +75,7 @@ int main(int argc, char **argv)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* pass in the URL from an external source */
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
 
@@ -82,7 +83,8 @@ int main(int argc, char **argv)
     curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_REFERER.md
+++ b/docs/libcurl/opts/CURLOPT_REFERER.md
@@ -51,12 +51,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* tell it where we found the link to this place */
     curl_easy_setopt(curl, CURLOPT_REFERER, "https://example.org/me.html");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.md
+++ b/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.md
@@ -53,6 +53,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/*");
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
 
@@ -60,7 +61,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_REQUEST_TARGET, "*");
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.md
@@ -96,10 +96,11 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_RESOLVE, host);
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.md
@@ -53,10 +53,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, resolver_start_cb);
     curl_easy_setopt(curl, CURLOPT_RESOLVER_START_DATA, curl);
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.md
@@ -71,10 +71,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, start_cb);
     curl_easy_setopt(curl, CURLOPT_RESOLVER_START_DATA, curl);
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM.md
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM.md
@@ -53,6 +53,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     long size_of_file = 6789;
 
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com");
@@ -67,7 +68,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_INFILESIZE, size_of_file);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.md
@@ -51,6 +51,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_off_t resume_position = 1234; /* get it somehow */
     curl_off_t file_size = 9876; /* get it somehow as well */
 
@@ -66,7 +67,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, file_size);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -55,6 +55,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* request to use a SOCKS5 proxy */
@@ -64,7 +65,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_SOCKS5_AUTH, CURLAUTH_BASIC);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.md
@@ -45,13 +45,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "sftp://example.com");
 
     /* enable built-in compression */
     curl_easy_setopt(curl, CURLOPT_SSH_COMPRESSION, 1L);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.md
@@ -56,12 +56,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     struct mine callback_data;
     curl_easy_setopt(curl, CURLOPT_URL, "sftp://example.com/thisfile.txt");
     curl_easy_setopt(curl, CURLOPT_SSH_HOSTKEYFUNCTION, hostkeycb);
     curl_easy_setopt(curl, CURLOPT_SSH_HOSTKEYDATA, &callback_data);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.md
@@ -82,11 +82,13 @@ int main(void)
   struct mine callback_data;
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "sftp://example.com/thisfile.txt");
     curl_easy_setopt(curl, CURLOPT_SSH_HOSTKEYFUNCTION, hostkeycb);
     curl_easy_setopt(curl, CURLOPT_SSH_HOSTKEYDATA, &callback_data);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
@@ -57,13 +57,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     struct mine callback_data;
     curl_easy_setopt(curl, CURLOPT_URL, "sftp://example.com/thisfile.txt");
     curl_easy_setopt(curl, CURLOPT_SSH_KEYFUNCTION, keycb);
     curl_easy_setopt(curl, CURLOPT_SSH_KEYDATA, &callback_data);
     curl_easy_setopt(curl, CURLOPT_SSH_KNOWNHOSTS, "/home/user/known_hosts");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
@@ -134,13 +134,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     struct mine callback_data;
     curl_easy_setopt(curl, CURLOPT_URL, "sftp://example.com/thisfile.txt");
     curl_easy_setopt(curl, CURLOPT_SSH_KEYFUNCTION, keycb);
     curl_easy_setopt(curl, CURLOPT_SSH_KEYDATA, &callback_data);
     curl_easy_setopt(curl, CURLOPT_SSH_KNOWNHOSTS, "/home/user/known_hosts");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -114,13 +114,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* ask libcurl to use TLS version 1.0 or later */
     curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
@@ -47,9 +47,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_SSL_FALSESTART, 1L);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -88,12 +88,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* Set the default value: strict name check please */
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
@@ -82,12 +82,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* Set the default value: strict certificate check please */
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_STDERR.md
+++ b/docs/libcurl/opts/CURLOPT_STDERR.md
@@ -49,10 +49,12 @@ int main(void)
   CURL *curl = curl_easy_init();
   FILE *filep = fopen("dump", "wb");
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_STDERR, filep);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_STDERR.md
+++ b/docs/libcurl/opts/CURLOPT_STDERR.md
@@ -46,8 +46,11 @@ stderr
 ~~~c
 int main(void)
 {
-  CURL *curl = curl_easy_init();
+  CURL *curl;
   FILE *filep = fopen("dump", "wb");
+  if(!filep)
+    return 1;
+  curl = curl_easy_init();
   if(curl) {
     CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
@@ -56,6 +59,7 @@ int main(void)
     result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
+  fclose(filep);
 }
 ~~~
 

--- a/docs/libcurl/opts/CURLOPT_SUPPRESS_CONNECT_HEADERS.md
+++ b/docs/libcurl/opts/CURLOPT_SUPPRESS_CONNECT_HEADERS.md
@@ -80,6 +80,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
@@ -87,7 +88,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
     curl_easy_setopt(curl, CURLOPT_SUPPRESS_CONNECT_HEADERS, 1L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
@@ -47,9 +47,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_TCP_FASTOPEN, 1L);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.md
@@ -48,6 +48,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* enable TCP keep-alive for this transfer */
@@ -62,7 +63,8 @@ int main(void)
     /* maximum number of keep-alive probes: 3 */
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPCNT, 3L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPCNT.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPCNT.md
@@ -48,6 +48,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* enable TCP keep-alive for this transfer */
@@ -62,7 +63,8 @@ int main(void)
     /* maximum number of keep-alive probes: 3 */
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPCNT, 3L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.md
@@ -47,6 +47,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* enable TCP keep-alive for this transfer */
@@ -61,7 +62,8 @@ int main(void)
     /* maximum number of keep-alive probes: 3 */
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPCNT, 3L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
@@ -46,6 +46,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* enable TCP keep-alive for this transfer */
@@ -60,7 +61,8 @@ int main(void)
     /* maximum number of keep-alive probes: 3 */
     curl_easy_setopt(curl, CURLOPT_TCP_KEEPCNT, 3L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
@@ -54,10 +54,12 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     /* leave Nagle enabled */
     curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 0L);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.md
@@ -50,6 +50,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result = CURLE_OK;
     FILE *fp = fopen("foo.bin", "wb");
     if(fp) {
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)fp);
@@ -61,7 +62,7 @@ int main(void)
       curl_easy_setopt(curl, CURLOPT_TFTP_NO_OPTIONS, 1L);
 
       /* Perform the request */
-      curl_easy_perform(curl);
+      result = curl_easy_perform(curl);
 
       fclose(fp);
     }

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -51,6 +51,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* January 1, 2020 is 1577833200 */
@@ -60,7 +61,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.md
@@ -71,12 +71,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* complete within 20 seconds */
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 20L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.md
@@ -46,12 +46,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* complete within 20000 milliseconds */
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 20000L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -47,6 +47,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* January 1, 2020 is 1577833200 */
@@ -56,7 +57,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -49,6 +49,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* January 1, 2020 is 1577833200 */
@@ -58,7 +59,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
@@ -53,9 +53,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_TRANSFER_ENCODING, 1L);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.md
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.md
@@ -62,10 +62,12 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, "/tmp/httpd.sock");
     curl_easy_setopt(curl, CURLOPT_URL, "http://localhost/");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.md
@@ -69,10 +69,12 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.md
+++ b/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.md
@@ -51,13 +51,14 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     /* Make a connection to an HTTP/2 server. */
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* Set the interval to 30000ms / 30s */
     curl_easy_setopt(curl, CURLOPT_UPKEEP_INTERVAL_MS, 30000L);
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
 
     /* Perform more work here. */
 

--- a/docs/libcurl/opts/CURLOPT_UPLOAD.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD.md
@@ -65,6 +65,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     FILE *src = fopen("local-file", "r");
     curl_off_t fsize = 1234; /* set this to the size of the input file */
 
@@ -84,7 +85,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsize);
 
     /* Now run off and do what you have been told */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_UPLOAD_FLAGS.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD_FLAGS.md
@@ -77,10 +77,14 @@ static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 int main(void)
 {
-  CURL *curl = curl_easy_init();
+  CURL *curl;
+  FILE *src = fopen("local-file", "r");
+  if(!src)
+    return 1;
+
+  curl = curl_easy_init();
   if(curl) {
     CURLcode result;
-    FILE *src = fopen("local-file", "r");
     curl_off_t fsize = 9876; /* set this to the size of the input file */
 
     /* we want to use our own read function */
@@ -111,6 +115,7 @@ int main(void)
     result = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
+  fclose(src);
 }
 ~~~
 

--- a/docs/libcurl/opts/CURLOPT_UPLOAD_FLAGS.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD_FLAGS.md
@@ -79,6 +79,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     FILE *src = fopen("local-file", "r");
     curl_off_t fsize = 9876; /* set this to the size of the input file */
 
@@ -107,7 +108,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsize);
 
     /* perform the upload */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_URL.md
+++ b/docs/libcurl/opts/CURLOPT_URL.md
@@ -127,9 +127,11 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.md
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.md
@@ -51,11 +51,13 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "Dark Secret Ninja/1.0");
 
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -40,16 +40,19 @@ This is for enabling SSL/TLS when you use FTP, SMTP, POP3, IMAP etc.
 
 ## CURLUSESSL_NONE
 
-do not attempt to use SSL.
+Do not attempt to use SSL.
 
 ## CURLUSESSL_TRY
 
 Try using SSL, proceed as normal otherwise. Note that server may close the
-connection if the negotiation fails.
+connection if the negotiation fails. This level is *insecure* and should be
+avoided since it allows the connection to remain unprotected.
 
 ## CURLUSESSL_CONTROL
 
 Require SSL for the control connection or fail with *CURLE_USE_SSL_FAILED*.
+This level is partially *insecure* and should be avoided since it lets the
+data connection remain unprotected.
 
 ## CURLUSESSL_ALL
 
@@ -68,13 +71,15 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/dir/file.ext");
 
     /* require use of SSL for this, or fail */
     curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -55,7 +55,7 @@ This level is partially *insecure* and should be avoided since it lets the
 data connection remain unprotected.
 
 This level is meant for FTP, since that is the only protocol with separate
-connections for control and data. If used for IMAP, POP3 or IMAP it equals
+connections for control and data. If used for IMAP, POP3 or SMTP it equals
 `CURLUSESSL_ALL`.
 
 ## CURLUSESSL_ALL

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -54,6 +54,10 @@ Require SSL for the control connection or fail with *CURLE_USE_SSL_FAILED*.
 This level is partially *insecure* and should be avoided since it lets the
 data connection remain unprotected.
 
+This level is meant for FTP, since that is the only protocol with separate
+connections for control and data. If used for IMAP, POP3 or IMAP it equals
+`CURLUSESSL_ALL`.
+
 ## CURLUSESSL_ALL
 
 Require SSL for all communication or fail with *CURLE_USE_SSL_FAILED*.

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.md
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.md
@@ -54,13 +54,16 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
+    CURLcode result;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* ask libcurl to show us the verbose output */
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
     /* Perform the request */
-    curl_easy_perform(curl);
+    result = curl_easy_perform(curl);
+
+    curl_easy_cleanup(curl);
   }
 }
 ~~~


### PR DESCRIPTION
- always assign the curl_easy_perform() return code (and declare the necessary 'result' variable for it)

- always call curl_easy_cleanup() on the created easy handles