### PR TITLE
vtls_scache: add callback protection

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3777,13 +3777,17 @@ static void process_pending_handles(struct Curl_multi *multi)
 
 void Curl_set_in_callback(struct Curl_easy *data, bool value)
 {
-  if(data && data->multi)
-    data->multi->in_callback = value;
+  if(data) {
+    data->state.in_callback = value;
+    if(data->multi)
+      data->multi->in_callback = value;
+  }
 }
 
 bool Curl_is_in_callback(struct Curl_easy *data)
 {
-  return data && data->multi && data->multi->in_callback;
+  return (data && data->state.in_callback) ||
+    (data && data->multi && data->multi->in_callback);
 }
 
 unsigned int Curl_multi_max_concurrent_streams(struct Curl_multi *multi)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -869,6 +869,7 @@ struct UrlState {
   BIT(maybe_folded);
   BIT(leading_unfold); /* unfold started, this is the leading bytes */
 #endif
+  BIT(in_callback); /* set TRUE when a callback is invoked */
 };
 
 /*

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -44,7 +44,7 @@
 #include "curl_trc.h"
 #include "curl_sha256.h"
 #include "rand.h"
-
+#include "multiif.h"
 
 /* a peer+tls-config we cache sessions for */
 struct Curl_ssl_scache_peer {
@@ -1085,14 +1085,14 @@ CURLcode Curl_ssl_session_import(struct Curl_easy *data,
   bool locked = FALSE;
   CURLcode result;
 
-  if(!scache) {
-    result = CURLE_BAD_FUNCTION_ARGUMENT;
-    goto out;
-  }
-  if(!ssl_peer_key && (!shmac || !shmac_len)) {
-    result = CURLE_BAD_FUNCTION_ARGUMENT;
-    goto out;
-  }
+  if(!GOOD_EASY_HANDLE(data))
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  if(Curl_is_in_callback(data))
+    return CURLE_RECURSIVE_API_CALL;
+  if(!scache)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  if(!ssl_peer_key && (!shmac || !shmac_len))
+    return CURLE_BAD_FUNCTION_ARGUMENT;
 
   result = Curl_ssl_session_unpack(data, sdata, sdata_len, &s);
   if(result)
@@ -1161,10 +1161,12 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
   size_t npeers = 0, ntickets = 0;
 #endif
 
-  if(!export_fn)
+  if(!GOOD_EASY_HANDLE(data) || !export_fn)
     return CURLE_BAD_FUNCTION_ARGUMENT;
   if(!scache)
     return CURLE_OK;
+  if(Curl_is_in_callback(data))
+    return CURLE_RECURSIVE_API_CALL;
 
   Curl_ssl_scache_lock(data);
 
@@ -1203,11 +1205,13 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
       if(r)
         goto out;
 
+      Curl_set_in_callback(data, TRUE);
       r = export_fn(data, userptr, peer->ssl_peer_key,
                     curlx_dyn_uptr(&hbuf), curlx_dyn_len(&hbuf),
                     curlx_dyn_uptr(&sbuf), curlx_dyn_len(&sbuf),
                     s->valid_until, s->ietf_tls_id,
                     s->alpn, s->earlydata_max);
+      Curl_set_in_callback(data, FALSE);
       if(r)
         goto out;
       VERBOSE(++ntickets);

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -1079,7 +1079,7 @@ CURLcode Curl_ssl_session_import(struct Curl_easy *data,
                                  const unsigned char *shmac, size_t shmac_len,
                                  const void *sdata, size_t sdata_len)
 {
-  struct Curl_ssl_scache *scache = cf_ssl_scache_get(data);
+  struct Curl_ssl_scache *scache;
   struct Curl_ssl_scache_peer *peer = NULL;
   struct Curl_ssl_session *s = NULL;
   bool locked = FALSE;
@@ -1089,6 +1089,7 @@ CURLcode Curl_ssl_session_import(struct Curl_easy *data,
     return CURLE_BAD_FUNCTION_ARGUMENT;
   if(Curl_is_in_callback(data))
     return CURLE_RECURSIVE_API_CALL;
+  scache = cf_ssl_scache_get(data);
   if(!scache)
     return CURLE_BAD_FUNCTION_ARGUMENT;
   if(!ssl_peer_key && (!shmac || !shmac_len))
@@ -1150,7 +1151,7 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
                                  curl_ssls_export_cb *export_fn,
                                  void *userptr)
 {
-  struct Curl_ssl_scache *scache = cf_ssl_scache_get(data);
+  struct Curl_ssl_scache *scache;
   struct Curl_ssl_scache_peer *peer;
   struct dynbuf sbuf, hbuf;
   struct Curl_llist_node *n;
@@ -1163,6 +1164,8 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
 
   if(!GOOD_EASY_HANDLE(data) || !export_fn)
     return CURLE_BAD_FUNCTION_ARGUMENT;
+
+  scache = cf_ssl_scache_get(data);
   if(!scache)
     return CURLE_OK;
   if(Curl_is_in_callback(data))

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -1164,12 +1164,12 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
 
   if(!GOOD_EASY_HANDLE(data) || !export_fn)
     return CURLE_BAD_FUNCTION_ARGUMENT;
+  if(Curl_is_in_callback(data))
+    return CURLE_RECURSIVE_API_CALL;
 
   scache = cf_ssl_scache_get(data);
   if(!scache)
     return CURLE_OK;
-  if(Curl_is_in_callback(data))
-    return CURLE_RECURSIVE_API_CALL;
 
   Curl_ssl_scache_lock(data);
 


### PR DESCRIPTION
- when the ssls-export callback is called, mark the handle as "in callback" which makes most libcurl functions return error if called from within the callback

- make the import and export functions check if "in callback" and return error if so

- make the import and export functions check that the easy handle is "good" or return error otherwise