### PR TITLE
setup connection filter: mark as setup

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -117,7 +117,7 @@ CURLcode Curl_cf_def_query(struct Curl_cfilter *cf,
 }
 
 #ifdef CURLVERBOSE
-static void conn_trc_filter_chain(struct Curl_easy *data,
+static void conn_trc_filters(struct Curl_easy *data,
                                   int sockindex,
                                   const char *info)
 {
@@ -131,7 +131,8 @@ static void conn_trc_filter_chain(struct Curl_easy *data,
       curlx_dyn_init(&msg, 1024);
       result = curlx_dyn_addf(&msg, "%s [%d]", info, sockindex);
       for(; cf && !result; cf = cf->next) {
-        result = curlx_dyn_addf(&msg, "[%s]", cf->cft->name);
+        result = curlx_dyn_addf(&msg, "[%s%s]",
+                                cf->connected ? "" : "!", cf->cft->name);
       }
       if(!result)
         CURL_TRC_M(data, "%s", curlx_dyn_ptr(&msg));
@@ -590,13 +591,14 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
       conn_report_connect_stats(cf, data);
       data->conn->keepalive = *Curl_pgrs_now(data);
       VERBOSE(result = cf_verboseconnect(data, cf));
+      VERBOSE(conn_trc_filters(data, sockindex, "connected"));
       conn_remove_setup_filters(data, sockindex);
-      VERBOSE(conn_trc_filter_chain(data, sockindex, "connected"));
+      VERBOSE(conn_trc_filters(data, sockindex, "reduced to"));
       goto out;
     }
     else if(result) {
       CURL_TRC_CF(data, cf, "Curl_conn_connect(), filter returned %d", result);
-      VERBOSE(conn_trc_filter_chain(data, sockindex, "failed to connect"));
+      VERBOSE(conn_trc_filters(data, sockindex, "failed to connect"));
       conn_report_connect_stats(cf, data);
       goto out;
     }

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -116,6 +116,36 @@ CURLcode Curl_cf_def_query(struct Curl_cfilter *cf,
     CURLE_UNKNOWN_OPTION;
 }
 
+#ifdef CURLVERBOSE
+static void conn_trc_filter_chain(struct Curl_easy *data,
+                                  int sockindex,
+                                  const char *info)
+{
+  if(CURL_TRC_M_is_verbose(data) && data->conn) {
+    struct Curl_cfilter *cf = data->conn->cfilter[sockindex];
+
+    if(cf) {
+      struct dynbuf msg;
+      CURLcode result = CURLE_OK;
+
+      curlx_dyn_init(&msg, 1024);
+      result = curlx_dyn_addf(&msg, "%s [%d]", info, sockindex);
+      for(; cf && !result; cf = cf->next) {
+        result = curlx_dyn_addf(&msg, "[%s]", cf->cft->name);
+      }
+      if(!result)
+        CURL_TRC_M(data, "%s", curlx_dyn_ptr(&msg));
+      else
+        CURL_TRC_M(data, "%s [%d] error %d tracing chain",
+                   info, sockindex, result);
+      curlx_dyn_free(&msg);
+    }
+    else
+      CURL_TRC_M(data, "%s [%d][-]", info, sockindex);
+  }
+}
+#endif /* CURLVERBOSE */
+
 void Curl_conn_cf_discard_chain(struct Curl_cfilter **pcf,
                                 struct Curl_easy *data)
 {
@@ -561,10 +591,12 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
       data->conn->keepalive = *Curl_pgrs_now(data);
       VERBOSE(result = cf_verboseconnect(data, cf));
       conn_remove_setup_filters(data, sockindex);
+      VERBOSE(conn_trc_filter_chain(data, sockindex, "connected"));
       goto out;
     }
     else if(result) {
       CURL_TRC_CF(data, cf, "Curl_conn_connect(), filter returned %d", result);
+      VERBOSE(conn_trc_filter_chain(data, sockindex, "failed to connect"));
       conn_report_connect_stats(cf, data);
       goto out;
     }

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -470,7 +470,7 @@ static void cf_setup_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 
 struct Curl_cftype Curl_cft_setup = {
   "SETUP",
-  0,
+  CF_TYPE_SETUP,
   CURL_LOG_LVL_NONE,
   cf_setup_destroy,
   cf_setup_connect,


### PR DESCRIPTION
Add CF_TYPE_SETUP to the setup connection filter so that it is removed and destroyed after the connection has been established.

As an extra: add tracing of the filter chain when connect attempt succeeded or failed. Which then shows something like:

```
* [MULTI] [CONNECTING] connected [0][DNS][HTTPS-CONNECT][HTTP/2][SETUP][SSL][HAPPY-EYEBALLS][TCP]
* [MULTI] [CONNECTING] reduced to [0][HTTP/2][SSL][TCP]
```
