### PR TITLE
sectrust: fail on missing OCSP stapling

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4703,16 +4703,26 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
     unsigned char *ocsp_data = NULL;
 #endif
     long ocsp_len = 0;
+    bool ocsp_missing = FALSE;
     if(conn_config->verifystatus && !octx->reused_session)
       ocsp_len = (long)SSL_get_tlsext_status_ocsp_resp(octx->ssl, &ocsp_data);
 
     /* SSL_get_tlsext_status_ocsp_resp() returns the length of the OCSP
        response data or -1 if there is no OCSP response data. */
-    if(ocsp_len < 0)
+    if(ocsp_len < 0) {
       ocsp_len = 0; /* no data available */
+      ocsp_missing = TRUE;
+    }
     result = Curl_vtls_apple_verify(cf, data, peer, chain.num_certs,
                                     ossl_chain_get_der, &chain,
                                     ocsp_data, ocsp_len);
+    if(!result && ocsp_missing && conn_config->verifystatus &&
+       !octx->reused_session) {
+      /* verified, but OCSP stapling is required and but server sent none */
+      *pverified = TRUE;
+      failf(data, "No OCSP response received");
+      return CURLE_SSL_INVALIDCERTSTATUS;
+    }
   }
   *pverified = !result;
   return result;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4718,7 +4718,7 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
                                     ocsp_data, ocsp_len);
     if(!result && ocsp_missing && conn_config->verifystatus &&
        !octx->reused_session) {
-      /* verified, but OCSP stapling is required and but server sent none */
+      /* verified, but OCSP stapling is required and server sent none */
       *pverified = TRUE;
       failf(data, "No OCSP response received");
       return CURLE_SSL_INVALIDCERTSTATUS;


### PR DESCRIPTION
When using Apple SecTrust, requiring the server to send an OCSP response and does not, fail correctly.