### PR TITLE
wolfssl: fix `-Wmissing-prototypes`

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -30,8 +30,7 @@
 
 #ifdef USE_WOLFSSL
 
-#include "vtls/wolfssl.h"
-
+#include <wolfssl/options.h>
 #include <wolfssl/version.h>
 
 #if LIBWOLFSSL_VERSION_HEX < 0x05000000 /* wolfSSL 5.0.0 (2021-11-01) */
@@ -73,6 +72,8 @@
 
 #include <wolfssl/ssl.h>
 #include <wolfssl/error-ssl.h>
+
+#include "vtls/wolfssl.h"
 
 /* KEEP_PEER_CERT is a product of the presence of build time symbol
    OPENSSL_EXTRA without NO_CERTS, depending on the version. KEEP_PEER_CERT is

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -30,7 +30,8 @@
 
 #ifdef USE_WOLFSSL
 
-#include <wolfssl/options.h>
+#include "vtls/wolfssl.h"
+
 #include <wolfssl/version.h>
 
 #if LIBWOLFSSL_VERSION_HEX < 0x05000000 /* wolfSSL 5.0.0 (2021-11-01) */
@@ -72,8 +73,6 @@
 
 #include <wolfssl/ssl.h>
 #include <wolfssl/error-ssl.h>
-
-#include "vtls/wolfssl.h"
 
 /* KEEP_PEER_CERT is a product of the presence of build time symbol
    OPENSSL_EXTRA without NO_CERTS, depending on the version. KEEP_PEER_CERT is

--- a/lib/vtls/wolfssl.h
+++ b/lib/vtls/wolfssl.h
@@ -29,6 +29,8 @@
 
 #include "urldata.h"
 
+#include <wolfssl/options.h>
+
 struct alpn_spec;
 struct ssl_peer;
 struct Curl_ssl_session;


### PR DESCRIPTION
Seen with unity, H3, wolfssl with `HAVE_EX_DATA`.

Fixing:
```
lib/vtls/wolfssl.c:412:10: error: no previous prototype for function 'Curl_wssl_cache_session' [-Wmissing-prototypes]
  412 | CURLcode Curl_wssl_cache_session(struct Curl_cfilter *cf,
      |          ^
lib/vtls/wolfssl.c:412:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
  412 | CURLcode Curl_wssl_cache_session(struct Curl_cfilter *cf,
      | ^
      | static
1 error generated.
```

Follow-up to cc5c1553fbdb8c1391d0cf81134583ee32da64d4 #19852
