### PR TITLE
units: tidy up dynbuf init

### DIFF
--- a/tests/unit/unit1656.c
+++ b/tests/unit/unit1656.c
@@ -94,12 +94,12 @@ static CURLcode test_unit1656(const char *arg)
   struct dynbuf dbuf;
   bool all_ok = TRUE;
 
-  curlx_dyn_init(&dbuf, 32 * 1024);
-
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     curl_mfprintf(stderr, "curl_global_init() failed\n");
     return TEST_ERR_MAJOR_BAD;
   }
+
+  curlx_dyn_init(&dbuf, 32 * 1024);
 
   for(i = 0; i < CURL_ARRAYSIZE(test_specs); ++i) {
     if(!do_test(&test_specs[i], i, &dbuf))

--- a/tests/unit/unit1657.c
+++ b/tests/unit/unit1657.c
@@ -94,12 +94,12 @@ static CURLcode test_unit1657(const char *arg)
   bool all_ok = TRUE;
   struct dynbuf dbuf;
 
-  curlx_dyn_init(&dbuf, 32 * 1024);
-
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     curl_mfprintf(stderr, "curl_global_init() failed\n");
     return TEST_ERR_MAJOR_BAD;
   }
+
+  curlx_dyn_init(&dbuf, 32 * 1024);
 
   for(i = 0; i < CURL_ARRAYSIZE(test1657_specs); ++i) {
     if(!do_test1657(&test1657_specs[i], i, &dbuf))

--- a/tests/unit/unit1666.c
+++ b/tests/unit/unit1666.c
@@ -168,15 +168,15 @@ static CURLcode test_unit1666(const char *arg)
   struct dynbuf dbuf;
   bool all_ok = TRUE;
 
-  /* the real code uses CURL_X509_STR_MAX for maximum size, but we set a
-     smaller one here so that we can test running into the limit a little
-     easier */
-  curlx_dyn_init(&dbuf, 100);
-
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     curl_mfprintf(stderr, "curl_global_init() failed\n");
     return TEST_ERR_MAJOR_BAD;
   }
+
+  /* the real code uses CURL_X509_STR_MAX for maximum size, but we set a
+     smaller one here so that we can test running into the limit a little
+     easier */
+  curlx_dyn_init(&dbuf, 100);
 
   for(i = 0; i < CURL_ARRAYSIZE(test_specs); ++i) {
     if(!test1666(&test_specs[i], i, &dbuf))

--- a/tests/unit/unit1667.c
+++ b/tests/unit/unit1667.c
@@ -313,6 +313,7 @@ static CURLcode test_unit1667(const char *arg)
      smaller one here so that we can test running into the limit a little
      easier */
   curlx_dyn_init(&dbuf, 40);
+
   for(i = 0; i < CURL_ARRAYSIZE(test_specs); ++i) {
     if(!test1667(&test_specs[i], i, &dbuf))
       all_ok = FALSE;


### PR DESCRIPTION
Init dynbuf after global init to bring closer to use, improve
readability and sync test sources.
