### PR TITLE
async-ares: fix query counter handling

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -667,9 +667,9 @@ CURLcode Curl_async_getaddrinfo(struct Curl_easy *data,
     hints.ai_family = PF_INET6;
     hints.ai_socktype = socktype;
     hints.ai_flags = ARES_AI_NUMERICSERV;
+    async->queries_ongoing++;
     ares_getaddrinfo(ares->channel, async->hostname,
                      service, &hints, async_ares_AAAA_cb, async);
-    async->queries_ongoing++;
   }
 #endif /* CURLRES_IPV6 */
 
@@ -681,9 +681,9 @@ CURLcode Curl_async_getaddrinfo(struct Curl_easy *data,
     hints.ai_family = PF_INET;
     hints.ai_socktype = socktype;
     hints.ai_flags = ARES_AI_NUMERICSERV;
+    async->queries_ongoing++;
     ares_getaddrinfo(ares->channel, async->hostname,
                      service, &hints, async_ares_A_cb, async);
-    async->queries_ongoing++;
   }
 
 #ifdef USE_HTTPSRR

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -240,11 +240,11 @@ static CURLcode async_rr_start(struct Curl_easy *data,
 
   memset(&thrdd->rr.hinfo, 0, sizeof(thrdd->rr.hinfo));
   thrdd->rr.hinfo.rrname = rrname;
+  async->queries_ongoing++;
   ares_query_dnsrec(thrdd->rr.channel,
                     rrname ? rrname : async->hostname, ARES_CLASS_IN,
                     ARES_REC_TYPE_HTTPS,
                     async_thrdd_rr_done, async, NULL);
-  async->queries_ongoing++;
   CURL_TRC_DNS(data, "[HTTPS-RR] initiated request for %s",
                rrname ? rrname : async->hostname);
   return CURLE_OK;


### PR DESCRIPTION
When starting an c-ares query, the provided callback may be invoked right away, leading to a decrement of `queries_ongoing`. Increment the counter *before* call c-ares. Otherwise, the `async->done` bit is not properly set.