### PR TITLE
curl_easy_setopt.md: change options when no transfer runs

### DIFF
--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -50,8 +50,8 @@ any way reset between transfers, so if you want subsequent transfers with
 different options, you must change them between the transfers. You can
 optionally reset all options back to internal default with curl_easy_reset(3).
 
-Changing options with curl_easy_setup(3) while a transfer is still in progress
-may cause undefined and undesired behavior.
+Changing options with curl_easy_setopt(3) while a transfer is still in
+progress may cause undefined and undesired behavior.
 
 The order in which the options are set does not matter.
 

--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -50,6 +50,9 @@ any way reset between transfers, so if you want subsequent transfers with
 different options, you must change them between the transfers. You can
 optionally reset all options back to internal default with curl_easy_reset(3).
 
+Changing options with curl_easy_setup(3) while a transfer is still in progress
+may cause undefined and undesired behavior.
+
 The order in which the options are set does not matter.
 
 # STRINGS


### PR DESCRIPTION
Underscore this. Changing them mid-transfer may cause problems.

Fixes #21604
Reported-by: Joshua Rogers