### PR TITLE
VULN-DISCLOSURE-POLICY.md: remove lingering reference to reward

### DIFF
--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -248,8 +248,8 @@ already do much worse harm and the problem is not really in curl.
 ## Debug & Experiments
 
 Vulnerabilities in features which are off by default (in the build) and
-documented as experimental, or exist only in debug mode, are not eligible for a
-reward and we do not consider them security problems.
+documented as experimental, or exist only in debug mode, are not considered
+security problems.
 
 The same applies to scripts and software which are not installed by default
 through the make install rule.


### PR DESCRIPTION
The bug-bounty does not exist anymore.

Fixes #21571
Reported-by: Alan De Smet