### PR TITLE
creds: mask OAuth bearer token in trace logs

### DIFF
--- a/lib/creds.c
+++ b/lib/creds.c
@@ -181,7 +181,7 @@ void Curl_creds_trace(struct Curl_easy *data, struct Curl_creds *creds,
                Curl_creds_user(creds),
                Curl_creds_has_passwd(creds) ? "***" : "",
                Curl_creds_sasl_authzid(creds),
-               Curl_creds_oauth_bearer(creds),
+               Curl_creds_has_oauth_bearer(creds) ? "***" : "",
                creds->source);
   }
   else


### PR DESCRIPTION
Masked OAuth bearer tokens in credential trace output by emitting *** when a bearer token is present, matching the existing password redaction behavior and preventing sensitive token disclosure in verbose/debug logs.