### PR TITLE
checksrc: fix code quality findings

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -273,8 +273,8 @@ sub readlocalfile {
 sub checkwarn {
     my ($name, $num, $col, $file, $line, $msg, $error) = @_;
 
-    my $w=$error ? "error" : "warning";
-    my $nowarn=0;
+    my $w = $error ? "error" : "warning";
+    my $nowarn = 0;
 
     #if(!$warnings{$name}) {
     #    print STDERR "Dev! there is no description for $name!\n";
@@ -443,7 +443,7 @@ sub checksrc_endoffile {
     for(keys %ignore_set) {
         if($ignore_set{$_} && !$ignore_used{$_}) {
             checkwarn("UNUSEDIGNORE", $ignore_set{$_},
-                      length($_)+11, $file,
+                      length($_) + 11, $file,
                       $ignore_line[$ignore_set{$_}],
                       "Unused ignore: $_");
         }

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -610,7 +610,7 @@ sub scanfile {
         if($l =~ /^(.*)\w\*\//) {
             checkwarn("COMMENTNOSPACEEND",
                       $line, length($1) + 1, $file, $l,
-                      "Missing space end comment end");
+                      "Missing space before comment end");
         }
 
         if($l =~ /(.*)(FIXME|TODO)/) {

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -414,7 +414,7 @@ readlocalfile($file);
 do {
     if($wlist !~ / $file /) {
         my $fullname = $file;
-        $fullname = "$dir/$file" if($fullname !~ '^\.?\.?/');
+        $fullname = "$dir/$file" if($fullname !~ /^\.?\.?\//);
         scanfile($fullname);
     }
     $file = shift @ARGV;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -297,20 +297,20 @@ sub checkwarn {
 
     if($nowarn) {
         $suppressed++;
-        if($w) {
-            $swarnings++;
+        if($error) {
+            $serrors++;
         }
         else {
-            $serrors++;
+            $swarnings++;
         }
         return;
     }
 
-    if($w) {
-        $warnings++;
+    if($error) {
+        $errors++;
     }
     else {
-        $errors++;
+        $warnings++;
     }
 
     $col++;

--- a/tests/data/test1185
+++ b/tests/data/test1185
@@ -233,7 +233,7 @@ void startfunc(int a, int b) {
 ./%LOGDIR/code1185.c:1:1: error: Missing closing comment (OPENCOMMENT)
 %SP
  ^
-checksrc: 0 errors and 45 warnings
+checksrc: 3 errors and 42 warnings
 </stdout>
 <errorcode>
 5


### PR DESCRIPTION
- fix counting errors. Update test1185 results accordingly.
- fix an error message.
- tidy up regexp syntax.

Pointed out by GitHub Code Quality
