### PR TITLE
GHA/curl-for-win: switch riscv job to debian:stable (testing broke)

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -112,6 +112,8 @@ jobs:
           export CW_CONFIG='-main-werror-unitybatch-nocertdata-linux-musl-r64-x64'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
+          export CW_CCSUFFIX='-19'
+          export CW_GCCSUFFIX='-14'
           sudo podman image trust set --type reject default
           sudo podman image trust set --type accept docker.io/library
           time podman pull "${OCI_IMAGE_DEBIAN_STABLE}"

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -114,12 +114,12 @@ jobs:
           . ./_versions.sh
           sudo podman image trust set --type reject default
           sudo podman image trust set --type accept docker.io/library
-          time podman pull "${OCI_IMAGE_DEBIAN}"
+          time podman pull "${OCI_IMAGE_DEBIAN_STABLE}"
           podman images --digests
           time podman run --volume "$(pwd):$(pwd)" --workdir "$(pwd)" \
             --env-file <(env | grep -a -E \
               '^(CW_|DO_NOT_TRACK|GITHUB_)') \
-            "${OCI_IMAGE_DEBIAN}" \
+            "${OCI_IMAGE_DEBIAN_STABLE}" \
             sh -c ./_ci-linux-debian.sh
 
   mac-clang:


### PR DESCRIPTION
```
The following packages have unmet dependencies:
[...]
E: Unable to satisfy dependencies. Reached two conflicting assignments:
   1. musl-dev:amd64=1.2.5-3+b1 is selected for install
   2. musl-dev:amd64 is not selected for install because:
      1. musl-dev:riscv64=1.2.5-3 is selected for install
      2. musl-dev:amd64 Breaks musl-dev:riscv64 (!= 1.2.5-3+b1)
```
Ref: https://github.com/curl/curl/actions/runs/25168601672/job/73785600341#step:3:154