### PR TITLE
fix a blocking curl_ws_send() to report written length correctly.

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1749,6 +1749,8 @@ static CURLcode ws_send_raw(struct Curl_easy *data, const void *buffer,
     if(result)
       return result;
     result = ws_send_raw_blocking(data, ws, buffer, buflen);
+    if(!result)
+      *pnwritten = buflen;
   }
   else {
     /* We need any pending data to be sent or EAGAIN this call. */


### PR DESCRIPTION
Refs #21372