### PR TITLE
curl.rc: add option to enable SegmentHeap via embedded manifest

### DIFF
--- a/src/curl.rc
+++ b/src/curl.rc
@@ -63,3 +63,31 @@ BEGIN
     VALUE "Translation", 0x409, 1200
   END
 END
+
+#ifdef CURL_EMBED_MANIFEST_SEGMENTHEAP
+
+/* String escaping rules:
+     https://learn.microsoft.com/windows/win32/menurc/stringtable-resource
+   Application Manifest doc, including the list of 'supportedOS Id's:
+     https://learn.microsoft.com/windows/win32/sbscs/application-manifests */
+
+#ifndef CREATEPROCESS_MANIFEST_RESOURCE_ID
+#define CREATEPROCESS_MANIFEST_RESOURCE_ID  1
+#endif
+#ifndef RT_MANIFEST
+#define RT_MANIFEST  24
+#endif
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST
+BEGIN
+  "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>"
+  "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"">"
+    "<asmv3:application>"
+      "<asmv3:windowsSettings xmlns=""http://schemas.microsoft.com/SMI/2020/WindowsSettings"">"
+        "<heapType>SegmentHeap</heapType>"
+      "</asmv3:windowsSettings>"
+    "</asmv3:application>"
+  "</assembly>"
+END
+
+#endif

--- a/src/curl.rc
+++ b/src/curl.rc
@@ -65,7 +65,6 @@ BEGIN
 END
 
 #ifdef CURL_EMBED_MANIFEST_SEGMENTHEAP
-
 /* String escaping rules:
      https://learn.microsoft.com/windows/win32/menurc/stringtable-resource
    Application Manifest doc, including the list of 'supportedOS Id's:
@@ -82,5 +81,4 @@ BEGIN
     "</asmv3:application>"
   "</assembly>"
 END
-
 #endif

--- a/src/curl.rc
+++ b/src/curl.rc
@@ -71,13 +71,6 @@ END
    Application Manifest doc, including the list of 'supportedOS Id's:
      https://learn.microsoft.com/windows/win32/sbscs/application-manifests */
 
-#ifndef CREATEPROCESS_MANIFEST_RESOURCE_ID
-#define CREATEPROCESS_MANIFEST_RESOURCE_ID  1
-#endif
-#ifndef RT_MANIFEST
-#define RT_MANIFEST  24
-#endif
-
 CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST
 BEGIN
   "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>"

--- a/src/curl.rc
+++ b/src/curl.rc
@@ -71,7 +71,7 @@ END
    Application Manifest doc, including the list of 'supportedOS Id's:
      https://learn.microsoft.com/windows/win32/sbscs/application-manifests */
 
-CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST
+1 /* CREATEPROCESS_MANIFEST_RESOURCE_ID */ 24 /* RT_MANIFEST */
 BEGIN
   "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>"
   "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"">"


### PR DESCRIPTION
Enable by passing `CURL_EMBED_MANIFEST_SEGMENTHEAP` flag to `rc`.

Aiming to enable in curl-for-win. It's already enabled there in ARM64 
builds, because SegmentHeap is the default for ARM64 binaries.

Refs:
https://learn.microsoft.com/windows/win32/sbscs/application-manifests#heaptype
https://news.ycombinator.com/item?id=47858177
https://blackhat.com/docs/us-16/materials/us-16-Yason-Windows-10-Segment-Heap-Internals.pdf

---

I could not find a way to verify if this is indeed enabled. (tried Process Explorer,
Task Manager, there is a `umdh` tool but installlation is more complex than
flying to the moon, also probably useless to detect this.)
