### PR TITLE
show-headers.md: mention bold headers and --no-styled-output

### DIFF
--- a/.github/scripts/pyspelling.words
+++ b/.github/scripts/pyspelling.words
@@ -896,6 +896,7 @@ trustless
 Tse
 Tsujikawa
 TTL
+tty
 tvOS
 txt
 typedef

--- a/docs/cmdline-opts/show-headers.md
+++ b/docs/cmdline-opts/show-headers.md
@@ -24,6 +24,11 @@ non-HTTP protocols, the "headers" are other server communication.
 This option makes the response headers get saved in the same stream/output as
 the data. --dump-header exists to save headers in a separate stream.
 
+When HTTP headers is output to a tty, curl may use escape codes to make the
+header field names appear as bold and URLs in `Location:` headers to be
+especially marked as such. Disable the use of terminal escape codes with
+--no-styled-output.
+
 To view the request headers, consider the --verbose option.
 
 Prior to 7.75.0 curl did not print the headers if --fail was used in

--- a/docs/cmdline-opts/show-headers.md
+++ b/docs/cmdline-opts/show-headers.md
@@ -27,7 +27,8 @@ the data. --dump-header exists to save headers in a separate stream.
 When HTTP headers are output to a tty, curl may use escape codes to make the
 header field names appear in bold and URLs in `Location:` headers be
 especially marked as such. Disable the use of terminal escape codes with
---no-styled-output.
+--no-styled-output. (This means using the --styled-output option with a
+`--no-` prefix to disable it.)
 
 To view the request headers, consider the --verbose option.
 

--- a/docs/cmdline-opts/show-headers.md
+++ b/docs/cmdline-opts/show-headers.md
@@ -24,8 +24,8 @@ non-HTTP protocols, the "headers" are other server communication.
 This option makes the response headers get saved in the same stream/output as
 the data. --dump-header exists to save headers in a separate stream.
 
-When HTTP headers is output to a tty, curl may use escape codes to make the
-header field names appear as bold and URLs in `Location:` headers to be
+When HTTP headers are output to a tty, curl may use escape codes to make the
+header field names appear in bold and URLs in `Location:` headers be
 especially marked as such. Disable the use of terminal escape codes with
 --no-styled-output.
 


### PR DESCRIPTION
Mentioned-by: Sollace on github
Fixes #21495