### PR TITLE
tool_urlglob: avoid overflow at end of range

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -320,7 +320,8 @@ static CURLcode glob_range(struct URLGlob *glob, const char **patternp,
 
     if(!step_n ||
        (min_n == max_n && step_n != 1) ||
-       (min_n != max_n && (min_n > max_n || step_n > (max_n - min_n))))
+       (min_n != max_n && (min_n > max_n || step_n > (max_n - min_n))) ||
+       ((CURL_OFF_T_MAX - step_n) < max_n))
       /* the pattern is not well-formed */
       return globerror(glob, "bad range", *posp, CURLE_URL_MALFORMAT);
 

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -325,8 +325,6 @@ static CURLcode glob_range(struct URLGlob *glob, const char **patternp,
       /* the pattern is not well-formed */
       return globerror(glob, "bad range", *posp, CURLE_URL_MALFORMAT);
 
-    /* typecasting to ints are fine here since we make sure above that we
-       are within 31 bits */
     pat->c.num.idx = pat->c.num.min = min_n;
     pat->c.num.max = max_n;
     pat->c.num.step = step_n;

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -320,10 +320,13 @@ static CURLcode glob_range(struct URLGlob *glob, const char **patternp,
 
     if(!step_n ||
        (min_n == max_n && step_n != 1) ||
-       (min_n != max_n && (min_n > max_n || step_n > (max_n - min_n))) ||
-       ((CURL_OFF_T_MAX - step_n) < max_n))
+       (min_n != max_n && (min_n > max_n || step_n > (max_n - min_n))))
       /* the pattern is not well-formed */
       return globerror(glob, "bad range", *posp, CURLE_URL_MALFORMAT);
+
+    if((CURL_OFF_T_MAX - step_n) < max_n)
+      return globerror(glob, "range end/step overflow", *posp,
+                       CURLE_URL_MALFORMAT);
 
     pat->c.num.idx = pat->c.num.min = min_n;
     pat->c.num.max = max_n;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -256,7 +256,7 @@ test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
-test2088 test2089 test2090 test2091 \
+test2088 test2089 test2090 test2091 test2092 \
 test2100 test2101 test2102 test2103 test2104 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \

--- a/tests/data/test2092
+++ b/tests/data/test2092
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+globbing
+</keywords>
+</info>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+glob range that ends with 9223372036854775807
+</name>
+<command>
+"%HOSTIP:%HTTPPORT/[0-1][9223372036854775806-9223372036854775807]/%TESTNUMBER"
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+3
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Due to how the range span globbing code works, a range that ends with 9223372036854775807 (the maximum signed 63 bit value) cannot be used as it triggers an integer overflow.

Verified in test 2092

Reported-by: Andrew Nesbit