### PR TITLE
GHA/linux: work around Linuxbrew install failure

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -345,8 +345,9 @@ jobs:
               -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-20
 
           - name: 'address-sanitizer'
-            install_packages: clang-20 libssl-dev libssh-dev libidn2-dev libnghttp2-dev libubsan1 libasan8 libtsan2
+            install_packages: clang-20 libssh-dev libidn2-dev libnghttp2-dev libubsan1 libasan8 libtsan2
             install_steps: pytest randcurl
+            install_steps_brew: openssl@4
             CC: clang-20
             CFLAGS: >-
               -fsanitize=address,bounds,leak,signed-integer-overflow,undefined
@@ -357,12 +358,12 @@ jobs:
               -fsanitize=address,bounds,leak,signed-integer-overflow,undefined
               -fno-sanitize-recover=address,bounds,leak,signed-integer-overflow,undefined -ldl -lubsan
 
-            generate: -DENABLE_DEBUG=ON -DCURL_USE_LIBSSH=ON
+            generate: -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_USE_LIBSSH=ON
 
           - name: 'address-sanitizer H3 c-ares'
             install_packages: clang-20 libubsan1 libasan8 libtsan2
             install_steps: pytest
-            install_steps_brew: openssl@4 libssh2 libngtcp2 libnghttp3 c-ares
+            install_steps_brew: openssl libssh2 libngtcp2 libnghttp3 c-ares
             CC: clang-20
             CFLAGS: >-
               -fsanitize=address,bounds,leak,signed-integer-overflow,undefined
@@ -379,7 +380,7 @@ jobs:
               /home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:\
               /home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig"
             generate: >-
-              -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl@4 -DUSE_ECH=ON -DUSE_NGTCP2=ON
+              -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl -DUSE_ECH=ON -DUSE_NGTCP2=ON
               -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON
 
           - name: 'thread-sanitizer'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -380,7 +380,7 @@ jobs:
               /home/linuxbrew/.linuxbrew/opt/libnghttp3/lib/pkgconfig:\
               /home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig"
             generate: >-
-              -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl -DUSE_ECH=ON -DUSE_NGTCP2=ON
+              -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl -DUSE_NGTCP2=ON
               -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON
 
           - name: 'thread-sanitizer'


### PR DESCRIPTION
Root cause unknown, it appeared today without any local change:
```
==> Installing dependencies for libssh2: openssl@3 and zlib-ng-compat
==> Installing libssh2 dependency: openssl@3
==> Pouring openssl@3--3.6.2.x86_64_linux.bottle.tar.gz
Error: A `brew install openssl@4 libssh2 libngtcp2 libnghttp3 c-ares` process has already locked /home/linuxbrew/.linuxbrew/Cellar/openssl@4.
Please wait for it to finish or terminate it to continue.
Error: Process completed with exit code 1.
```
Ref: https://github.com/curl/curl/actions/runs/25129061781/job/73650161844?pr=21468#step:2:407

Last known good run: https://github.com/curl/curl/actions/runs/25038989485/job/73337289504

Ref: 1fbffe7f08f0d551038520b569b817f58084f77b #21379
