### PR TITLE
url: remove ssh_config_matches

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -682,19 +682,6 @@ CURLcode Curl_conn_upkeep(struct Curl_easy *data,
   return result;
 }
 
-#ifdef USE_SSH
-static bool ssh_config_matches(struct connectdata *one,
-                               struct connectdata *two)
-{
-  struct ssh_conn *sshc1, *sshc2;
-
-  sshc1 = Curl_conn_meta_get(one, CURL_META_SSH_CONN);
-  sshc2 = Curl_conn_meta_get(two, CURL_META_SSH_CONN);
-  return sshc1 && sshc2 && Curl_safecmp(sshc1->rsa, sshc2->rsa) &&
-         Curl_safecmp(sshc1->rsa_pub, sshc2->rsa_pub);
-}
-#endif
-
 struct url_conn_match {
   struct connectdata *found;
   struct Curl_easy *data;
@@ -947,12 +934,6 @@ static bool url_match_proto_config(struct connectdata *conn,
   if(!url_match_http_version(conn, m))
     return FALSE;
 
-#ifdef USE_SSH
-  if(get_protocol_family(m->needle->scheme) & PROTO_FAMILY_SSH) {
-    if(!ssh_config_matches(m->needle, conn))
-      return FALSE;
-  }
-#endif
 #ifndef CURL_DISABLE_FTP
   else if(get_protocol_family(m->needle->scheme) & PROTO_FAMILY_FTP) {
     if(!ftp_conns_match(m->needle, conn))


### PR DESCRIPTION
The CURLOPT_SSH_HOST_PUBLIC_KEY_* options are documented to verify the host at connect time and not for connection reuse. Once the SSH host has been deemed okay, it remains okay as long as the connection survives.

In addition: this function currently always returned TRUE since the pointers have been NULLed in the SSH backend code before this function is called.

Follow-up to c31fcf2decfbf1259cc1f31

Reported-by: Andrew Nesbit