### PR TITLE
event: fix wakeup consumption

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2703,6 +2703,11 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
   Curl_uint32_bset_remove(&multi->dirty, data->mid);
 
   if(data == multi->admin) {
+#ifdef ENABLE_WAKEUP
+    /* Consume any pending wakeup signals before processing.
+     * This is necessary for event based processing. See #21547 */
+    (void)Curl_wakeup_consume(multi->wakeup_pair, TRUE);
+#endif
 #ifdef USE_RESOLV_THREADED
     Curl_async_thrdd_multi_process(multi);
 #endif


### PR DESCRIPTION
The events on a multi wakeup socketpair were only consumed via curl_multi_poll()/curl_multi_wait() but not in event based processing on a curl_multi_socket() call. That led to busy loops as reported in #21547.