### PR TITLE
strparse: split a multi-line assert into many separate ones

### DIFF
--- a/lib/curlx/strparse.c
+++ b/lib/curlx/strparse.c
@@ -49,12 +49,13 @@ void curlx_str_trim(struct Curl_str *out, size_t len)
 int curlx_str_until(const char **linep, struct Curl_str *out,
                     const size_t max, char delim)
 {
-  const char *s = *linep;
+  const char *s;
   size_t len = 0;
   DEBUGASSERT(linep);
   DEBUGASSERT(out);
   DEBUGASSERT(max);
   DEBUGASSERT(delim);
+  s = *linep;
 
   curlx_str_init(out);
   while(*s && (*s != delim)) {

--- a/lib/curlx/strparse.c
+++ b/lib/curlx/strparse.c
@@ -51,7 +51,10 @@ int curlx_str_until(const char **linep, struct Curl_str *out,
 {
   const char *s = *linep;
   size_t len = 0;
-  DEBUGASSERT(linep && *linep && out && max && delim);
+  DEBUGASSERT(linep);
+  DEBUGASSERT(out);
+  DEBUGASSERT(max);
+  DEBUGASSERT(delim);
 
   curlx_str_init(out);
   while(*s && (*s != delim)) {


### PR DESCRIPTION
This way we can better tell exactly which condition that triggers. Like in fuzzer logs.