### PR TITLE
docs: end "...can be used several times..." sentences with period

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -787,7 +787,7 @@ sub single {
     }
     elsif($multi eq "append") {
         push @extra,
-            sprintf("${pre}%s can be used several times in a command line\n",
+            sprintf("${pre}%s can be used several times in a command line.\n",
                     manpageify($long, $manpage));
     }
     elsif($multi eq "boolean") {


### PR DESCRIPTION
Several options in the man pages have a sentence in the following format:

> [option] can be used several times in a command line

Here, we terminate those sentences with periods to match the writing style seen in the rest of the man page documentation.