### PR TITLE
ftp: remove 2 Curl_resolv_blocking() calls

### DIFF
--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -53,8 +53,7 @@ static struct cf_dns_ctx *cf_dns_ctx_create(struct Curl_easy *data,
                                             uint8_t dns_queries,
                                             uint8_t transport,
                                             bool for_proxy,
-                                            bool complete_resolve,
-                                            struct Curl_dns_entry *dns)
+                                            bool complete_resolve)
 {
   struct cf_dns_ctx *ctx;
 
@@ -67,8 +66,6 @@ static struct cf_dns_ctx *cf_dns_ctx_create(struct Curl_easy *data,
   ctx->transport = transport;
   ctx->for_proxy = for_proxy;
   ctx->complete_resolve = complete_resolve;
-  ctx->dns = Curl_dns_entry_link(data, dns);
-  ctx->started = !!ctx->dns;
 
   CURL_TRC_DNS(data, "created DNS filter for %s:%u, transport=%x, queries=%x",
                peer->hostname, peer->port, ctx->transport, ctx->dns_queries);
@@ -383,8 +380,7 @@ static CURLcode cf_dns_create(struct Curl_cfilter **pcf,
                               uint8_t dns_queries,
                               uint8_t transport,
                               bool for_proxy,
-                              bool complete_resolve,
-                              struct Curl_dns_entry *dns)
+                              bool complete_resolve)
 {
   struct Curl_cfilter *cf = NULL;
   struct cf_dns_ctx *ctx;
@@ -392,7 +388,7 @@ static CURLcode cf_dns_create(struct Curl_cfilter **pcf,
 
   (void)data;
   ctx = cf_dns_ctx_create(data, peer, dns_queries, transport,
-                          for_proxy, complete_resolve, dns);
+                          for_proxy, complete_resolve);
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -418,8 +414,7 @@ CURLcode Curl_cf_dns_add(struct Curl_easy *data,
                          int sockindex,
                          struct Curl_peer *peer,
                          uint8_t dns_queries,
-                         uint8_t transport,
-                         struct Curl_dns_entry *dns)
+                         uint8_t transport)
 {
   struct Curl_cfilter *cf = NULL;
   bool for_proxy = FALSE;
@@ -433,7 +428,7 @@ CURLcode Curl_cf_dns_add(struct Curl_easy *data,
 #endif
 
   result = cf_dns_create(&cf, data, peer, dns_queries, transport,
-                         for_proxy, FALSE, dns);
+                         for_proxy, FALSE);
   if(result)
     goto out;
   Curl_conn_cf_add(data, conn, sockindex, cf);
@@ -458,7 +453,7 @@ CURLcode Curl_cf_dns_insert_after(struct Curl_cfilter *cf_at,
   CURLcode result;
 
   result = cf_dns_create(&cf, data, peer, dns_queries, transport,
-                         FALSE, complete_resolve, NULL);
+                         FALSE, complete_resolve);
   if(result)
     return result;
 

--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -404,11 +404,7 @@ out:
 }
 
 /* Adds a "resolv" filter at the top of the connection's filter chain.
- * For FIRSTSOCKET, the `dns` parameter may be NULL. The filter will
- * figure out hostname and port to connect to and start the DNS resolve
- * on the first connect attempt.
- * For SECONDARYSOCKET, the `dns` parameter must be given.
- */
+ * The filter will resolve the peer on the first connect attempt. */
 CURLcode Curl_cf_dns_add(struct Curl_easy *data,
                          struct connectdata *conn,
                          int sockindex,

--- a/lib/cf-dns.h
+++ b/lib/cf-dns.h
@@ -36,8 +36,7 @@ CURLcode Curl_cf_dns_add(struct Curl_easy *data,
                          int sockindex,
                          struct Curl_peer *peer,
                          uint8_t dns_queries,
-                         uint8_t transport,
-                         struct Curl_dns_entry *dns);
+                         uint8_t transport);
 
 CURLcode Curl_cf_dns_insert_after(struct Curl_cfilter *cf_at,
                                   struct Curl_easy *data,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -576,7 +576,6 @@ out:
 CURLcode Curl_conn_setup(struct Curl_easy *data,
                          struct connectdata *conn,
                          int sockindex,
-                         struct Curl_dns_entry *dns,
                          int ssl_mode)
 {
   CURLcode result = CURLE_OK;
@@ -614,7 +613,7 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
     dns_queries |= CURL_DNSQ_HTTPS;
 #endif
   result = Curl_cf_dns_add(data, conn, sockindex, peer, dns_queries,
-                           conn->transport_wanted, dns);
+                           conn->transport_wanted);
   DEBUGASSERT(conn->cfilter[sockindex]);
 out:
   return result;

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -116,7 +116,7 @@ CURLcode Curl_cf_setup_insert_after(struct Curl_cfilter *cf_at,
 /**
  * Setup the cfilters at `sockindex` in connection `conn`.
  * If no filter chain is installed yet, inspects the configuration
- * in `data` and `conn? to install a suitable filter chain.
+ * in `data` and `conn` to install a suitable filter chain.
  */
 CURLcode Curl_conn_setup(struct Curl_easy *data,
                          struct connectdata *conn,

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -121,7 +121,6 @@ CURLcode Curl_cf_setup_insert_after(struct Curl_cfilter *cf_at,
 CURLcode Curl_conn_setup(struct Curl_easy *data,
                          struct connectdata *conn,
                          int sockindex,
-                         struct Curl_dns_entry *dns,
                          int ssl_mode);
 
 /* Set conn to allow multiplexing. */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2183,9 +2183,8 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
 
 #ifdef CURLVERBOSE
   if(data->set.verbose) {
-    /* Dump information about this second connection when we have issued a PASV
-     * command before and thus we have connected to a possibly new IP address.
-     */
+    /* Dump information about this second connection when we have issued
+     * a PASV command. */
     infof(data, "Connecting to %s port %d",
           conn->origin2->hostname, conn->origin2->port);
   }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2059,7 +2059,6 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
 {
   struct connectdata *conn = data->conn;
   CURLcode result;
-  struct Curl_dns_entry *dns = NULL;
   const struct pingpong *pp = &ftpc->pp;
   char *newhost = NULL;
   unsigned short newport = 0;
@@ -2146,63 +2145,6 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
     return CURLE_FTP_WEIRD_PASV_REPLY;
   }
 
-#ifndef CURL_DISABLE_PROXY
-  if(conn->bits.proxy) {
-    /* This connection uses a proxy and we need to connect to the proxy again
-     * here. We do not want to rely on a former host lookup that might have
-     * expired now, instead we remake the lookup here and now! */
-    struct ip_quadruple ipquad;
-    bool is_ipv6;
-    const struct Curl_peer *dest = conn->bits.socksproxy ?
-      conn->socks_proxy.peer : conn->http_proxy.peer;
-
-    if(!dest) {
-      result = CURLE_FAILED_INIT;
-      goto error;
-    }
-
-    result = Curl_conn_get_ip_info(data, data->conn, FIRSTSOCKET,
-                                   &is_ipv6, &ipquad);
-    if(result)
-      goto error;
-
-    (void)Curl_resolv_blocking(
-      data, is_ipv6 ? CURL_DNSQ_AAAA : CURL_DNSQ_A,
-      dest->hostname, dest->port, Curl_conn_get_transport(data, conn),
-      &dns);
-
-    if(!dns) {
-      failf(data, "cannot resolve proxy host %s:%hu",
-            dest->hostname, dest->port);
-      result = CURLE_COULDNT_RESOLVE_PROXY;
-      goto error;
-    }
-  }
-  else
-#endif
-  {
-    /* normal, direct, ftp connection */
-    DEBUGASSERT(newhost);
-
-    /* postponed address resolution in case of tcp fastopen */
-    if(conn->bits.tcp_fastopen && !conn->bits.reuse && !newhost[0]) {
-      curlx_free(newhost);
-      result = ftp_control_addr_dup(data, &newhost);
-      if(result)
-        goto error;
-    }
-
-    (void)Curl_resolv_blocking(
-      data, Curl_resolv_dns_queries(data, conn->ip_version),
-      newhost, newport, Curl_conn_get_transport(data, conn), &dns);
-
-    if(!dns) {
-      failf(data, "cannot resolve new host %s:%hu", newhost, newport);
-      result = CURLE_FTP_CANT_GET_HOST;
-      goto error;
-    }
-  }
-
   DEBUGASSERT(newhost);
   Curl_peer_unlink(&conn->origin2);
   result = Curl_peer_create(data, conn->scheme, newhost, newport,
@@ -2221,7 +2163,7 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
       goto error;
   }
 
-  result = Curl_conn_setup(data, conn, SECONDARYSOCKET, dns,
+  result = Curl_conn_setup(data, conn, SECONDARYSOCKET, NULL,
                            conn->bits.ftp_use_data_ssl ?
                            CURL_CF_SSL_ENABLE : CURL_CF_SSL_DISABLE);
 
@@ -2244,10 +2186,8 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
     /* Dump information about this second connection when we have issued a PASV
      * command before and thus we have connected to a possibly new IP address.
      */
-    char buf[256];
-    Curl_printable_address(dns->addr, buf, sizeof(buf));
-    infof(data, "Connecting to %s (%s) port %d",
-          conn->origin2->hostname, buf, conn->origin2->port);
+    infof(data, "Connecting to %s port %d",
+          conn->origin2->hostname, conn->origin2->port);
   }
 #endif
 
@@ -2255,7 +2195,6 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
   ftp_state(data, ftpc, FTP_STOP); /* this phase is completed */
 
 error:
-  Curl_dns_entry_unlink(data, &dns);
   curlx_free(newhost);
   return result;
 }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2163,7 +2163,7 @@ static CURLcode ftp_state_pasv_resp(struct Curl_easy *data,
       goto error;
   }
 
-  result = Curl_conn_setup(data, conn, SECONDARYSOCKET, NULL,
+  result = Curl_conn_setup(data, conn, SECONDARYSOCKET,
                            conn->bits.ftp_use_data_ssl ?
                            CURL_CF_SSL_ENABLE : CURL_CF_SSL_DISABLE);
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -3021,8 +3021,7 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
     *pconnected = TRUE;
   }
   else {
-    result = Curl_conn_setup(data, conn, FIRSTSOCKET, NULL,
-                             CURL_CF_SSL_DEFAULT);
+    result = Curl_conn_setup(data, conn, FIRSTSOCKET, CURL_CF_SSL_DEFAULT);
     if(!result)
       result = Curl_headers_init(data);
     CURL_TRC_M(data, "Curl_conn_setup() -> %d", result);


### PR DESCRIPTION
They are no longer needed with the new peers and dns filter. Connection setup will take care of the resoling and connecting.