### PR TITLE
pythonlint.sh: make it fail on error, fix ruff warnings in pytest

### DIFF
--- a/scripts/pythonlint.sh
+++ b/scripts/pythonlint.sh
@@ -27,6 +27,8 @@
 # locations, or all Python files found in the current directory tree by
 # default.
 
+set -eu
+
 ruff check --extend-select=B007,B016,C405,C416,COM818,D200,D213,D204,D401,\
 D415,FURB129,N818,PERF401,PERF403,PIE790,PIE808,PLW0127,Q004,RUF010,SIM101,\
 SIM117,SIM118,TRY400,TRY401,RET503,RET504,UP004,B018,B904,RSE102,RET505,I001 \

--- a/tests/http/test_21_resolve.py
+++ b/tests/http/test_21_resolve.py
@@ -30,7 +30,7 @@ from datetime import timedelta
 from typing import Generator
 
 import pytest
-from testenv import CurlClient, Env, LocalClient, Dnsd
+from testenv import CurlClient, Dnsd, Env, LocalClient
 
 log = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ class TestResolve:
         run_env = os.environ.copy()
         run_env['CURL_DNS_SERVER'] = f'127.0.0.1:{dnsd.port}'
         curl = CurlClient(env=env, run_env=run_env, force_resolv=False)
-        url = f'https://test-dnsd.http.curl.invalid/'
+        url = 'https://test-dnsd.http.curl.invalid/'
         r = curl.http_download(urls=[url], with_stats=True)
         r.check_exit_code(6)  # could not resolve host
         r.check_stats(count=1, http_status=0, exitcode=6)

--- a/tests/http/test_22_httpsrr.py
+++ b/tests/http/test_22_httpsrr.py
@@ -29,7 +29,7 @@ import os
 from typing import Generator
 
 import pytest
-from testenv import CurlClient, Env, Dnsd
+from testenv import CurlClient, Dnsd, Env
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Follow-up to a5542c23e7427b8ea8f6183f503f2935d88d5d65 #21289
Follow-up to 17e8200733a1fd9db148f794d7e1cfb47e491fcd

---

FAIL test passed: https://github.com/curl/curl/actions/runs/25825678164/job/75878081066?pr=21597
