### PR TITLE
GHA: pin containers to hash (where missing)

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -56,7 +56,7 @@ jobs:
   cmake-autotools:
     name: 'autotools & cmake'
     runs-on: ubuntu-latest
-    container: 'debian:stretch'
+    container: 'debian:stretch-20220622-slim@sha256:f186c98e81a67c2fba071c2a71545c4c7e5696c8fd9a66529939d0af337d5a73'
 
     steps:
       - name: 'install prereqs'

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -56,7 +56,7 @@ jobs:
   cmake-autotools:
     name: 'autotools & cmake'
     runs-on: ubuntu-latest
-    container: 'debian:stretch-20220622-slim@sha256:c5cd3ffceeb25b683bf5111ea89bf8049a177e00fb237235d48076a19cc80097'
+    container: debian:stretch-20220622-slim@sha256:c5cd3ffceeb25b683bf5111ea89bf8049a177e00fb237235d48076a19cc80097
 
     steps:
       - name: 'install prereqs'

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -56,7 +56,7 @@ jobs:
   cmake-autotools:
     name: 'autotools & cmake'
     runs-on: ubuntu-latest
-    container: 'debian:stretch-20220622-slim@sha256:f186c98e81a67c2fba071c2a71545c4c7e5696c8fd9a66529939d0af337d5a73'
+    container: 'debian:stretch-20220622-slim@sha256:c5cd3ffceeb25b683bf5111ea89bf8049a177e00fb237235d48076a19cc80097'
 
     steps:
       - name: 'install prereqs'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -444,11 +444,11 @@ jobs:
 
           - name: 'Alpine MUSL https-rr'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --enable-threaded-resolver
-            container: 'alpine:3.20'
+            container: 'alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11' # v3.23.4
 
           - name: 'Alpine MUSL https-rr c-ares'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --disable-threaded-resolver
-            container: 'alpine:3.20'
+            container: 'alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11' # v3.23.4
 
     steps:
       - name: 'install prereqs'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -440,15 +440,15 @@ jobs:
             # https://ftpmirror.infania.net/slackware/slackware64-current/source/n/curl/curl.SlackBuild
             configure: --enable-debug --without-ssl --with-libssh2 --with-gssapi --enable-ares --without-ca-bundle --with-ca-path=/etc/ssl/certs
             # Docker Hub image that `container-job` executes in
-            container: 'andy5995/slackware-build-essential:15.0@sha256:f4f2242999038a2c2deb4e5727187caaae92502a7daf8353068932621e1ec92f'
+            container: andy5995/slackware-build-essential:15.0@sha256:f4f2242999038a2c2deb4e5727187caaae92502a7daf8353068932621e1ec92f
 
           - name: 'Alpine MUSL https-rr'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --enable-threaded-resolver
-            container: 'alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11' # v3.23.4
+            container: alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
           - name: 'Alpine MUSL https-rr c-ares'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --disable-threaded-resolver
-            container: 'alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11' # v3.23.4
+            container: alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # v3.23.4
 
     steps:
       - name: 'install prereqs'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -444,11 +444,11 @@ jobs:
 
           - name: 'Alpine MUSL https-rr'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --enable-threaded-resolver
-            container: alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+            container: alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # 3.23.4
 
           - name: 'Alpine MUSL https-rr c-ares'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --disable-threaded-resolver
-            container: alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 # v3.23.4
+            container: alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc # 3.20.10
 
     steps:
       - name: 'install prereqs'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -440,7 +440,7 @@ jobs:
             # https://ftpmirror.infania.net/slackware/slackware64-current/source/n/curl/curl.SlackBuild
             configure: --enable-debug --without-ssl --with-libssh2 --with-gssapi --enable-ares --without-ca-bundle --with-ca-path=/etc/ssl/certs
             # Docker Hub image that `container-job` executes in
-            container: 'andy5995/slackware-build-essential:15.0@f4f2242999038a2c2deb4e5727187caaae92502a7daf8353068932621e1ec92f'
+            container: 'andy5995/slackware-build-essential:15.0@sha256:f4f2242999038a2c2deb4e5727187caaae92502a7daf8353068932621e1ec92f'
 
           - name: 'Alpine MUSL https-rr'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --enable-threaded-resolver

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -440,7 +440,7 @@ jobs:
             # https://ftpmirror.infania.net/slackware/slackware64-current/source/n/curl/curl.SlackBuild
             configure: --enable-debug --without-ssl --with-libssh2 --with-gssapi --enable-ares --without-ca-bundle --with-ca-path=/etc/ssl/certs
             # Docker Hub image that `container-job` executes in
-            container: 'andy5995/slackware-build-essential:15.0'
+            container: 'andy5995/slackware-build-essential:15.0@f4f2242999038a2c2deb4e5727187caaae92502a7daf8353068932621e1ec92f'
 
           - name: 'Alpine MUSL https-rr'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-httpsrr --enable-ares --enable-threaded-resolver


### PR DESCRIPTION
Fixing this with zizmor v1.25.0:
```
error[unpinned-images]: unpinned image references
  --> .github/workflows/linux-old.yml:59:5
59 |     container: 'debian:stretch'
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-images
[...]
```
Ref: https://github.com/curl/curl/actions/runs/25890035949/job/76090925291?pr=21618

Sadly there is no automatic mechanism to bump them..

Also:
- replace `debian-stretch` with its slim variant.
- bump one of the two Alpine jobs from 3.20 to 3.23.4.
