### PR TITLE
tests: drop support for the hex="yes" option in getpart

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -260,7 +260,7 @@ similar.
 
 ## `<reply>`
 
-### `<data [nocheck="yes"] [sendzero="yes"] [hex="yes"] [nonewline="yes"] [crlf="yes|headers"]>`
+### `<data [nocheck="yes"] [sendzero="yes"] [nonewline="yes"] [crlf="yes|headers"]>`
 
 data to be sent to the client on its request and later verified that it
 arrived safely. Set `nocheck="yes"` to prevent the test script from verifying
@@ -281,9 +281,6 @@ auth tests and similar.
 
 `sendzero=yes` means that the (FTP) server "sends" the data even if the size
 is zero bytes. Used to verify curl's behavior on zero bytes transfers.
-
-`hex=yes` means that the data is a sequence of hex pairs. It gets decoded and
-used as "raw" data.
 
 `nonewline=yes` means that the last byte (the trailing newline character)
 should be cut off from the data before sending or comparing it.

--- a/tests/data/test1132
+++ b/tests/data/test1132
@@ -12,8 +12,8 @@ MQTT CONNACK
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 
 # Remaining Length must be 2 in a CONNACK

--- a/tests/data/test1132
+++ b/tests/data/test1132
@@ -12,9 +12,6 @@ MQTT CONNACK
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 
 # Remaining Length must be 2 in a CONNACK
 <servercmd>

--- a/tests/data/test1190
+++ b/tests/data/test1190
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test1190
+++ b/tests/data/test1190
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test1192
+++ b/tests/data/test1192
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test1192
+++ b/tests/data/test1192
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test1194
+++ b/tests/data/test1194
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 <servercmd>
 PUBLISH-before-SUBACK TRUE

--- a/tests/data/test1194
+++ b/tests/data/test1194
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 <servercmd>
 PUBLISH-before-SUBACK TRUE
 </servercmd>

--- a/tests/data/test1195
+++ b/tests/data/test1195
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 <servercmd>
 PUBLISH-before-SUBACK TRUE

--- a/tests/data/test1195
+++ b/tests/data/test1195
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 <servercmd>
 PUBLISH-before-SUBACK TRUE
 short-PUBLISH TRUE

--- a/tests/data/test1196
+++ b/tests/data/test1196
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 
 # error 1 - "Connection Refused, unacceptable protocol version"
 <servercmd>

--- a/tests/data/test1196
+++ b/tests/data/test1196
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 
 # error 1 - "Connection Refused, unacceptable protocol version"

--- a/tests/data/test1198
+++ b/tests/data/test1198
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test1198
+++ b/tests/data/test1198
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test1199
+++ b/tests/data/test1199
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test1199
+++ b/tests/data/test1199
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test1640
+++ b/tests/data/test1640
@@ -13,8 +13,8 @@ MQTTS
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test1640
+++ b/tests/data/test1640
@@ -13,9 +13,6 @@ MQTTS
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test1916
+++ b/tests/data/test1916
@@ -12,8 +12,8 @@ MQTT PUBLISH
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test1916
+++ b/tests/data/test1916
@@ -12,9 +12,6 @@ MQTT PUBLISH
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test1917
+++ b/tests/data/test1917
@@ -12,8 +12,8 @@ MQTT PUBLISH
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test1917
+++ b/tests/data/test1917
@@ -12,9 +12,6 @@ MQTT PUBLISH
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test2200
+++ b/tests/data/test2200
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 
 # error 5 - "Connection Refused, not authorized. Wrong data supplied"
 <servercmd>

--- a/tests/data/test2200
+++ b/tests/data/test2200
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 
 # error 5 - "Connection Refused, not authorized. Wrong data supplied"

--- a/tests/data/test2203
+++ b/tests/data/test2203
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 
 # error 5 - "Connection Refused, not authorized. No user or password supplied"

--- a/tests/data/test2203
+++ b/tests/data/test2203
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 
 # error 5 - "Connection Refused, not authorized. No user or password supplied"
 <servercmd>

--- a/tests/data/test2204
+++ b/tests/data/test2204
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 31 31 39 30   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/data/test2204
+++ b/tests/data/test2204
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test3017
+++ b/tests/data/test3017
@@ -12,9 +12,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 <servercmd>
 excessive-remaining TRUE
 </servercmd>

--- a/tests/data/test3017
+++ b/tests/data/test3017
@@ -12,8 +12,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 33 30 31 37   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 <servercmd>
 excessive-remaining TRUE

--- a/tests/data/test3018
+++ b/tests/data/test3018
@@ -13,9 +13,6 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck>
-%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
-</datacheck>
 </reply>
 
 # Client-side

--- a/tests/data/test3018
+++ b/tests/data/test3018
@@ -13,8 +13,8 @@ MQTT SUBSCRIBE
 <data nocheck="yes">
 hello
 </data>
-<datacheck hex="yes">
-00 04 33 30 31 38   68 65 6c 6c 6f 5b 4c 46 5d 0a
+<datacheck>
+%hex[%00%04%31%31%39%30hello%5b%4c%46%5d]hex%
 </datacheck>
 </reply>
 

--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -62,15 +62,6 @@ sub normalize_part {
     return join("\t", @_);
 }
 
-sub decode_hex {
-    my $s = $_;
-    # remove everything not hex
-    $s =~ s/[^A-Fa-f0-9]//g;
-    # encode everything
-    $s =~ s/([a-fA-F0-9][a-fA-F0-9])/chr(hex($1))/eg;
-    return $s;
-}
-
 sub testcaseattr {
     my %hash;
     for(@xml) {
@@ -134,7 +125,6 @@ sub getpart {
 
     my @this;
     my $inside=0;
-    my $hex=0;
     my $line;
 
     for(@xml) {
@@ -145,10 +135,6 @@ sub getpart {
         elsif(($inside >= 1) && ($_ =~ /^ *\<$part[ \>]/)) {
             if($inside > 1) {
                 push @this, $_;
-            }
-            elsif($_ =~ /$part [^>]*hex=/) {
-                # attempt to detect a hex-encoded part
-                $hex=1;
             }
             $inside++;
         }
@@ -168,13 +154,6 @@ sub getpart {
             }
             if($warning && !@this) {
                 print STDERR "*** getpart.pm: $section/$part returned empty!\n";
-            }
-            if($hex) {
-                # decode the whole array before returning it!
-                for(@this) {
-                    my $decoded = decode_hex($_);
-                    $_ = $decoded;
-                }
             }
             return @this;
         }


### PR DESCRIPTION
Stick to the %hex[] function which is universal, provides the same feature and works for all test servers contrary to the getpart function since it done by the preprocessor.