### PR TITLE
setopt: fix to honor `CURLOPT_PROXY_CAINFO_BLOB` over Native CA

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2834,8 +2834,10 @@ static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
      * Specify entire PEM of the CA certificate
      */
 #ifdef USE_SSL
-    if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB))
+    if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB)) {
+      s->proxy_ssl.custom_cablob = TRUE;
       return Curl_setblobopt(&s->blobs[BLOB_CAINFO_PROXY], blob);
+    }
 #endif
     return CURLE_NOT_BUILT_IN;
   case CURLOPT_PROXY_ISSUERCERT_BLOB:


### PR DESCRIPTION
In AppleSecTrust or NativeCA-enabled builds, make sure override it when 
setting a custom `CURLOPT_PROXY_CAINFO_BLOB`.

Reported-by: Joshua Rogers (Aisle Research)

Follow-up to 1730407b74f41cfd33f189348be54d0504b7c291 #18279
Follow-up to eefd03c572996e5de4dec4fe295ad6f103e0eefc #18703
