### PR TITLE
schannel_verify: avoid out of blob access

### DIFF
--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -92,11 +92,6 @@ struct cert_chain_engine_config_win7 {
   HCERTSTORE hExclusiveTrustedPeople;
 };
 
-static int is_cr_or_lf(char c)
-{
-  return c == '\r' || c == '\n';
-}
-
 /* Search the substring needle,needlelen into string haystack,haystacklen
  * Strings do not need to be terminated by a '\0'.
  * Similar of macOS/Linux memmem (not available on Visual Studio).
@@ -134,10 +129,11 @@ static CURLcode add_certs_data_to_store(HCERTSTORE trust_store,
 
   while(more_certs && (current_ca_file_ptr < ca_buffer_limit)) {
     const char *begin_cert_ptr = c_memmem(current_ca_file_ptr,
-                                          ca_buffer_limit-current_ca_file_ptr,
+                                          ca_buffer_limit -
+                                          current_ca_file_ptr - 1,
                                           BEGIN_CERT,
                                           begin_cert_len);
-    if(!begin_cert_ptr || !is_cr_or_lf(begin_cert_ptr[begin_cert_len])) {
+    if(!begin_cert_ptr || !ISNEWLINE(begin_cert_ptr[begin_cert_len])) {
       more_certs = 0;
     }
     else {


### PR DESCRIPTION
The code would previously read one byte past the provided CURLOPT_CAINFO_BLOB if the blob ends exactly with -----BEGIN CERTIFICATE-----

Reported-by: Andrew Nesbit