### PR TITLE
url: compare full origin when setting credentials

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -106,6 +106,7 @@
 #include "telnet.h"
 #include "tftp.h"
 #include "http.h"
+#include "vauth/vauth.h"
 #include "file.h"
 #include "curl_ldap.h"
 #include "vssh/ssh.h"
@@ -1439,8 +1440,7 @@ static CURLcode url_set_data_creds(struct Curl_easy *data,
       data->set.str[STRING_BEARER] ||
       data->set.str[STRING_SASL_AUTHZID] ||
       data->set.str[STRING_SERVICE_NAME]) &&
-     (data->set.allow_auth_to_other_hosts ||
-      Curl_peer_same_destination(data->state.initial_origin, conn->origin))) {
+     Curl_auth_allowed_to_origin(data, conn->origin)) {
     result = Curl_creds_create(data->set.str[STRING_USERNAME],
                                data->set.str[STRING_PASSWORD],
                                data->set.str[STRING_BEARER],

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -139,8 +139,14 @@ bool Curl_auth_user_contains_domain(struct Curl_creds *creds)
  */
 bool Curl_auth_allowed_to_host(struct Curl_easy *data)
 {
+  return Curl_auth_allowed_to_origin(data, data->conn->origin);
+}
+
+bool Curl_auth_allowed_to_origin(struct Curl_easy *data,
+                                 struct Curl_peer *origin)
+{
   return data->set.allow_auth_to_other_hosts ||
-         Curl_peer_equal(data->state.initial_origin, data->conn->origin);
+         Curl_peer_equal(data->state.initial_origin, origin);
 }
 
 #ifdef USE_NTLM

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -32,6 +32,7 @@
 struct Curl_easy;
 struct Curl_creds;
 struct connectdata;
+struct Curl_peer;
 
 #ifndef CURL_DISABLE_DIGEST_AUTH
 struct digestdata;
@@ -59,6 +60,8 @@ struct gsasldata;
  * "sensitive data" can (still) be sent to this host.
  */
 bool Curl_auth_allowed_to_host(struct Curl_easy *data);
+bool Curl_auth_allowed_to_origin(struct Curl_easy *data,
+                                 struct Curl_peer *origin);
 
 /* This is used to build an SPN string */
 #ifndef USE_WINDOWS_SSPI

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -282,7 +282,7 @@ test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
 test3024 test3025 test3026 test3027 test3028 test3029 test3030 test3031 \
 test3032 test3033 test3034 test3035 test3036 \
 \
-test3100 test3101 test3102 test3103 test3104 test3105 \
+test3100 test3101 test3102 test3103 test3104 test3105 test3106 \
 \
 test3200 test3201 test3202 test3203 test3204 test3205 test3206 test3207 \
 test3208 test3209 test3210 test3211 test3212 test3213 test3214 test3215 \

--- a/tests/data/test3106
+++ b/tests/data/test3106
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTPS
+HTTP proxy
+HTTP Basic auth
+followlocation
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<connect crlf="headers">
+HTTP/1.1 200 OK
+
+</connect>
+
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 302 Found
+Location: http://example.com:%HTTPSPORT/%TESTNUMBER0002
+Content-Length: 0
+
+</data>
+
+<data2 crlf="headers">
+HTTP/1.1 200 OK
+Content-Length: 2
+
+OK
+</data2>
+</reply>
+
+# Client-side
+<client>
+<features>
+SSL
+proxy
+</features>
+<server>
+https
+http-proxy
+</server>
+<name>
+HTTPS to HTTP redirect on same host and port without auth
+</name>
+<command>
+--insecure --location --user user:secret --proxy %HOSTIP:%PROXYPORT https://example.com:%HTTPSPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<proxy crlf="headers">
+CONNECT example.com:%HTTPSPORT HTTP/1.1
+Host: example.com:%HTTPSPORT
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+GET http://example.com:%HTTPSPORT/%TESTNUMBER0002 HTTP/1.1
+Host: example.com:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</proxy>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: example.com:%HTTPSPORT
+Authorization: Basic %b64[user:secret]b64%
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
When setting transfer credentials from options, use the full origin comparison instead of the destination-only comparison.

Problem:
- By default, option credentials are only supposed to be used for the initial origin unless unrestricted auth is enabled.
- A redirect can change scheme while keeping the same host and numeric port, for example from https://example.com:8443/ to http://example.com:8443/.
- Curl_peer_same_destination() ignores the scheme, so option credentials could remain available for that redirected request.
- Curl_peer_equal() includes the scheme and matches the origin check used elsewhere.

Test:
- Added test3106, which makes an HTTPS request with Basic auth through the test HTTP proxy, redirects to HTTP on the same host and port, and verifies that the redirected HTTP request does not include Authorization.