### PR TITLE
thrdqueue.h: forward declare curl_thrdq unconditionally

### DIFF
--- a/lib/thrdqueue.h
+++ b/lib/thrdqueue.h
@@ -26,10 +26,11 @@
 #include "curl_setup.h"
 #include "curlx/timediff.h"
 
+struct curl_thrdq;
+
 #ifdef USE_THREADS
 
 struct Curl_easy;
-struct curl_thrdq;
 
 typedef enum {
   CURL_THRDQ_EV_ITEM_DONE /* an item has been processed and is ready */


### PR DESCRIPTION
This allows the unit tests to have a prototype involving such a struct pointer - even when the build is done without threaded resolver.

Follow-up to 117d50b4bf48ca04908f87dd665ba