### PR TITLE
x509asn1: fix operator order in do_pubkey

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -1013,7 +1013,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum, const char *algo,
       return 1;
 
     /* Compute key length. */
-    for(q = elem.beg; !*q && q < elem.end; q++)
+    for(q = elem.beg; q < elem.end && !*q; q++)
       ;
     len = ((elem.end - q) * 8);
     if(len) {


### PR DESCRIPTION
Check the range before reading data, as it would otherwise read one byte too many.

Reported-by: Andrew Nesbit