### PR TITLE
http: include Proxy-Authorization in custom-header redirect filter

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -153,6 +153,11 @@ Starting in 7.64.0, libcurl specifically prevents "Cookie:" headers from being
 sent to other hosts than the first used one, unless specifically permitted
 with the CURLOPT_UNRESTRICTED_AUTH(3) option.
 
+Starting in 8.21.0, libcurl specifically prevents "Proxy-Authorization:"
+headers from being forwarded to a redirected origin host (proxy
+authentication is unaffected), unless specifically permitted with the
+CURLOPT_UNRESTRICTED_AUTH(3) option.
+
 # DEFAULT
 
 NULL

--- a/lib/http.c
+++ b/lib/http.c
@@ -1846,6 +1846,15 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
                  other hosts */
               !Curl_auth_allowed_to_host(data))
         ;
+      else if(curlx_str_casecompare(&name, "Proxy-Authorization") &&
+#ifndef CURL_DISABLE_PROXY
+              /* only when this hop targets the origin server: the proxy
+                 itself is unchanged by an origin redirect and still needs
+                 the credential */
+              proxy == HEADER_SERVER &&
+#endif
+              !Curl_auth_allowed_to_host(data))
+        ;
       else if(blankheader)
         result = curlx_dyn_addf(req, "%.*s:\r\n", (int)curlx_strlen(&name),
                                 curlx_str(&name));

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -285,7 +285,7 @@ test3100 test3101 test3102 test3103 test3104 test3105 \
 \
 test3200 test3201 test3202 test3203 test3204 test3205 test3206 test3207 \
 test3208 test3209 test3210 test3211 test3212 test3213 test3214 test3215 \
-test3216 test3217 test3218 test3219 test3220 \
+test3216 test3217 test3218 test3219 test3220 test3221 test3222 test3223 \
 \
 test3300 test3301 test3302 \
 \

--- a/tests/data/test3221
+++ b/tests/data/test3221
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+followlocation
+--resolve
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now:%HTTPPORT/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+contents
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data2>
+
+<datacheck>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now:%HTTPPORT/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with custom Proxy-Authorization: stripped on cross-origin redirect (no proxy)
+</name>
+<command>
+--resolve first.host.it.is:%HTTPPORT:%HOSTIP --resolve goto.second.host.now:%HTTPPORT:%HOSTIP -H "Proxy-Authorization: Basic c2VjcmV0" --location http://first.host.it.is:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: first.host.it.is:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Authorization: Basic c2VjcmV0
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: goto.second.host.now:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test3222
+++ b/tests/data/test3222
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+followlocation
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+contents
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data2>
+
+<datacheck>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP through proxy keeps custom Proxy-Authorization: across cross-origin redirect
+</name>
+<command>
+http://first.host.it.is/we/want/that/page/%TESTNUMBER -x %HOSTIP:%HTTPPORT -H "Proxy-Authorization: Basic c2VjcmV0" --location
+</command>
+<features>
+proxy
+</features>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://first.host.it.is/we/want/that/page/%TESTNUMBER HTTP/1.1
+Host: first.host.it.is
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+Proxy-Authorization: Basic c2VjcmV0
+
+GET http://goto.second.host.now/%TESTNUMBER0002 HTTP/1.1
+Host: goto.second.host.now
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+Proxy-Authorization: Basic c2VjcmV0
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test3223
+++ b/tests/data/test3223
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+followlocation
+--resolve
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now:%HTTPPORT/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+contents
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data2>
+
+<datacheck>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now:%HTTPPORT/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with custom Proxy-Authorization: and --location-trusted to other origin
+</name>
+<command>
+--resolve first.host.it.is:%HTTPPORT:%HOSTIP --resolve goto.second.host.now:%HTTPPORT:%HOSTIP -H "Proxy-Authorization: Basic c2VjcmV0" --location-trusted http://first.host.it.is:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: first.host.it.is:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Authorization: Basic c2VjcmV0
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: goto.second.host.now:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Authorization: Basic c2VjcmV0
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
## Summary

A user-supplied `Proxy-Authorization:` custom header attached via
`CURLOPT_HTTPHEADER` / `-H` is stripped on a cross-origin redirect **only
when the next hop targets the origin server directly** (`HEADER_SERVER`
mode). When a proxy is in use the header is left intact — the proxy is
unchanged by an origin redirect and still needs the credential.

Matches the existing `Authorization:` (7.58.0) and `Cookie:` (7.64.0)
filters in spirit but with the narrower scope: those two are
origin-bound; `Proxy-Authorization:` is proxy-bound.

Unaffected by `CURLOPT_UNRESTRICTED_AUTH` / `--location-trusted`, and by
`--proxy-user` / `CURLOPT_PROXYUSERPWD` (separate path).

## Tests

- `test3221` (no proxy, `--location` cross-origin) → header stripped.
- `test3222` (`-x proxy`, `--location` cross-origin) → header kept
  (regression guard for proxy auth flows).
- `test3223` (no proxy, `--location-trusted`) → header forwarded.