### PR TITLE
revert 117d50b4bf48ca04908f87dd665ba183573587b6

### DIFF
--- a/lib/thrdqueue.c
+++ b/lib/thrdqueue.c
@@ -351,16 +351,11 @@ out:
   Curl_mutex_release(&tqueue->lock);
 }
 
-#ifdef UNITTESTS
-/* @unittest 3301 */
-UNITTEST CURLcode thrdq_await_done(struct curl_thrdq *tqueue,
-                                   uint32_t timeout_ms);
-UNITTEST CURLcode thrdq_await_done(struct curl_thrdq *tqueue,
-                                   uint32_t timeout_ms)
+CURLcode Curl_thrdq_await_done(struct curl_thrdq *tqueue,
+                          uint32_t timeout_ms)
 {
   return Curl_thrdpool_await_idle(tqueue->tpool, timeout_ms);
 }
-#endif
 
 CURLcode Curl_thrdq_set_props(struct curl_thrdq *tqueue,
                               uint32_t max_len,

--- a/tests/unit/unit3301.c
+++ b/tests/unit/unit3301.c
@@ -110,7 +110,7 @@ static CURLcode test_unit3301(const char *arg)
     fail_unless(!r, "queue-b send");
   }
 
-  r = thrdq_await_done(tqueue, 0);
+  r = Curl_thrdq_await_done(tqueue, 0);
   fail_unless(!r, "queue-b await done");
 
   nrecvd = 0;


### PR DESCRIPTION
The UNITTEST for the thrdq function does not compile when USE_THREADS is not defined. The function prototype ends up in unitprotos.h but does not know the parameter type.