### PR TITLE
lib: drop support for CURLAUTH_DIGEST_IE

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -54,11 +54,8 @@ regular old-fashioned Basic method.
 
 ## CURLAUTH_DIGEST_IE
 
-HTTP Digest authentication with an IE flavor. Digest authentication is defined
-in RFC 2617 and is a more secure way to do authentication over public networks
-than the regular old-fashioned Basic method. The IE flavor means that
-libcurl uses a special "quirk" that IE is known to have used before version 7
-and that some servers require the client to use.
+The IE-specific Digest authentication behavior is no longer supported.
+This bit is kept for compatibility and is treated as CURLAUTH_DIGEST.
 
 ## CURLAUTH_BEARER
 
@@ -158,6 +155,8 @@ a `long` cast was necessary when passed to curl_easy_setopt(3).
 CURLAUTH_BEARER was added in 7.61.0
 
 CURLAUTH_AWS_SIGV4 was added in 7.74.0
+
+CURLAUTH_DIGEST_IE does nothing since 8.21.0
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -205,7 +205,7 @@ CURLAUTH_AWS_SIGV4              7.75.0
 CURLAUTH_BASIC                  7.10.6
 CURLAUTH_BEARER                 7.61.0
 CURLAUTH_DIGEST                 7.10.6
-CURLAUTH_DIGEST_IE              7.19.3
+CURLAUTH_DIGEST_IE              7.19.3        8.21.0
 CURLAUTH_GSSAPI                 7.55.0
 CURLAUTH_GSSNEGOTIATE           7.10.6        7.38.0
 CURLAUTH_NEGOTIATE              7.38.0

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -68,8 +68,6 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
                             const unsigned char *uripath)
 {
   CURLcode result;
-  unsigned char *path = NULL;
-  const char *tmp = NULL;
   char *response;
   size_t len;
   bool have_chlg;
@@ -125,36 +123,9 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
     return CURLE_OK;
   }
 
-  /* IE browsers < v7 cut off the URI part at the query part when they
-     evaluate the MD5 and some (IIS?) servers work with them so we may need to
-     do the Digest IE-style. Note that the different ways cause different MD5
-     sums to get sent.
-
-     Apache servers can be set to do the Digest IE-style automatically using
-     the BrowserMatch feature:
-     https://httpd.apache.org/docs/2.2/mod/mod_auth_digest.html#msie
-
-     Further details on Digest implementation differences:
-     https://web.archive.org/web/2009/fngtps.com/2006/09/http-authentication
-  */
-
-  if(authp->iestyle) {
-    tmp = strchr((const char *)uripath, '?');
-    if(tmp) {
-      size_t urilen = tmp - (const char *)uripath;
-      /* typecast is fine here since the value is always less than 32 bits */
-      path = (unsigned char *)curl_maprintf("%.*s", (int)urilen, uripath);
-    }
-  }
-  if(!tmp)
-    path = (unsigned char *)curlx_strdup((const char *)uripath);
-
-  if(!path)
-    return CURLE_OUT_OF_MEMORY;
-
-  result = Curl_auth_create_digest_http_message(data, userp, passwdp, request,
-                                                path, digest, &response, &len);
-  curlx_free(path);
+  result = Curl_auth_create_digest_http_message(data, userp, passwdp,
+                                                request, uripath, digest,
+                                                &response, &len);
   if(result)
     return result;
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -240,17 +240,9 @@ static CURLcode httpauth(struct Curl_easy *data, bool proxy,
   if(auth != CURLAUTH_NONE) {
     int bitcheck = 0;
     bool authbits = FALSE;
-    /* the DIGEST_IE bit is only used to set a special marker, for all the
-       rest we need to handle it as normal DIGEST */
-    bool iestyle = !!(auth & CURLAUTH_DIGEST_IE);
-    if(proxy)
-      data->state.authproxy.iestyle = iestyle;
-    else
-      data->state.authhost.iestyle = iestyle;
-
     if(auth & CURLAUTH_DIGEST_IE) {
       auth |= CURLAUTH_DIGEST; /* set standard digest bit */
-      auth &= ~CURLAUTH_DIGEST_IE; /* unset ie digest bit */
+      auth &= ~CURLAUTH_DIGEST_IE; /* drop the legacy bit */
     }
 
     /* switch off bits we cannot support */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -586,8 +586,6 @@ struct auth {
                  actual request */
   BIT(multipass); /* TRUE if this is not yet authenticated but within the
                      auth multipass negotiation */
-  BIT(iestyle); /* TRUE if digest should be done IE-style or FALSE if it
-                   should be RFC compliant */
 };
 
 #ifdef USE_NGHTTP2


### PR DESCRIPTION
This bit was used to do Digest authentication like Internet Explorer before version 7 (released on October 18, 2006). Presumably no one uses this anymore and since it is hard to use and does broken auth, starting in 8.21.0 this bit does nothing (except setting the actual Digest bit).