### PR TITLE
tool_urlglob: better 'Duplicate glob name' position

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -524,7 +524,7 @@ static CURLcode glob_parse(struct URLGlob *glob, const char *pattern,
           /* check that the name is not already used */
           struct URLPattern *p = glob_find_name(glob, &name);
           if(p)
-            return globerror(glob, "Duplicate glob name", 2 + start - ipattern,
+            return globerror(glob, "Duplicate glob name", pattern - ipattern,
                              CURLE_URL_MALFORMAT);
           pos += (pattern - start);
         }

--- a/tests/data/test2410
+++ b/tests/data/test2410
@@ -12,23 +12,20 @@ globbing
 
 # Client-side
 <client>
-<server>
-http
-</server>
 <name>
 duplicate named glob
 </name>
 <command option="no-output">
-"%HOSTIP:%HTTPPORT/{%LTtest%GTA,B}{%LTtest%GTC,D}" -o "%LOGDIR/dump"
+"https://dummy.example/{%LTtest%GTA,B}{%LTtest%GTC,D}" -o "%LOGDIR/dump"
 </command>
 </client>
 
 # Verify data after the test has been "shot"
 <verify>
 <stderr mode="text">
-curl: (3) Duplicate glob name in position 30:
-%HOSTIP:%HTTPPORT/{%LTtest%GTA,B}{%LTtest%GTC,D}
-                             ^
+curl: (3) Duplicate glob name in position 40:
+https://dummy.example/{%LTtest%GTA,B}{%LTtest%GTC,D}
+                                       ^
 </stderr>
 <errorcode>
 3


### PR DESCRIPTION
This now points to the point where the duplicate name ends, not where it starts, Also fixes test 2410 to use a fixed hostname so that the error position remains the same.

Reported-by: Viktor Szakats
Fixes #21567