### PR TITLE
tidy-up: prefer "initialize" with a 'z'

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -593,7 +593,7 @@ typedef enum {
   CURLE_USE_SSL_FAILED,          /* 64 - Requested FTP SSL level failed */
   CURLE_SEND_FAIL_REWIND,        /* 65 - Sending the data requires a rewind
                                     that failed */
-  CURLE_SSL_ENGINE_INITFAILED,   /* 66 - failed to initialise ENGINE */
+  CURLE_SSL_ENGINE_INITFAILED,   /* 66 - failed to initialize ENGINE */
   CURLE_LOGIN_DENIED,            /* 67 - user, password or similar was not
                                     accepted and we failed to login */
   CURLE_TFTP_NOTFOUND,           /* 68 - file not found on server */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -122,7 +122,7 @@ void Curl_cpool_init(struct cpool *cpool,
 
   cpool->idata = idata;
   cpool->share = share;
-  cpool->initialised = TRUE;
+  cpool->initialized = TRUE;
 }
 
 /* Return the "first" connection in the pool or NULL. */
@@ -230,7 +230,7 @@ static void cpool_discard_conn(struct cpool *cpool,
 
 void Curl_cpool_destroy(struct cpool *cpool)
 {
-  if(cpool && cpool->initialised && cpool->idata) {
+  if(cpool && cpool->initialized && cpool->idata) {
     struct connectdata *conn;
     struct Curl_sigpipe_ctx pipe_ctx;
 

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -56,7 +56,7 @@ struct cpool {
   struct Curl_easy *idata; /* internal handle for maintenance */
   struct Curl_share *share; /* != NULL if pool belongs to share */
   BIT(locked);
-  BIT(initialised);
+  BIT(initialized);
 };
 
 /* Init the pool, pass multi only if pool is owned by it.

--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -322,14 +322,14 @@ int Curl_cshutdn_init(struct cshutdn *cshutdn,
   DEBUGASSERT(multi);
   cshutdn->multi = multi;
   Curl_llist_init(&cshutdn->list, NULL);
-  cshutdn->initialised = TRUE;
+  cshutdn->initialized = TRUE;
   return 0; /* good */
 }
 
 void Curl_cshutdn_destroy(struct cshutdn *cshutdn,
                           struct Curl_easy *data)
 {
-  if(cshutdn->initialised && data) {
+  if(cshutdn->initialized && data) {
     int timeout_ms = 0;
     /* for testing, run graceful shutdown */
 #ifdef DEBUGBUILD

--- a/lib/cshutdn.h
+++ b/lib/cshutdn.h
@@ -54,7 +54,7 @@ void Curl_cshutdn_terminate(struct Curl_easy *data,
 struct cshutdn {
   struct Curl_llist list;    /* connections being shut down */
   struct Curl_multi *multi;  /* the multi owning this */
-  BIT(initialised);
+  BIT(initialized);
 };
 
 /* Init as part of the given multi handle. */

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -103,7 +103,7 @@
 typedef EVP_MD_CTX *Curl_sha512_256_ctx;
 
 /**
- * Initialise structure for SHA-512/256 calculation.
+ * Initialize structure for SHA-512/256 calculation.
  *
  * @param context the calculation context
  * @return CURLE_OK if succeed,
@@ -232,7 +232,7 @@ static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *ctx)
 typedef struct sha512_256_ctx Curl_sha512_256_ctx;
 
 /**
- * Initialise structure for SHA-512/256 calculation.
+ * Initialize structure for SHA-512/256 calculation.
  *
  * @param context the calculation context
  * @return always CURLE_OK
@@ -435,7 +435,7 @@ struct Curl_sha512_256ctx {
 typedef struct Curl_sha512_256ctx Curl_sha512_256_ctx;
 
 /**
- * Initialise structure for SHA-512/256 calculation.
+ * Initialize structure for SHA-512/256 calculation.
  *
  * @param context the calculation context
  * @return always CURLE_OK
@@ -461,7 +461,7 @@ static CURLcode Curl_sha512_256_init(void *context)
   ctx->H[6] = UINT64_C(0x2B0199FC2C85B8AA);
   ctx->H[7] = UINT64_C(0x0EB72DDC81C52CA2);
 
-  /* Initialise number of bytes and high part of number of bits. */
+  /* Initialize number of bytes and high part of number of bits. */
   ctx->count = UINT64_C(0);
   ctx->count_bits_hi = UINT64_C(0);
 

--- a/lib/curl_share.c
+++ b/lib/curl_share.c
@@ -260,7 +260,7 @@ CURLSHcode curl_share_setopt(CURLSH *sh, CURLSHoption option, ...)
 
     case CURL_LOCK_DATA_CONNECT:
       /* It is safe to set this option several times on a share. */
-      if(!share->cpool.initialised) {
+      if(!share->cpool.initialized) {
         Curl_cpool_init(&share->cpool, share->admin, share, 103);
       }
       break;

--- a/lib/curlx/strerr.c
+++ b/lib/curlx/strerr.c
@@ -190,7 +190,7 @@ static const char *get_winsock_error(int err, char *buf, size_t len)
     p = "Winsock library is not ready";
     break;
   case WSANOTINITIALISED:
-    p = "Winsock library not initialised";
+    p = "Winsock library not initialized";
     break;
   case WSAVERNOTSUPPORTED:
     p = "Winsock version not supported";

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1795,7 +1795,7 @@ static CURLcode imap_parse_url_options(struct connectdata *conn,
 static CURLcode imap_parse_url_path(struct Curl_easy *data,
                                     struct IMAP *imap)
 {
-  /* The imap struct is already initialised in imap_connect() */
+  /* The imap struct is already initialized in imap_connect() */
   CURLcode result = CURLE_OK;
   const char *begin = &data->state.up.path[1]; /* skip leading slash */
   const char *ptr = begin;

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -120,13 +120,13 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
 /* initialize stuff to prepare for reading a fresh new response */
 void Curl_pp_init(struct pingpong *pp, const struct curltime *pnow)
 {
-  DEBUGASSERT(!pp->initialised);
+  DEBUGASSERT(!pp->initialized);
   pp->nread_resp = 0;
   pp->response = *pnow; /* start response time-out */
   pp->pending_resp = TRUE;
   curlx_dyn_init(&pp->sendbuf, DYN_PINGPPONG_CMD);
   curlx_dyn_init(&pp->recvbuf, DYN_PINGPPONG_CMD);
-  pp->initialised = TRUE;
+  pp->initialized = TRUE;
 }
 
 /***********************************************************************
@@ -389,7 +389,7 @@ CURLcode Curl_pp_flushsend(struct Curl_easy *data,
 
 CURLcode Curl_pp_disconnect(struct pingpong *pp)
 {
-  if(pp->initialised) {
+  if(pp->initialized) {
     curlx_dyn_free(&pp->sendbuf);
     curlx_dyn_free(&pp->recvbuf);
     memset(pp, 0, sizeof(*pp));

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -64,7 +64,7 @@ struct pingpong {
   CURLcode (*statemachine)(struct Curl_easy *data, struct connectdata *conn);
   bool (*endofresp)(struct Curl_easy *data, struct connectdata *conn,
                     const char *ptr, size_t len, int *code);
-  BIT(initialised);
+  BIT(initialized);
   BIT(pending_resp);  /* set TRUE when a server response is pending or in
                          progress, and is cleared once the last response is
                          read */

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -231,7 +231,7 @@ static CURLcode pop3_parse_url_options(struct connectdata *conn)
  */
 static CURLcode pop3_parse_url_path(struct Curl_easy *data)
 {
-  /* The POP3 struct is already initialised in pop3_connect() */
+  /* The POP3 struct is already initialized in pop3_connect() */
   struct POP3 *pop3 = Curl_meta_get(data, CURL_META_POP3_EASY);
   const char *path = &data->state.up.path[1]; /* skip leading path */
 
@@ -1439,7 +1439,7 @@ static CURLcode pop3_connect(struct Curl_easy *data, bool *done)
   pop3c->preftype = POP3_TYPE_ANY;
   Curl_sasl_init(&pop3c->sasl, data, &saslpop3);
 
-  /* Initialise the pingpong layer */
+  /* Initialize the pingpong layer */
   Curl_pp_init(pp, Curl_pgrs_now(data));
 
   /* Parse the URL options */

--- a/lib/select.h
+++ b/lib/select.h
@@ -131,7 +131,7 @@ struct easy_pollset {
 #define CURL_EASY_POLLSET_MAGIC  0x7a657370
 #endif
 
-/* allocate and initialise */
+/* allocate and initialize */
 struct easy_pollset *Curl_pollset_create(void);
 
 /* Initialize before first use */

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -182,7 +182,7 @@ static CURLcode smtp_parse_url_options(struct connectdata *conn,
 static CURLcode smtp_parse_url_path(struct Curl_easy *data,
                                     struct smtp_conn *smtpc)
 {
-  /* The SMTP struct is already initialised in smtp_connect() */
+  /* The SMTP struct is already initialized in smtp_connect() */
   const char *path = &data->state.up.path[1]; /* skip leading path */
   char localhost[HOSTNAME_MAX + 1];
 
@@ -608,7 +608,7 @@ static void smtp_state(struct Curl_easy *data,
  *
  * smtp_perform_ehlo()
  *
- * Sends the EHLO command to not only initialise communication with the ESMTP
+ * Sends the EHLO command to not only initialize communication with the ESMTP
  * server but to also obtain a list of server side supported capabilities.
  */
 static CURLcode smtp_perform_ehlo(struct Curl_easy *data,
@@ -635,7 +635,7 @@ static CURLcode smtp_perform_ehlo(struct Curl_easy *data,
  *
  * smtp_perform_helo()
  *
- * Sends the HELO command to initialise communication with the SMTP server.
+ * Sends the HELO command to initialize communication with the SMTP server.
  */
 static CURLcode smtp_perform_helo(struct Curl_easy *data,
                                   struct smtp_conn *smtpc)
@@ -1677,7 +1677,7 @@ static CURLcode smtp_connect(struct Curl_easy *data, bool *done)
   /* Initialize the SASL storage */
   Curl_sasl_init(&smtpc->sasl, data, &saslsmtp);
 
-  /* Initialise the pingpong layer */
+  /* Initialize the pingpong layer */
   Curl_pp_init(&smtpc->pp, Curl_pgrs_now(data));
 
   /* Parse the URL options */

--- a/lib/socketpair.h
+++ b/lib/socketpair.h
@@ -27,7 +27,7 @@
 
 #ifndef CURL_DISABLE_SOCKETPAIR
 
-/* return < 0 for failure to initialise */
+/* return < 0 for failure to initialize */
 int Curl_wakeup_init(curl_socket_t socks[2], bool nonblocking);
 void Curl_wakeup_destroy(curl_socket_t socks[2]);
 

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -164,7 +164,7 @@ static CURLcode socks5_sspi_loop(struct Curl_cfilter *cf,
     sspi_recv_token.cbBuffer = 0;
 
     if(check_sspi_err(data, status, "InitializeSecurityContext")) {
-      failf(data, "Failed to initialise security context.");
+      failf(data, "Failed to initialize security context.");
       return socks5_free_token(&sspi_send_token, CURLE_COULDNT_CONNECT);
     }
 

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -172,7 +172,7 @@ const char *curl_easy_strerror(CURLcode error)
     return "Can not set SSL crypto engine as default";
 
   case CURLE_SSL_ENGINE_INITFAILED:
-    return "Failed to initialise SSL crypto engine";
+    return "Failed to initialize SSL crypto engine";
 
   case CURLE_SEND_ERROR:
     return "Failed sending data to the peer";

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -231,7 +231,7 @@ static bool auth_digest_get_key_value(const char *chlg, const char *key,
 static void auth_digest_get_qop_values(const char *options, int *value)
 {
   struct Curl_str out;
-  /* Initialise the output */
+  /* Initialize the output */
   *value = 0;
 
   while(!curlx_str_until(&options, &out, 32, ',')) {
@@ -520,7 +520,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
   if(digest->nonce)
     before = TRUE;
 
-  /* Clean up any former leftovers and initialise to defaults */
+  /* Clean up any former leftovers and initialize to defaults */
   Curl_auth_digest_cleanup(digest);
 
   for(;;) {

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -458,7 +458,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   (void)service;
   (void)host;
 
-  /* Clean up any former leftovers and initialise to defaults */
+  /* Clean up any former leftovers and initialize to defaults */
   Curl_auth_cleanup_ntlm(ntlm);
 
   ntlmbuf = curl_maprintf(NTLMSSP_SIGNATURE "%c"

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -90,7 +90,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   const char *service = Curl_creds_has_sasl_service(creds) ?
     Curl_creds_sasl_service(creds) : default_service;
 
-  /* Clean up any former leftovers and initialise to defaults */
+  /* Clean up any former leftovers and initialize to defaults */
   Curl_auth_cleanup_ntlm(ntlm);
 
   /* Query the security package for NTLM */

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -500,7 +500,7 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
 
   DEBUGASSERT(max_pkts > 0);
   for(pkts = 0, total_nread = 0, calls = 0; pkts < max_pkts;) {
-    /* fully initialise this on each call to `recvmsg()`. There seem to
+    /* fully initialize this on each call to `recvmsg()`. There seem to
      * operating systems out there that mess with `msg_iov.iov_len`. */
     memset(&msg, 0, sizeof(msg));
     msg_iov.iov_base = buf;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1809,7 +1809,7 @@ static int myssh_in_TRANS_INIT(struct Curl_easy *data, struct ssh_conn *sshc,
 
 static void sshc_cleanup(struct ssh_conn *sshc)
 {
-  if(sshc->initialised) {
+  if(sshc->initialized) {
     if(sshc->sftp_file) {
       sftp_close(sshc->sftp_file);
       sshc->sftp_file = NULL;
@@ -1859,7 +1859,7 @@ static void sshc_cleanup(struct ssh_conn *sshc)
     curlx_dyn_free(&sshc->readdir_buf);
     curlx_safefree(sshc->readdir_linkPath);
     SSH_STRING_FREE_CHAR(sshc->homedir);
-    sshc->initialised = FALSE;
+    sshc->initialized = FALSE;
   }
 }
 
@@ -2504,7 +2504,7 @@ static CURLcode myssh_setup_connection(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
 
   curlx_dyn_init(&sshc->readdir_buf, CURL_PATH_MAX * 2);
-  sshc->initialised = TRUE;
+  sshc->initialized = TRUE;
   if(Curl_conn_meta_set(conn, CURL_META_SSH_CONN, sshc, myssh_conn_dtor))
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -195,7 +195,7 @@ struct ssh_conn {
   const char *readdir_filename; /* points within readdir_attrs */
   const char *readdir_longentry;
   char *readdir_tmp;
-  BIT(initialised);
+  BIT(initialized);
 #elif defined(USE_LIBSSH2)
   LIBSSH2_SESSION *ssh_session; /* Secure Shell session */
   LIBSSH2_CHANNEL *ssh_channel; /* Secure Shell channel handle */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1671,7 +1671,7 @@ static CURLcode ossl_set_engine(struct Curl_easy *data, const char *name)
       char buf[256];
 
       ENGINE_free(e);
-      failf(data, "Failed to initialise SSL Engine '%s': %s",
+      failf(data, "Failed to initialize SSL Engine '%s': %s",
             name, ossl_strerror(ERR_get_error(), buf, sizeof(buf)));
       result = CURLE_SSL_ENGINE_INITFAILED;
       e = NULL;

--- a/projects/vms/curlmsg.msg
+++ b/projects/vms/curlmsg.msg
@@ -111,7 +111,7 @@ LDAP_INVALID_URL        <LDAP invalid url>
 FILESIZE_EXCEEDED       <maximum file size exceeded>
 USE_SSL_FAILED          <requested FTP SSL level failed>
 SEND_FAIL_REWIND        <sending data requires a rewind that failed>
-SSL_ENGINE_INITFAILED   <failed to initialise ENGINE>
+SSL_ENGINE_INITFAILED   <failed to initialize ENGINE>
 LOGIN_DENIED            <user or password not accepted. failed to login>
 TFTP_NOTFOUND           <file not found on server>
 TFTP_PERM               <permission problem on server>

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -316,7 +316,7 @@ CURLcode globalconf_init(void)
   _djstat_flags |= _STAT_INODE | _STAT_EXEC_MAGIC | _STAT_DIRSIZE;
 #endif
 
-  /* Initialise the global config */
+  /* Initialize the global config */
   global->showerror = FALSE;          /* show errors when silent */
   global->styled_output = TRUE;       /* enable detection */
   global->parallel_max = PARALLEL_DEFAULT;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2459,7 +2459,7 @@ CURLcode operate(int argc, argv_item_t argv[])
     }
     else {
       if(global->libcurl) {
-        /* Initialise the libcurl source output */
+        /* Initialize the libcurl source output */
         result = easysrc_init();
       }
 

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -94,7 +94,7 @@ e62: Unknown error
 e63: Maximum file size exceeded
 e64: Requested SSL level failed
 e65: Send failed since rewinding of the data stream failed
-e66: Failed to initialise SSL crypto engine
+e66: Failed to initialize SSL crypto engine
 e67: Login denied
 e68: TFTP: File Not Found
 e69: TFTP: Access Violation


### PR DESCRIPTION
To match the majority of usage in source.