### PR TITLE
scripts/contri*: fix the Credits-to regex

### DIFF
--- a/scripts/contributors.sh
+++ b/scripts/contributors.sh
@@ -62,7 +62,7 @@ CURLWWW="${CURLWWW:-../curl-www}"
       git -C "$CURLWWW" log --pretty=full --use-mailmap "$start..HEAD"
     fi
   } | \
-  grep -Eai '(^Author|^Commit|^ +[a-z-]+-by|^Credits-to):' | \
+  grep -Eai '(^Author|^Commit|^ +[a-z-]+-by|^ +Credits-to):' | \
   cut -d: -f2- | \
   cut '-d(' -f1 | \
   cut '-d<' -f1 | \

--- a/scripts/contrithanks.sh
+++ b/scripts/contrithanks.sh
@@ -62,7 +62,7 @@ tail -n +7 ./docs/THANKS | sed 's/ github/ github/i'  > $rand
       git -C "$CURLWWW" log --use-mailmap "$start..HEAD"
     fi
   } | \
-  grep -Eai '(^Author|^Commit|^ +[a-z-]+-by|^Credits-to):' | \
+  grep -Eai '(^Author|^Commit|^ +[a-z-]+-by|^ +Credits-to):' | \
   cut -d: -f2- | \
   cut '-d(' -f1 | \
   cut '-d<' -f1 | \


### PR DESCRIPTION
On my suggestion, the regex turned up wrong when looking for Credits-to in git logs. This adjustment allows the leading spaces.

Follow-up to 64adc43a6ea07e4d807bbf9b5