### PR TITLE
GHA: delete all apt sources except `ubuntu.sources`

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: 'install'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install aspell aspell-en
           python3 -m venv ~/venv

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -103,7 +103,7 @@ jobs:
       - name: 'install pmccabe'
         run: |
           ls -l /etc/apt/sources.list.d
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             pmccabe
@@ -122,7 +122,7 @@ jobs:
     steps:
       - name: 'install prereqs'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             libxml2-utils

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ matrix.platform == 'Linux' }}
         timeout-minutes: 5
         run: |
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo apt-get -o Dpkg::Use-Pty=0 update
           printf "#!/bin/sh
             while [ \$? = 0 ]; do for i in 1 2 3; do timeout 60 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -207,7 +207,7 @@ jobs:
       - name: 'install build prereqs'
         if: ${{ steps.settings.outputs.needs-build == 'true' }}
         run: |
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo apt-get -o Dpkg::Use-Pty=0 update
           printf "#!/bin/sh
             while [ \$? = 0 ]; do for i in 1 2 3; do timeout 60 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
@@ -558,7 +558,7 @@ jobs:
               'apache2 apache2-dev libnghttp2-dev vsftpd dante-server libev-dev' || '' }}
 
         run: |
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo apt-get -o Dpkg::Use-Pty=0 update
           printf "#!/bin/sh
             while [ \$? = 0 ]; do for i in 1 2 3; do timeout 45 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -459,7 +459,7 @@ jobs:
 
         run: |
           ls -l /etc/apt/sources.list.d
-          sudo find /etc/apt/sources.list.d -not -name 'ubuntu.sources' -delete
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete
           ls -l /etc/apt/sources.list.d
           sudo apt-get -o Dpkg::Use-Pty=0 update
           printf "#!/bin/sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -459,7 +459,8 @@ jobs:
 
         run: |
           ls -l /etc/apt/sources.list.d
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -not -name 'ubuntu.sources' -delete
+          ls -l /etc/apt/sources.list.d
           sudo apt-get -o Dpkg::Use-Pty=0 update
           printf "#!/bin/sh
             while [ \$? = 0 ]; do for i in 1 2 3; do timeout 45 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -459,8 +459,7 @@ jobs:
 
         run: |
           ls -l /etc/apt/sources.list.d
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete
-          ls -l /etc/apt/sources.list.d
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo apt-get -o Dpkg::Use-Pty=0 update
           printf "#!/bin/sh
             while [ \$? = 0 ]; do for i in 1 2 3; do timeout 45 \"\$@\" && break 2; echo \"Error: slow server, retry \$i\"; sleep 1
@@ -483,7 +482,7 @@ jobs:
       - name: 'install prereqs (i686)'
         if: ${{ contains(matrix.build.name, 'i686') }}
         run: |
-          sudo rm -f /etc/apt/sources.list.d/{azure-cli.sources,docker.list,microsoft-prod.list}
+          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo dpkg --add-architecture i386
           sudo apt-get -o Dpkg::Use-Pty=0 update
           printf "#!/bin/sh


### PR DESCRIPTION
GitHub runners are getting new 3rd-party sources frequntly now, last
week `docker.list`, this week: `google-chrome.sources`. To avoid
playing catch up, allowlist the only one we use: `ubuntu.sources`. If
this is renamed, CI would break. Let's hope this happens much less
often than new sources.

Bug: https://github.com/curl/curl/pull/21414#issuecomment-4297788640

Follow-up to 3e0e2cc1ab6f3f44c7d35e84256858edc2ef73f5 #21344
