### PR TITLE
KNOWN_BUGS.md: remove fixed x509asn.1 bug

### DIFF
--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -45,10 +45,6 @@ fail, resulting in error SEC_E_BUFFER_TOO_SMALL or SEC_E_MESSAGE_ALTERED.
 
 [curl issue 5488](https://github.com/curl/curl/issues/5488)
 
-## `CURLOPT_CERTINFO` results in `CURLE_OUT_OF_MEMORY` with Schannel
-
-[curl issue 8741](https://github.com/curl/curl/issues/8741)
-
 ## mbedTLS and CURLE_AGAIN handling
 
 [curl issue 15801](https://github.com/curl/curl/issues/15801)


### PR DESCRIPTION
KNOWN_BUGS.md contains an entry about a CURLE_OUT_OF_MEMORY error on a CURLOPT_CERTINFO call when using Schannel.

This bug was fixed by 137a668e8cb42dda1673bf2c79cbb24c8fe0b405.

remove the entry from KNOWN_BUGS.md.

Ref: https://github.com/curl/curl/issues/8741#issuecomment-4445486705