### PR TITLE
build: omit zlib pkg-config reference for Android

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -297,6 +297,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: cat bld/config.log bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
 
+      - name: 'dump config files'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2177,7 +2177,7 @@ if(NOT CURL_DISABLE_INSTALL)
       endif()
       if(_lib STREQUAL OpenSSL::SSL AND NOT HAVE_BORINGSSL)  # BoringSSL does not provide openssl.pc
         set(_modules "openssl")
-      elseif(_lib STREQUAL ZLIB::ZLIB AND NOT ANDROID)  # Android does not offer zlib.pc
+      elseif(_lib STREQUAL ZLIB::ZLIB AND NOT ANDROID)  # Android does not provide zlib.pc
         set(_modules "zlib")
       else()
         get_target_property(_modules "${_lib}" INTERFACE_LIBCURL_PC_MODULES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2177,7 +2177,7 @@ if(NOT CURL_DISABLE_INSTALL)
       endif()
       if(_lib STREQUAL OpenSSL::SSL AND NOT HAVE_BORINGSSL)  # BoringSSL does not provide openssl.pc
         set(_modules "openssl")
-      elseif(_lib STREQUAL ZLIB::ZLIB)
+      elseif(_lib STREQUAL ZLIB::ZLIB AND NOT ANDROID)  # Android does not offer zlib.pc
         set(_modules "zlib")
       else()
         get_target_property(_modules "${_lib}" INTERFACE_LIBCURL_PC_MODULES)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1441,15 +1441,13 @@ AC_DEFUN([CURL_PREPARE_BUILDINFO], [
     *-*-*bsd*)
       curl_pflags="${curl_pflags} BSD";;
   esac
-  case $host in
-    *-*-android*)
-      curl_pflags="${curl_pflags} ANDROID"
-      ANDROID_PLATFORM_LEVEL=`echo "$host_os" | $SED -ne 's/.*android\(@<:@0-9@:>@*\).*/\1/p'`
-      if test -n "${ANDROID_PLATFORM_LEVEL}"; then
-        curl_pflags="${curl_pflags}-${ANDROID_PLATFORM_LEVEL}"
-      fi
-      ;;
-  esac
+  if test "$curl_cv_android" = "yes"; then
+    curl_pflags="${curl_pflags} ANDROID"
+    ANDROID_PLATFORM_LEVEL=`echo "$host_os" | $SED -ne 's/.*android\(@<:@0-9@:>@*\).*/\1/p'`
+    if test -n "${ANDROID_PLATFORM_LEVEL}"; then
+      curl_pflags="${curl_pflags}-${ANDROID_PLATFORM_LEVEL}"
+    fi
+  fi
   if test "$curl_cv_native_windows" = "yes"; then
     curl_pflags="${curl_pflags} WIN32"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -1514,7 +1514,10 @@ else
     dnl replace 'HAVE_LIBZ' in the automake makefile.ams
     AMFIXLIB="1"
     AC_MSG_NOTICE([found both libz and libz.h header])
-    LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE zlib"
+    dnl Android does not offer zlib.pc
+    if test "$curl_cv_android" = "no"; then
+      LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE zlib"
+    fi
     curl_zlib_msg="enabled"
   fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1514,7 +1514,7 @@ else
     dnl replace 'HAVE_LIBZ' in the automake makefile.ams
     AMFIXLIB="1"
     AC_MSG_NOTICE([found both libz and libz.h header])
-    dnl Android does not offer zlib.pc
+    dnl Android does not provide zlib.pc
     if test "$curl_cv_android" = "no"; then
       LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE zlib"
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -694,8 +694,10 @@ dnl **********************************************************************
 
 CURL_CHECK_WIN32_CRYPTO
 
+curl_cv_android='no'
 curl_cv_apple='no'
 case $host in
+  *-*-android*) curl_cv_android='yes';;
   *-apple-*) curl_cv_apple='yes';;
 esac
 


### PR DESCRIPTION
In both autotools and cmake builds, because Android does not offer
a `zlib.pc`.

Also:
- GHA/non-native: dump config files, to verify.

Reported-by: sfan5 on github
Fixes #21647

---

https://github.com/curl/curl/pull/21648/files?w=1
