### PR TITLE
tftp: stricter option name checks

### DIFF
--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -266,16 +266,19 @@ static CURLcode tftp_parse_option_ack(struct tftp_conn *state,
 
   while(tmp < ptr + len) {
     const char *option, *value;
+    size_t olen;
 
     tmp = tftp_option_get(tmp, ptr + len - tmp, &option, &value);
     if(!tmp) {
       failf(data, "Malformed ACK packet, rejecting");
       return CURLE_TFTP_ILLEGAL;
     }
+    olen = strlen(option);
 
     infof(data, "got option=(%s) value=(%s)", option, value);
 
-    if(checkprefix(TFTP_OPTION_BLKSIZE, option)) {
+    if((strlen(TFTP_OPTION_BLKSIZE) == olen) &&
+       checkprefix(TFTP_OPTION_BLKSIZE, option)) {
       curl_off_t blksize;
       if(curlx_str_number(&value, &blksize, TFTP_BLKSIZE_MAX)) {
         failf(data, "%s (%d)", "blksize is larger than max supported",
@@ -304,7 +307,8 @@ static CURLcode tftp_parse_option_ack(struct tftp_conn *state,
       infof(data, "blksize parsed from OACK (%u) requested (%u)",
             state->blksize, state->requested_blksize);
     }
-    else if(checkprefix(TFTP_OPTION_TSIZE, option)) {
+    else if((strlen(TFTP_OPTION_TSIZE) == olen) &&
+            checkprefix(TFTP_OPTION_TSIZE, option)) {
       curl_off_t tsize = 0;
       /* tsize should be ignored on upload: Who cares about the size of the
          remote file? */


### PR DESCRIPTION
Previously, the use of checkprefix() alone allowed the code to match not only on "blksize" but also (mistakenly) on "blksizeFOO" etc.

Reported-by: Andrew Nesbit