### PR TITLE
unix-sockets: ignore proxy settings

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2629,10 +2629,13 @@ static CURLcode url_create_needle(struct Curl_easy *data,
   }
 
 #ifndef CURL_DISABLE_PROXY
-  /* After the Unix socket init but before the proxy vars are used, parse and
-   * initialize the proxy settings.
-   * Any UDS `via_peer` disables proxies. */
-  if(network_scheme && !(needle->via_peer && needle->via_peer->unix_socket)) {
+  /* Going via a unix socket ignores any proxy settings */
+  if(needle->via_peer && needle->via_peer->unix_socket) {
+    needle->bits.socksproxy = FALSE;
+    needle->bits.httpproxy = FALSE;
+    needle->bits.proxy = FALSE;
+  }
+  else if(network_scheme) {
     result = url_set_conn_proxies(data, needle);
     if(result)
       goto out;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -452,8 +452,8 @@ struct connectdata {
 
 #ifndef CURL_DISABLE_PROXY
 #define CURL_CONN_HOST_DISPNAME(c) \
-  ((c)->bits.socksproxy ? (c)->socks_proxy.peer->user_hostname : \
-    (c)->bits.httpproxy ? (c)->http_proxy.peer->user_hostname : \
+  ((c)->socks_proxy.peer ? (c)->socks_proxy.peer->user_hostname : \
+    (c)->http_proxy.peer ? (c)->http_proxy.peer->user_hostname : \
       (c)->via_peer ? (c)->via_peer->user_hostname : \
         (c)->origin->user_hostname)
 #else

--- a/tests/http/test_11_unix.py
+++ b/tests/http/test_11_unix.py
@@ -149,4 +149,3 @@ class TestUnix:
         r.check_response(count=1, http_status=200)
         assert r.stats[0]['remote_port'] == -1, f'{r.dump_logs()}'
         assert r.stats[0]['local_port'] == -1, f'{r.dump_logs()}'
-

--- a/tests/http/test_11_unix.py
+++ b/tests/http/test_11_unix.py
@@ -136,3 +136,17 @@ class TestUnix:
         r.check_response(exitcode=96, http_status=None)
         assert r.stats[0]['remote_port'] == -1, f'{r.dump_logs()}'
         assert r.stats[0]['local_port'] == -1, f'{r.dump_logs()}'
+
+    # download http: via Unix socket, ignore proxy args
+    def test_11_04_unix_connect_http(self, env: Env, httpd, uds_faker):
+        curl = CurlClient(env=env)
+        url = f'http://{env.domain1}:{env.http_port}/data.json'
+        xargs = curl.get_proxy_args(proto='http/1.1', use_ip=True, proxys=False)
+        xargs.extend([
+            '--unix-socket', uds_faker.path,
+        ])
+        r = curl.http_download(urls=[url], with_stats=True, extra_args=xargs)
+        r.check_response(count=1, http_status=200)
+        assert r.stats[0]['remote_port'] == -1, f'{r.dump_logs()}'
+        assert r.stats[0]['local_port'] == -1, f'{r.dump_logs()}'
+


### PR DESCRIPTION
Fix a recent regression: when a unix-socket is configured, all proxy settings must be ignored. The `via_peer` had been checked correctly, but the connections proxy bits were not cleared.

Add test_11_04 to verify.

Reported-by: Fabian Keil (libcurl mailing list)