### PR TITLE
VULN-DISCLOSURE-POLICY.md: remove mention of bug bounty reward

### DIFF
--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -248,8 +248,8 @@ already do much worse harm and the problem is not really in curl.
 ## Debug & Experiments
 
 Vulnerabilities in features which are off by default (in the build) and
-documented as experimental, or exist only in debug mode, are not eligible for a
-reward and we do not consider them security problems.
+documented as experimental, or exist only in debug mode, are not considered
+security problems.
 
 The same applies to scripts and software which are not installed by default
 through the make install rule.


### PR DESCRIPTION
Minor documentation cleanup. Details are described in the commit message, quote:

> As a follow-up to commits ca7ef4b817 ("BUG-BOUNTY.md: we stop the
> bug-bounty end of Jan 2026", 2026-01-22) and ed7bf43a08 ("BUG-BOUNTY.md:
> minor rephrase to say there is no bug bounty", 2026-03-10), remove a
> leftover mention of the reward for vulnerability reports, that no longer
> exists, in file `VULN-DISCLOSURE-POLICY.md`.