### PR TITLE
build: stop building and installing `runtests.1` and `testcurl.1`

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -30,7 +30,7 @@ if(ENABLE_CURL_MANUAL AND BUILD_CURL_EXE)
 endif()
 
 if(BUILD_MISC_DOCS)
-  set(_man_targets "curl-config" "mk-ca-bundle" "runtests" "testcurl")
+  set(_man_targets "curl-config" "mk-ca-bundle")
   if(BUILD_CURL_EXE)
     list(APPEND _man_targets "wcurl")
   endif()

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -28,7 +28,6 @@ if BUILD_DOCS
 # if we disable man page building, ignore these
 MK_CA_DOCS = mk-ca-bundle.1
 CURLCONF_DOCS = curl-config.1
-TEST_DOCS = runtests.1 testcurl.1
 man_MANS = curl-config.1 wcurl.1
 endif
 
@@ -38,7 +37,7 @@ SUBDIRS = . cmdline-opts libcurl
 DIST_SUBDIRS = $(SUBDIRS) examples
 
 if BUILD_DOCS
-CLEANFILES = $(MK_CA_DOCS) $(man_MANS) $(TEST_DOCS)
+CLEANFILES = $(MK_CA_DOCS) $(man_MANS)
 endif
 
 TESTDOCS =                                       \
@@ -140,7 +139,7 @@ CD2_ = $(CD2_0)
 
 SUFFIXES = .1 .md
 
-all: $(MK_CA_DOCS) $(CURLCONF_DOCS) $(TEST_DOCS)
+all: $(MK_CA_DOCS) $(CURLCONF_DOCS)
 
 .md.1:
 	$(CD2)$(CD2NROFF)

--- a/docs/tests/TEST-SUITE.md
+++ b/docs/tests/TEST-SUITE.md
@@ -22,14 +22,14 @@ To run the tests faster, pass the -j (parallelism) flag:
 
     make test TFLAGS="-j10"
 
-"make test" builds the test suite support code and invokes the 'runtests.pl'
+`make test` builds the test suite support code and invokes the `runtests.pl`
 perl script to run all the tests. The value of `TFLAGS` is passed directly
-to 'runtests.pl'.
+to `runtests.pl`.
 
 When you run tests via make, the flags `-a` and `-s` are passed, meaning to
 continue running tests even after one fails, and to emit short output.
 
-If you would like to not use those flags, you can run 'runtests.pl'
+If you would like to not use those flags, you can run `runtests.pl`
 directly. You must `chdir` into the tests directory, then you can run it
 like so:
 
@@ -37,10 +37,8 @@ like so:
 
 You must have run `make test` at least once first to build the support code.
 
-To see what flags are available for runtests.pl, and what output it emits,
-run:
-
-    man ./docs/runtests.1
+To see what flags are available for `runtests.pl`, and what output it emits,
+see `docs/runtests.md`.
 
 After a test fails, examine the tests/log directory for stdout, stderr, and
 output from the servers used in the test.

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -21,5 +21,3 @@ log*
 *.port
 config
 second-hsts.txt
-runtests.1
-testcurl.1

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -23,7 +23,7 @@
 #
 ###########################################################################
 
-# For documentation, run `man ./runtests.1` and see README.md.
+# For documentation, see docs/runtests.md and README.md.
 
 # Experimental hooks are available to run tests remotely on machines that
 # are able to run curl but are unable to run the test harness.


### PR DESCRIPTION
The corresponding tools are never installed, and both are dev tools.
Refer to their `.md` originals instead.

Also markdownify text in lines nearby.

Ref: https://github.com/curl/curl/pull/21460#issuecomment-4328258450
