### PR TITLE
runtests: skip setting ed25519 SSH key format

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,7 +33,7 @@ permissions: {}
 
 env:
   CURL_CI: github
-  CURL_TEST_MIN: 1750
+  CURL_TEST_MIN: 1800
   CURL_TEST_SSH_KEYALGO: ed25519
   OPENSSH_WINDOWS_VERSION: 10.0.0.0p2-Preview
   OPENSSH_WINDOWS_SHA256_ARM64: 698c6aec31c1dd0fb996206e8741f4531a97355686b5431ef347d531b07fcd42
@@ -76,7 +76,6 @@ jobs:
       run:
         shell: D:\cygwin\bin\bash.exe '{0}'  # zizmor: ignore[misfeature]
     env:
-      CURL_TEST_MIN: 1800
       LDFLAGS: -s
       MAKEFLAGS: -j 5
       SHELLOPTS: 'igncr'

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -411,9 +411,8 @@ if((! -e pp($hstprvkeyf)) || (! -s pp($hstprvkeyf)) ||
         # for libssh2 crypto backends that do not understand the OpenSSH (RFC4716)
         # format, e.g. WinCNG.
         # Accepted values: RFC4716, PKCS8, PEM (see also 'man ssh-keygen')
-        push @sshkeygenopt, '-m';
         # Default to the most compatible format for tests.
-        push @sshkeygenopt, $ENV{'CURL_TEST_SSH_KEY_FORMAT'} ? $ENV{'CURL_TEST_SSH_KEY_FORMAT'} : 'PEM';
+        push @sshkeygenopt, '-m', $ENV{'CURL_TEST_SSH_KEY_FORMAT'} ? $ENV{'CURL_TEST_SSH_KEY_FORMAT'} : 'PEM';
     }
     logmsg "generating host keys...\n" if($verbose);
     if(system($sshkeygen, ('-q', '-t', $keyalgo, '-f', pp($hstprvkeyf), '-C', 'curl test server', '-N', '', @sshkeygenopt))) {

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -406,7 +406,7 @@ if((! -e pp($hstprvkeyf)) || (! -s pp($hstprvkeyf)) ||
            pp($hstpubsha256f), pp($cliprvkeyf), pp($clipubkeyf));
 
     my @sshkeygenopt;
-    if(($sshid =~ /OpenSSH/) && ($sshvernum >= 560)) {
+    if(($sshid =~ /OpenSSH/) && ($sshvernum >= 560) && $keyalgo ne 'ed25519') {
         # Override the default key format. Necessary to force legacy PEM format
         # for libssh2 crypto backends that do not understand the OpenSSH (RFC4716)
         # format, e.g. WinCNG.

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -406,7 +406,7 @@ if((! -e pp($hstprvkeyf)) || (! -s pp($hstprvkeyf)) ||
            pp($hstpubsha256f), pp($cliprvkeyf), pp($clipubkeyf));
 
     my @sshkeygenopt;
-    if(($sshid =~ /OpenSSH/) && ($sshvernum >= 560) && $keyalgo ne 'ed25519') {
+    if(($sshid =~ /OpenSSH/) && ($sshvernum >= 560) && ($keyalgo ne 'ed25519')) {
         # Override the default key format. Necessary to force legacy PEM format
         # for libssh2 crypto backends that do not understand the OpenSSH (RFC4716)
         # format, e.g. WinCNG.


### PR DESCRIPTION
`ssh-keygen -t ed25519` does not support PEM key format, and it 
defaults to `RFC4716` which is what we want.                   

It affected GHA/windows tests that explicitly used ed25519 keys.

Also:
- GHA/windows: bump minimums to hopefully catch this early next time.
  1701a8319ec96c0b73c39e16c5db68dd758419c2 #21353
- merge two Perl lines.

Reported-by: herbenderbler on github
Fixes #21360
Follow-up to acda4eae5eeb24a7b0ab9ec7b1783d74eb43687c #21223
