### PR TITLE
CURLOPT_SHARE: warn about early remove

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLOPT_SHARE.md
@@ -43,6 +43,9 @@ if no share was used.
 
 Set this option to NULL again to stop using that share object.
 
+Warning: adding a *share* and then setting it to NULL while the transfer
+is ongoing is discouraged and may lead to undefined behavior.
+
 # DEFAULT
 
 NULL


### PR DESCRIPTION
Add a warning to removing a SHARE from an EASY handle before it is finished.