### PR TITLE
Avoid infinite recursion for `make check`

### DIFF
--- a/tests/http/Makefile.am
+++ b/tests/http/Makefile.am
@@ -81,4 +81,4 @@ clean-local:
 check: libtests
 
 libtests:
-	@(cd ../libtests; $(MAKE) check)
+	@(cd ../libtest && $(MAKE) check)


### PR DESCRIPTION
The combination of a misspelled directory name and failing to check the result of cd leads to infinite recursion as `make check` simply invokes itself over and over.