### PR TITLE
misc: fix code quality findings

### DIFF
--- a/lib/httpsrr.c
+++ b/lib/httpsrr.c
@@ -249,10 +249,9 @@ bool Curl_httpsrr_applicable(struct Curl_easy *data,
 {
   if(!data->conn || !rr)
     return FALSE;
-  return (data->conn && rr &&
-          (!rr->target || !rr->target[0] ||
-           (rr->target[0] == '.' && !rr->target[1])) &&
-          (!rr->port_set || rr->port == data->conn->remote_port));
+  return (!rr->target || !rr->target[0] ||
+          (rr->target[0] == '.' && !rr->target[1])) &&
+         (!rr->port_set || rr->port == data->conn->remote_port);
 }
 
 #ifdef USE_ARES

--- a/lib/httpsrr.h
+++ b/lib/httpsrr.h
@@ -52,7 +52,7 @@ struct Curl_https_rrinfo {
   size_t ipv6hints_len;
   unsigned char alpns[MAX_HTTPSRR_ALPNS]; /* keytag = 1 */
   /* store parsed alpnid entries in the array, end with ALPN_none */
-  uint16_t port; /* -1 means not set */
+  uint16_t port;
   uint16_t priority;
   BIT(no_def_alpn); /* keytag = 2 */
   BIT(mandatory); /* keytag = 0 */

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1878,6 +1878,7 @@ CURL_EXTERN CURLcode curl_ws_start_frame(CURL *curl,
 
   if(!GOOD_EASY_HANDLE(data))
     return CURLE_BAD_FUNCTION_ARGUMENT;
+
   if(data->set.ws_raw_mode) {
     failf(data, "cannot curl_ws_start_frame() with CURLWS_RAW_MODE enabled");
     return CURLE_FAILED_INIT;
@@ -1894,12 +1895,6 @@ CURL_EXTERN CURLcode curl_ws_start_frame(CURL *curl,
   ws = Curl_conn_meta_get(data->conn, CURL_META_PROTO_WS_CONN);
   if(!ws) {
     failf(data, "[WS] Not a websocket transfer");
-    result = CURLE_SEND_ERROR;
-    goto out;
-  }
-
-  if(data->set.ws_raw_mode) {
-    failf(data, "[WS] cannot start frame in raw mode");
     result = CURLE_SEND_ERROR;
     goto out;
   }

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -564,7 +564,7 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
     dec->state = WS_DEC_INIT;
     break;
   default:
-    /* we covered all enums above, but some code analyzers are whimps */
+    /* we covered all enums above, but some code analyzers are wimps */
     result = CURLE_FAILED_INIT;
   }
   return result;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -269,7 +269,7 @@ static CURLcode pre_transfer(struct per_transfer *per)
     /* Calculate the real upload size for VMS */
     per->infd = -1;
     if(curlx_stat(per->uploadfile, &fileinfo) == 0) {
-      fileinfo.st_size = VmsSpecialSize(uploadfile, &fileinfo);
+      fileinfo.st_size = VmsSpecialSize(per->uploadfile, &fileinfo);
       switch(fileinfo.st_fab_rfm) {
       case FAB$C_VAR:
       case FAB$C_VFC:
@@ -1129,7 +1129,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
 #ifdef __VMS
     /* open file for output, forcing VMS output format into stream
        mode which is needed for stat() call above to always work. */
-    FILE *file = curlx_fopen(outfile, "ab",
+    FILE *file = curlx_fopen(per->outfile, "ab",
                              "ctx=stm", "rfm=stmlf", "rat=cr", "mrs=0");
 #else
     /* open file for output: */


### PR DESCRIPTION
- httpsrr: drop redundant checks.
  Follow-up to 809dda3a37363160d4bf5ea2dafa0bcb8188a3f0 #21354
- httpsrr.h: drop obsolete comment.
  Follow-up to 2b3dfb4ad47ec05efad9af930c47968a49916999 #21175
- ws: drop redundant check in `curl_ws_start_frame()`.
  Follow-up to 37cecfc7b91118f116cf16af8f50a18b15d00d51 #17683
- ws: fix typo in comment.
- tool_operate: fix VMS build. (broken since 2019-07-20, v7.66.0)
  Follow-up to b88940850002a3f1c25bc6488b95ad30eb80d696 #3804

Pointed out by Copilot Code Quality
