### PR TITLE
vauth: clear SSPI credentials on AcquireCredentialsHandle failure

### DIFF
--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -154,8 +154,14 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
                                  SECPKG_CRED_OUTBOUND, NULL,
                                  krb5->p_identity, NULL, NULL,
                                  krb5->credentials, NULL);
-    if(status != SEC_E_OK)
+    if(status != SEC_E_OK) {
+      /* On failure the handle contents are undefined per the SSPI contract;
+         clear our pointer so the outer guard re-attempts on retry and so the
+         cleanup path does not call FreeCredentialsHandle on it. */
+      curlx_free(krb5->credentials);
+      krb5->credentials = NULL;
       return CURLE_LOGIN_DENIED;
+    }
 
     /* Allocate our new context handle */
     krb5->context = curlx_calloc(1, sizeof(CtxtHandle));

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -155,9 +155,6 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
                                  krb5->p_identity, NULL, NULL,
                                  krb5->credentials, NULL);
     if(status != SEC_E_OK) {
-      /* On failure the handle contents are undefined per the SSPI contract;
-         clear our pointer so the outer guard re-attempts on retry and so the
-         cleanup path does not call FreeCredentialsHandle on it. */
       curlx_free(krb5->credentials);
       krb5->credentials = NULL;
       return CURLE_LOGIN_DENIED;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -140,9 +140,6 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                      ntlm->p_identity, NULL, NULL,
                                      ntlm->credentials, NULL);
   if(status != SEC_E_OK) {
-    /* On failure the handle contents are undefined per the SSPI contract;
-       free and clear our pointer so a subsequent cleanup pass does not call
-       FreeCredentialsHandle on it. */
     curlx_free(ntlm->credentials);
     ntlm->credentials = NULL;
     return CURLE_LOGIN_DENIED;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -139,8 +139,14 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
                                      SECPKG_CRED_OUTBOUND, NULL,
                                      ntlm->p_identity, NULL, NULL,
                                      ntlm->credentials, NULL);
-  if(status != SEC_E_OK)
+  if(status != SEC_E_OK) {
+    /* On failure the handle contents are undefined per the SSPI contract;
+       free and clear our pointer so a subsequent cleanup pass does not call
+       FreeCredentialsHandle on it. */
+    curlx_free(ntlm->credentials);
+    ntlm->credentials = NULL;
     return CURLE_LOGIN_DENIED;
+  }
 
   /* Allocate our new context handle */
   ntlm->context = curlx_calloc(1, sizeof(CtxtHandle));

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -160,9 +160,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                 nego->p_identity, NULL, NULL,
                                 nego->credentials, NULL);
     if(nego->status != SEC_E_OK) {
-      /* On failure the handle contents are undefined per the SSPI contract;
-         clear our pointer so the outer guard re-attempts on retry and so the
-         cleanup path does not call FreeCredentialsHandle on it. */
       curlx_free(nego->credentials);
       nego->credentials = NULL;
       return CURLE_AUTH_ERROR;

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -159,8 +159,14 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                 SECPKG_CRED_OUTBOUND, NULL,
                                 nego->p_identity, NULL, NULL,
                                 nego->credentials, NULL);
-    if(nego->status != SEC_E_OK)
+    if(nego->status != SEC_E_OK) {
+      /* On failure the handle contents are undefined per the SSPI contract;
+         clear our pointer so the outer guard re-attempts on retry and so the
+         cleanup path does not call FreeCredentialsHandle on it. */
+      curlx_free(nego->credentials);
+      nego->credentials = NULL;
       return CURLE_AUTH_ERROR;
+    }
 
     /* Allocate our new context handle */
     nego->context = curlx_calloc(1, sizeof(CtxtHandle));


### PR DESCRIPTION
## Summary
Three small SSPI cleanup patches across `lib/vauth/`:
- `krb5_sspi.c` — clear `krb5->credentials` after a failed `AcquireCredentialsHandle()`
- `spnego_sspi.c` — clear `nego->credentials` after a failed `AcquireCredentialsHandle()`
- `ntlm_sspi.c` — clear `ntlm->credentials` after a failed `AcquireCredentialsHandle()`

## The problem
Per the [Microsoft SSPI contract for `AcquireCredentialsHandle`](https://learn.microsoft.com/en-us/windows/win32/api/sspi/nf-sspi-acquirecredentialshandlea), on failure the output handle is invalid and must not be passed to any other security function.
The current code in all three sites leaves the heap-allocated `CredHandle` buffer referenced from the auth struct, which produces two real-world consequences:

1. **API misuse on cleanup.** Each protocol's cleanup function (`Curl_auth_cleanup_gssapi`, `Curl_auth_cleanup_spnego`, `Curl_auth_cleanup_ntlm`) later calls `FreeCredentialsHandle()` on the calloc'd-but-invalid handle. In practice all Windows SSPI
providers I'm aware of return `SEC_E_INVALID_HANDLE` and do not crash, but this is API misuse and not contract-safe across SSPI provider implementations.

2. **State-machine wart (krb5, spnego only).** The outer `if(!field->credentials)` guard at the top of each function skips re-initialization on subsequent calls. After a transient `AcquireCredentialsHandle` failure, the field stays non-NULL but invalid, so the next attempt at authentication on the same connection re-enters with a dead handle and `InitializeSecurityContext` fails — the connection's auth is wedged until the connection itself is torn down. NTLM is not affected by this aspect since it calls `Curl_auth_cleanup_ntlm` at function entry.

## The fix
On the `AcquireCredentialsHandle` failure path, `curlx_free` the buffer and set the field to `NULL`. After the change:

- The cleanup function's `if(field->credentials)` guard correctly skips the invalid handle.
- For krb5 and spnego, the outer guard allows the next call to re-attempt initialization.
- No behavior change in the success path.

## Testing
- **Build:** cross-compiled clean for `x86_64-w64-mingw32` (gcc 15.2.0) with `--enable-sspi`. Zero warnings or errors across the full libcurl build. The three patched objects emit as PE/COFF.
- **Style:** `make checksrc` passes.
- **Runtime:** I do not have a Windows development environment, so I have **not** exercised the patched paths against live Kerberos/Negotiate/NTLM providers. Reviewers with Windows CI access would help confirm by hitting a deliberately broken auth scenario (bad principal, unreachable KDC, etc.) and verifying retry behavior.

