### PR TITLE
cf-h2-proxy: drop interim responses

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -561,7 +561,7 @@ static int proxy_h2_on_header(nghttp2_session *session,
     struct http_resp *resp;
 
     /* status: always comes first, we might get more than one response,
-     * link the previous ones for keepers */
+     * discard previous, interim responses */
     result = Curl_http_decode_status(&http_status,
                                     (const char *)value, valuelen);
     if(result)

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -569,7 +569,8 @@ static int proxy_h2_on_header(nghttp2_session *session,
     result = Curl_http_resp_make(&resp, http_status, NULL);
     if(result)
       return NGHTTP2_ERR_CALLBACK_FAILURE;
-    resp->prev = ctx->tunnel.resp;
+    if(ctx->tunnel.resp)
+      Curl_http_resp_free(ctx->tunnel.resp);
     ctx->tunnel.resp = resp;
     CURL_TRC_CF(data, cf, "[%d] status: HTTP/2 %03d",
                 stream_id, ctx->tunnel.resp->status);


### PR DESCRIPTION
Any 1xx response before the CONNECT final one can be dropped as no one uses those in the HTTP/2 proxy filter. This eliminates a potential memory exhaustion by the famous malicious server on the internet.