### PR TITLE
docs: update curl-library mailing list links

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: curl
 
 If any of these deprecated features is a cause for concern for you, please
 email the
-[curl-library mailing list](https://lists.haxx.se/listinfo/curl-library)
+[curl-library mailing list](https://curl.se/mail/list.cgi?list=curl-library)
 as soon as possible and explain to us why this is a problem for you and
 how your use case cannot be satisfied properly using a workaround.
 

--- a/docs/HELP-US.md
+++ b/docs/HELP-US.md
@@ -11,7 +11,7 @@ looking for ways to contribute and help out, this document aims to give a few
 good starting points.
 
 You may subscribe to the [curl-library mailing
-list](https://lists.haxx.se/listinfo/curl-library) to keep track of the
+list](https://curl.se/mail/list.cgi?list=curl-library) to keep track of the
 current discussion topics; or if you are registered on GitHub, you can use the
 [Discussions section](https://github.com/curl/curl/discussions) on the main
 curl repository.


### PR DESCRIPTION

**Repo:** curl/curl (⭐ 37000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Updated two contributor-facing documentation pages, [docs/HELP-US.md](/Users/bojun/Desktop/agent-pr-mission-v2/h/curl-curl/docs/HELP-US.md) and [docs/DEPRECATE.md](/Users/bojun/Desktop/agent-pr-mission-v2/h/curl-curl/docs/DEPRECATE.md), to replace the legacy `lists.haxx.se` curl-library mailing-list URL with curl's current `curl.se/mail/list.cgi?list=curl-library` endpoint.

## Why
The repo already points users to `curl.se/mail/` and `curl.se/mail/list.cgi?...` elsewhere, but these two pages still sent readers to an older mailing-list host. Fixing the stale links keeps contributor guidance consistent and reduces the chance that new contributors or affected users land on an outdated subscription page when trying to ask for help or discuss deprecations.

## Testing
Verified the diff locally with `git diff` and confirmed the final patch stats with `git show --stat -1`. No runtime tests were needed because this is a documentation-only change.

## Risk
Low - this only updates two markdown links in docs and does not affect build or runtime behavior.
