### PR TITLE
runner.pm: apply minor correctness fix

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -241,8 +241,10 @@ sub runner_init {
     }
 
     $controllerw{$thisrunnerid} = $thiscontrollerw;
-    $runnerr = $thisrunnerr;
-    $runnerw = $thisrunnerw;
+    if(!$multiprocess) {
+        $runnerr = $thisrunnerr;
+        $runnerw = $thisrunnerw;
+    }
     $controllerr{$thisrunnerid} = $thiscontrollerr;
 
     return $thisrunnerid;


### PR DESCRIPTION
"Lines 244-245 overwrite global variables `$runnerr` and `$runnerw` that 
were already assigned in the child process (lines 205-206). In the
parent process context, these assignments appear incorrect and could
cause issues if `runner_init` is called multiple times. The parent
should only store references in the controller hashes."        

It could never cause an actual issue, but clarifies the intent of the
code.

Spotted and fixed by GitHub Code Quality

Cherry-picked from #21646

---

https://github.com/curl/curl/pull/21672/files?w=1
