### PR TITLE
hostip: remove unused MAX_HOSTCACHE_LEN and MAX_DNS_CACHE_SIZE

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -70,10 +70,6 @@
 #define USE_ALARM_TIMEOUT
 #endif
 
-#define MAX_HOSTCACHE_LEN (255 + 7) /* max FQDN + colon + port number + zero */
-
-#define MAX_DNS_CACHE_SIZE 29999
-
 #define RESOLV_FAIL(for_proxy) \
   ((for_proxy) ? CURLE_COULDNT_RESOLVE_PROXY : CURLE_COULDNT_RESOLVE_HOST)
 


### PR DESCRIPTION
These macros are leftovers from 96d5b5c688 (`dnscache: own source file, improvements`) which split DNS caching out of hostip.c into lib/dnscache.c. Both macros are still defined and used in dnscache.c; the copies in hostip.c are no longer referenced anywhere.

Detected by building with clang `-Wunused-macros` on macOS.