### PR TITLE
openssl: fix unused variable warnings in !verbose builds

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4051,8 +4051,8 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
 
 #ifdef HAVE_SSL_SET1_ECH_CONFIG_LIST
 /* If we have retry configs, then trace those out */
-static void ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL *ssl,
-                                         int reason)
+static int ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL *ssl,
+                                        int reason)
 {
   CURLcode result = CURLE_OK;
   size_t rcl = 0;
@@ -4109,7 +4109,7 @@ static void ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL *ssl,
   OPENSSL_free(rcs);
   OPENSSL_free(outer);
 #endif
-  return;
+  return rv;
 }
 
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4072,7 +4072,7 @@ static int ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL *ssl,
 
   /* nothing to trace if not doing ECH */
   if(!CURLECH_ENABLED(data))
-    return;
+    return rv;
 #ifndef HAVE_BORINGSSL_LIKE
   rv = SSL_ech_get1_retry_config(ssl, &rcs, &rcl);
 #else

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4068,6 +4068,7 @@ static void ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL *ssl,
   size_t out_name_len = 0;
   int servername_type = 0;
 #endif
+  NOVERBOSE((void)reason);
 
   /* nothing to trace if not doing ECH */
   if(!CURLECH_ENABLED(data))
@@ -4276,49 +4277,50 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
 #if defined(HAVE_SSL_SET1_ECH_CONFIG_LIST) && !defined(HAVE_BORINGSSL_LIKE)
     if(CURLECH_ENABLED(data)) {
       char *inner = NULL, *outer = NULL;
-      const char *status = NULL;
       int rv;
+      VERBOSE(const char *status);
 
       rv = SSL_ech_get1_status(octx->ssl, &inner, &outer);
       switch(rv) {
       case SSL_ECH_STATUS_SUCCESS:
-        status = "succeeded";
+        VERBOSE(status = "succeeded");
         break;
       case SSL_ECH_STATUS_GREASE_ECH:
-        status = "sent GREASE, got retry-configs";
+        VERBOSE(status = "sent GREASE, got retry-configs");
         break;
       case SSL_ECH_STATUS_GREASE:
-        status = "sent GREASE";
+        VERBOSE(status = "sent GREASE");
         break;
       case SSL_ECH_STATUS_NOT_TRIED:
-        status = "not attempted";
+        VERBOSE(status = "not attempted");
         break;
       case SSL_ECH_STATUS_NOT_CONFIGURED:
-        status = "not configured";
+        VERBOSE(status = "not configured");
         break;
       case SSL_ECH_STATUS_BACKEND:
-        status = "backend (unexpected)";
+        VERBOSE(status = "backend (unexpected)");
         break;
       case SSL_ECH_STATUS_FAILED:
-        status = "failed";
+        VERBOSE(status = "failed");
         break;
       case SSL_ECH_STATUS_BAD_CALL:
-        status = "bad call (unexpected)";
+        VERBOSE(status = "bad call (unexpected)");
         break;
       case SSL_ECH_STATUS_BAD_NAME: {
         struct ssl_primary_config *conn_config =
           Curl_ssl_cf_get_primary_config(cf);
         if(!conn_config->verifypeer && !conn_config->verifyhost &&
            inner && !strcmp(inner, connssl->peer.hostname)) {
-          status = "bad name (tolerated without peer verification)";
+          VERBOSE(status = "bad name (tolerated without peer verification)");
           rv = SSL_ECH_STATUS_SUCCESS;
         }
-        else
-          status = "bad name (unexpected)";
+        else {
+          VERBOSE(status = "bad name (unexpected)");
+        }
         break;
       }
       default:
-        status = "unexpected status";
+        VERBOSE(status = "unexpected status");
         infof(data, "ECH: unexpected status %d", rv);
       }
       infof(data, "ECH: result: status is %s, inner is %s, outer is %s",


### PR DESCRIPTION
Also fix clang-tidy `readability-redundant-control-flow`.

```
lib/vtls/openssl.c:4055:46: error: unused parameter 'reason' [-Wunused-parameter]
 4055 |                                          int reason)
      |                                              ^
lib/vtls/openssl.c:4279:19: error: variable 'status' set but not used [-Wunused-but-set-variable]
 4279 |       const char *status = NULL;
      |                   ^
```
Ref: https://github.com/curl/curl/actions/runs/24641388439/job/72045859306?pr=21379

```
lib/vtls/openssl.c:4092:7: error: Value stored to 'rv' is never read [clang-analyzer-deadcode.DeadStores]
 4092 |       rv = SSL_ech_get1_status(ssl, &inner, &outer);
      |       ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/vtls/openssl.c:4092:7: note: Value stored to 'rv' is never read
 4092 |       rv = SSL_ech_get1_status(ssl, &inner, &outer);
      |       ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/vtls/openssl.c:4112:3: error: redundant return statement at the end of a function with a void return type [readability-redundant-control-flow]
 4111 | #endif
      | ~~~~~~
 4112 |   return;
      |   ^~~~~~~
 4113 | }
```
Ref: https://github.com/curl/curl/actions/runs/24642154148/job/72047919525?pr=21379#step:42:186

Cherry-picked from #21379
