### PR TITLE
remove conn->bits.doh

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -457,10 +457,8 @@ CURLcode Curl_doh(struct Curl_easy *data,
 {
   CURLcode result = CURLE_OK;
   struct doh_probes *dohp = NULL;
-  struct connectdata *conn = data->conn;
   size_t i;
 
-  DEBUGASSERT(conn);
   DEBUGASSERT(!async->doh);
   DEBUGASSERT(async->hostname[0]);
   if(async->doh) {

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -463,8 +463,10 @@ CURLcode Curl_doh(struct Curl_easy *data,
   DEBUGASSERT(conn);
   DEBUGASSERT(!async->doh);
   DEBUGASSERT(async->hostname[0]);
-  if(async->doh)
+  if(async->doh) {
+    DEBUGASSERT(0); /* should not happen */
     Curl_doh_cleanup(data, async);
+  }
 
   /* start clean, consider allocating this struct on demand */
   async->doh = dohp = curlx_calloc(1, sizeof(struct doh_probes));
@@ -476,7 +478,6 @@ CURLcode Curl_doh(struct Curl_easy *data,
     curlx_dyn_init(&dohp->probe_resp[i].body, DYN_DOH_RESPONSE);
   }
 
-  conn->bits.doh = TRUE;
   dohp->host = async->hostname;
   dohp->port = async->port;
   /* We are making sub easy handles and want to be called back when

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -424,7 +424,7 @@ static CURLcode hostip_resolv_take_result(struct Curl_easy *data,
     return CURLE_FAILED_INIT;
 
 #ifndef CURL_DISABLE_DOH
-  if(data->conn->bits.doh)
+  if(async->doh)
     result = Curl_doh_take_result(data, async, pdns);
   else
 #endif
@@ -670,9 +670,7 @@ static CURLcode hostip_resolv(struct Curl_easy *data,
   *presolv_id = 0;
   *pdns = NULL;
 
-#ifndef CURL_DISABLE_DOH
-  data->conn->bits.doh = FALSE; /* default is not */
-#else
+#ifdef CURL_DISABLE_DOH
   (void)allowDOH;
 #endif
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -295,9 +295,6 @@ struct ConnectBits {
   BIT(multiplex); /* connection is multiplexed */
   BIT(tcp_fastopen); /* use TCP Fast Open */
   BIT(tls_enable_alpn); /* TLS ALPN extension? */
-#ifndef CURL_DISABLE_DOH
-  BIT(doh);
-#endif
 #ifdef USE_UNIX_SOCKETS
   BIT(abstract_unix_socket);
 #endif


### PR DESCRIPTION
Since we have a new struct instance for each async operation now and async operation may happen in parallel, remove the connection bit indicating doh is in progress.