### PR TITLE
gsasl: fix potential double free

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -30,6 +30,7 @@ We aim to support these or later versions.
 - c-ares       1.16.0 (2020-03-13)
 - GnuTLS       3.6.5 (2018-12-01)
 - libidn2      2.0.0 (2017-03-29)
+- libgsasl     1.6.0 (2010-12-14)
 - LibreSSL     2.9.1 (2019-04-22)
 - libssh       0.9.0 (2019-06-28)
 - libssh2      1.9.0 (2019-06-20)

--- a/lib/vauth/gsasl.c
+++ b/lib/vauth/gsasl.c
@@ -47,6 +47,7 @@ bool Curl_auth_gsasl_is_supported(struct Curl_easy *data,
   res = gsasl_client_start(gsasl->ctx, mech, &gsasl->client);
   if(res != GSASL_OK) {
     gsasl_done(gsasl->ctx);
+    gsasl->ctx = NULL;
     return FALSE;
   }
 

--- a/lib/vauth/gsasl.c
+++ b/lib/vauth/gsasl.c
@@ -32,6 +32,10 @@
 
 #include <gsasl.h>
 
+#if GSASL_VERSION_NUMBER < 0x010600
+#error "requires libgsasl 1.6.0+"
+#endif
+
 bool Curl_auth_gsasl_is_supported(struct Curl_easy *data,
                                   const char *mech,
                                   struct gsasldata *gsasl)


### PR DESCRIPTION
Also:
- require libgsasl 1.6.0+ (2010-12-14) for a `gsasl_finish()` that
  handles a NULL argument.
  Ref: https://gitlab.com/gsasl/gsasl/-/commit/b550032df8488a9ceaa3cfd4c634947d8f219717

Reported-by: Joshua Rogers (Aisle Research)
