### PR TITLE
urlapi: prevent a terminal `.0x` component to normalize IPv4

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -523,6 +523,8 @@ UNITTEST int ipv4_normalize(struct dynbuf *host)
       if(c[1] == 'x') {
         c += 2; /* skip the prefix */
         rc = curlx_str_hex(&c, &l, UINT_MAX);
+        if(rc)
+          return HOST_NAME;
       }
       else
         rc = curlx_str_octal(&c, &l, UINT_MAX);

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -625,6 +625,10 @@ static const struct testcase get_parts_list[] = {
 };
 
 static const struct urltestcase get_url_list[] = {
+  {"https://127.1.0x", "https://127.1.0x/", 0, 0, CURLUE_OK},
+  {"https://127.0x", "https://127.0x/", 0, 0, CURLUE_OK},
+  {"https://127.0x.1", "https://127.0x.1/", 0, 0, CURLUE_OK},
+  {"https://127.1.1.0x", "https://127.1.1.0x/", 0, 0, CURLUE_OK},
   {"https://127.1.", "https://127.0.0.1/", 0, 0, CURLUE_OK},
   {"https://127.1.:443", "https://127.0.0.1:443/", 0, 0, CURLUE_OK},
   {"https://127.1.?moo", "https://127.0.0.1/?moo", 0, 0, CURLUE_OK},


### PR DESCRIPTION
Extend test 1560 to verify

Follow-up to 831a1514843bfa4d4d006627

Spotted by Codex Security