### PR TITLE
hardening: clear handles on cleanup

### DIFF
--- a/lib/curl_share.c
+++ b/lib/curl_share.c
@@ -61,7 +61,9 @@ static void share_destroy(struct Curl_share *share)
 #ifdef USE_MUTEX
   Curl_mutex_destroy(&share->lock);
 #endif
-  share->magic = 0;
+
+  /* clear everything */
+  memset(share, 0, sizeof(*share));
   curlx_free(share);
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2998,6 +2998,8 @@ CURLMcode curl_multi_cleanup(CURLM *m)
       Curl_close(&multi->admin);
     }
 
+    multi->magic = 0; /* not good anymore */
+
     Curl_multi_ev_cleanup(multi);
     Curl_hash_destroy(&multi->proto_hash);
     Curl_dnscache_destroy(&multi->dnscache);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2998,8 +2998,6 @@ CURLMcode curl_multi_cleanup(CURLM *m)
       Curl_close(&multi->admin);
     }
 
-    multi->magic = 0; /* not good anymore */
-
     Curl_multi_ev_cleanup(multi);
     Curl_hash_destroy(&multi->proto_hash);
     Curl_dnscache_destroy(&multi->dnscache);
@@ -3028,6 +3026,9 @@ CURLMcode curl_multi_cleanup(CURLM *m)
     Curl_uint32_bset_destroy(&multi->pending);
     Curl_uint32_bset_destroy(&multi->msgsent);
     Curl_uint32_tbl_destroy(&multi->xfers);
+
+    /* clear everything, including the magic number */
+    memset(multi, 0, sizeof(*multi));
     curlx_free(multi);
 
     return CURLM_OK;

--- a/lib/url.c
+++ b/lib/url.c
@@ -304,6 +304,9 @@ CURLcode Curl_close(struct Curl_easy **datap)
   Curl_freeset(data);
   Curl_headers_cleanup(data);
   Curl_netrc_cleanup(&data->state.netrc);
+
+  /* clear everything */
+  memset(data, 0, sizeof(*data));
   curlx_free(data);
   return CURLE_OK;
 }


### PR DESCRIPTION
When destroying an easy/multi/share handle, clear the handles' memory before freeing it. Before, we cleared only the magic numbers and that *should* suffice. But just in case, do a full wipe and make apps that do funny business more likely to fault.