### PR TITLE
mk-unity.pl: `#include`, and not concatenate input headers

### DIFF
--- a/scripts/mk-unity.pl
+++ b/scripts/mk-unity.pl
@@ -65,7 +65,7 @@ foreach my $src (@ARGV) {
 
 sub include($@) {
     my $filename = shift;
-    if($concat) {
+    if($concat && $filename =~ /([a-z0-9_]+)\.c$/) {
         if(! -f $filename) {
             foreach my $path (@incpath) {
                 my $fullfn = $path . "/" . $filename;

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -108,10 +108,7 @@ void ws_close(CURL *curl);  /* just close the connection */
  *
  * For portability reasons TEST_ERR_* values should be less than 127.
  */
-#if !defined(UNITTESTS) || defined(BUILDING_LIBCURL)
 #define TEST_ERR_MAJOR_BAD    CURLE_OBSOLETE20
-#endif
-#ifndef UNITTESTS
 #define TEST_ERR_RUNS_FOREVER CURLE_OBSOLETE24
 #define TEST_ERR_EASY_INIT    CURLE_OBSOLETE29
 #define TEST_ERR_MULTI        CURLE_OBSOLETE32
@@ -152,6 +149,7 @@ void ws_close(CURL *curl);  /* just close the connection */
  * TEST_ERR_* values defined above. It is advisable to return this value
  * as test result.
  */
+#ifndef UNITTESTS
 
 /* ---------------------------------------------------------------- */
 


### PR DESCRIPTION
When using `-D_CURL_TESTS_CONCAT=ON` with CMake, do not concatenate
`first.h` (or any future header) into the output C file, but `#include`
it instead. This is to play nice with compilers and analyzers which may
apply different checker rules on logic found in headers, vs. the input
source file. As seen for example with `-Wunused-macro` enabled in CI. 
After this patch concatenated sources behave closer to regular C
sources.

Also:
- first.h: drop some `-Wunused-macro` silencers that became redundant
  with this patch.

Follow-up to 47f411c6d840dcee63a2ac9cbc0bfbea522ac5cd #21554
Follow-up to 39542f09935aba0b7130c20b6aae0be5cd6ff709 #20667
