### PR TITLE
some auth related cleanups

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -174,7 +174,7 @@ static void h1_tunnel_go_state(struct Curl_cfilter *cf,
     /* If a proxy-authorization header was used for the proxy, then we should
        make sure that it is not accidentally used for the document request
        after we have connected. Let's thus free and clear it here. */
-    curlx_safefree(data->req.proxyuserpwd);
+    curlx_safefree(data->req.hd_proxy_auth);
     break;
   }
 }
@@ -461,7 +461,7 @@ static CURLcode recv_CONNECT_resp(struct Curl_cfilter *cf,
 
     if(!nread) {
       if(data->set.proxyauth && data->state.authproxy.avail &&
-         data->req.proxyuserpwd) {
+         data->req.hd_proxy_auth) {
         /* proxy auth was requested and there was proxy auth available,
            then deem this as "mere" proxy disconnect */
         ts->close_connection = TRUE;
@@ -702,7 +702,7 @@ static CURLcode cf_h1_proxy_connect(struct Curl_cfilter *cf,
   result = H1_CONNECT(cf, data, ts);
   if(result)
     goto out;
-  curlx_safefree(data->req.proxyuserpwd);
+  curlx_safefree(data->req.hd_proxy_auth);
 
 out:
   *done = (result == CURLE_OK) && tunnel_is_established(cf->ctx);

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -154,7 +154,7 @@ static void h2_tunnel_go_state(struct Curl_cfilter *cf,
     /* If a proxy-authorization header was used for the proxy, then we should
        make sure that it is not accidentally used for the document request
        after we have connected. Let's thus free and clear it here. */
-    curlx_safefree(data->req.proxyuserpwd);
+    curlx_safefree(data->req.hd_proxy_auth);
     break;
   }
 }

--- a/lib/http.c
+++ b/lib/http.c
@@ -254,7 +254,7 @@ static CURLcode http_output_basic(struct Curl_easy *data, bool proxy)
 {
   size_t size = 0;
   char *authorization = NULL;
-  char **userp;
+  char **p_hd;
   const char *user;
   const char *pwd;
   CURLcode result;
@@ -264,7 +264,7 @@ static CURLcode http_output_basic(struct Curl_easy *data, bool proxy)
      connection */
   if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-    userp = &data->req.proxyuserpwd;
+    p_hd = &data->req.hd_proxy_auth;
     user = data->state.aptr.proxyuser;
     pwd = data->state.aptr.proxypasswd;
 #else
@@ -272,7 +272,7 @@ static CURLcode http_output_basic(struct Curl_easy *data, bool proxy)
 #endif
   }
   else {
-    userp = &data->req.userpwd;
+    p_hd = &data->req.hd_auth;
     user = data->state.aptr.user;
     pwd = data->state.aptr.passwd;
   }
@@ -291,12 +291,12 @@ static CURLcode http_output_basic(struct Curl_easy *data, bool proxy)
     goto fail;
   }
 
-  curlx_free(*userp);
-  *userp = curl_maprintf("%sAuthorization: Basic %s\r\n",
-                         proxy ? "Proxy-" : "",
-                         authorization);
+  curlx_free(*p_hd);
+  *p_hd = curl_maprintf("%sAuthorization: Basic %s\r\n",
+                        proxy ? "Proxy-" : "",
+                        authorization);
   curlx_free(authorization);
-  if(!*userp) {
+  if(!*p_hd) {
     result = CURLE_OUT_OF_MEMORY;
     goto fail;
   }
@@ -320,7 +320,7 @@ static CURLcode http_output_bearer(struct Curl_easy *data)
   char **userp;
   CURLcode result = CURLE_OK;
 
-  userp = &data->req.userpwd;
+  userp = &data->req.hd_auth;
   curlx_free(*userp);
   *userp = curl_maprintf("Authorization: Bearer %s\r\n",
                          data->set.str[STRING_BEARER]);
@@ -760,53 +760,48 @@ static CURLcode output_auth_headers(struct Curl_easy *data,
   return result;
 }
 
-/**
- * Curl_http_output_auth() setups the authentication headers for the
- * host/proxy and the correct authentication
- * method. data->state.authdone is set to TRUE when authentication is
- * done.
- *
- * @param conn all information about the current connection
- * @param request pointer to the request keyword
- * @param path pointer to the requested path; should include query part
- * @param proxytunnel boolean if this is the request setting up a "proxy
- * tunnel"
- *
- * @returns CURLcode
- */
 CURLcode Curl_http_output_auth(struct Curl_easy *data,
                                struct connectdata *conn,
                                const char *request,
                                Curl_HttpReq httpreq,
                                const char *path,
-                               bool proxytunnel) /* TRUE if this is
-                                                    the request setting up
-                                                    the proxy tunnel */
+                               const char *query,
+                               bool is_connect)
 {
   CURLcode result = CURLE_OK;
   struct auth *authhost;
   struct auth *authproxy;
+  const char *path_and_query = path;
+  char *tmp_str = NULL;
 
   DEBUGASSERT(data);
-
   authhost = &data->state.authhost;
   authproxy = &data->state.authproxy;
 
   if(
 #ifndef CURL_DISABLE_PROXY
-    (conn->bits.httpproxy && conn->bits.proxy_user_passwd) ||
+    (!conn->bits.httpproxy || !conn->bits.proxy_user_passwd) &&
 #endif
-    data->state.aptr.user ||
+    !data->state.aptr.user &&
 #ifdef USE_SPNEGO
-    authhost->want & CURLAUTH_NEGOTIATE ||
-    authproxy->want & CURLAUTH_NEGOTIATE ||
+    !(authhost->want & CURLAUTH_NEGOTIATE) &&
+    !(authproxy->want & CURLAUTH_NEGOTIATE) &&
 #endif
-    data->set.str[STRING_BEARER])
-    /* continue please */;
-  else {
+    !data->set.str[STRING_BEARER]) {
+    /* no authentication with no user or password */
     authhost->done = TRUE;
     authproxy->done = TRUE;
-    return CURLE_OK; /* no authentication with no user or password */
+    result = CURLE_OK;
+    goto out;
+  }
+
+  if(query) {
+    tmp_str = curl_maprintf("%s?%s", path, query);
+    if(!tmp_str) {
+      result = CURLE_OUT_OF_MEMORY;
+      goto out;
+    }
+    path_and_query = tmp_str;
   }
 
   if(authhost->want && !authhost->picked)
@@ -823,15 +818,15 @@ CURLcode Curl_http_output_auth(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_PROXY
   /* Send proxy authentication header if needed */
-  if(conn->bits.httpproxy &&
-     (conn->bits.tunnel_proxy == (curl_bit)proxytunnel)) {
-    result = output_auth_headers(data, conn, authproxy, request, path, TRUE);
+  if(conn->bits.httpproxy && (!conn->bits.tunnel_proxy || is_connect)) {
+    result = output_auth_headers(data, conn, authproxy, request,
+                                 path_and_query, TRUE);
     if(result)
       return result;
   }
   else
 #else
-  (void)proxytunnel;
+  (void)is_connect;
 #endif /* CURL_DISABLE_PROXY */
     /* we have no proxy so let's pretend we are done authenticating
        with it */
@@ -844,7 +839,8 @@ CURLcode Curl_http_output_auth(struct Curl_easy *data,
      || conn->bits.netrc
 #endif
     )
-    result = output_auth_headers(data, conn, authhost, request, path, FALSE);
+    result = output_auth_headers(data, conn, authhost, request,
+                                 path_and_query, FALSE);
   else
     authhost->done = TRUE;
 
@@ -859,27 +855,31 @@ CURLcode Curl_http_output_auth(struct Curl_easy *data,
   else
     data->req.authneg = FALSE;
 
+out:
+  curlx_free(tmp_str);
   return result;
 }
 
-#else
+#else /* !CURL_DISABLE_HTTP_AUTH */
 /* when disabled */
 CURLcode Curl_http_output_auth(struct Curl_easy *data,
                                struct connectdata *conn,
                                const char *request,
                                Curl_HttpReq httpreq,
                                const char *path,
-                               bool proxytunnel)
+                               const char *query,
+                               bool is_connect)
 {
   (void)data;
   (void)conn;
   (void)request;
   (void)httpreq;
   (void)path;
-  (void)proxytunnel;
+  (void)query;
+  (void)is_connect;
   return CURLE_OK;
 }
-#endif
+#endif /* !CURL_DISABLE_HTTP_AUTH, else */
 
 #if defined(USE_SPNEGO) || defined(USE_NTLM) || \
   !defined(CURL_DISABLE_DIGEST_AUTH) || \
@@ -2059,8 +2059,8 @@ static CURLcode http_set_aptr_host(struct Curl_easy *data)
   }
   else {
     /* Use the hostname as present in the URL if it was IPv6. */
-    char *host = (data->state.up.hostname[0] == '[') ?
-       data->state.up.hostname : conn->origin->hostname;
+    char *host = (conn->origin->user_hostname[0] == '[') ?
+       conn->origin->user_hostname : conn->origin->hostname;
 
     if(((conn->given->protocol & (CURLPROTO_HTTPS | CURLPROTO_WSS)) &&
         (conn->origin->port == PORT_HTTPS)) ||
@@ -2834,7 +2834,7 @@ typedef enum {
 #ifndef CURL_DISABLE_PROXY
   H1_HD_PROXY_AUTH,
 #endif
-  H1_HD_USER_AUTH,
+  H1_HD_AUTH,
   H1_HD_RANGE,
   H1_HD_USER_AGENT,
   H1_HD_ACCEPT,
@@ -2889,14 +2889,14 @@ static CURLcode http_add_hd(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_PROXY
   case H1_HD_PROXY_AUTH:
-    if(data->req.proxyuserpwd)
-      result = curlx_dyn_add(req, data->req.proxyuserpwd);
+    if(data->req.hd_proxy_auth)
+      result = curlx_dyn_add(req, data->req.hd_proxy_auth);
     break;
 #endif
 
-  case H1_HD_USER_AUTH:
-    if(data->req.userpwd)
-      result = curlx_dyn_add(req, data->req.userpwd);
+  case H1_HD_AUTH:
+    if(data->req.hd_auth)
+      result = curlx_dyn_add(req, data->req.hd_auth);
     break;
 
   case H1_HD_RANGE:
@@ -3054,29 +3054,16 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
 
   /* select host to send */
   result = http_set_aptr_host(data);
-  if(!result) {
-    /* setup the authentication headers, how that method and host are known */
-    char *pq = NULL;
-    if(data->state.up.query) {
-      pq = curl_maprintf("%s?%s", data->state.up.path, data->state.up.query);
-      if(!pq) {
-        result = CURLE_OUT_OF_MEMORY;
-        goto out;
-      }
-    }
+  /* setup the authentication headers, how that method and host are known */
+  if(!result)
     result = Curl_http_output_auth(data, data->conn, method, httpreq,
-                                   (pq ? pq : data->state.up.path), FALSE);
-    curlx_free(pq);
-  }
-  if(result)
-    goto out;
-
-  result = http_useragent(data);
-  if(result)
-    goto out;
-
+                                   data->state.up.path,
+                                   data->state.up.query, FALSE);
+  if(!result)
+    result = http_useragent(data);
   /* Setup input reader, resume information and ranges */
-  result = set_reader(data, httpreq);
+  if(!result)
+    result = set_reader(data, httpreq);
   if(!result)
     result = http_resume(data, httpreq);
   if(!result)

--- a/lib/http.c
+++ b/lib/http.c
@@ -822,7 +822,7 @@ CURLcode Curl_http_output_auth(struct Curl_easy *data,
     result = output_auth_headers(data, conn, authproxy, request,
                                  path_and_query, TRUE);
     if(result)
-      return result;
+      goto out;
   }
   else
 #else

--- a/lib/http.h
+++ b/lib/http.h
@@ -180,6 +180,7 @@ CURLcode Curl_http_write_resp_hds(struct Curl_easy *data,
  * @param request pointer to the request keyword
  * @param httpreq is the request type
  * @param path pointer to the requested path
+ * @param query pointer to the requested query or NULL
  * @param is_connect boolean if this is a CONNECT request
  *        (where httpreq is HTTPREQ_GET since there is no HTTPREQ_CONNECT)
  *

--- a/lib/http.h
+++ b/lib/http.h
@@ -180,8 +180,8 @@ CURLcode Curl_http_write_resp_hds(struct Curl_easy *data,
  * @param request pointer to the request keyword
  * @param httpreq is the request type
  * @param path pointer to the requested path
- * @param proxytunnel boolean if this is the request setting up a "proxy
- * tunnel"
+ * @param is_connect boolean if this is a CONNECT request
+ *        (where httpreq is HTTPREQ_GET since there is no HTTPREQ_CONNECT)
  *
  * @returns CURLcode
  */
@@ -190,9 +190,8 @@ CURLcode Curl_http_output_auth(struct Curl_easy *data,
                                const char *request,
                                Curl_HttpReq httpreq,
                                const char *path,
-                               bool proxytunnel); /* TRUE if this is
-                                                     the request setting up
-                                                     the proxy tunnel */
+                               const char *query,
+                               bool is_connect);
 
 /* Decode HTTP status code string. */
 CURLcode Curl_http_decode_status(int *pstatus, const char *s, size_t len);

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -1113,8 +1113,8 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
   Curl_strntoupper(&auth_headers[sizeof("Authorization: ") - 1],
                    curlx_str(&provider0), curlx_strlen(&provider0));
 
-  curlx_free(data->req.userpwd);
-  data->req.userpwd = auth_headers;
+  curlx_free(data->req.hd_auth);
+  data->req.hd_auth = auth_headers;
   data->state.authhost.done = TRUE;
   result = CURLE_OK;
 

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -91,7 +91,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
     return CURLE_NOT_BUILT_IN;
 #else
     digest = &data->state.proxydigest;
-    allocuserpwd = &data->req.proxyuserpwd;
+    allocuserpwd = &data->req.hd_proxy_auth;
     userp = data->state.aptr.proxyuser;
     passwdp = data->state.aptr.proxypasswd;
     authp = &data->state.authproxy;
@@ -99,7 +99,7 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
   }
   else {
     digest = &data->state.digest;
-    allocuserpwd = &data->req.userpwd;
+    allocuserpwd = &data->req.hd_auth;
     userp = data->state.aptr.user;
     passwdp = data->state.aptr.passwd;
     authp = &data->state.authhost;

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -217,13 +217,13 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
 
     if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-      curlx_free(data->req.proxyuserpwd);
-      data->req.proxyuserpwd = userp;
+      curlx_free(data->req.hd_proxy_auth);
+      data->req.hd_proxy_auth = userp;
 #endif
     }
     else {
-      curlx_free(data->req.userpwd);
-      data->req.userpwd = userp;
+      curlx_free(data->req.hd_auth);
+      data->req.hd_auth = userp;
     }
 
     curlx_free(base64);

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -139,7 +139,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 
   if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-    allocuserpwd = &data->req.proxyuserpwd;
+    allocuserpwd = &data->req.hd_proxy_auth;
     userp = data->state.aptr.proxyuser;
     passwdp = data->state.aptr.proxypasswd;
     service = data->set.str[STRING_PROXY_SERVICE_NAME] ?
@@ -152,7 +152,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 #endif
   }
   else {
-    allocuserpwd = &data->req.userpwd;
+    allocuserpwd = &data->req.hd_auth;
     userp = data->state.aptr.user;
     passwdp = data->state.aptr.passwd;
     service = data->set.str[STRING_SERVICE_NAME] ?

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -196,7 +196,7 @@ CURLcode Curl_http_proxy_create_CONNECT(struct httpreq **preq,
 
   /* Setup the proxy-authorization header, if any */
   result = Curl_http_output_auth(data, cf->conn, req->method, HTTPREQ_GET,
-                                 req->authority, TRUE);
+                                 req->authority, NULL, TRUE);
   if(result)
     goto out;
 
@@ -208,9 +208,9 @@ CURLcode Curl_http_proxy_create_CONNECT(struct httpreq **preq,
       goto out;
   }
 
-  if(data->req.proxyuserpwd) {
+  if(data->req.hd_proxy_auth) {
     result = Curl_dynhds_h1_cadd_line(&req->headers,
-                                      data->req.proxyuserpwd);
+                                      data->req.hd_proxy_auth);
     if(result)
       goto out;
   }

--- a/lib/request.c
+++ b/lib/request.c
@@ -65,9 +65,9 @@ CURLcode Curl_req_soft_reset(struct SingleRequest *req,
   req->httpversion = 0;
   req->sendbuf_hds_len = 0;
 
-  curlx_safefree(req->userpwd);
+  curlx_safefree(req->hd_auth);
 #ifndef CURL_DISABLE_PROXY
-  curlx_safefree(req->proxyuserpwd);
+  curlx_safefree(req->hd_proxy_auth);
 #endif
 
   result = Curl_client_start(data);
@@ -115,9 +115,9 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   struct curltime t0 = { 0, 0 };
 
   curlx_safefree(req->newurl);
-  curlx_safefree(req->userpwd);
+  curlx_safefree(req->hd_auth);
 #ifndef CURL_DISABLE_PROXY
-  curlx_safefree(req->proxyuserpwd);
+  curlx_safefree(req->hd_proxy_auth);
 #endif
 #ifndef CURL_DISABLE_COOKIES
   curlx_safefree(req->cookiehost);
@@ -175,9 +175,9 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
 void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
 {
   curlx_safefree(req->newurl);
-  curlx_safefree(req->userpwd);
+  curlx_safefree(req->hd_auth);
 #ifndef CURL_DISABLE_PROXY
-  curlx_safefree(req->proxyuserpwd);
+  curlx_safefree(req->hd_proxy_auth);
 #endif
   if(req->sendbuf_init)
     Curl_bufq_free(&req->sendbuf);

--- a/lib/request.h
+++ b/lib/request.h
@@ -116,7 +116,7 @@ struct SingleRequest {
 
   char *hd_auth;      /* Authorization header, full HTTP/1.x line */
 #ifndef CURL_DISABLE_PROXY
-  char *hd_proxy_auth; /* ProxyAuthorization header, full HTTP/1.x line */
+  char *hd_proxy_auth; /* Proxy-Authorization header, full HTTP/1.x line */
 #endif
 #ifndef CURL_DISABLE_COOKIES
   char *cookiehost;

--- a/lib/request.h
+++ b/lib/request.h
@@ -114,9 +114,9 @@ struct SingleRequest {
                        wanted */
   uint8_t io_flags; /* REQ_IO_RECV | REQ_IO_SEND */
 
-  char *userpwd;      /* auth header */
+  char *hd_auth;      /* Authorization header, full HTTP/1.x line */
 #ifndef CURL_DISABLE_PROXY
-  char *proxyuserpwd; /* proxy auth header */
+  char *hd_proxy_auth; /* ProxyAuthorization header, full HTTP/1.x line */
 #endif
 #ifndef CURL_DISABLE_COOKIES
   char *cookiehost;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -288,8 +288,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   const char *p_stream_uri = NULL;
   const char *p_transport = NULL;
   const char *p_uagent = NULL;
-  const char *p_proxyuserpwd = NULL;
-  const char *p_userpwd = NULL;
+  const char *p_hd_proxy_auth = NULL;
+  const char *p_hd_auth = NULL;
 
   *done = TRUE;
   if(!rtsp)
@@ -442,14 +442,14 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
 
   /* setup the authentication headers */
   result = Curl_http_output_auth(data, conn, p_request, HTTPREQ_GET,
-                                 p_stream_uri, FALSE);
+                                 p_stream_uri, NULL, FALSE);
   if(result)
     goto out;
 
 #ifndef CURL_DISABLE_PROXY
-  p_proxyuserpwd = data->req.proxyuserpwd;
+  p_hd_proxy_auth = data->req.hd_proxy_auth;
 #endif
-  p_userpwd = data->req.userpwd;
+  p_hd_auth = data->req.hd_auth;
 
   /* Referrer */
   curlx_safefree(data->state.aptr.ref);
@@ -520,8 +520,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                           "%s" /* range */
                           "%s" /* referrer */
                           "%s" /* user-agent */
-                          "%s" /* proxyuserpwd */
-                          "%s" /* userpwd */
+                          "%s" /* hd_proxy_auth */
+                          "%s" /* hd_auth */
                           ,
                           p_transport ? p_transport : "",
                           p_accept ? p_accept : "",
@@ -529,8 +529,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                           p_range ? p_range : "",
                           p_referrer ? p_referrer : "",
                           p_uagent ? p_uagent : "",
-                          p_proxyuserpwd ? p_proxyuserpwd : "",
-                          p_userpwd ? p_userpwd : "");
+                          p_hd_proxy_auth ? p_hd_proxy_auth : "",
+                          p_hd_auth ? p_hd_auth : "");
 
   if(result)
     goto out;


### PR DESCRIPTION
- rename `req->proxyuserpwd` to `req->hd_proxy_auth`
- rename `req->userpwd` to `req->hd_auth`
- rename parameter `proxytunnel` to `is_connect` for Curl_http_output_auth()
- move path+query concatenation into Curl_http_output_auth(), saving an alloc when no auth is in play
- rename `H1_HD_USER_AUTH` into `H1_HD_AUTH`