### PR TITLE
ci: update RUSTLS_VERSION 0.15.2 -> 0.15.3

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,7 @@ env:
   # renovate: datasource=github-releases depName=openssl/openssl versioning=semver extractVersion=^openssl-(?<version>.+)$ registryUrl=https://github.com
   OPENSSL_VERSION: 4.0.0
   # renovate: datasource=github-tags depName=rustls/rustls-ffi versioning=semver registryUrl=https://github.com
-  RUSTLS_VERSION: 0.15.2
+  RUSTLS_VERSION: 0.15.3
   # handled in renovate.json
   OPENLDAP_VERSION: 2.6.10
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com


### PR DESCRIPTION
Updates CI to take [rustls-ffi 0.15.3](https://github.com/rustls/rustls-ffi/releases/tag/v0.15.3).
