### PR TITLE
src: improve `curlx_memzero()` internal APIs

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1661,4 +1661,11 @@ void curlx_memzero_low(void *buf, size_t size);
       curlx_memzero_low(ptr, size); \
   } while(0)
 
+/* Public macro with NULL-check for null-terminated strings */
+#define curlx_strzero(str)                 \
+  do {                                     \
+    if(str)                                \
+      curlx_memzero_low(str, strlen(str)); \
+  } while(0)
+
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1628,14 +1628,14 @@ typedef struct sockaddr_un {
 #if defined(_MSC_VER) && defined(NTDDI_VERSION) && \
   (NTDDI_VERSION >= 0x0A000010) /* MS SDK 10.0.26100.0+ */
 #pragma comment(lib, "volatileaccessu.lib")
-#define curlx_memzero(buf, size)  SecureZeroMemory2(buf, size)
+#define curlx_memzero_low(buf, size)  SecureZeroMemory2(buf, size)
 #else
-#define curlx_memzero(buf, size)  SecureZeroMemory(buf, size)
+#define curlx_memzero_low(buf, size)  SecureZeroMemory(buf, size)
 #endif
 #elif defined(HAVE_MEMSET_S)
-#define curlx_memzero(buf, size)  (void)memset_s(buf, size, 0, size)
+#define curlx_memzero_low(buf, size)  (void)memset_s(buf, size, 0, size)
 #elif defined(HAVE_MEMSET_EXPLICIT)
-#define curlx_memzero(buf, size)  (void)memset_explicit(buf, 0, size)
+#define curlx_memzero_low(buf, size)  (void)memset_explicit(buf, 0, size)
 #elif defined(__CYGWIN__) || \
   (defined(__NEWLIB__) && !defined(__CLIB2__)) || \
   (defined(__GLIBC__) && \
@@ -1643,15 +1643,22 @@ typedef struct sockaddr_un {
   (defined(__DragonFly__) && __DragonFly_version >= 500600 /* v5.6+ */) || \
   (defined(__FreeBSD__) && __FreeBSD_version >= 1100037 /* v11.0+ */) || \
   (defined(__OpenBSD__) && OpenBSD >= 201405 /* v5.5+ */)
-#define curlx_memzero(buf, size)  explicit_bzero(buf, size)
+#define curlx_memzero_low(buf, size)  explicit_bzero(buf, size)
 #elif defined(__NetBSD__) && __NetBSD_Version__ >= 702000000 /* v7.2+ */
-#define curlx_memzero(buf, size)  (void)explicit_memset(buf, 0, size)
+#define curlx_memzero_low(buf, size)  (void)explicit_memset(buf, 0, size)
 #endif
 #endif /* !_CURL_LOCAL_MEMZERO */
 
-#ifndef curlx_memzero
+#ifndef curlx_memzero_low
 #define USE_CURLX_MEMZERO
-void curlx_memzero(void *buf, size_t size);
+void curlx_memzero_low(void *buf, size_t size);
 #endif
+
+/* Public macro with NULL-check */
+#define curlx_memzero(ptr, size)    \
+  do {                              \
+    if(ptr)                         \
+      curlx_memzero_low(ptr, size); \
+  } while(0)
 
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1653,19 +1653,7 @@ typedef struct sockaddr_un {
 #define USE_CURLX_MEMZERO
 void curlx_memzero_low(void *buf, size_t size);
 #endif
-
-/* Public macro with NULL-check */
-#define curlx_memzero(ptr, size)    \
-  do {                              \
-    if(ptr)                         \
-      curlx_memzero_low(ptr, size); \
-  } while(0)
-
-/* Public macro with NULL-check for null-terminated strings */
-#define curlx_strzero(str)                 \
-  do {                                     \
-    if(str)                                \
-      curlx_memzero_low(str, strlen(str)); \
-  } while(0)
+void curlx_memzero(void *buf, size_t size);
+void curlx_strzero(void *buf);
 
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1338,20 +1338,6 @@ extern curl_calloc_callback Curl_ccalloc;
     (ptr) = NULL;           \
   } while(0)
 
-/* Same as curlx_safefree() but zeroes memory before freeing */
-#define curlx_safefreezero(ptr, size) \
-  do {                                \
-    curlx_freezero(ptr, size);        \
-    (ptr) = NULL;                     \
-  } while(0)
-
-/* Same as curlx_safefreezero() but determines length with strlen() */
-#define curlx_safefreezeroz(ptr) \
-  do {                           \
-    curlx_freezeroz(ptr);        \
-    (ptr) = NULL;                \
-  } while(0)
-
 #include <curl/curl.h> /* for CURL_EXTERN, curl_socket_t, mprintf.h */
 
 #ifdef DEBUGBUILD
@@ -1667,7 +1653,5 @@ typedef struct sockaddr_un {
 #define USE_CURLX_MEMZERO
 void curlx_memzero(void *buf, size_t size);
 #endif
-void curlx_freezero(void *buf, size_t size);
-void curlx_freezeroz(void *buf);
 
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/curlx/strdup.c
+++ b/lib/curlx/strdup.c
@@ -101,25 +101,9 @@ static void *(* const volatile p_curlx_memset)(void *buf, int val,
 
 /* Local fallback in case there is no system function to securely zero a memory
    buffer. */
-void curlx_memzero(void *buf, size_t size)
+void curlx_memzero_low(void *buf, size_t size)
 {
   if(buf)
     p_curlx_memset(buf, 0, size);
 }
 #endif
-
-/* Free 'buf' after zeroing its content. */
-void curlx_freezero(void *buf, size_t size)
-{
-  if(buf)
-    curlx_memzero(buf, size);
-  curlx_free(buf);
-}
-
-/* Free 'buf' after zeroing its content, where 'buf' is null-terminated. */
-void curlx_freezeroz(void *buf)
-{
-  if(buf)
-    curlx_memzero(buf, strlen(buf));
-  curlx_free(buf);
-}

--- a/lib/curlx/strdup.c
+++ b/lib/curlx/strdup.c
@@ -107,3 +107,17 @@ void curlx_memzero_low(void *buf, size_t size)
     p_curlx_memset(buf, 0, size);
 }
 #endif
+
+/* Free 'buf' after zeroing its content. */
+void curlx_memzero(void *buf, size_t size)
+{
+  if(buf)
+    curlx_memzero_low(buf, size);
+}
+
+/* Free 'buf' after zeroing its content, where 'buf' is null-terminated. */
+void curlx_strzero(void *buf)
+{
+  if(buf)
+    curlx_memzero_low(buf, strlen(buf));
+}


### PR DESCRIPTION
- delete zero-and-free wrapper macros. (not yet used)
  To keep it simple.
- do NULL-check in `curlx_memzero()`.
  To avoid noise at call sites.
- add `curlx_strzero()` for null-terminated strings, also with
  NULL-check.

Ref: #21637
Follow-up to 066478f6346a2d987a9ecc3bd3bf45764d69c1c4 #21598
