### PR TITLE
test_22_httpsrr: avoid class name clash with `test_21_resolve`

### DIFF
--- a/tests/http/test_22_httpsrr.py
+++ b/tests/http/test_22_httpsrr.py
@@ -37,7 +37,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.skipif(condition=not Env.curl_is_debug(), reason="needs curl debug")
 @pytest.mark.skipif(condition=not Env.curl_override_dns(), reason="no DNS override")
 @pytest.mark.skipif(condition=not Env.curl_has_feature('HTTPSRR'), reason="no HTTPSRR support")
-class TestResolve:
+class TestHTTPSRR:
 
     @pytest.fixture(scope='class')
     def dnsd(self, env: Env) -> Generator[Dnsd, None, None]:


### PR DESCRIPTION
Spotted by GitHub Code Quality
