### PR TITLE
Fix lib1960 test failure

### DIFF
--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -100,6 +100,7 @@ static CURLcode test_lib1960(const char *URL)
     goto test_cleanup;
   }
 
+  memset(&serv_addr, 0, sizeof(serv_addr));
   serv_addr.sin_family = AF_INET;
   serv_addr.sin_port = htons((unsigned short)port);
 


### PR DESCRIPTION
On platforms where struct sockaddr has a length field, the current code leaves it uninitialized, resulting in a test failure when valgrind is used.