### PR TITLE
idn: replace header guards with forward declaration

### DIFF
--- a/lib/idn.h
+++ b/lib/idn.h
@@ -25,19 +25,16 @@
  ***************************************************************************/
 
 struct Curl_str;
+struct hostname;
 
 bool Curl_is_ASCII_name(const char *hostname);
 bool Curl_is_ASCII_str(struct Curl_str *s);
 
-#ifdef HEADER_CURL_URLDATA_H /* HACK */
 CURLcode Curl_idnconvert_hostname(struct hostname *host);
-#endif
 
 #if defined(USE_LIBIDN2) || defined(USE_WIN32_IDN) || defined(USE_APPLE_IDN)
 #define USE_IDN
-#ifdef HEADER_CURL_URLDATA_H /* HACK */
 void Curl_free_idnconverted_hostname(struct hostname *host);
-#endif
 CURLcode Curl_idn_decode(const char *input, char **output);
 CURLcode Curl_idn_encode(const char *puny, char **output);
 #else


### PR DESCRIPTION
Follow-up to bc40e09f63889a8bc14fa8f7221921eb5b4a559e #21472
