### PR TITLE
lib678: fix to not be perma-skipped

### DIFF
--- a/tests/libtest/lib678.c
+++ b/tests/libtest/lib678.c
@@ -97,7 +97,7 @@ static CURLcode test_lib678(const char *URL)
   curl_global_init(CURL_GLOBAL_DEFAULT);
   if(!strcmp("check", URL)) {
     CURLcode w = CURLE_OK;
-    struct curl_blob blob = { 0 };
+    struct curl_blob blob = { CURL_UNCONST("silly"), 5, 0 };
     CURL *curl = curl_easy_init();
     if(curl) {
       w = curl_easy_setopt(curl, CURLOPT_CAINFO_BLOB, &blob);


### PR DESCRIPTION
Prior to this patch the test was always skipped due to failing precheck
with `CURLE_BAD_FUNCTION_ARGUMENT`, because of the zero-length blob
passed to setopt. Fix by passing a non-zero long dummy blob as done in
`mk-lib1521.pl`.

Fixing:
```
test 0678 SKIPPED: CURLOPT_CAINFO_BLOB is not supported
```

Follow-up to 956e1ae84f2fec9f027b4ce80999744326b30992 #20705
