### PR TITLE
asyn-thrdd: fix result processing without wakeup socketpair

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -701,6 +701,9 @@ CURLcode Curl_async_take_result(struct Curl_easy *data,
   if(thrdd->rr.channel)
     (void)Curl_ares_perform(thrdd->rr.channel, 0);
 #endif
+#ifndef ENABLE_WAKEUP
+  Curl_async_thrdd_multi_process(data->multi);
+#endif
 
   if(!async->done)
     return CURLE_AGAIN;


### PR DESCRIPTION
When building curl 8.20.0 with socketpair disabled, there is no wakeup socket and the resolve results are not processed.

This fix performs result processing in the absence of a wakeup socket before checking the resolve result.