### PR TITLE
windows: update MS SDK versions in comments

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -132,7 +132,7 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
                                     VERSION_GREATER_THAN_EQUAL)) {
       CURL_TRC_CF(data, cf, "Set TCP_KEEP* on fd=%" FMT_SOCKET_T, sockfd);
       optval = curlx_sltosi(data->set.tcp_keepidle);
-/* Offered by mingw-w64 v12+, MS SDK 6.0A+ */
+/* Offered by mingw-w64 v12+, MS SDK 6.0A+/VS2008 */
 #ifndef TCP_KEEPALIVE
 #define TCP_KEEPALIVE 3
 #endif
@@ -1370,7 +1370,7 @@ static CURLcode cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 
 #ifdef USE_WINSOCK
 
-/* Offered by mingw-w64 v13+, MS SDK 7.0A+ */
+/* Offered by mingw-w64 v13+, MS SDK 7.0A+/VS2010+ */
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
 #define SIO_IDEAL_SEND_BACKLOG_QUERY 0x4004747B
 #endif

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -132,7 +132,7 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
                                     VERSION_GREATER_THAN_EQUAL)) {
       CURL_TRC_CF(data, cf, "Set TCP_KEEP* on fd=%" FMT_SOCKET_T, sockfd);
       optval = curlx_sltosi(data->set.tcp_keepidle);
-/* Offered by mingw-w64 v12+, MS SDK 6.0A+/VS2008 */
+/* Offered by mingw-w64 v12+, MS SDK 6.0A/VS2008+ */
 #ifndef TCP_KEEPALIVE
 #define TCP_KEEPALIVE 3
 #endif

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1370,7 +1370,7 @@ static CURLcode cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 
 #ifdef USE_WINSOCK
 
-/* Offered by mingw-w64 v13+, MS SDK 7.0A+/VS2010+ */
+/* Offered by mingw-w64 v13+, MS SDK 7.0A/VS2010+ */
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
 #define SIO_IDEAL_SEND_BACKLOG_QUERY 0x4004747B
 #endif

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -132,14 +132,15 @@ static void tcpkeepalive(struct Curl_cfilter *cf,
                                     VERSION_GREATER_THAN_EQUAL)) {
       CURL_TRC_CF(data, cf, "Set TCP_KEEP* on fd=%" FMT_SOCKET_T, sockfd);
       optval = curlx_sltosi(data->set.tcp_keepidle);
-/* Offered by mingw-w64 v12+. MS SDK 6.0A+. */
+/* Offered by mingw-w64 v12+, MS SDK 6.0A+ */
 #ifndef TCP_KEEPALIVE
 #define TCP_KEEPALIVE 3
 #endif
-/* Offered by mingw-w64 v12+. MS SDK ~10+/~VS2017+. */
+/* Offered by mingw-w64 v12+, MS SDK 10.0.15063.0/VS2017 15.1+ */
 #ifndef TCP_KEEPCNT
 #define TCP_KEEPCNT 16
 #endif
+/* Offered by mingw-w64 v12+, MS SDK 10.0.16299.0/VS2017 15.4+ */
 #ifndef TCP_KEEPIDLE
 #define TCP_KEEPIDLE TCP_KEEPALIVE
 #endif
@@ -1369,7 +1370,7 @@ static CURLcode cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 
 #ifdef USE_WINSOCK
 
-/* Offered by mingw-w64 v13+. MS SDK 7.0A+. */
+/* Offered by mingw-w64 v13+, MS SDK 7.0A+ */
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
 #define SIO_IDEAL_SEND_BACKLOG_QUERY 0x4004747B
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1542,7 +1542,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #endif
 
 #if defined(USE_UNIX_SOCKETS) && defined(_WIN32)
-/* Offered by mingw-w64 v10+. MS SDK 10.17763/~VS2017+. */
+/* Offered by mingw-w64 v10+, MS SDK 10.0.16299.0/VS2017 15.4+ */
 #if defined(__MINGW32__) && (__MINGW64_VERSION_MAJOR >= 10)
 #  include <afunix.h>
 #elif !defined(UNIX_PATH_MAX) /* Replicate logic present in afunix.h */

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -59,15 +59,15 @@ extern PSecurityFunctionTable Curl_pSecFn;
 
 /* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */
 #ifndef SEC_E_INVALID_PARAMETER
-#define SEC_E_INVALID_PARAMETER              ((HRESULT)0x8009035DL)
+#define SEC_E_INVALID_PARAMETER               ((HRESULT)0x8009035DL)
 #endif
 /* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */
 #ifndef SEC_E_DELEGATION_POLICY
-#define SEC_E_DELEGATION_POLICY              ((HRESULT)0x8009035EL)
+#define SEC_E_DELEGATION_POLICY               ((HRESULT)0x8009035EL)
 #endif
 /* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */
 #ifndef SEC_E_POLICY_NLTM_ONLY
-#define SEC_E_POLICY_NLTM_ONLY               ((HRESULT)0x8009035FL)
+#define SEC_E_POLICY_NLTM_ONLY                ((HRESULT)0x8009035FL)
 #endif
 
 /* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -52,25 +52,25 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SP_NAME_NEGOTIATE           "Negotiate"
 #define SP_NAME_KERBEROS            "Kerberos"
 
-/* Offered by mingw-w64 v9+. MS SDK 7.0A+. */
+/* Offered by mingw-w64 v9+, MS SDK 7.0A+ */
 #ifndef ISC_REQ_USE_HTTP_STYLE
 #define ISC_REQ_USE_HTTP_STYLE                0x01000000
 #endif
 
-/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
 #ifndef SEC_E_INVALID_PARAMETER
-#define SEC_E_INVALID_PARAMETER               ((HRESULT)0x8009035DL)
+#define SEC_E_INVALID_PARAMETER              ((HRESULT)0x8009035DL)
 #endif
-/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
 #ifndef SEC_E_DELEGATION_POLICY
-#define SEC_E_DELEGATION_POLICY               ((HRESULT)0x8009035EL)
+#define SEC_E_DELEGATION_POLICY              ((HRESULT)0x8009035EL)
 #endif
-/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
 #ifndef SEC_E_POLICY_NLTM_ONLY
-#define SEC_E_POLICY_NLTM_ONLY                ((HRESULT)0x8009035FL)
+#define SEC_E_POLICY_NLTM_ONLY               ((HRESULT)0x8009035FL)
 #endif
 
-/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
 #ifndef SEC_I_SIGNATURE_NEEDED
 #define SEC_I_SIGNATURE_NEEDED                ((HRESULT)0x0009035CL)
 #endif

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -52,25 +52,25 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SP_NAME_NEGOTIATE           "Negotiate"
 #define SP_NAME_KERBEROS            "Kerberos"
 
-/* Offered by mingw-w64 v9+, MS SDK 7.0A+/VS2010+ */
+/* Offered by mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
 #ifndef ISC_REQ_USE_HTTP_STYLE
 #define ISC_REQ_USE_HTTP_STYLE                0x01000000
 #endif
 
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */
 #ifndef SEC_E_INVALID_PARAMETER
 #define SEC_E_INVALID_PARAMETER              ((HRESULT)0x8009035DL)
 #endif
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */
 #ifndef SEC_E_DELEGATION_POLICY
 #define SEC_E_DELEGATION_POLICY              ((HRESULT)0x8009035EL)
 #endif
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */
 #ifndef SEC_E_POLICY_NLTM_ONLY
 #define SEC_E_POLICY_NLTM_ONLY               ((HRESULT)0x8009035FL)
 #endif
 
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A/VS2008+ */
 #ifndef SEC_I_SIGNATURE_NEEDED
 #define SEC_I_SIGNATURE_NEEDED                ((HRESULT)0x0009035CL)
 #endif

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -52,25 +52,25 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SP_NAME_NEGOTIATE           "Negotiate"
 #define SP_NAME_KERBEROS            "Kerberos"
 
-/* Offered by mingw-w64 v9+, MS SDK 7.0A+ */
+/* Offered by mingw-w64 v9+, MS SDK 7.0A+/VS2010+ */
 #ifndef ISC_REQ_USE_HTTP_STYLE
 #define ISC_REQ_USE_HTTP_STYLE                0x01000000
 #endif
 
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
 #ifndef SEC_E_INVALID_PARAMETER
 #define SEC_E_INVALID_PARAMETER              ((HRESULT)0x8009035DL)
 #endif
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
 #ifndef SEC_E_DELEGATION_POLICY
 #define SEC_E_DELEGATION_POLICY              ((HRESULT)0x8009035EL)
 #endif
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
 #ifndef SEC_E_POLICY_NLTM_ONLY
 #define SEC_E_POLICY_NLTM_ONLY               ((HRESULT)0x8009035FL)
 #endif
 
-/* Offered by mingw-w64 v8+, MS SDK 6.0A+ */
+/* Offered by mingw-w64 v8+, MS SDK 6.0A+/VS2008+ */
 #ifndef SEC_I_SIGNATURE_NEEDED
 #define SEC_I_SIGNATURE_NEEDED                ((HRESULT)0x0009035CL)
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -410,7 +410,7 @@ struct connectdata {
 
   /*************** Request - specific items ************/
 #if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
-  CtxtHandle *sslContext;  /* mingw-w64 v9+. MS SDK 7.0A+. */
+  CtxtHandle *sslContext;  /* mingw-w64 v9+, MS SDK 7.0A+ */
 #endif
 
 #ifdef USE_NTLM

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -410,7 +410,7 @@ struct connectdata {
 
   /*************** Request - specific items ************/
 #if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
-  CtxtHandle *sslContext;  /* mingw-w64 v9+, MS SDK 7.0A+ */
+  CtxtHandle *sslContext;  /* mingw-w64 v9+, MS SDK 7.0A+/VS2010+ */
 #endif
 
 #ifdef USE_NTLM

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -410,7 +410,7 @@ struct connectdata {
 
   /*************** Request - specific items ************/
 #if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
-  CtxtHandle *sslContext;  /* mingw-w64 v9+, MS SDK 7.0A+/VS2010+ */
+  CtxtHandle *sslContext;  /* mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
 #endif
 
 #ifdef USE_NTLM

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -69,7 +69,7 @@
 #define SCH_DEV_SHOWBOOL(x) do {} while(0)
 #endif
 
-/* Offered by mingw-w64 v8+, MS SDK 7.0A+/VS2010+ */
+/* Offered by mingw-w64 v8+, MS SDK 7.0A/VS2010+ */
 #ifndef SP_PROT_TLS1_0_CLIENT
 #define SP_PROT_TLS1_0_CLIENT           SP_PROT_TLS1_CLIENT
 #endif
@@ -84,12 +84,12 @@
 #ifndef SP_PROT_TLS1_3_CLIENT
 #define SP_PROT_TLS1_3_CLIENT           0x00002000
 #endif
-/* Offered by mingw-w64 v8+, MS SDK 8.1+ */
+/* Offered by mingw-w64 v8+, MS SDK 8.1/~VS2013+ */
 #ifndef SCH_USE_STRONG_CRYPTO
 #define SCH_USE_STRONG_CRYPTO           0x00400000
 #endif
 
-/* Offered by mingw-w64 v10+, MS SDK 7.0A+/VS2010+ */
+/* Offered by mingw-w64 v10+, MS SDK 7.0A/VS2010+ */
 #ifndef SECBUFFER_ALERT
 #define SECBUFFER_ALERT                 17
 #endif
@@ -106,12 +106,12 @@
  * #define failf(x, y, ...) curl_mprintf(y, __VA_ARGS__)
  */
 
-/* Offered by mingw-w64 v4+, MS SDK 6.0A+/VS2008+ */
+/* Offered by mingw-w64 v4+, MS SDK 6.0A/VS2008+ */
 #ifndef PKCS12_NO_PERSIST_KEY
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
-/* Offered by mingw-w64 v4+, MS SDK 8.0+ */
+/* Offered by mingw-w64 v4+, MS SDK 8.0/~VS2012+ */
 #ifndef CERT_FIND_HAS_PRIVATE_KEY
 #define CERT_FIND_HAS_PRIVATE_KEY (21 << CERT_COMPARE_SHIFT)
 #endif
@@ -253,12 +253,12 @@ static const struct algo algs[] = {
   CIPHEROPTION(CALG_SHA_384),
   CIPHEROPTION(CALG_SHA_512),
   CIPHEROPTION(CALG_ECDH),
-/* Offered by mingw-w64 v4+, MS SDK 6.0A+/VS2008+ */
+/* Offered by mingw-w64 v4+, MS SDK 6.0A/VS2008+ */
 #ifdef CALG_ECMQV
   CIPHEROPTION(CALG_ECMQV),
 #endif
   CIPHEROPTION(CALG_ECDSA),
-/* Offered by mingw-w64 v7+, MS SDK 7.0A+/VS2010+ */
+/* Offered by mingw-w64 v7+, MS SDK 7.0A/VS2010+ */
 #ifdef CALG_ECDH_EPHEM
   CIPHEROPTION(CALG_ECDH_EPHEM),
 #endif
@@ -1734,7 +1734,7 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+, MS SDK 7.0A+/VS2010+ */
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -69,7 +69,7 @@
 #define SCH_DEV_SHOWBOOL(x) do {} while(0)
 #endif
 
-/* Offered by mingw-w64 v8+, MS SDK 7.0A+ */
+/* Offered by mingw-w64 v8+, MS SDK 7.0A+/VS2010+ */
 #ifndef SP_PROT_TLS1_0_CLIENT
 #define SP_PROT_TLS1_0_CLIENT           SP_PROT_TLS1_CLIENT
 #endif
@@ -89,7 +89,7 @@
 #define SCH_USE_STRONG_CRYPTO           0x00400000
 #endif
 
-/* Offered by mingw-w64 v10+, MS SDK 7.0A+ */
+/* Offered by mingw-w64 v10+, MS SDK 7.0A+/VS2010+ */
 #ifndef SECBUFFER_ALERT
 #define SECBUFFER_ALERT                 17
 #endif
@@ -106,7 +106,7 @@
  * #define failf(x, y, ...) curl_mprintf(y, __VA_ARGS__)
  */
 
-/* Offered by mingw-w64 v4+, MS SDK 6.0A+ */
+/* Offered by mingw-w64 v4+, MS SDK 6.0A+/VS2008+ */
 #ifndef PKCS12_NO_PERSIST_KEY
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
@@ -253,12 +253,12 @@ static const struct algo algs[] = {
   CIPHEROPTION(CALG_SHA_384),
   CIPHEROPTION(CALG_SHA_512),
   CIPHEROPTION(CALG_ECDH),
-/* Offered by mingw-w64 v4+, MS SDK 6.0A+ */
+/* Offered by mingw-w64 v4+, MS SDK 6.0A+/VS2008+ */
 #ifdef CALG_ECMQV
   CIPHEROPTION(CALG_ECMQV),
 #endif
   CIPHEROPTION(CALG_ECDSA),
-/* Offered by mingw-w64 v7+, MS SDK 7.0A+ */
+/* Offered by mingw-w64 v7+, MS SDK 7.0A+/VS2010+ */
 #ifdef CALG_ECDH_EPHEM
   CIPHEROPTION(CALG_ECDH_EPHEM),
 #endif
@@ -1734,7 +1734,7 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+, MS SDK 7.0A+ */
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+, MS SDK 7.0A+/VS2010+ */
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -69,7 +69,7 @@
 #define SCH_DEV_SHOWBOOL(x) do {} while(0)
 #endif
 
-/* Offered by mingw-w64 v8+. MS SDK 7.0A+. */
+/* Offered by mingw-w64 v8+, MS SDK 7.0A+ */
 #ifndef SP_PROT_TLS1_0_CLIENT
 #define SP_PROT_TLS1_0_CLIENT           SP_PROT_TLS1_CLIENT
 #endif
@@ -80,15 +80,16 @@
 #define SP_PROT_TLS1_2_CLIENT           0x00000800
 #endif
 
-/* Offered by mingw-w64 v8+. MS SDK ~10+/~VS2017+. */
+/* Offered by mingw-w64 v8+, MS SDK 10.0.15063.0/VS2017 15.1+ */
 #ifndef SP_PROT_TLS1_3_CLIENT
 #define SP_PROT_TLS1_3_CLIENT           0x00002000
 #endif
+/* Offered by mingw-w64 v8+, MS SDK 8.1+ */
 #ifndef SCH_USE_STRONG_CRYPTO
 #define SCH_USE_STRONG_CRYPTO           0x00400000
 #endif
 
-/* Offered by mingw-w64 v10+. MS SDK 7.0A+. */
+/* Offered by mingw-w64 v10+, MS SDK 7.0A+ */
 #ifndef SECBUFFER_ALERT
 #define SECBUFFER_ALERT                 17
 #endif
@@ -105,12 +106,12 @@
  * #define failf(x, y, ...) curl_mprintf(y, __VA_ARGS__)
  */
 
-/* Offered by mingw-w64 v4+. MS SDK 6.0A+. */
+/* Offered by mingw-w64 v4+, MS SDK 6.0A+ */
 #ifndef PKCS12_NO_PERSIST_KEY
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
-/* Offered by mingw-w64 v4+. MS SDK ~10+/~VS2017+. */
+/* Offered by mingw-w64 v4+, MS SDK 8.0+ */
 #ifndef CERT_FIND_HAS_PRIVATE_KEY
 #define CERT_FIND_HAS_PRIVATE_KEY (21 << CERT_COMPARE_SHIFT)
 #endif
@@ -252,12 +253,12 @@ static const struct algo algs[] = {
   CIPHEROPTION(CALG_SHA_384),
   CIPHEROPTION(CALG_SHA_512),
   CIPHEROPTION(CALG_ECDH),
-/* Offered by mingw-w64 v4+. MS SDK 6.0A+. */
+/* Offered by mingw-w64 v4+, MS SDK 6.0A+ */
 #ifdef CALG_ECMQV
   CIPHEROPTION(CALG_ECMQV),
 #endif
   CIPHEROPTION(CALG_ECDSA),
-/* Offered by mingw-w64 v7+. MS SDK 7.0A+. */
+/* Offered by mingw-w64 v7+, MS SDK 7.0A+ */
 #ifdef CALG_ECDH_EPHEM
   CIPHEROPTION(CALG_ECDH_EPHEM),
 #endif
@@ -1733,7 +1734,7 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+. MS SDK 7.0A+. */
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+, MS SDK 7.0A+ */
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -62,7 +62,7 @@ typedef struct _CRYPTO_SETTINGS {
   PUNICODE_STRING     rgstrChainingModes; /* spellchecker:disable-line */
   DWORD               dwMinBitLength;
   DWORD               dwMaxBitLength;
-} CRYPTO_SETTINGS, * PCRYPTO_SETTINGS;
+} CRYPTO_SETTINGS, *PCRYPTO_SETTINGS;
 
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct _TLS_PARAMETERS {
@@ -72,14 +72,14 @@ typedef struct _TLS_PARAMETERS {
   DWORD               cDisabledCrypto;
   PCRYPTO_SETTINGS    pDisabledCrypto;
   DWORD               dwFlags;
-} TLS_PARAMETERS, * PTLS_PARAMETERS;
+} TLS_PARAMETERS, *PTLS_PARAMETERS;
 
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct _SCH_CREDENTIALS {
   DWORD               dwVersion;
   DWORD               dwCredFormat;
   DWORD               cCreds;
-  PCCERT_CONTEXT* paCred;
+  PCCERT_CONTEXT *paCred;
   HCERTSTORE          hRootStore;
 
   DWORD               cMappers;
@@ -89,7 +89,7 @@ typedef struct _SCH_CREDENTIALS {
   DWORD               dwFlags;
   DWORD               cTlsParameters;
   PTLS_PARAMETERS     pTlsParameters;
-} SCH_CREDENTIALS, * PSCH_CREDENTIALS;
+} SCH_CREDENTIALS, *PSCH_CREDENTIALS;
 
 #endif /* SCH_CREDENTIALS_VERSION */
 

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -56,42 +56,42 @@ typedef enum _eTlsAlgorithmUsage {
 
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct _CRYPTO_SETTINGS {
-  eTlsAlgorithmUsage  eAlgorithmUsage;
-  UNICODE_STRING      strCngAlgId;
-  DWORD               cChainingModes;
-  PUNICODE_STRING     rgstrChainingModes; /* spellchecker:disable-line */
-  DWORD               dwMinBitLength;
-  DWORD               dwMaxBitLength;
+  eTlsAlgorithmUsage eAlgorithmUsage;
+  UNICODE_STRING strCngAlgId;
+  DWORD cChainingModes;
+  PUNICODE_STRING rgstrChainingModes; /* spellchecker:disable-line */
+  DWORD dwMinBitLength;
+  DWORD dwMaxBitLength;
 } CRYPTO_SETTINGS, *PCRYPTO_SETTINGS;
 
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct _TLS_PARAMETERS {
-  DWORD               cAlpnIds;
-  PUNICODE_STRING     rgstrAlpnIds; /* spellchecker:disable-line */
-  DWORD               grbitDisabledProtocols;
-  DWORD               cDisabledCrypto;
-  PCRYPTO_SETTINGS    pDisabledCrypto;
-  DWORD               dwFlags;
+  DWORD cAlpnIds;
+  PUNICODE_STRING rgstrAlpnIds; /* spellchecker:disable-line */
+  DWORD grbitDisabledProtocols;
+  DWORD cDisabledCrypto;
+  PCRYPTO_SETTINGS pDisabledCrypto;
+  DWORD dwFlags;
 } TLS_PARAMETERS, *PTLS_PARAMETERS;
 
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct _SCH_CREDENTIALS {
-  DWORD               dwVersion;
-  DWORD               dwCredFormat;
-  DWORD               cCreds;
+  DWORD dwVersion;
+  DWORD dwCredFormat;
+  DWORD cCreds;
   PCCERT_CONTEXT *paCred;
-  HCERTSTORE          hRootStore;
+  HCERTSTORE hRootStore;
 
-  DWORD               cMappers;
+  DWORD cMappers;
   struct _HMAPPER **aphMappers;
 
-  DWORD               dwSessionLifespan;
-  DWORD               dwFlags;
-  DWORD               cTlsParameters;
-  PTLS_PARAMETERS     pTlsParameters;
+  DWORD dwSessionLifespan;
+  DWORD dwFlags;
+  DWORD cTlsParameters;
+  PTLS_PARAMETERS pTlsParameters;
 } SCH_CREDENTIALS, *PSCH_CREDENTIALS;
 
-#endif /* SCH_CREDENTIALS_VERSION */
+#endif /* !SCH_CREDENTIALS_VERSION */
 
 struct Curl_schannel_cred {
   CredHandle cred_handle;

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -42,7 +42,7 @@
 #define CERT_STORE_PROV_SYSTEM_W  ((LPCSTR)(size_t)10)
 #endif
 
-/* Offered by mingw-w64 v8+, MS SDK ~10+/~VS2022+ */
+/* Offered by mingw-w64 v8+, MS SDK 10.0.17763.0/VS2017 15.8+ */
 #ifndef SCH_CREDENTIALS_VERSION
 #define SCH_CREDENTIALS_VERSION  0x00000005
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -71,7 +71,7 @@ struct cert_chain_engine_config_win8 {
   DWORD dwExclusiveFlags;
 };
 
-/* Offered by mingw-w64 v4+. MS SDK ~10+/~VS2017+. */
+/* Offered by mingw-w64 v4+, MS SDK 8.0+ */
 #ifndef CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG
 #define CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG 0x00000001
 #endif
@@ -358,7 +358,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
 
   /* CERT_NAME_SEARCH_ALL_NAMES_FLAG is available from Windows 8 onwards. */
   if(Win8_compat) {
-/* Offered by mingw-w64 v4+. MS SDK ~10+/~VS2017+. */
+/* Offered by mingw-w64 v4+, MS SDK 8.0+ */
 #ifndef CERT_NAME_SEARCH_ALL_NAMES_FLAG
 #define CERT_NAME_SEARCH_ALL_NAMES_FLAG 0x2
 #endif

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -71,7 +71,7 @@ struct cert_chain_engine_config_win8 {
   DWORD dwExclusiveFlags;
 };
 
-/* Offered by mingw-w64 v4+, MS SDK 8.0+ */
+/* Offered by mingw-w64 v4+, MS SDK 8.0/~VS2012+ */
 #ifndef CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG
 #define CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG 0x00000001
 #endif
@@ -358,7 +358,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
 
   /* CERT_NAME_SEARCH_ALL_NAMES_FLAG is available from Windows 8 onwards. */
   if(Win8_compat) {
-/* Offered by mingw-w64 v4+, MS SDK 8.0+ */
+/* Offered by mingw-w64 v4+, MS SDK 8.0/~VS2012+ */
 #ifndef CERT_NAME_SEARCH_ALL_NAMES_FLAG
 #define CERT_NAME_SEARCH_ALL_NAMES_FLAG 0x2
 #endif

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -639,7 +639,7 @@ static struct TerminalSettings {
   LONG valid;
 } TerminalSettings;
 
-/* Offered by mingw-w64 v7+. MS SDK ~10.16299/~VS2017+. */
+/* Offered by mingw-w64 v7+, MS SDK 10.0.10586.0/VS2015 Update 1+ */
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif


### PR DESCRIPTION
To make them more accurate.

Also:
- show Visual Studio version, where missing.
- ease the formatting.
- schannel_int.h: clang-tidy fallback code.

Used: `rg -l --sort=path CERT_FIND_HAS_PRIVATE_KEY`

---

https://github.com/curl/curl/pull/21621/files?w=1

Searched in this set of SDKs:

winsdk-07.0A-vs2010
winsdk-07.1A-vs2012
winsdk-08.0
winsdk-08.1
winsdk-10.0.10240.0-vs2015
winsdk-10.0.10586.0-vs2015-u1-u2
winsdk-10.0.14393.0-vs2015-u3
winsdk-10.0.15063.0-vs2017-15.1
winsdk-10.0.16299.0-vs2017-15.4
winsdk-10.0.17134.0-vs2017-15.7
winsdk-10.0.17763.0-vs2017-15.8
winsdk-10.0.18362.0-vs2019
winsdk-10.0.19041.0-vs2019-win10-2004
winsdk-10.0.20348.0-vs2019-win10-21H1
winsdk-10.0.22000.0-vs2019-win11
winsdk-10.0.22621.0-vs2022
winsdk-10.0.25926-preview
