### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2088,7 +2088,7 @@ Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schann
     dnl explicitly built without TLS
     ;;
   xD*)
-    AC_MSG_ERROR([--without-ssl has been set together with an explicit option to use an ssl library
+    AC_MSG_ERROR([--without-ssl has been set together with an explicit option to use an SSL library
 (e.g. --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schannel, --with-amissl, --with-rustls).
 Since these are conflicting parameters, verify which is the desired one and drop the other.])
     ;;

--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -238,7 +238,7 @@ other keywords that tweak its operations. Applications or a system
 may define new alias names for priority strings that can then be used here.
 
 Since the order of items in priority strings is significant, it makes no
-sense for curl to puzzle other ssl options somehow together. `--ciphers`
+sense for curl to puzzle other SSL options somehow together. `--ciphers`
 is the single way to change priority.
 
 ### Examples

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -465,7 +465,7 @@ December 21: dropped hyper
 
 ## 2025
 
-February 5: first 0RTT for QUIC, ssl session import/export
+February 5: first 0RTT for QUIC, SSL session import/export
 
 February: experimental HTTPS RR support
 

--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -215,6 +215,10 @@ https://curl.se/mail/lib-2012-07/0073.html
 
 # Authentication
 
+## `--aws-sigv4` does not handle multipart/form-data correctly
+
+[curl issue 13351](https://github.com/curl/curl/issues/13351)
+
 ## Digest `auth-int` for PUT/POST
 
 We do not support auth-int for Digest using PUT or POST
@@ -515,12 +519,6 @@ that involve compilation are doomed from that point, the configured tree
 cannot be built.
 
 [curl issue 6904](https://github.com/curl/curl/issues/6904)
-
-# Authentication
-
-## `--aws-sigv4` does not handle multipart/form-data correctly
-
-[curl issue 13351](https://github.com/curl/curl/issues/13351)
 
 # HTTP/2
 

--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -418,7 +418,7 @@ See [curl issue 13350](https://github.com/curl/curl/issues/13350)
 ## `CURLOPT_CONNECT_TO` does not work for HTTPS proxy
 
 It is unclear if the same option should even cover the proxy connection or if
-if requires a separate option.
+it requires a separate option.
 
 See [curl issue 14481](https://github.com/curl/curl/issues/14481)
 

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -423,7 +423,8 @@ roles:
 * **incident lead** - Coordinates technical efforts
 * **communication lead** - Single point of public contact
 
-It is likely that our [BDFL](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) occupies
+It is likely that our
+[BDFL](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) occupies
 one of these roles, though this plan does not depend on it.
 
 A declaration may also contain more detailed information but as we honor
@@ -432,8 +433,8 @@ contain a brief notification that a **major incident** is occurring.
 
 ## Major incident ongoing
 
-During the incident - all press, media, legal or commercial entities should contact
-communication lead (security@curl.se).
+During the incident - all press, media, legal or commercial entities should
+contact communication lead (security@curl.se).
 
 Existing **curl-security** team internal communication channels are used
 for all internal communication.

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -433,7 +433,7 @@ contain a brief notification that a **major incident** is occurring.
 ## Major incident ongoing
 
 During the incident - all press, media, legal or commercial entities should contact
-communication leader (security@curl.se).
+communication lead (security@curl.se).
 
 Existing **curl-security** team internal communication channels are used
 for all internal communication.
@@ -442,8 +442,8 @@ Existing vulnerability disclosure process are followed for any embargoes
 and fixes.
 
 Where possible, public communication are provided:
-* regular communication from communication leader (for example daily update)
-* asynchronous communication from incident leader
+* regular communication from communication lead (for example daily update)
+* asynchronous communication from incident lead
 
 * Delivered to the aforementioned curl communication channels.
 

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -218,9 +218,11 @@ problem. There are already several benign and likely reasons for transfers to
 stall and never end, so applications that cannot deal with never-ending
 transfers already need to have counter-measures established.
 
-Well known attacks, like [Slowloris](https://en.wikipedia.org/wiki/Slowloris_(cyber_attack)), that send partial
-requests are usually not considered a flaw. If the problem avoids the regular counter-measures when it causes a never-
-ending transfer, it might be a security problem.
+Well known attacks, like
+[Slowloris](https://en.wikipedia.org/wiki/Slowloris_(cyber_attack)), that send
+partial requests are usually not considered a flaw. If the problem bypasses
+the regular counter-measures and it causes a never-ending transfer, it might
+be a security problem.
 
 ## Not practically possible
 

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -218,7 +218,7 @@ problem. There are already several benign and likely reasons for transfers to
 stall and never end, so applications that cannot deal with never-ending
 transfers already need to have counter-measures established.
 
-Well known attacks, like
+Well-known attacks, like
 [Slowloris](https://en.wikipedia.org/wiki/Slowloris_(cyber_attack)), that send
 partial requests are usually not considered a flaw. If the problem bypasses
 the regular counter-measures and it causes a never-ending transfer, it might

--- a/docs/examples/cacertinmem.c
+++ b/docs/examples/cacertinmem.c
@@ -166,10 +166,10 @@ int main(void)
 
     /* use a fresh connection (optional) this option seriously impacts
      * performance of multiple transfers but it is necessary order to
-     * demonstrate this example. recall that the ssl ctx callback is only
+     * demonstrate this example. recall that the SSL ctx callback is only
      * called _before_ an SSL connection is established, therefore it does not
      * affect existing verified SSL connections already in the connection
-     * cache associated with this handle. normally you would set the ssl ctx
+     * cache associated with this handle. normally you would set the SSL ctx
      * function before making any transfers, and not use this option.
      */
     curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1L);

--- a/docs/examples/simplessl.c
+++ b/docs/examples/simplessl.c
@@ -22,7 +22,7 @@
  *
  ***************************************************************************/
 /* <DESC>
- * Shows HTTPS usage with client certs and optional ssl engine use.
+ * Shows HTTPS usage with client certs and optional SSL engine use.
  * </DESC>
  */
 #ifdef _MSC_VER

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -125,7 +125,7 @@ static void *create_thread(void *progress_bar)
   pthread_t tid[NUMT];
   int i;
 
-  /* Make sure I do not create more threads than urls. */
+  /* Make sure I do not create more threads than URLs. */
   for(i = 0; i < NUMT && i < num_urls; i++) {
     int error = pthread_create(&tid[i],
                                NULL, /* default attributes please */

--- a/docs/examples/sslbackend.c
+++ b/docs/examples/sslbackend.c
@@ -22,7 +22,7 @@
  *
  ***************************************************************************/
 /* <DESC>
- * Shows HTTPS usage with client certs and optional ssl engine use.
+ * Shows HTTPS usage with client certs and optional SSL engine use.
  * </DESC>
  */
 #include <assert.h>

--- a/docs/internals/TLS-SESSIONS.md
+++ b/docs/internals/TLS-SESSIONS.md
@@ -119,7 +119,7 @@ concurrent connections do not reuse the same ticket.
 
 #### Privacy and Security
 
-As mentioned above, ssl peer keys are not intended for storage in a file
+As mentioned above, SSL peer keys are not intended for storage in a file
 system. They clearly show which hosts the user talked to. This is not only
 privacy relevant, but also has security implications as an attacker might find
 worthy targets among your peer keys.

--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -72,7 +72,7 @@ Passing in "creative octets" like newlines where they are not expected might
 trigger unexpected results.
 
 Before version 7.17.0, strings were not copied. Instead the user was forced
-keep them available until libcurl no longer needed them.
+to keep them available until libcurl no longer needed them.
 
 # OPTIONS
 

--- a/docs/libcurl/curl_multi_socket_action.md
+++ b/docs/libcurl/curl_multi_socket_action.md
@@ -103,7 +103,7 @@ call curl_multi_socket_action(3) with *CURL_SOCKET_TIMEOUT*.
 ~~~c
 int main(void)
 {
-  /* the event-library gets told when there activity on the socket 'fd',
+  /* the event-library gets told when there is activity on the socket 'fd',
      which we translate to a call to curl_multi_socket_action() */
   int running = 0;
   int fd = 3; /* the descriptor that had action */

--- a/docs/libcurl/curl_multi_socket_action.md
+++ b/docs/libcurl/curl_multi_socket_action.md
@@ -92,7 +92,7 @@ to kickstart everything. To get one or more callbacks called.
 7. Wait for activity on any of libcurl's sockets, use the timeout value your
 callback has been told.
 
-8, When activity is detected, call curl_multi_socket_action() for the
+8. When activity is detected, call curl_multi_socket_action() for the
 socket(s) that got action. If no activity is detected and the timeout expires,
 call curl_multi_socket_action(3) with *CURL_SOCKET_TIMEOUT*.
 

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
@@ -30,7 +30,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_CTX_DATA, void *pointer);
 
 # DESCRIPTION
 
-Data *pointer* to pass to the ssl context callback set by the option
+Data *pointer* to pass to the SSL context callback set by the option
 CURLOPT_SSL_CTX_FUNCTION(3), this is the pointer you get as third
 parameter.
 

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1362,7 +1362,7 @@ typedef enum {
   CURLOPTDEPRECATED(CURLOPT_KRBLEVEL, CURLOPTTYPE_STRINGPOINT, 63,
                     8.17.0, "removed"),
 
-  /* Set if we should verify the peer in ssl handshake, set 1 to verify. */
+  /* Set if we should verify the peer in SSL handshake, set 1 to verify. */
   CURLOPT(CURLOPT_SSL_VERIFYPEER, CURLOPTTYPE_LONG, 64),
 
   /* The CApath or CAfile used to validate the peer certificate
@@ -1420,7 +1420,7 @@ typedef enum {
    */
   CURLOPT(CURLOPT_HTTPGET, CURLOPTTYPE_LONG, 80),
 
-  /* Set if we should verify the Common name from the peer certificate in ssl
+  /* Set if we should verify the Common name from the peer certificate in SSL
    * handshake, set 1 to check existence, 2 to ensure that it matches the
    * provided hostname. */
   CURLOPT(CURLOPT_SSL_VERIFYHOST, CURLOPTTYPE_LONG, 81),
@@ -1524,12 +1524,12 @@ typedef enum {
      Note that setting multiple bits may cause extra network round-trips. */
   CURLOPT(CURLOPT_HTTPAUTH, CURLOPTTYPE_VALUES, 107),
 
-  /* Set the ssl context callback function, currently only for OpenSSL or
+  /* Set the SSL context callback function, currently only for OpenSSL or
      wolfSSL ssl_ctx, or mbedTLS mbedtls_ssl_config in the second argument.
      The function must match the curl_ssl_ctx_callback prototype. */
   CURLOPT(CURLOPT_SSL_CTX_FUNCTION, CURLOPTTYPE_FUNCTIONPOINT, 108),
 
-  /* Set the userdata for the ssl context callback function's third
+  /* Set the userdata for the SSL context callback function's third
      argument */
   CURLOPT(CURLOPT_SSL_CTX_DATA, CURLOPTTYPE_CBPOINT, 109),
 
@@ -1935,11 +1935,11 @@ typedef enum {
   /* Set authentication options directly */
   CURLOPT(CURLOPT_LOGIN_OPTIONS, CURLOPTTYPE_STRINGPOINT, 224),
 
-  /* Enable/disable TLS NPN extension (http2 over ssl might fail without) */
+  /* Enable/disable TLS NPN extension (http2 over SSL might fail without) */
   CURLOPTDEPRECATED(CURLOPT_SSL_ENABLE_NPN, CURLOPTTYPE_LONG, 225,
                     7.86.0, "Has no function"),
 
-  /* Enable/disable TLS ALPN extension (http2 over ssl might fail without) */
+  /* Enable/disable TLS ALPN extension (http2 over SSL might fail without) */
   CURLOPT(CURLOPT_SSL_ENABLE_ALPN, CURLOPTTYPE_LONG, 226),
 
   /* Time to wait for a response to an HTTP request containing an
@@ -2012,11 +2012,11 @@ typedef enum {
      this option is used only if PROXY_SSL_VERIFYPEER is true */
   CURLOPT(CURLOPT_PROXY_CAPATH, CURLOPTTYPE_STRINGPOINT, 247),
 
-  /* Set if we should verify the proxy in ssl handshake,
+  /* Set if we should verify the proxy in SSL handshake,
      set 1 to verify. */
   CURLOPT(CURLOPT_PROXY_SSL_VERIFYPEER, CURLOPTTYPE_LONG, 248),
 
-  /* Set if we should verify the Common name from the proxy certificate in ssl
+  /* Set if we should verify the Common name from the proxy certificate in SSL
    * handshake, set 1 to check existence, 2 to ensure that it matches
    * the provided hostname. */
   CURLOPT(CURLOPT_PROXY_SSL_VERIFYHOST, CURLOPTTYPE_LONG, 249),

--- a/lib/bufq.h
+++ b/lib/bufq.h
@@ -204,6 +204,7 @@ void Curl_bufq_skip(struct bufq *q, size_t amount);
 typedef CURLcode Curl_bufq_writer(void *writer_ctx,
                                   const uint8_t *buf, size_t len,
                                   size_t *pwritten);
+
 /**
  * Passes the chunks in the buffer queue to the writer and returns
  * the amount of buf written. A writer may return -1 and CURLE_AGAIN

--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -80,7 +80,7 @@ static wchar_t *fn_convert_UTF8_to_wchar(const char *str_utf8)
 }
 #endif
 
-/* declare GetFullPathNameW for mingw-w64 UWP builds targeting old windows */
+/* declare GetFullPathNameW for mingw-w64 UWP builds targeting old Windows */
 #if defined(CURL_WINDOWS_UWP) && defined(__MINGW32__) && \
   (_WIN32_WINNT < _WIN32_WINNT_WIN10)
 WINBASEAPI DWORD WINAPI GetFullPathNameW(LPCWSTR, DWORD, LPWSTR, LPWSTR *);

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -148,7 +148,7 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
 
   *done = TRUE; /* unconditionally */
 
-  /* url-decode path before further evaluation */
+  /* URL-decode path before further evaluation */
   result = Curl_urldecode(data->state.up.path, 0, &path, NULL, REJECT_CTRL);
   if(result)
     return result;

--- a/lib/ftp-int.h
+++ b/lib/ftp-int.h
@@ -113,10 +113,10 @@ struct ftp_conn {
   char *account;
   char *alternative_to_user;
   char *entrypath; /* the PWD reply when we logged on */
-  const char *file; /* url-decoded filename (or path), points into rawpath */
+  const char *file; /* URL-decoded filename (or path), points into rawpath */
   char *rawpath; /* URL decoded, allocated, version of the path */
   struct pathcomp *dirs; /* allocated array for path components */
-  char *prevpath;   /* url-decoded conn->path from the previous transfer */
+  char *prevpath;   /* URL-decoded conn->path from the previous transfer */
   char transfertype; /* set by ftp_transfertype for use by Curl_client_write()a
                         and others (A/I or zero) */
   char *server_os;     /* The target server operating system. */

--- a/lib/url.c
+++ b/lib/url.c
@@ -2857,7 +2857,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data)
      * remaining parts like the cloned SSL configuration. */
     result = Curl_ssl_conn_config_init(data, needle);
     if(result) {
-      DEBUGF(curl_mfprintf(stderr, "Error: init connection ssl config\n"));
+      DEBUGF(curl_mfprintf(stderr, "Error: init connection SSL config\n"));
       goto out;
     }
     /* attach it and no longer own it */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -175,7 +175,7 @@ struct ssl_primary_config {
 struct ssl_config_data {
   struct ssl_primary_config primary;
   long certverifyresult; /* result from the certificate verification */
-  curl_ssl_ctx_callback fsslctx; /* function to initialize ssl ctx */
+  curl_ssl_ctx_callback fsslctx; /* function to initialize SSL ctx */
   void *fsslctxp;        /* parameter for call back */
   BIT(certinfo);     /* gather lots of certificate info */
   BIT(earlydata);    /* use TLS 1.3 early data */
@@ -887,7 +887,7 @@ enum dupstring {
   STRING_SET_REFERER,     /* custom string for the HTTP referer field */
   STRING_SET_URL,         /* what original URL to work on */
   STRING_USERAGENT,       /* User-Agent string */
-  STRING_SSL_ENGINE,      /* name of ssl engine */
+  STRING_SSL_ENGINE,      /* name of SSL engine */
   STRING_USERNAME,        /* <username>, if used */
   STRING_PASSWORD,        /* <password>, if used */
   STRING_OPTIONS,         /* <options>, if used */

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -252,7 +252,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   type_2_bufs[0].cbBuffer   = curlx_uztoul(ntlm->input_token_len);
 
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
-  /* ssl context comes from schannel.
+  /* SSL context comes from schannel.
    * When extended protection is used in IIS server,
    * we have to pass a second SecBuffer to the SecBufferDesc
    * otherwise IIS does not pass the authentication (401 response).

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -191,7 +191,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     chlg_buf[0].cbBuffer   = curlx_uztoul(chlglen);
 
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
-    /* ssl context comes from Schannel.
+    /* SSL context comes from Schannel.
      * When extended protection is used in IIS server,
      * we have to pass a second SecBuffer to the SecBufferDesc
      * otherwise IIS does not pass the authentication (401 response).

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -973,7 +973,7 @@ static CURLcode mbed_configure_ssl(struct Curl_cfilter *cf,
     result = (*data->set.ssl.fsslctx)(data, &backend->config,
                                       data->set.ssl.fsslctxp);
     if(result)
-      failf(data, "error signaled by ssl ctx callback");
+      failf(data, "error signaled by SSL ctx callback");
   }
 
   return result;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -33,7 +33,7 @@
 #include "curl_trc.h"
 #include "httpsrr.h"
 #include "formdata.h" /* for the boundary function */
-#include "url.h" /* for the ssl config check function */
+#include "url.h" /* for the SSL config check function */
 #include "curlx/inet_pton.h"
 #include "vtls/openssl.h"
 #include "connect.h"
@@ -1188,13 +1188,13 @@ static int engineload(struct Curl_easy *data,
     /* Does the engine supports LOAD_CERT_CTRL ? */
     if(!ENGINE_ctrl(data->state.engine, ENGINE_CTRL_GET_CMD_FROM_NAME,
                     0, CURL_UNCONST(cmd_name), NULL)) {
-      failf(data, "ssl engine does not support loading certificates");
+      failf(data, "SSL engine does not support loading certificates");
       return 0;
     }
 
     /* Load the certificate from the engine */
     if(!ENGINE_ctrl_cmd(data->state.engine, cmd_name, 0, &params, NULL, 1)) {
-      failf(data, "ssl engine cannot load client cert with id '%s' [%s]",
+      failf(data, "SSL engine cannot load client cert with id '%s' [%s]",
             cert_file,
             ossl_strerror(ERR_get_error(), error_buffer,
                           sizeof(error_buffer)));
@@ -1202,7 +1202,7 @@ static int engineload(struct Curl_easy *data,
     }
 
     if(!params.cert) {
-      failf(data, "ssl engine did not initialized the certificate properly.");
+      failf(data, "SSL engine did not initialized the certificate properly.");
       return 0;
     }
 
@@ -2065,7 +2065,7 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
     break;
   default:
     DEBUGASSERT(0);
-    failf(data, "unexpected ssl peer type: %d", peer->type);
+    failf(data, "unexpected SSL peer type: %d", peer->type);
     return CURLE_PEER_FAILED_VERIFICATION;
   }
 
@@ -3949,7 +3949,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
                                       data->set.ssl.fsslctxp);
     Curl_set_in_callback(data, FALSE);
     if(result) {
-      failf(data, "error signaled by ssl ctx callback");
+      failf(data, "error signaled by SSL ctx callback");
       return result;
     }
   }

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -183,7 +183,7 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
 
 /*
  * Get the server cert, verify it and show it, etc., only call failf() if
- * ssl config verifypeer or -host is set. Otherwise all this is for
+ * SSL config verifypeer or -host is set. Otherwise all this is for
  * informational purposes only!
  */
 CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -104,7 +104,7 @@ CURLsslset Curl_init_sslset_nolock(curl_sslbackend id, const char *name,
 curl_sslbackend Curl_ssl_backend(void);
 
 /**
- * Init ssl config for a new easy handle.
+ * Init SSL config for a new easy handle.
  */
 void Curl_ssl_easy_config_init(struct Curl_easy *data);
 

--- a/lib/vtls/vtls_scache.h
+++ b/lib/vtls/vtls_scache.h
@@ -83,7 +83,7 @@ CURLcode Curl_ssl_peer_key_build(struct ssl_primary_config *ssl,
                                  char **ppeer_key);
 
 /* Return if there is a session cache shall be used.
- * An ssl session might not be configured or not available for
+ * An SSL session might not be configured or not available for
  * "connect-only" transfers.
  */
 bool Curl_ssl_scache_use(struct Curl_cfilter *cf, struct Curl_easy *data);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1440,7 +1440,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
     result = (*data->set.ssl.fsslctx)(data, wctx->ssl_ctx,
                                       data->set.ssl.fsslctxp);
     if(result) {
-      failf(data, "error signaled by ssl ctx callback");
+      failf(data, "error signaled by SSL ctx callback");
       goto out;
     }
   }

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -33,7 +33,7 @@ AC_DEFUN([CURL_WITH_OPENSSL], [
 if test "x$OPT_OPENSSL" != "xno"; then
   ssl_msg=
 
-  dnl backup the pre-ssl variables
+  dnl backup the pre-detection variables
   CLEANLDFLAGS="$LDFLAGS"
   CLEANLDFLAGSPC="$LDFLAGSPC"
   CLEANCPPFLAGS="$CPPFLAGS"
@@ -315,7 +315,7 @@ if test "x$OPT_OPENSSL" != "xno"; then
 
   if test "$OPENSSL_ENABLED" = "1"; then
     if test -n "$LIB_OPENSSL"; then
-      dnl when the ssl shared libs were found in a path that the runtime
+      dnl when the SSL shared libs were found in a path that the runtime
       dnl linker does not search through, we need to add it to CURL_LIBRARY_PATH
       dnl to prevent further configure tests to fail due to this
       if test "$cross_compiling" != "yes"; then

--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -30,7 +30,7 @@ dnl ----------------------------------------------------
 if test "x$OPT_RUSTLS" != "xno"; then
   ssl_msg=
 
-  dnl backup the pre-ssl variables
+  dnl backup the pre-detection variables
   CLEANLDFLAGS="$LDFLAGS"
   CLEANLDFLAGSPC="$LDFLAGSPC"
   CLEANCPPFLAGS="$CPPFLAGS"

--- a/projects/vms/generate_config_vms_h_curl.com
+++ b/projects/vms/generate_config_vms_h_curl.com
@@ -67,7 +67,7 @@ $if f$locate(",nossl,", args_lower) .lt. args_len then nossl = 1
 $if .not. nossl
 $then
 $!
-$!  ssl$* logicals means HP ssl is present
+$!  ssl$* logicals means HP SSL is present
 $!----------------------------------------
 $   if f$trnlnm("ssl$root") .nes. ""
 $   then
@@ -96,7 +96,7 @@ $       nohpssl = 1
 $       hpssl = 0
 $   endif
 $!
-$!  Finally check to see if hp ssl has been specifically included.
+$!  Finally check to see if HP SSL has been specifically included.
 $!----------------------------------------------------------------
 $   if f$locate(",nohpssl,", args_lower) .lt. args_len
 $   then

--- a/scripts/badwords.txt
+++ b/scripts/badwords.txt
@@ -16,6 +16,7 @@ tool chain:toolchain
 tool-chain:toolchain
 wild-card:wildcard
 wild card:wildcard
+threadsafe:thread-safe
 thread safe:thread-safe
 thread safety:thread-safety
 thread unsafe:thread-unsafe

--- a/scripts/badwords.txt
+++ b/scripts/badwords.txt
@@ -14,6 +14,7 @@ run-time:runtime
 set-up:setup
 tool chain:toolchain
 tool-chain:toolchain
+well known:well-known
 wild-card:wildcard
 wild card:wildcard
 threadsafe:thread-safe

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -549,7 +549,7 @@ SANITIZEcode sanitize_file_name(char ** const sanitized, const char *file_name,
  *  4. Windows Directory (e.g. C:\Windows)
  *  5. all directories along %PATH%
  *
- * For WinXP and later search order actually depends on registry value:
+ * For Windows XP and later search order actually depends on registry value:
  * HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\SafeProcessSearchMode
  */
 CURLcode FindWin32CACert(struct OperationConfig *config,

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -85,7 +85,7 @@ CURLcode tool_ssls_load(struct OperationConfig *config,
 
     c = memchr(line, ':', strlen(line));
     if(!c) {
-      warnf("unrecognized line %d in ssl session file %s", i, filename);
+      warnf("unrecognized line %d in SSL session file %s", i, filename);
       continue;
     }
     *c = '\0';

--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -32,9 +32,9 @@ BEGIN {
     use base qw(Exporter);
 
     our @EXPORT = qw(
-      appveyor_check_environment
-      appveyor_create_test_result
-      appveyor_update_test_result
+        appveyor_check_environment
+        appveyor_create_test_result
+        appveyor_update_test_result
     );
 }
 

--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -52,7 +52,7 @@ sub appveyor_create_test_result {
     $testname =~ s/\\/\\\\/g;
     $testname =~ s/\"/\\\"/g;
     $testname =~ s/\'/'"'"'/g;
-    my $appveyor_baseurl = "$ENV{'APPVEYOR_API_URL'}";
+    my $appveyor_baseurl = $ENV{'APPVEYOR_API_URL'};
     my $appveyor_result = `$curl --silent --noproxy '*' \\
     --header 'Content-Type: application/json' \\
     --data '
@@ -96,7 +96,7 @@ sub appveyor_update_test_result {
         $appveyor_outcome = 'Failed';
         $appveyor_category = 'Error';
     }
-    my $appveyor_baseurl = "$ENV{'APPVEYOR_API_URL'}";
+    my $appveyor_baseurl = $ENV{'APPVEYOR_API_URL'};
     my $appveyor_result = `$curl --silent --noproxy '*' --request PUT \\
     --header 'Content-Type: application/json' \\
     --data '

--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -48,12 +48,12 @@ sub appveyor_check_environment {
 }
 
 sub appveyor_create_test_result {
-    my ($curl, $testnum, $testname)=@_;
+    my ($curl, $testnum, $testname) = @_;
     $testname =~ s/\\/\\\\/g;
     $testname =~ s/\"/\\\"/g;
     $testname =~ s/\'/'"'"'/g;
-    my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`$curl --silent --noproxy '*' \\
+    my $appveyor_baseurl = "$ENV{'APPVEYOR_API_URL'}";
+    my $appveyor_result = `$curl --silent --noproxy '*' \\
     --header 'Content-Type: application/json' \\
     --data '
         {
@@ -69,8 +69,8 @@ sub appveyor_create_test_result {
 }
 
 sub appveyor_update_test_result {
-    my ($curl, $testnum, $error, $start, $stop)=@_;
-    my $testname=$APPVEYOR_TEST_NAMES{$testnum};
+    my ($curl, $testnum, $error, $start, $stop) = @_;
+    my $testname = $APPVEYOR_TEST_NAMES{$testnum};
     if(!defined $testname) {
         return;
     }
@@ -96,8 +96,8 @@ sub appveyor_update_test_result {
         $appveyor_outcome = 'Failed';
         $appveyor_category = 'Error';
     }
-    my $appveyor_baseurl="$ENV{'APPVEYOR_API_URL'}";
-    my $appveyor_result=`$curl --silent --noproxy '*' --request PUT \\
+    my $appveyor_baseurl = "$ENV{'APPVEYOR_API_URL'}";
+    my $appveyor_result = `$curl --silent --noproxy '*' --request PUT \\
     --header 'Content-Type: application/json' \\
     --data '
         {
@@ -112,7 +112,7 @@ sub appveyor_update_test_result {
     '$appveyor_baseurl/api/tests'`;
     print "AppVeyor API result: $appveyor_result\n" if($appveyor_result);
     if($appveyor_category eq 'Error') {
-        $appveyor_result=`$curl --silent --noproxy '*' \\
+        $appveyor_result = `$curl --silent --noproxy '*' \\
         --header 'Content-Type: application/json' \\
         --data '
             {

--- a/tests/azure.pm
+++ b/tests/azure.pm
@@ -54,8 +54,8 @@ sub azure_check_environment {
 
 sub azure_create_test_run {
     my ($curl)=@_;
-    my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run=`$curl --silent --noproxy "*" \\
+    my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
+    my $azure_run = `$curl --silent --noproxy "*" \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -77,9 +77,9 @@ sub azure_create_test_result {
     $testname =~ s/\\/\\\\/g;
     $testname =~ s/\"/\\\"/g;
     $testname =~ s/\'/'"'"'/g;
-    my $title_testnum=sprintf("%04d", $testnum);
-    my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`$curl --silent --noproxy '*' \\
+    my $title_testnum = sprintf("%04d", $testnum);
+    my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
+    my $azure_result = `$curl --silent --noproxy '*' \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header 'Content-Type: application/json' \\
     --data '
@@ -122,8 +122,8 @@ sub azure_update_test_result {
     else {
         $azure_outcome = 'Failed';
     }
-    my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result=`$curl --silent --noproxy '*' --request PATCH \\
+    my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
+    my $azure_result = `$curl --silent --noproxy '*' --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data '
@@ -146,8 +146,8 @@ sub azure_update_test_result {
 
 sub azure_update_test_run {
     my ($curl, $azure_run_id)=@_;
-    my $azure_baseurl="$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run=`$curl --silent --noproxy '*' --request PATCH \\
+    my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
+    my $azure_run = `$curl --silent --noproxy '*' --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header 'Content-Type: application/json' \\
     --data '

--- a/tests/azure.pm
+++ b/tests/azure.pm
@@ -53,7 +53,7 @@ sub azure_check_environment {
 }
 
 sub azure_create_test_run {
-    my ($curl)=@_;
+    my ($curl) = @_;
     my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
     my $azure_run = `$curl --silent --noproxy "*" \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
@@ -73,7 +73,7 @@ sub azure_create_test_run {
 }
 
 sub azure_create_test_result {
-    my ($curl, $azure_run_id, $testnum, $testname)=@_;
+    my ($curl, $azure_run_id, $testnum, $testname) = @_;
     $testname =~ s/\\/\\\\/g;
     $testname =~ s/\"/\\\"/g;
     $testname =~ s/\'/'"'"'/g;
@@ -102,7 +102,7 @@ sub azure_create_test_result {
 }
 
 sub azure_update_test_result {
-    my ($curl, $azure_run_id, $azure_result_id, $testnum, $error, $start, $stop)=@_;
+    my ($curl, $azure_run_id, $azure_result_id, $testnum, $error, $start, $stop) = @_;
     if(!defined $stop) {
         $stop = $start;
     }
@@ -145,7 +145,7 @@ sub azure_update_test_result {
 }
 
 sub azure_update_test_run {
-    my ($curl, $azure_run_id)=@_;
+    my ($curl, $azure_run_id) = @_;
     my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
     my $azure_run = `$curl --silent --noproxy '*' --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\

--- a/tests/data/test3207
+++ b/tests/data/test3207
@@ -32,7 +32,7 @@ OpenSSL
 https
 </server>
 <name>
-concurrent HTTPS GET using shared ssl session cache
+concurrent HTTPS GET using shared SSL session cache
 </name>
 <tool>
 lib%TESTNUMBER

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -397,7 +397,7 @@ class TestProxy:
         xargs.append('-6')
         r = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
                                extra_args=xargs)
-        r.check_exit_code(0), f'{r}'
+        r.check_exit_code(0)
         r.check_response(count=1, http_status=200, protocol='HTTP/1.1')
 
     # download via http: ipv6 proxy (no tunnel) using IP address, IPv4 only
@@ -411,7 +411,7 @@ class TestProxy:
         xargs.append('-4')
         r = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
                                extra_args=xargs)
-        r.check_exit_code(0), f'{r}'
+        r.check_exit_code(0)
         r.check_response(count=1, http_status=200, protocol='HTTP/1.1')
 
     # download via http: proxy (no tunnel), check connection reuse

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -587,7 +587,7 @@ cleanup:
       }
       if(t->result)
         result = t->result;
-      else /* on success we expect ssl to have been checked */
+      else /* on success we expect SSL to have been checked */
         assert(t->checked_ssl);
     }
     curlx_free(transfer_d);

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -103,7 +103,7 @@ void ws_close(CURL *curl);  /* just close the connection */
 #endif
 
 /*
- * TEST_ERR_* values must within the CURLcode range to not cause compiler
+ * TEST_ERR_* values must be within the CURLcode range to not cause compiler
  * errors.
  *
  * For portability reasons TEST_ERR_* values should be less than 127.

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -74,7 +74,7 @@ static unsigned int test_thread(void *ptr)
   int i;
 
   /* Loop the transfer and cleanup the handle properly every lap. This will
-     still reuse ssl session since the pool is in the shared object! */
+     still reuse SSL session since the pool is in the shared object! */
   for(i = 0; i < PER_THREAD_SIZE; i++) {
     CURL *curl = curl_easy_init();
     if(curl) {

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -251,7 +251,7 @@ sub runner_init {
 #######################################################################
 # Loop to execute incoming IPC calls until the shutdown call
 sub event_loop {
-    while() {
+    while(1) {
         if(ipcrecv()) {
             last;
         }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -29,7 +29,7 @@
 # (in controlleripccall) which is later read from and the arguments
 # unmarshalled (in ipcrecv) before the desired function is called normally.
 # The function return values are then marshalled and written into another pipe
-# (again in ipcrecv) when is later read from and unmarshalled (in runnerar)
+# (again in ipcrecv) which is later read from and unmarshalled (in runnerar)
 # before being returned to the caller.
 
 package runner;

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -666,7 +666,7 @@ sub singletest_setenv {
         if($s =~ /([^=]*)(.*)/) {
             my ($var, $content) = ($1, $2);
             # remember current setting, to restore it once test runs
-            $oldenv{$var} = ($ENV{$var}) ? "$ENV{$var}" : 'notset';
+            $oldenv{$var} = $ENV{$var} ? $ENV{$var} : 'notset';
 
             if($content =~ /^=(.*)/) {
                 # assign it

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3054,7 +3054,7 @@ else {
     $retry_left = $retry;
 }
 
-while() {
+while(1) {
     # check the abort flag
     if($globalabort) {
         logmsg singletest_dumplogs();

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -664,9 +664,9 @@ sub checksystemfeatures {
             $feature{"TrackMemory"} = $feat =~ /\bDebug/;
             # curl was built with --enable-debug
             $feature{"Debug"} = $feat =~ /\bDebug/;
-            # ssl enabled
+            # SSL enabled
             $feature{"SSL"} = $feat =~ /SSL/i;
-            # multiple ssl backends available.
+            # multiple SSL backends available.
             $feature{"MultiSSL"} = $feat =~ /MultiSSL/i;
             # large file support
             $feature{"Largefile"} = $feat =~ /Largefile/i;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -127,7 +127,7 @@ my %PORT = (nolisten => 47); # port we use for a local non-listening service
 my $server_response_maxtime=13;
 my $httptlssrv = find_httptlssrv();
 my %run;          # running server
-my %runcert;      # cert file currently in use by an ssl running server
+my %runcert;      # cert file currently in use by an SSL running server
 my $CLIENTIP="127.0.0.1";  # address which curl uses for incoming connections
 my $CLIENT6IP="[::1]";     # address which curl uses for incoming connections
 my $posix_pwd = build_sys_abs_path($pwd);  # current working directory in POSIX format
@@ -435,11 +435,11 @@ sub stopserver {
     #
     my @killservers;
     if($server =~ /^(ftp|http|imap|pop3|smtp)s((\d*)(-ipv6|-unix|))$/) {
-        # given a stunnel based ssl server, also kill non-ssl underlying one
+        # given a stunnel based SSL server, also kill non-SSL underlying one
         push @killservers, "${1}${2}";
     }
     elsif($server =~ /^(ftp|http|imap|pop3|smtp)((\d*)(-ipv6|-unix|))$/) {
-        # given a non-ssl server, also kill stunnel based ssl piggybacking one
+        # given a non-SSL server, also kill stunnel based SSL piggybacking one
         push @killservers, "${1}s${2}";
     }
     elsif($server =~ /^(socks)((\d*)(-ipv6|))$/) {


### PR DESCRIPTION
- fix typos and wording in documentation and comments.
- KNOWN_BUGS: merge duplicate H1 section.
- test_10_proxy: delete stray expressions.
- Perl: `while()` → `while(1)`.
- Perl: fix indent, whitespace, drop redundant quotes and parentheses.
- fix casing: URL, SSL, Windows.
- badwords: readd `threadsafe`, add `well-known` (and fix it).
- replace `WinXP` -> `Windows XP` to match other uses.
