### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -548,9 +548,9 @@ Windows:
               lib/curlx/fopen.*,\
               lib/curlx/multibyte.*,\
               lib/curlx/winapi.*,\
+              lib/libcurl.def,\
               lib/vtls/schannel*,\
               m4/curl-schannel.m4,\
               projects/Windows/**,\
-              src/tool_doswin.c,\
-              lib/libcurl.def\
+              src/tool_doswin.c\
               }"

--- a/docs/ECH.md
+++ b/docs/ECH.md
@@ -135,7 +135,7 @@ LD_LIBRARY_PATH=$HOME/code/openssl ./src/curl -vvv --ech ecl:AED+DQA8yAAgACDRMQo
 
 There is a reason to want this command line option - for use before publishing
 an ECHConfigList in the DNS as per the Internet-draft [A well-known URI for
-publishing ECHConfigList values](https://datatracker.ietf.org/doc/draft-ietf-tls-wkech/).
+publishing ECHConfigList values](https://datatracker.ietf.org/doc/html/draft-ietf-tls-wkech/).
 
 If you do use a wrong ECHConfigList value, then the server might return a
 good value, via the `retry_configs` mechanism. You can see that value in

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -791,7 +791,7 @@ done, and thus maintain its connection pool, DNS cache and more.
 
 Consider a command line option that can make curl do multiple serial requests
 while acknowledging server specified [rate
-limits](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/).
+limits](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers/).
 
 See [curl issue 5406](https://github.com/curl/curl/issues/5406)
 

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -69,12 +69,12 @@ dates. The tool was called `httpget` before 2.0, `urlget` before 4.0 then
 same version numbers.
 
 - 8.21.0: pending
-- 8.20.0: April 29, 2026
-- 8.19.0: March 11, 2026
-- 8.18.0: January 7, 2026
-- 8.17.0: November 5, 2025
-- 8.16.0: September 10, 2025
-- 8.15.0: July 16, 2025
+- 8.20.0: April 29 2026
+- 8.19.0: March 11 2026
+- 8.18.0: January 7 2026
+- 8.17.0: November 5 2025
+- 8.16.0: September 10 2025
+- 8.15.0: July 16 2025
 - 8.14.1: June 4 2025
 - 8.14.0: May 28 2025
 - 8.13.0: April 2 2025

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -43,8 +43,8 @@
  * 2. USE_WOLFSSL
  * 3. USE_GNUTLS
  * 4. USE_MBEDTLS
- * 5. USE_COMMON_CRYPTO
- * 6. USE_WIN32_CRYPTO
+ * 5. USE_WIN32_CRYPTO
+ * 6. USE_COMMON_CRYPTO
  *
  * This ensures that the same SSL branch gets activated throughout this source
  * file even if multiple backends are enabled at the same time.

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -704,7 +704,7 @@ static bool mqttd_incoming(curl_socket_t listenfd)
   }
 
 #ifdef HAVE_GETPPID
-  /* As a last resort, quit if socks5 process becomes orphan. */
+  /* As a last resort, quit if mqttd process becomes orphan. */
   if(getppid() <= 1) {
     logmsg("process becomes orphan, exiting");
     return FALSE;

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -245,7 +245,7 @@ static int puback(FILE *dump, curl_socket_t fd, unsigned short packetid)
   if(rc == sizeof(packet)) {
     logmsg("WROTE %zd bytes [PUBACK]", rc);
     loghex(packet, rc);
-    logprotocol(FROM_SERVER, dump, packet, rc);
+    logprotocol(FROM_SERVER, "PUBACK", 0, dump, packet, rc);
     return 0;
   }
   logmsg("Failed sending [PUBACK]");


### PR DESCRIPTION
- sha256: fix backend priority in comment.
- URLs: link to IETF URLs to the HTML document, to match others.
- VERSIONS.md: use unified date format for recent entries too.
  Ref: https://github.com/curl/curl-www/commit/ce5d32032f8d3d8601f3ef022bbca485020d1bb9
- GHA/labeler.yml: alpha-sort file masks in a label block.
- tests/server/mqttd: fix call arg list in a disabled function.
- tests/server/mqttd: fix comment.
