### PR TITLE
vtls: use Curl_safecmp for CRLfile and pinned_key comparison

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -217,8 +217,8 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
      curl_strequal(c1->cipher_list13, c2->cipher_list13) &&
      curl_strequal(c1->curves, c2->curves) &&
      curl_strequal(c1->signature_algorithms, c2->signature_algorithms) &&
-     curl_strequal(c1->CRLfile, c2->CRLfile) &&
-     curl_strequal(c1->pinned_key, c2->pinned_key))
+     Curl_safecmp(c1->CRLfile, c2->CRLfile) &&
+     Curl_safecmp(c1->pinned_key, c2->pinned_key))
     return TRUE;
 
   return FALSE;


### PR DESCRIPTION
Both are filesystem paths (or case-sensitive hash strings for pinned_key). curl_strequal is case-insensitive and would treat /etc/ssl/Crl.pem and /etc/ssl/crl.pem as the same file, unlike the other path fields (CApath, CAfile, issuercert, clientcert) which already use Curl_safecmp.