### PR TITLE
vtls_scache: include signature_algorithms in the SSL peer cache key

### DIFF
--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -223,6 +223,12 @@ CURLcode Curl_ssl_peer_key_make(struct Curl_cfilter *cf,
     if(r)
       goto out;
   }
+  if(ssl->signature_algorithms) {
+    r = curlx_dyn_addf(&buf, ":SIGALGS-%s",
+                       ssl->signature_algorithms);
+    if(r)
+      goto out;
+  }
   if(ssl->verifypeer) {
     r = cf_ssl_peer_key_add_path(&buf, "CA", ssl->CAfile, &is_local);
     if(r)


### PR DESCRIPTION
Curl_ssl_peer_key_make() did not include ssl->signature_algorithms in
the SSL peer cache key, while match_ssl_primary_config() compares the
field. Handles differing only in CURLOPT_SSL_SIGNATURE_ALGORITHMS
shared a peer key and could resume each other's sessions across a
shared CURLSH SSL session cache.

Add :SIGALGS-%s alongside CIPHER13 and CURVES.

Verified on Linux (ubuntu:24.04, distro OpenSSL) and macOS (Homebrew
OpenSSL 3.6.2) that pre-patch reproduces the bypass and post-patch
returns rc=35.