### PR TITLE
GHA: enable `-Wunused-macros` in clang-tidy jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -321,6 +321,7 @@ jobs:
             install_steps: skiprun mbedtls-latest-intel rustls wolfssl-opensslextra-intel
             install_steps_brew: openssl@4 gsasl
             CC: clang-20
+            CFLAGS: -Wunused-macros
             LDFLAGS: >-
               -Wl,-rpath,/home/runner/wolfssl-opensslextra/lib
               -Wl,-rpath,/home/runner/mbedtls/lib
@@ -345,6 +346,7 @@ jobs:
             install_steps: skiprun
             install_steps_brew: libngtcp2 libnghttp3 c-ares
             CC: clang-20
+            CFLAGS: -Wunused-macros
             LDFLAGS: >-
               -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl/lib
               -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libngtcp2/lib

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -300,6 +300,7 @@ jobs:
             compiler: clang
             install: llvm gnutls nettle libressl krb5 mbedtls gsasl rustls-ffi libssh fish
             install_steps: skiprun
+            CFLAGS: -Wunused-macros
             chkprefill: _chkprefill
             generate: >-
               -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/libressl -DCURL_DEFAULT_SSL_BACKEND=openssl
@@ -316,6 +317,7 @@ jobs:
             compiler: clang
             install: llvm libnghttp3 libngtcp2 openldap krb5
             install_steps: skipall
+            CFLAGS: -Wunused-macros
             generate: >-
               -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON
               -DLDAP_INCLUDE_DIR=/opt/homebrew/opt/openldap/include
@@ -445,6 +447,7 @@ jobs:
 
       - name: 'configure'
         env:
+          CFLAGS: '${{ matrix.build.CFLAGS }}'
           MATRIX_CHKPREFILL: '${{ matrix.build.chkprefill }}'
           MATRIX_CONFIGURE: '${{ matrix.build.configure }}'
           MATRIX_GENERATE: '${{ matrix.build.generate }}'
@@ -479,7 +482,6 @@ jobs:
               false
             fi
           else
-            export CFLAGS
             if [[ "${MATRIX_COMPILER}" = 'llvm'* ]]; then
               options+=" --target=$(uname -m)-apple-darwin"
             fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -390,7 +390,7 @@ jobs:
               [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
               cmake -B "bld${_chkprefill}" -G Ninja ${options} \
                 -DCMAKE_INSTALL_PREFIX="${HOME}"/curl-install \
-                -DCMAKE_C_FLAGS="${CFLAGS_CMAKE} ${CPPFLAGS}" \
+                -DCMAKE_C_FLAGS="${CFLAGS_CMAKE} ${CPPFLAGS} -Wunused-macros" \
                 -DCMAKE_BUILD_TYPE="${MATRIX_TYPE}" \
                 -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=30 \
                 -DCURL_WERROR=ON \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -390,7 +390,7 @@ jobs:
               [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
               cmake -B "bld${_chkprefill}" -G Ninja ${options} \
                 -DCMAKE_INSTALL_PREFIX="${HOME}"/curl-install \
-                -DCMAKE_C_FLAGS="${CFLAGS_CMAKE} ${CPPFLAGS} -Wunused-macros" \
+                -DCMAKE_C_FLAGS="${CFLAGS_CMAKE} ${CPPFLAGS}" \
                 -DCMAKE_BUILD_TYPE="${MATRIX_TYPE}" \
                 -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=30 \
                 -DCURL_WERROR=ON \
@@ -784,7 +784,7 @@ jobs:
         include:
           - { build: 'autotools', compiler: 'gcc' }
           - { build: 'cmake'    , compiler: 'gcc' }
-          - { build: 'cmake'    , compiler: 'clang-tidy', install_packages: 'clang-20 clang-tidy-20' }
+          - { build: 'cmake'    , compiler: 'clang-tidy', install_packages: 'clang-20 clang-tidy-20', CFLAGS: '-Wunused-macros' }
     steps:
       - name: 'install packages'
         timeout-minutes: 2
@@ -803,6 +803,8 @@ jobs:
         run: autoreconf -fi
 
       - name: 'configure'
+        env:
+          CFLAGS: '${{ matrix.CFLAGS }}'
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             if [ "${MATRIX_COMPILER}" = 'clang-tidy' ]; then

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -100,10 +100,10 @@ const char * const Curl_month[] = {
 
 #if SIZEOF_TIME_T < 5
 #define PARSEDATE_LATER  1
-#ifdef HAVE_TIME_T_UNSIGNED
+#endif
+#if SIZEOF_TIME_T < 5 || defined(HAVE_TIME_T_UNSIGNED)
 #define PARSEDATE_SOONER 2
-#endif /* HAVE_TIME_T_UNSIGNED */
-#endif /* SIZEOF_TIME_T < 5 */
+#endif
 
 static const char * const weekday[] = {
   "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -98,8 +98,12 @@ const char * const Curl_month[] = {
 
 #ifndef CURL_DISABLE_PARSEDATE
 
+#if SIZEOF_TIME_T < 5
 #define PARSEDATE_LATER  1
+#ifdef HAVE_TIME_T_UNSIGNED
 #define PARSEDATE_SOONER 2
+#endif /* HAVE_TIME_T_UNSIGNED */
+#endif /* SIZEOF_TIME_T < 5 */
 
 static const char * const weekday[] = {
   "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -98,16 +98,14 @@ CURLcode ws_recv_pong(CURL *curl, const char *expected_payload);
 void ws_close(CURL *curl);  /* just close the connection */
 #endif
 
-#ifndef UNITTESTS
-
 /*
  * TEST_ERR_* values must within the CURLcode range to not cause compiler
  * errors.
  *
  * For portability reasons TEST_ERR_* values should be less than 127.
  */
-
 #define TEST_ERR_MAJOR_BAD    CURLE_OBSOLETE20
+#ifndef UNITTESTS
 #define TEST_ERR_RUNS_FOREVER CURLE_OBSOLETE24
 #define TEST_ERR_EASY_INIT    CURLE_OBSOLETE29
 #define TEST_ERR_MULTI        CURLE_OBSOLETE32

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -108,7 +108,9 @@ void ws_close(CURL *curl);  /* just close the connection */
  *
  * For portability reasons TEST_ERR_* values should be less than 127.
  */
+#if !defined(UNITTESTS) || defined(BUILDING_LIBCURL)
 #define TEST_ERR_MAJOR_BAD    CURLE_OBSOLETE20
+#endif
 #ifndef UNITTESTS
 #define TEST_ERR_RUNS_FOREVER CURLE_OBSOLETE24
 #define TEST_ERR_EASY_INIT    CURLE_OBSOLETE29
@@ -555,6 +557,8 @@ void ws_close(CURL *curl);  /* just close the connection */
 
 #endif /* !UNITTESTS */
 
+#if !defined(UNITTESTS) || defined(BUILDING_LIBCURL)
+
 /* ---------------------------------------------------------------- */
 
 #define exe_global_init(A, Y, Z)                        \
@@ -581,5 +585,7 @@ void ws_close(CURL *curl);  /* just close the connection */
 
 #define global_init(A) \
   chk_global_init(A, __FILE__, __LINE__)
+
+#endif /* !UNITTESTS || BUILDING_LIBCURL */
 
 #endif /* HEADER_LIBTEST_FIRST_H */

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -544,6 +544,17 @@ void ws_close(CURL *curl);  /* just close the connection */
 #define abort_on_test_timeout_custom(T) \
   chk_test_timedout(T, __FILE__, __LINE__)
 
+#define NUM_HANDLES 4  /* global default */
+
+#define NO_SUPPORT_BUILT_IN                     \
+  {                                             \
+    (void)URL;                                  \
+    curl_mfprintf(stderr, "Missing support\n"); \
+    return CURLE_UNSUPPORTED_PROTOCOL;          \
+  }
+
+#endif /* UNITTESTS */
+
 /* ---------------------------------------------------------------- */
 
 #define exe_global_init(A, Y, Z)                        \
@@ -573,16 +584,5 @@ void ws_close(CURL *curl);  /* just close the connection */
 
 #define global_init(A) \
   chk_global_init(A, __FILE__, __LINE__)
-
-#define NO_SUPPORT_BUILT_IN                     \
-  {                                             \
-    (void)URL;                                  \
-    curl_mfprintf(stderr, "Missing support\n"); \
-    return CURLE_UNSUPPORTED_PROTOCOL;          \
-  }
-
-#define NUM_HANDLES 4  /* global default */
-
-#endif /* UNITTESTS */
 
 #endif /* HEADER_LIBTEST_FIRST_H */

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -548,13 +548,6 @@ void ws_close(CURL *curl);  /* just close the connection */
 
 #define NUM_HANDLES 4  /* global default */
 
-#define NO_SUPPORT_BUILT_IN                     \
-  {                                             \
-    (void)URL;                                  \
-    curl_mfprintf(stderr, "Missing support\n"); \
-    return CURLE_UNSUPPORTED_PROTOCOL;          \
-  }
-
 #endif /* UNITTESTS */
 
 /* ---------------------------------------------------------------- */

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -58,12 +58,14 @@ extern int unitfail; /* for unittests */
 #include <sys/select.h>
 #endif
 
+#ifndef UNITTESTS
 #define test_setopt(A, B, C)            \
   do {                                  \
     result = curl_easy_setopt(A, B, C); \
     if(result != CURLE_OK)              \
       goto test_cleanup;                \
   } while(0)
+#endif /* !UNITTESTS */
 
 #if 0
 #define test_multi_setopt(A, B, C)       \
@@ -548,7 +550,10 @@ void ws_close(CURL *curl);  /* just close the connection */
 
 #define NUM_HANDLES 4  /* global default */
 
-#endif /* UNITTESTS */
+#define res_global_init(A) \
+  exe_global_init(A, __FILE__, __LINE__)
+
+#endif /* !UNITTESTS */
 
 /* ---------------------------------------------------------------- */
 
@@ -563,9 +568,6 @@ void ws_close(CURL *curl);  /* just close the connection */
       result = ec;                                      \
     }                                                   \
   } while(0)
-
-#define res_global_init(A) \
-  exe_global_init(A, __FILE__, __LINE__)
 
 #define chk_global_init(A, Y, Z) \
   do {                           \

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -236,8 +236,10 @@ void ws_close(CURL *curl);  /* just close the connection */
     }                                                    \
   } while(0)
 
+#if 0
 #define res_multi_setopt(A, B, C) \
   exe_multi_setopt(A, B, C, __FILE__, __LINE__)
+#endif
 
 #define chk_multi_setopt(A, B, C, Y, Z) \
   do {                                  \
@@ -290,8 +292,10 @@ void ws_close(CURL *curl);  /* just close the connection */
     }                                                           \
   } while(0)
 
+#if 0
 #define res_multi_remove_handle(A, B) \
   exe_multi_remove_handle(A, B, __FILE__, __LINE__)
+#endif
 
 #define chk_multi_remove_handle(A, B, Y, Z) \
   do {                                      \
@@ -456,6 +460,7 @@ void ws_close(CURL *curl);  /* just close the connection */
 #define res_multi_wakeup(A) \
   exe_multi_wakeup(A, __FILE__, __LINE__)
 
+#if 0
 #define chk_multi_wakeup(A, Y, Z) \
   do {                            \
     exe_multi_wakeup(A, Y, Z);    \
@@ -465,6 +470,7 @@ void ws_close(CURL *curl);  /* just close the connection */
 
 #define multi_wakeup(A) \
   chk_multi_wakeup(A, __FILE__, __LINE__)
+#endif
 
 /* ---------------------------------------------------------------- */
 
@@ -518,8 +524,10 @@ void ws_close(CURL *curl);  /* just close the connection */
 #define res_test_timedout() \
   exe_test_timedout(TEST_HANG_TIMEOUT, __FILE__, __LINE__)
 
+#if 0
 #define res_test_timedout_custom(T) \
   exe_test_timedout(T, __FILE__, __LINE__)
+#endif
 
 #define chk_test_timedout(T, Y, Z) \
   do {                             \

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -98,6 +98,8 @@ CURLcode ws_recv_pong(CURL *curl, const char *expected_payload);
 void ws_close(CURL *curl);  /* just close the connection */
 #endif
 
+#ifndef UNITTESTS
+
 /*
  * TEST_ERR_* values must within the CURLcode range to not cause compiler
  * errors.
@@ -580,5 +582,7 @@ void ws_close(CURL *curl);  /* just close the connection */
   }
 
 #define NUM_HANDLES 4  /* global default */
+
+#endif /* UNITTESTS */
 
 #endif /* HEADER_LIBTEST_FIRST_H */

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -65,12 +65,14 @@ extern int unitfail; /* for unittests */
       goto test_cleanup;                \
   } while(0)
 
+#if 0
 #define test_multi_setopt(A, B, C)       \
   do {                                   \
     result = curl_multi_setopt(A, B, C); \
     if(result != CURLE_OK)               \
       goto test_cleanup;                 \
   } while(0)
+#endif
 
 extern const char *libtest_arg2; /* set by first.c to the argv[2] or NULL */
 extern const char *libtest_arg3; /* set by first.c to the argv[3] or NULL */
@@ -430,8 +432,10 @@ void ws_close(CURL *curl);  /* just close the connection */
     }                                                           \
   } while(0)
 
+#if 0
 #define res_multi_poll(A, B, C, D, E) \
   exe_multi_poll(A, B, C, D, E, __FILE__, __LINE__)
+#endif
 
 #define chk_multi_poll(A, B, C, D, E, Y, Z) \
   do {                                      \

--- a/tests/libtest/lib1912.c
+++ b/tests/libtest/lib1912.c
@@ -23,16 +23,17 @@
  ***************************************************************************/
 #include "first.h"
 
-#define print_err(name, exp)                                            \
-  curl_mfprintf(stderr, "Type mismatch for CURLOPT_%s (expected %s)\n", \
-                name, exp)
-
 static CURLcode test_lib1912(const char *URL)
 {
 /* Only test if GCC/clang type checking is available */
   int error = 0;
 #ifdef CURLINC_TYPECHECK_GCC_H
   const struct curl_easyoption *o;
+
+#define print_err(name, exp)                                            \
+  curl_mfprintf(stderr, "Type mismatch for CURLOPT_%s (expected %s)\n", \
+                name, exp)
+
   for(o = curl_easy_option_next(NULL); o; o = curl_easy_option_next(o)) {
     /* Test for mismatch OR missing typecheck macros */
     if(curlcheck_long_option(o->id) !=

--- a/tests/libtest/lib2301.c
+++ b/tests/libtest/lib2301.c
@@ -97,6 +97,8 @@ static CURLcode test_lib2301(const char *URL)
   curl_global_cleanup();
   return result;
 #else
-  NO_SUPPORT_BUILT_IN
+  (void)URL;
+  curl_mfprintf(stderr, "Missing support\n");
+  return CURLE_UNSUPPORTED_PROTOCOL;
 #endif
 }

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -125,6 +125,8 @@ static CURLcode test_lib2302(const char *URL)
   curl_global_cleanup();
   return result;
 #else
-  NO_SUPPORT_BUILT_IN
+  (void)URL;
+  curl_mfprintf(stderr, "Missing support\n");
+  return CURLE_UNSUPPORTED_PROTOCOL;
 #endif
 }

--- a/tests/libtest/lib2304.c
+++ b/tests/libtest/lib2304.c
@@ -85,6 +85,8 @@ static CURLcode test_lib2304(const char *URL)
   curl_global_cleanup();
   return result;
 #else
-  NO_SUPPORT_BUILT_IN
+  (void)URL;
+  curl_mfprintf(stderr, "Missing support\n");
+  return CURLE_UNSUPPORTED_PROTOCOL;
 #endif
 }

--- a/tests/libtest/lib2700.c
+++ b/tests/libtest/lib2700.c
@@ -249,6 +249,8 @@ test_cleanup:
   curl_global_cleanup();
   return result;
 #else
-  NO_SUPPORT_BUILT_IN
+  (void)URL;
+  curl_mfprintf(stderr, "Missing support\n");
+  return CURLE_UNSUPPORTED_PROTOCOL;
 #endif
 }

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -23,6 +23,8 @@
  ***************************************************************************/
 #include "first.h"
 
+#if defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT)
+
 #include "testutil.h"
 
 #define T518_SAFETY_MARGIN 16
@@ -35,8 +37,6 @@
 #else
 #define DEV_NULL "/dev/null"
 #endif
-
-#if defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT)
 
 static int *t518_testfd = NULL;
 static struct rlimit t518_num_open;

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -23,6 +23,8 @@
  ***************************************************************************/
 #include "first.h"
 
+#if defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT)
+
 #include "testutil.h"
 
 #define T537_SAFETY_MARGIN 11
@@ -32,8 +34,6 @@
 #else
 #define DEV_NULL "/dev/null"
 #endif
-
-#if defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT)
 
 static int *t537_testfd = NULL;
 static struct rlimit t537_num_open;

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -159,13 +159,17 @@ static int blob_add_qname(struct blob *b, const struct Curl_str *str)
 #define QTYPE_AAAA  28
 #define QTYPE_HTTPS 0x41
 
+#if 0
 #define HTTPS_RR_CODE_MANDATORY       0x00
+#endif
 #define HTTPS_RR_CODE_ALPN            0x01
 #define HTTPS_RR_CODE_NO_DEF_ALPN     0x02
+#if 0
 #define HTTPS_RR_CODE_PORT            0x03
 #define HTTPS_RR_CODE_IPV4            0x04
 #define HTTPS_RR_CODE_ECH             0x05
 #define HTTPS_RR_CODE_IPV6            0x06
+#endif
 
 static const char *type2string(uint16_t qtype)
 {

--- a/tests/unit/unit1307.c
+++ b/tests/unit/unit1307.c
@@ -43,8 +43,10 @@
 
 #define MAC_DIFFER    0x40
 #define MAC_SHIFT     16
+#if 0
 #define MAC_MATCH     ((CURL_FNMATCH_MATCH   << MAC_SHIFT) | MAC_DIFFER)
 #define MAC_NOMATCH   ((CURL_FNMATCH_NOMATCH << MAC_SHIFT) | MAC_DIFFER)
+#endif
 #define MAC_FAIL      ((CURL_FNMATCH_FAIL    << MAC_SHIFT) | MAC_DIFFER)
 
 static const char *ret2name(int i)

--- a/tests/unit/unit1666.c
+++ b/tests/unit/unit1666.c
@@ -190,8 +190,6 @@ static CURLcode test_unit1666(const char *arg)
   UNITTEST_END_SIMPLE
 }
 
-#undef OID
-
 #else
 
 static CURLcode test_unit1666(const char *arg)

--- a/tests/unit/unit1667.c
+++ b/tests/unit/unit1667.c
@@ -37,9 +37,6 @@ struct test_1667 {
   CURLcode result_exp;
 };
 
-/* the size of the object needs to deduct the null terminator */
-#define OID(x) x, sizeof(x) - 1
-
 static bool test1667(const struct test_1667 *spec, size_t i,
                      struct dynbuf *dbuf)
 {
@@ -325,8 +322,6 @@ static CURLcode test_unit1667(const char *arg)
 
   UNITTEST_END_SIMPLE
 }
-
-#undef OID
 
 #else
 


### PR DESCRIPTION
Also fix fallouts found.

Windows clang-tidy CI job is a little pickier than I'd prefer due to the
`_CURL_TESTS_CONCAT=ON` option used there, and all macros considered
local, thus checked by the compiler. Upside: it revealed macro usage
dynamics in tests. If too annoying, `first.h` may be opted-out from the
concat logic. Some macros may also be deleted instead of `#if 0`-ing.

Follow-up to e0e56e9ae434552bd6ac5570ed91483188d75788 #21550
Follow-up to 5fa5cb382560316a55f0954f1e8cebdbd6568cfb #20593
