### PR TITLE
hostip: init the curl_jmpenv_lock appropriately

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -201,7 +201,7 @@ void Curl_printable_address(const struct Curl_addrinfo *ai, char *buf,
    return address that we can jump back to from inside a signal handler. This
    is not thread-safe stuff. */
 static sigjmp_buf curl_jmpenv;
-static curl_simple_lock curl_jmpenv_lock;
+static curl_simple_lock curl_jmpenv_lock = CURL_SIMPLE_LOCK_INIT;
 #endif
 
 #ifdef USE_IPV6


### PR DESCRIPTION
A zero-initialized static value is not guaranteed to be a valid mutex on all POSIX implementations

Spotted by Codex Security