### PR TITLE
CURLOPT_MAXFILESIZE: clarify this also works for on-going transfers

### DIFF
--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
@@ -34,12 +34,14 @@ Passing a zero *size* disables this, and passing a negative *size* yields a
 
 If you want a limit above 2GB, use CURLOPT_MAXFILESIZE_LARGE(3).
 
-If the size is known to be too big before the transfer starts, it aborts
-already there. If it is instead found too big while the transfer is going, it
-instead stops then.
+If the size is known to be too big before the transfer starts, libcurl
+aborts before starting the transfer. If it is instead found to be too big
+while the transfer is in progress, libcurl aborts the transfer once the
+received bytes exceed the limit.
 
-Since 8.20.0, this option also stops ongoing transfers that would reach this
-threshold due to automatic decompression using CURLOPT_ACCEPT_ENCODING(3).
+Since 8.20.0, this option also aborts ongoing transfers once the
+decompressed bytes exceed this threshold due to automatic decompression using
+CURLOPT_ACCEPT_ENCODING(3).
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
@@ -32,14 +32,11 @@ value, the transfer is aborted and *CURLE_FILESIZE_EXCEEDED* is returned.
 Passing a zero *size* disables this, and passing a negative *size* yields a
 *CURLE_BAD_FUNCTION_ARGUMENT*.
 
-The file size is not always known prior to the download start, and for such
-transfers this option has no effect - even if the file transfer eventually
-ends up being larger than this given limit.
-
 If you want a limit above 2GB, use CURLOPT_MAXFILESIZE_LARGE(3).
 
-Since 8.4.0, this option also stops ongoing transfers if they reach this
-threshold.
+If the size is known to be too big before the transfer starts, it aborts
+already there. If it is instead found too big while the transfer is going, it
+instead stops then.
 
 Since 8.20.0, this option also stops ongoing transfers that would reach this
 threshold due to automatic decompression using CURLOPT_ACCEPT_ENCODING(3).
@@ -67,6 +64,10 @@ int main(void)
 ~~~
 
 # %AVAILABILITY%
+
+# HISTORY
+
+Before curl 8.4.0, the limit was not applied to transfers in progress.
 
 # RETURN VALUE
 

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
@@ -35,9 +35,9 @@ value, the transfer is aborted and *CURLE_FILESIZE_EXCEEDED* is returned.
 Passing a zero *size* disables this, and passing a negative *size* yields a
 *CURLE_BAD_FUNCTION_ARGUMENT*.
 
-If the size is known to be too big before the transfer starts, it aborts
-already there. If it is instead found too big while the transfer is going, it
-instead stops then.
+If the size is known to exceed the limit before the transfer starts, libcurl
+aborts before starting the transfer. If the transfer instead exceeds the limit
+while it is in progress, libcurl aborts it at that point.
 
 Since 8.20.0, this option also stops ongoing transfers that would reach this
 threshold due to automatic decompression using CURLOPT_ACCEPT_ENCODING(3).

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
@@ -29,18 +29,15 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXFILESIZE_LARGE,
 
 # DESCRIPTION
 
-Pass a curl_off_t as parameter. This specifies the maximum accepted *size*
-(in bytes) of a file to download. If the file requested is found larger than
-this value, the transfer is aborted and *CURLE_FILESIZE_EXCEEDED* is
-returned. Passing a zero *size* disables this, and passing a negative *size*
-yields a *CURLE_BAD_FUNCTION_ARGUMENT*.
+Pass a curl_off_t as parameter. This specifies the maximum accepted *size* (in
+bytes) of a file to download. If the file requested is found larger than this
+value, the transfer is aborted and *CURLE_FILESIZE_EXCEEDED* is returned.
+Passing a zero *size* disables this, and passing a negative *size* yields a
+*CURLE_BAD_FUNCTION_ARGUMENT*.
 
-The file size is not always known prior to the download start, and for such
-transfers this option has no effect - even if the file transfer eventually
-ends up being larger than this given limit.
-
-Since 8.4.0, this option also stops ongoing transfers if they reach this
-threshold.
+If the size is known to be too big before the transfer starts, it aborts
+already there. If it is instead found too big while the transfer is going, it
+instead stops then.
 
 Since 8.20.0, this option also stops ongoing transfers that would reach this
 threshold due to automatic decompression using CURLOPT_ACCEPT_ENCODING(3).
@@ -69,6 +66,10 @@ int main(void)
 ~~~
 
 # %AVAILABILITY%
+
+# HISTORY
+
+Before curl 8.4.0, the limit was not applied to transfers in progress.
 
 # RETURN VALUE
 


### PR DESCRIPTION
It was not really clear, but it has worked like this since 8.4.0 which now is a while.