### PR TITLE
tool_dirhie: fix to create drive-relative directory

### DIFF
--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -47,21 +47,13 @@ UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void)
 
 static int create_dir_hierarchy_trace_mkdir(const char *dir)
 {
-    printf("TRC-000\n");
-  if(curlx_dyn_add(&mkdir_results, dir)) {
+  if(curlx_dyn_add(&mkdir_results, dir) ||
+     curlx_dyn_add(&mkdir_results, "|")) {
     /* !checksrc! disable ERRNOVAR 1 */
     errno = ENOMEM;
-    printf("TRC-001a\n");
-    return -1;
-  }
-  if(curlx_dyn_add(&mkdir_results, "|")) {
-    /* !checksrc! disable ERRNOVAR 1 */
-    errno = ENOMEM;
-    printf("TRC-001b\n");
     return -1;
   }
   errno = 0;
-    printf("TRC-002\n");
   return 0;
 }
 #endif

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -26,13 +26,31 @@
 #include "tool_dirhie.h"
 #include "tool_msgs.h"
 
-#ifdef _WIN32
+#ifdef UNITTESTS
+#  define toolx_mkdir(x, y) create_dir_hierarchy_trace_mkdir(x)
+#elif defined(_WIN32)
 #  include <direct.h>
 #  define toolx_mkdir(x, y) _mkdir(x)
 #elif defined(MSDOS) && !defined(__DJGPP__)
 #  define toolx_mkdir(x, y) mkdir(x)
 #else
 #  define toolx_mkdir mkdir
+#endif
+
+#ifdef UNITTESTS
+static struct dynbuf mkdir_results;
+
+UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void)
+{
+  return &mkdir_results;
+}
+
+static int create_dir_hierarchy_trace_mkdir(const char *dir)
+{
+  (void)curlx_dyn_add(&mkdir_results, dir);
+  (void)curlx_dyn_add(&mkdir_results, "|");
+  return 0;
+}
 #endif
 
 static void show_dir_errno(const char *name)

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -47,13 +47,21 @@ UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void)
 
 static int create_dir_hierarchy_trace_mkdir(const char *dir)
 {
-  if(curlx_dyn_add(&mkdir_results, dir) ||
-     curlx_dyn_add(&mkdir_results, "|")) {
+    printf("TRC-000\n");
+  if(curlx_dyn_add(&mkdir_results, dir)) {
     /* !checksrc! disable ERRNOVAR 1 */
     errno = ENOMEM;
+    printf("TRC-001a\n");
+    return -1;
+  }
+  if(curlx_dyn_add(&mkdir_results, "|")) {
+    /* !checksrc! disable ERRNOVAR 1 */
+    errno = ENOMEM;
+    printf("TRC-001b\n");
     return -1;
   }
   errno = 0;
+    printf("TRC-002\n");
   return 0;
 }
 #endif

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -105,12 +105,11 @@ CURLcode create_dir_hierarchy(const char *outfile)
 
 #if defined(_WIN32) || defined(MSDOS)
     if(!curlx_dyn_len(&dirbuf)) {
-      /* Skip creating a drive's current directory. It may seem as though that
-         would harmlessly fail but it could be a corner case if X: did not
-         exist, since we would be creating it erroneously. eg if outfile is
-         X:\foo\bar\filename then do not mkdir X: This logic takes into
+      /* Skip creating a standalone Windows/MS-DOS drive letter 'X:', e.g.
+         if outfile is X:\foo\bar\filename. Do create drive-relative
+         directories e.g. in outfile X:foo\bar\filename. This logic takes into
          account unsupported drives !:, 1:, etc. */
-      if(len > 1 && (outfile[1] == ':'))
+      if(len == 2 && (outfile[1] == ':'))
         skip = TRUE;
     }
 #endif

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -47,9 +47,14 @@ UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void)
 
 static int create_dir_hierarchy_trace_mkdir(const char *dir)
 {
-  return
-    curlx_dyn_add(&mkdir_results, dir) ||
-    curlx_dyn_add(&mkdir_results, "|") ? -1 : 0;
+  if(curlx_dyn_add(&mkdir_results, dir) ||
+     curlx_dyn_add(&mkdir_results, "|")) {
+    /* !checksrc! disable ERRNOVAR 1 */
+    errno = ENOMEM;
+    return -1
+  }
+  errno = 0;
+  return 0;
 }
 #endif
 

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -48,8 +48,8 @@ UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void)
 static int create_dir_hierarchy_trace_mkdir(const char *dir)
 {
   return
-      curlx_dyn_add(&mkdir_results, dir) ||
-      curlx_dyn_add(&mkdir_results, "|") ? -1 : 0;
+    curlx_dyn_add(&mkdir_results, dir) ||
+    curlx_dyn_add(&mkdir_results, "|") ? -1 : 0;
 }
 #endif
 

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -51,7 +51,7 @@ static int create_dir_hierarchy_trace_mkdir(const char *dir)
      curlx_dyn_add(&mkdir_results, "|")) {
     /* !checksrc! disable ERRNOVAR 1 */
     errno = ENOMEM;
-    return -1
+    return -1;
   }
   errno = 0;
   return 0;

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -47,14 +47,9 @@ UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void)
 
 static int create_dir_hierarchy_trace_mkdir(const char *dir)
 {
-  if(curlx_dyn_add(&mkdir_results, dir) ||
-     curlx_dyn_add(&mkdir_results, "|")) {
-    /* !checksrc! disable ERRNOVAR 1 */
-    errno = ENOMEM;
-    return -1;
-  }
-  errno = 0;
-  return 0;
+  return !dir ||
+    curlx_dyn_add(&mkdir_results, dir) ||
+    curlx_dyn_add(&mkdir_results, "|") ? -1 : 0;
 }
 #endif
 

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -47,9 +47,9 @@ UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void)
 
 static int create_dir_hierarchy_trace_mkdir(const char *dir)
 {
-  (void)curlx_dyn_add(&mkdir_results, dir);
-  (void)curlx_dyn_add(&mkdir_results, "|");
-  return 0;
+  return
+      curlx_dyn_add(&mkdir_results, dir) ||
+      curlx_dyn_add(&mkdir_results, "|") ? -1 : 0;
 }
 #endif
 

--- a/src/tool_dirhie.h
+++ b/src/tool_dirhie.h
@@ -25,6 +25,10 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
+#ifdef UNITTESTS
+UNITTEST struct dynbuf *create_dir_hierarchy_trace_dynres(void);
+#endif
+
 CURLcode create_dir_hierarchy(const char *outfile);
 
 #endif /* HEADER_CURL_TOOL_DIRHIE_H */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -230,6 +230,7 @@ test1680 test1681 test1682 test1683 test1684 test1685 \
 \
 test1700 test1701 test1702 test1703 test1704 test1705 test1706 test1707 \
 test1708 test1709 test1710 test1711 test1712 test1713 test1714 test1715 \
+test1720 \
 \
 test1800 test1801 test1802 test1847 test1848 test1849 test1850 test1851 \
 \

--- a/tests/data/test1720
+++ b/tests/data/test1720
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+unittest
+</features>
+<name>
+create_dir_hierarchy()
+</name>
+<tool>
+tool%TESTNUMBER
+</tool>
+</client>
+
+<verify>
+</verify>
+</testcase>

--- a/tests/tunit/Makefile.inc
+++ b/tests/tunit/Makefile.inc
@@ -34,4 +34,5 @@ TESTS_C = \
   tool1604.c \
   tool1621.c \
   tool1622.c \
-  tool1623.c
+  tool1623.c \
+  tool1720.c

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -63,7 +63,7 @@ static CURLcode test_tool1720(const char *arg)
   for(i = 0; i < CURL_ARRAYSIZE(check); i += 2) {
     const char *actual;
     curlx_dyn_reset(res);
-    create_dir_hierarchy(check[i]);
+    printf("|%d|\n", create_dir_hierarchy(check[i]));
     actual = curlx_dyn_ptr(res);
     if(!actual)
       actual = "(null)";

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "unitcheck.h"
 #include "tool_dirhie.h"
+#include "tool_stderr.h"
 
 static CURLcode test_tool1720(const char *arg)
 {
@@ -57,6 +58,8 @@ static CURLcode test_tool1720(const char *arg)
 
   size_t i;
   struct dynbuf *res = create_dir_hierarchy_trace_dynres();
+
+  tool_init_stderr();
 
   curlx_dyn_init(res, 256);
 

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -29,6 +29,8 @@ static CURLcode test_tool1720(const char *arg)
   UNITTEST_BEGIN_SIMPLE
 
   static const char* check[] = {
+    "foo/bar/",
+    "foo|foo/bar|",
     "foo/bar/filename",
     "foo|foo/bar|",
     "/foo/bar/filename",
@@ -54,14 +56,9 @@ static CURLcode test_tool1720(const char *arg)
 
   curlx_dyn_init(res, 256);
 
-  curl_mprintf("start\n");
-
   for(i = 0; i < CURL_ARRAYSIZE(check); i++) {
     curlx_dyn_reset(res);
-    curl_mprintf("%zu->%s\n", i, check[i]);
     create_dir_hierarchy(check[i++]);
-    curl_mprintf("exp |%s|\n", check[i]);
-    curl_mprintf("act |%s|\n", curlx_dyn_ptr(res));
     if(strcmp(check[i], curlx_dyn_ptr(res))) {
       curl_mprintf("Expected '%s' got '%s'\n", check[i], curlx_dyn_ptr(res));
       unitfail++;

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+#include "tool_dirhie.h"
+
+static CURLcode test_tool1720(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+
+  static const char* check[] = {
+    "foo/bar/filename",
+    "foo|foo/bar|",
+    "/foo/bar/filename",
+    "/foo|/foo/bar|",
+#if defined(_WIN32) || defined(MSDOS)
+    "C:/foo/bar/filename",
+    "C:/foo|C:/foo/bar|",
+    "C:foo/bar/filename",
+    "C:foo|C:foo/bar|",
+    "foo\\bar\\filename",
+    "foo|foo\\bar|",
+    "\\foo\\bar\\filename",
+    "\\foo|\\foo\\bar|",
+    "C:\\foo\\bar\\filename",
+    "C:\\foo|C:\\foo\\bar|",
+    "C:foo\\bar\\filename",
+    "C:foo|C:foo\\bar|",
+#endif
+  };
+
+  size_t i;
+  struct dynbuf *res = create_dir_hierarchy_trace_dynres();
+
+  curlx_dyn_init(res, 256);
+
+  curl_mprintf("start\n");
+
+  for(i = 0; i < CURL_ARRAYSIZE(check); i++) {
+    curlx_dyn_reset(res);
+    curl_mprintf("%zu->%s\n", i, check[i]);
+    create_dir_hierarchy(check[i++]);
+    curl_mprintf("exp |%s|\n", check[i]);
+    curl_mprintf("act |%s|\n", curlx_dyn_ptr(res));
+    if(strcmp(check[i], curlx_dyn_ptr(res))) {
+      curl_mprintf("Expected '%s' got '%s'\n", check[i], curlx_dyn_ptr(res));
+      unitfail++;
+    }
+  }
+
+  curlx_dyn_free(res);
+
+  UNITTEST_END_SIMPLE
+}

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -56,11 +56,12 @@ static CURLcode test_tool1720(const char *arg)
 
   curlx_dyn_init(res, 256);
 
-  for(i = 0; i < CURL_ARRAYSIZE(check); i++) {
+  for(i = 0; i < CURL_ARRAYSIZE(check); i += 2) {
     curlx_dyn_reset(res);
-    create_dir_hierarchy(check[i++]);
-    if(strcmp(check[i], curlx_dyn_ptr(res))) {
-      curl_mprintf("Expected '%s' got '%s'\n", check[i], curlx_dyn_ptr(res));
+    create_dir_hierarchy(check[i]);
+    if(strcmp(check[i + 1], curlx_dyn_ptr(res))) {
+      curl_mprintf("Expected '%s' got '%s'\n",
+                   check[i + 1], curlx_dyn_ptr(res));
       unitfail++;
     }
   }

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -31,7 +31,7 @@ static CURLcode test_tool1720(const char *arg)
   static const char *check[] = {
     "",
     "(null)",
-    "bar",
+    "filename",
     "(null)",
     "foo/bar/",
     "foo|foo/bar|",

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -23,7 +23,6 @@
  ***************************************************************************/
 #include "unitcheck.h"
 #include "tool_dirhie.h"
-#include "tool_stderr.h"
 
 static CURLcode test_tool1720(const char *arg)
 {
@@ -58,8 +57,6 @@ static CURLcode test_tool1720(const char *arg)
 
   size_t i;
   struct dynbuf *res = create_dir_hierarchy_trace_dynres();
-
-  tool_init_stderr();
 
   curlx_dyn_init(res, 256);
 

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -29,6 +29,8 @@ static CURLcode test_tool1720(const char *arg)
   UNITTEST_BEGIN_SIMPLE
 
   static const char *check[] = {
+    "",
+    "(null)",
     "foo/bar/",
     "foo|foo/bar|",
     "foo/bar/filename",
@@ -57,11 +59,14 @@ static CURLcode test_tool1720(const char *arg)
   curlx_dyn_init(res, 256);
 
   for(i = 0; i < CURL_ARRAYSIZE(check); i += 2) {
+    const char *actual;
     curlx_dyn_reset(res);
     create_dir_hierarchy(check[i]);
-    if(strcmp(check[i + 1], curlx_dyn_ptr(res))) {
-      curl_mprintf("Expected '%s' got '%s'\n",
-                   check[i + 1], curlx_dyn_ptr(res));
+    actual = curlx_dyn_ptr(res);
+    if(!actual)
+      actual = "(null)";
+    if(strcmp(check[i + 1], actual)) {
+      curl_mprintf("Expected '%s' got '%s'\n", check[i + 1], actual);
       unitfail++;
     }
   }

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -31,6 +31,8 @@ static CURLcode test_tool1720(const char *arg)
   static const char *check[] = {
     "",
     "(null)",
+    "bar",
+    "(null)",
     "foo/bar/",
     "foo|foo/bar|",
     "foo/bar/filename",

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -66,7 +66,7 @@ static CURLcode test_tool1720(const char *arg)
   for(i = 0; i < CURL_ARRAYSIZE(check); i += 2) {
     const char *actual;
     curlx_dyn_reset(res);
-    printf("|%d|\n", create_dir_hierarchy(check[i]));
+    create_dir_hierarchy(check[i]);
     actual = curlx_dyn_ptr(res);
     if(!actual)
       actual = "(null)";

--- a/tests/tunit/tool1720.c
+++ b/tests/tunit/tool1720.c
@@ -28,7 +28,7 @@ static CURLcode test_tool1720(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
 
-  static const char* check[] = {
+  static const char *check[] = {
     "foo/bar/",
     "foo|foo/bar|",
     "foo/bar/filename",


### PR DESCRIPTION
Fix to create the top directory `foo` when specified as
`X:foo\bar\filename`, on Windows and MS-DOS. Add test to verify.

Caught by Codex Security

Follow-up to 787ee935acd5867bdac836b2043b6095eed2c29e #16566

---

- [x] rebase on two patches move to separate PRs. #21454 #21452