### PR TITLE
tool_urlglob: check glob use before access

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -716,7 +716,7 @@ CURLcode glob_match_url(char **output, const char *filename,
   while(*filename) {
     CURLcode result = CURLE_OK;
     struct URLPattern *pat = NULL;
-    if(*filename == '#' && ISDIGIT(filename[1])) {
+    if(glob_inuse(glob) && *filename == '#' && ISDIGIT(filename[1])) {
       /* a numbered glob reference */
       const char *ptr = filename++;
       curl_off_t num;


### PR DESCRIPTION
As this function can now be invoked with only the second glob "active", it must avoid accessing the first one if not in use.

Follow-up to 2238f0921cb00b3395847

Spotted by Codex Security