### PR TITLE
tool1622: assert width and exact format boundaries

### DIFF
--- a/tests/tunit/tool1622.c
+++ b/tests/tunit/tool1622.c
@@ -40,14 +40,34 @@ static CURLcode test_tool1622(const char *arg)
     1099445657078333,
     0 /* end of list */
   };
+  struct exactcase {
+    curl_off_t value;
+    const char *output;
+  };
+  static const struct exactcase timecases[] = {
+    { 0, "        " },
+    { 1, "00:00:01" },
+    { 524287, "  6d 01h" },
+    { 134217727, " 51m 23d" },
+    { 4294967295, "    136y" },
+    { 4398046511103, " >99999y" },
+    { 0, NULL }
+  };
+  static const struct exactcase datacases[] = {
+    { 0, "    0" },
+    { 99999, "99999" },
+    { 100000, "97.6k" },
+    { 131072, " 128k" },
+    { 12645826, "12.0M" },
+    { 1099445657078333, " 999T" },
+    { 0, NULL }
+  };
 
   puts("timebuf");
   for(i = 0, secs = 0; i < 63; i++) {
     timebuf(buffer, sizeof(buffer), secs);
     curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
-    if(strlen(buffer) != 8) {
-      curl_mprintf("^^ was too long!\n");
-    }
+    fail_unless(strlen(buffer) == 8, "timebuf output width");
     secs *= 2;
     secs++;
   }
@@ -55,9 +75,7 @@ static CURLcode test_tool1622(const char *arg)
   for(i = 0, secs = 0; i < 63; i++) {
     max5data(secs, buffer, sizeof(buffer));
     curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
-    if(strlen(buffer) != 5) {
-      curl_mprintf("^^ was too long!\n");
-    }
+    fail_unless(strlen(buffer) == 5, "max5data output width");
     secs *= 2;
     secs++;
   }
@@ -65,9 +83,15 @@ static CURLcode test_tool1622(const char *arg)
     secs = check[i];
     max5data(secs, buffer, sizeof(buffer));
     curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
-    if(strlen(buffer) != 5) {
-      curl_mprintf("^^ was too long!\n");
-    }
+    fail_unless(strlen(buffer) == 5, "max5data check output width");
+  }
+  for(i = 0; timecases[i].output; i++) {
+    timebuf(buffer, sizeof(buffer), timecases[i].value);
+    fail_unless(!strcmp(buffer, timecases[i].output), timecases[i].output);
+  }
+  for(i = 0; datacases[i].output; i++) {
+    max5data(datacases[i].value, buffer, sizeof(buffer));
+    fail_unless(!strcmp(buffer, datacases[i].output), datacases[i].output);
   }
 
   UNITTEST_END_SIMPLE


### PR DESCRIPTION
The width checks in the timebuf and max5data loops printed
"^^ was too long!" but never failed the test, so a regression in
output width would not be caught by unit1622.

This converts those checks to fail_unless assertions and adds two
small exact-output tables that probe format-transition boundaries
the geometric sweep can step over (suffix kick-in at 100000 for
max5data; 6d/01h, 51m, 136y, and >99999y roll points for timebuf).

Test-only; no production change. tests/data/test1622 unchanged.