### PR TITLE
tidy-up: rename more `CURLcode` variables to `result`

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -384,7 +384,7 @@ static CURLcode make_headers(struct Curl_easy *data,
   char date_full_hdr[DATE_FULL_HDR_LEN];
   struct curl_slist *head = NULL;
   struct curl_slist *tmp_head = NULL;
-  CURLcode ret = CURLE_OUT_OF_MEMORY;
+  CURLcode result = CURLE_OUT_OF_MEMORY;
   struct curl_slist *l;
   bool again = TRUE;
 
@@ -516,8 +516,8 @@ static CURLcode make_headers(struct Curl_easy *data,
     }
   } while(again);
 
-  ret = merge_duplicate_headers(head);
-  if(ret)
+  result = merge_duplicate_headers(head);
+  if(result)
     goto fail;
 
   for(l = head; l; l = l->next) {
@@ -540,11 +540,11 @@ static CURLcode make_headers(struct Curl_easy *data,
       goto fail;
   }
 
-  ret = CURLE_OK;
+  result = CURLE_OK;
 fail:
   curl_slist_free_all(head);
 
-  return ret;
+  return result;
 }
 
 #define CONTENT_SHA256_KEY_LEN (MAX_SIGV4_LEN + sizeof("X--Content-Sha256"))
@@ -618,12 +618,12 @@ static CURLcode calc_s3_payload_hash(struct Curl_easy *data,
   bool empty_payload = (empty_method || data->set.filesize == 0);
   /* The POST payload is in memory */
   bool post_payload = (httpreq == HTTPREQ_POST && data->set.postfields);
-  CURLcode ret = CURLE_OUT_OF_MEMORY;
+  CURLcode result = CURLE_OUT_OF_MEMORY;
 
   if(empty_payload || post_payload) {
     /* Calculate a real hash when we know the request payload */
-    ret = calc_payload_hash(data, sha_hash, sha_hex);
-    if(ret)
+    result = calc_payload_hash(data, sha_hash, sha_hex);
+    if(result)
       goto fail;
   }
   else {
@@ -638,9 +638,9 @@ static CURLcode calc_s3_payload_hash(struct Curl_easy *data,
   curl_msnprintf(header, CONTENT_SHA256_HDR_LEN,
                  "x-%.*s-content-sha256: %s", (int)plen, provider1, sha_hex);
 
-  ret = CURLE_OK;
+  result = CURLE_OK;
 fail:
-  return ret;
+  return result;
 }
 
 static int compare_func(const void *a, const void *b)

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1123,7 +1123,7 @@ CURLcode Curl_mime_duppart(struct Curl_easy *data,
   curl_mime *mime;
   curl_mimepart *d;
   const curl_mimepart *s;
-  CURLcode res = CURLE_OK;
+  CURLcode result = CURLE_OK;
 
   DEBUGASSERT(dst);
 
@@ -1132,66 +1132,67 @@ CURLcode Curl_mime_duppart(struct Curl_easy *data,
   case MIMEKIND_NONE:
     break;
   case MIMEKIND_DATA:
-    res = curl_mime_data(dst, src->data, (size_t)src->datasize);
+    result = curl_mime_data(dst, src->data, (size_t)src->datasize);
     break;
   case MIMEKIND_FILE:
-    res = curl_mime_filedata(dst, src->data);
+    result = curl_mime_filedata(dst, src->data);
     /* Do not abort duplication if file is not readable. */
-    if(res == CURLE_READ_ERROR)
-      res = CURLE_OK;
+    if(result == CURLE_READ_ERROR)
+      result = CURLE_OK;
     break;
   case MIMEKIND_CALLBACK:
-    res = curl_mime_data_cb(dst, src->datasize, src->readfunc,
-                            src->seekfunc, src->freefunc, src->arg);
+    result = curl_mime_data_cb(dst, src->datasize, src->readfunc,
+                               src->seekfunc, src->freefunc, src->arg);
     break;
   case MIMEKIND_MULTIPART:
     /* No one knows about the cloned subparts, thus always attach ownership
        to the part. */
     mime = curl_mime_init(data);
-    res = mime ? curl_mime_subparts(dst, mime) : CURLE_OUT_OF_MEMORY;
+    result = mime ? curl_mime_subparts(dst, mime) : CURLE_OUT_OF_MEMORY;
 
     /* Duplicate subparts. */
-    for(s = ((curl_mime *)src->arg)->firstpart; !res && s; s = s->nextpart) {
+    for(s = ((curl_mime *)src->arg)->firstpart; !result && s;
+        s = s->nextpart) {
       d = curl_mime_addpart(mime);
-      res = d ? Curl_mime_duppart(data, d, s) : CURLE_OUT_OF_MEMORY;
+      result = d ? Curl_mime_duppart(data, d, s) : CURLE_OUT_OF_MEMORY;
     }
     break;
   default:  /* Invalid kind: should not occur. */
     DEBUGF(infof(data, "invalid MIMEKIND* attempt"));
-    res = CURLE_BAD_FUNCTION_ARGUMENT;  /* Internal error? */
+    result = CURLE_BAD_FUNCTION_ARGUMENT;  /* Internal error? */
     break;
   }
 
   /* Duplicate headers. */
-  if(!res && src->userheaders) {
+  if(!result && src->userheaders) {
     struct curl_slist *hdrs = Curl_slist_duplicate(src->userheaders);
 
     if(!hdrs)
-      res = CURLE_OUT_OF_MEMORY;
+      result = CURLE_OUT_OF_MEMORY;
     else {
       /* No one but this procedure knows about the new header list,
          so always take ownership. */
-      res = curl_mime_headers(dst, hdrs, TRUE);
-      if(res)
+      result = curl_mime_headers(dst, hdrs, TRUE);
+      if(result)
         curl_slist_free_all(hdrs);
     }
   }
 
-  if(!res) {
+  if(!result) {
     /* Duplicate other fields. */
     dst->encoder = src->encoder;
-    res = curl_mime_type(dst, src->mimetype);
+    result = curl_mime_type(dst, src->mimetype);
   }
-  if(!res)
-    res = curl_mime_name(dst, src->name);
-  if(!res)
-    res = curl_mime_filename(dst, src->filename);
+  if(!result)
+    result = curl_mime_name(dst, src->name);
+  if(!result)
+    result = curl_mime_filename(dst, src->filename);
 
   /* If an error occurred, rollback. */
-  if(res)
+  if(result)
     Curl_mime_cleanpart(dst);
 
-  return res;
+  return result;
 }
 
 /*

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2648,17 +2648,17 @@ static CURLMcode multistate_did(struct Curl_multi *multi,
   return CURLM_CALL_MULTI_PERFORM;
 }
 
-static CURLMcode multistate_done(struct Curl_easy *data, CURLcode *result)
+static CURLMcode multistate_done(struct Curl_easy *data, CURLcode *presult)
 {
   if(data->conn) {
-    CURLcode res;
+    CURLcode result;
 
     /* post-transfer command */
-    res = multi_done(data, *result, FALSE);
+    result = multi_done(data, *presult, FALSE);
 
     /* allow a previously set error code take precedence */
-    if(!(*result))
-      *result = res;
+    if(!(*presult))
+      *presult = result;
   }
 
 #ifndef CURL_DISABLE_FTP

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -486,9 +486,9 @@ static CURLMcode mev_assess(struct Curl_multi *multi,
 
   Curl_pollset_init(&ps);
   if(conn) {
-    CURLcode r = Curl_conn_adjust_pollset(data, conn, &ps);
-    if(r) {
-      mresult = (r == CURLE_OUT_OF_MEMORY) ?
+    CURLcode result = Curl_conn_adjust_pollset(data, conn, &ps);
+    if(result) {
+      mresult = (result == CURLE_OUT_OF_MEMORY) ?
         CURLM_OUT_OF_MEMORY : CURLM_INTERNAL_ERROR;
       goto out;
     }

--- a/lib/thrdpool.c
+++ b/lib/thrdpool.c
@@ -130,9 +130,9 @@ static CURL_THREAD_RETURN_T CURL_STDCALL thrdslot_run(void *arg)
      * on activating threads that have no means to shut down. */
     if((tpool->idle_time_ms > 0) &&
        (Curl_llist_count(&tpool->slots) > tpool->min_threads)) {
-      CURLcode r = Curl_cond_timedwait(&tslot->await, &tpool->lock,
-                                       tpool->idle_time_ms);
-      if((r == CURLE_OPERATION_TIMEDOUT) &&
+      CURLcode result = Curl_cond_timedwait(&tslot->await, &tpool->lock,
+                                            tpool->idle_time_ms);
+      if((result == CURLE_OPERATION_TIMEDOUT) &&
          (Curl_llist_count(&tpool->slots) > tpool->min_threads)) {
         goto out;
       }

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2016,7 +2016,7 @@ static CURLcode cf_progress_egress(struct Curl_cfilter *cf,
   size_t pktcnt = 0;
   size_t gsolen = 0;  /* this disables gso until we have a clue */
   size_t send_quantum;
-  CURLcode curlcode;
+  CURLcode result;
   struct pkt_io_ctx local_pktx;
 
   if(!pktx) {
@@ -2028,13 +2028,13 @@ static CURLcode cf_progress_egress(struct Curl_cfilter *cf,
     ngtcp2_path_storage_zero(&pktx->ps);
   }
 
-  curlcode = vquic_flush(cf, data, &ctx->q);
-  if(curlcode) {
-    if(curlcode == CURLE_AGAIN) {
+  result = vquic_flush(cf, data, &ctx->q);
+  if(result) {
+    if(result == CURLE_AGAIN) {
       Curl_expire(data, 1, EXPIRE_QUIC);
       return CURLE_OK;
     }
-    return curlcode;
+    return result;
   }
 
   /* In UDP, there is a maximum theoretical packet payload length and
@@ -2056,12 +2056,12 @@ static CURLcode cf_progress_egress(struct Curl_cfilter *cf,
               send_quantum);
   for(;;) {
     /* add the next packet to send, if any, to our buffer */
-    curlcode = Curl_bufq_sipn(&ctx->q.sendbuf, max_payload_size,
-                              read_pkt_to_send, pktx, &nread);
-    if(curlcode == CURLE_AGAIN)
+    result = Curl_bufq_sipn(&ctx->q.sendbuf, max_payload_size,
+                            read_pkt_to_send, pktx, &nread);
+    if(result == CURLE_AGAIN)
       break;
-    else if(curlcode)
-      return curlcode;
+    else if(result)
+      return result;
     else {
       size_t buflen = Curl_bufq_len(&ctx->q.sendbuf);
       if((buflen >= send_quantum) ||
@@ -2079,14 +2079,14 @@ static CURLcode cf_progress_egress(struct Curl_cfilter *cf,
         /* The added packet is a PMTUD *or* the one(s) before the
          * added were PMTUD and the last one is smaller.
          * Flush the buffer before the last add. */
-        curlcode = vquic_send_tail_split(cf, data, &ctx->q,
-                                         gsolen, nread, nread);
-        if(curlcode) {
-          if(curlcode == CURLE_AGAIN) {
+        result = vquic_send_tail_split(cf, data, &ctx->q,
+                                       gsolen, nread, nread);
+        if(result) {
+          if(result == CURLE_AGAIN) {
             Curl_expire(data, 1, EXPIRE_QUIC);
             return CURLE_OK;
           }
-          return curlcode;
+          return result;
         }
         pktcnt = 0;
       }
@@ -2102,13 +2102,13 @@ static CURLcode cf_progress_egress(struct Curl_cfilter *cf,
     /* time to send */
     CURL_TRC_CF(data, cf, "egress, send collected %zu packets in %zu bytes",
                 pktcnt, Curl_bufq_len(&ctx->q.sendbuf));
-    curlcode = vquic_send(cf, data, &ctx->q, gsolen);
-    if(curlcode) {
-      if(curlcode == CURLE_AGAIN) {
+    result = vquic_send(cf, data, &ctx->q, gsolen);
+    if(result) {
+      if(result == CURLE_AGAIN) {
         Curl_expire(data, 1, EXPIRE_QUIC);
         return CURLE_OK;
       }
-      return curlcode;
+      return result;
     }
     pktx_update_time(data, pktx, cf);
     ngtcp2_conn_update_pkt_tx_time(ctx->qconn, pktx->ts);

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -85,10 +85,10 @@ static CURLcode cf_ssl_peer_key_add_path(struct dynbuf *buf,
     if(path[0] != '/') {
       char *abspath = realpath(path, NULL);
       if(abspath) {
-        CURLcode r = curlx_dyn_addf(buf, ":%s-%s", name, abspath);
+        CURLcode result = curlx_dyn_addf(buf, ":%s-%s", name, abspath);
         /* !checksrc! disable BANNEDFUNC 1 */
         free(abspath); /* allocated by libc, free without memdebug */
-        return r;
+        return result;
       }
       *is_local = TRUE;
     }
@@ -102,25 +102,25 @@ static CURLcode cf_ssl_peer_key_add_hash(struct dynbuf *buf,
                                          const char *name,
                                          struct curl_blob *blob)
 {
-  CURLcode r = CURLE_OK;
+  CURLcode result = CURLE_OK;
   if(blob && blob->len) {
     unsigned char hash[CURL_SHA256_DIGEST_LENGTH];
     size_t i;
 
-    r = curlx_dyn_addf(buf, ":%s-", name);
-    if(r)
+    result = curlx_dyn_addf(buf, ":%s-", name);
+    if(result)
       goto out;
-    r = Curl_sha256it(hash, blob->data, blob->len);
-    if(r)
+    result = Curl_sha256it(hash, blob->data, blob->len);
+    if(result)
       goto out;
     for(i = 0; i < CURL_SHA256_DIGEST_LENGTH; ++i) {
-      r = curlx_dyn_addf(buf, "%02x", hash[i]);
-      if(r)
+      result = curlx_dyn_addf(buf, "%02x", hash[i]);
+      if(result)
         goto out;
     }
   }
 out:
-  return r;
+  return result;
 }
 
 #define CURL_SSLS_LOCAL_SUFFIX     ":L"
@@ -143,151 +143,153 @@ CURLcode Curl_ssl_peer_key_make(struct Curl_cfilter *cf,
   struct dynbuf buf;
   size_t key_len;
   bool is_local = FALSE;
-  CURLcode r;
+  CURLcode result;
 
   *ppeer_key = NULL;
   curlx_dyn_init(&buf, 10 * 1024);
 
-  r = curlx_dyn_addf(&buf, "%s:%d",
-                     peer->dest->hostname, peer->dest->port);
-  if(r)
+  result = curlx_dyn_addf(&buf, "%s:%d",
+                          peer->dest->hostname, peer->dest->port);
+  if(result)
     goto out;
 
   switch(peer->transport) {
   case TRNSPRT_TCP:
     break;
   case TRNSPRT_UDP:
-    r = curlx_dyn_add(&buf, ":UDP");
+    result = curlx_dyn_add(&buf, ":UDP");
     break;
   case TRNSPRT_QUIC:
-    r = curlx_dyn_add(&buf, ":QUIC");
+    result = curlx_dyn_add(&buf, ":QUIC");
     break;
   case TRNSPRT_UNIX:
-    r = curlx_dyn_add(&buf, ":UNIX");
+    result = curlx_dyn_add(&buf, ":UNIX");
     break;
   default:
-    r = curlx_dyn_addf(&buf, ":TRNSPRT-%d", peer->transport);
+    result = curlx_dyn_addf(&buf, ":TRNSPRT-%d", peer->transport);
     break;
   }
-  if(r)
+  if(result)
     goto out;
 
   if(!ssl->verifypeer) {
-    r = curlx_dyn_add(&buf, ":NO-VRFY-PEER");
-    if(r)
+    result = curlx_dyn_add(&buf, ":NO-VRFY-PEER");
+    if(result)
       goto out;
   }
   if(!ssl->verifyhost) {
-    r = curlx_dyn_add(&buf, ":NO-VRFY-HOST");
-    if(r)
+    result = curlx_dyn_add(&buf, ":NO-VRFY-HOST");
+    if(result)
       goto out;
   }
   if(ssl->verifystatus) {
-    r = curlx_dyn_add(&buf, ":VRFY-STATUS");
-    if(r)
+    result = curlx_dyn_add(&buf, ":VRFY-STATUS");
+    if(result)
       goto out;
   }
   if(!ssl->verifypeer || !ssl->verifyhost) {
     if(cf->conn->via_peer) {
-      r = curlx_dyn_addf(&buf, ":CHOST-%s:CPORT-%u",
-                         cf->conn->via_peer->hostname,
-                         cf->conn->via_peer->port);
-      if(r)
+      result = curlx_dyn_addf(&buf, ":CHOST-%s:CPORT-%u",
+                              cf->conn->via_peer->hostname,
+                              cf->conn->via_peer->port);
+      if(result)
         goto out;
     }
   }
 
   if(ssl->version || ssl->version_max) {
-    r = curlx_dyn_addf(&buf, ":TLSVER-%d-%u", ssl->version,
-                       (ssl->version_max >> 16));
-    if(r)
+    result = curlx_dyn_addf(&buf, ":TLSVER-%d-%u", ssl->version,
+                            (ssl->version_max >> 16));
+    if(result)
       goto out;
   }
   if(ssl->ssl_options) {
-    r = curlx_dyn_addf(&buf, ":TLSOPT-%x", ssl->ssl_options);
-    if(r)
+    result = curlx_dyn_addf(&buf, ":TLSOPT-%x", ssl->ssl_options);
+    if(result)
       goto out;
   }
   if(ssl->cipher_list) {
-    r = curlx_dyn_addf(&buf, ":CIPHER-%s", ssl->cipher_list);
-    if(r)
+    result = curlx_dyn_addf(&buf, ":CIPHER-%s", ssl->cipher_list);
+    if(result)
       goto out;
   }
   if(ssl->cipher_list13) {
-    r = curlx_dyn_addf(&buf, ":CIPHER13-%s", ssl->cipher_list13);
-    if(r)
+    result = curlx_dyn_addf(&buf, ":CIPHER13-%s", ssl->cipher_list13);
+    if(result)
       goto out;
   }
   if(ssl->curves) {
-    r = curlx_dyn_addf(&buf, ":CURVES-%s", ssl->curves);
-    if(r)
+    result = curlx_dyn_addf(&buf, ":CURVES-%s", ssl->curves);
+    if(result)
       goto out;
   }
   if(ssl->signature_algorithms) {
-    r = curlx_dyn_addf(&buf, ":SIGALGS-%s",
-                       ssl->signature_algorithms);
-    if(r)
+    result = curlx_dyn_addf(&buf, ":SIGALGS-%s",
+                            ssl->signature_algorithms);
+    if(result)
       goto out;
   }
   if(ssl->verifypeer) {
-    r = cf_ssl_peer_key_add_path(&buf, "CA", ssl->CAfile, &is_local);
-    if(r)
+    result = cf_ssl_peer_key_add_path(&buf, "CA", ssl->CAfile, &is_local);
+    if(result)
       goto out;
-    r = cf_ssl_peer_key_add_path(&buf, "CApath", ssl->CApath, &is_local);
-    if(r)
+    result = cf_ssl_peer_key_add_path(&buf, "CApath", ssl->CApath, &is_local);
+    if(result)
       goto out;
-    r = cf_ssl_peer_key_add_path(&buf, "CRL", ssl->CRLfile, &is_local);
-    if(r)
+    result = cf_ssl_peer_key_add_path(&buf, "CRL", ssl->CRLfile, &is_local);
+    if(result)
       goto out;
-    r = cf_ssl_peer_key_add_path(&buf, "Issuer", ssl->issuercert, &is_local);
-    if(r)
+    result = cf_ssl_peer_key_add_path(&buf, "Issuer", ssl->issuercert,
+                                      &is_local);
+    if(result)
       goto out;
     if(ssl->ca_info_blob) {
-      r = cf_ssl_peer_key_add_hash(&buf, "CAInfoBlob", ssl->ca_info_blob);
-      if(r)
+      result = cf_ssl_peer_key_add_hash(&buf, "CAInfoBlob", ssl->ca_info_blob);
+      if(result)
         goto out;
     }
     if(ssl->issuercert_blob) {
-      r = cf_ssl_peer_key_add_hash(&buf, "IssuerBlob", ssl->issuercert_blob);
-      if(r)
+      result = cf_ssl_peer_key_add_hash(&buf, "IssuerBlob",
+                                        ssl->issuercert_blob);
+      if(result)
         goto out;
     }
   }
   if(ssl->cert_blob) {
-    r = cf_ssl_peer_key_add_hash(&buf, "CertBlob", ssl->cert_blob);
-    if(r)
+    result = cf_ssl_peer_key_add_hash(&buf, "CertBlob", ssl->cert_blob);
+    if(result)
       goto out;
   }
   if(ssl->pinned_key && ssl->pinned_key[0]) {
-    r = curlx_dyn_addf(&buf, ":Pinned-%s", ssl->pinned_key);
-    if(r)
+    result = curlx_dyn_addf(&buf, ":Pinned-%s", ssl->pinned_key);
+    if(result)
       goto out;
   }
 
   if(ssl->clientcert && ssl->clientcert[0]) {
-    r = curlx_dyn_add(&buf, ":CCERT");
-    if(r)
+    result = curlx_dyn_add(&buf, ":CCERT");
+    if(result)
       goto out;
   }
 #ifdef USE_TLS_SRP
   if(ssl->username || ssl->password) {
-    r = curlx_dyn_add(&buf, ":SRP-AUTH");
-    if(r)
+    result = curlx_dyn_add(&buf, ":SRP-AUTH");
+    if(result)
       goto out;
   }
 #endif
 
   if(!tls_id || !tls_id[0]) {
-    r = CURLE_FAILED_INIT;
+    result = CURLE_FAILED_INIT;
     goto out;
   }
-  r = curlx_dyn_addf(&buf, ":IMPL-%s", tls_id);
-  if(r)
+  result = curlx_dyn_addf(&buf, ":IMPL-%s", tls_id);
+  if(result)
     goto out;
 
-  r = curlx_dyn_addf(&buf, is_local ?
-                     CURL_SSLS_LOCAL_SUFFIX : CURL_SSLS_GLOBAL_SUFFIX);
-  if(r)
+  result = curlx_dyn_addf(&buf, is_local ?
+                          CURL_SSLS_LOCAL_SUFFIX : CURL_SSLS_GLOBAL_SUFFIX);
+  if(result)
     goto out;
 
   *ppeer_key = curlx_dyn_take(&buf, &key_len);
@@ -296,7 +298,7 @@ CURLcode Curl_ssl_peer_key_make(struct Curl_cfilter *cf,
 
 out:
   curlx_dyn_free(&buf);
-  return r;
+  return result;
 }
 
 struct Curl_ssl_scache {
@@ -1176,7 +1178,7 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
   struct Curl_llist_node *n;
   size_t i;
   curl_off_t now = time(NULL);
-  CURLcode r = CURLE_OK;
+  CURLcode result = CURLE_OK;
 #ifdef CURLVERBOSE
   size_t npeers = 0, ntickets = 0;
 #endif
@@ -1204,35 +1206,35 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
     while(n) {
       struct Curl_ssl_session *s = Curl_node_elem(n);
       if(!peer->hmac_set) {
-        r = cf_ssl_scache_peer_set_hmac(peer);
-        if(r)
+        result = cf_ssl_scache_peer_set_hmac(peer);
+        if(result)
           goto out;
       }
       if(!curlx_dyn_len(&hbuf)) {
-        r = curlx_dyn_addn(&hbuf, peer->key_salt, sizeof(peer->key_salt));
-        if(r)
+        result = curlx_dyn_addn(&hbuf, peer->key_salt, sizeof(peer->key_salt));
+        if(result)
           goto out;
-        r = curlx_dyn_addn(&hbuf, peer->key_hmac, sizeof(peer->key_hmac));
-        if(r)
+        result = curlx_dyn_addn(&hbuf, peer->key_hmac, sizeof(peer->key_hmac));
+        if(result)
           goto out;
       }
       curlx_dyn_reset(&sbuf);
-      r = Curl_ssl_session_pack(data, s, &sbuf);
-      if(r)
+      result = Curl_ssl_session_pack(data, s, &sbuf);
+      if(result)
         goto out;
 
-      r = export_fn(data, userptr, peer->ssl_peer_key,
-                    curlx_dyn_uptr(&hbuf), curlx_dyn_len(&hbuf),
-                    curlx_dyn_uptr(&sbuf), curlx_dyn_len(&sbuf),
-                    s->valid_until, s->ietf_tls_id,
-                    s->alpn, s->earlydata_max);
-      if(r)
+      result = export_fn(data, userptr, peer->ssl_peer_key,
+                         curlx_dyn_uptr(&hbuf), curlx_dyn_len(&hbuf),
+                         curlx_dyn_uptr(&sbuf), curlx_dyn_len(&sbuf),
+                         s->valid_until, s->ietf_tls_id,
+                         s->alpn, s->earlydata_max);
+      if(result)
         goto out;
       VERBOSE(++ntickets);
       n = Curl_node_next(n);
     }
   }
-  r = CURLE_OK;
+  result = CURLE_OK;
   CURL_TRC_SSLS(data, "exported %zu session tickets for %zu peers",
                 ntickets, npeers);
 
@@ -1240,7 +1242,7 @@ out:
   Curl_ssl_scache_unlock(data);
   curlx_dyn_free(&hbuf);
   curlx_dyn_free(&sbuf);
-  return r;
+  return result;
 }
 
 #endif /* USE_SSLS_EXPORT */

--- a/lib/vtls/vtls_spack.c
+++ b/lib/vtls/vtls_spack.c
@@ -130,26 +130,26 @@ static CURLcode spack_dec64(uint64_t *val, const uint8_t **src,
 static CURLcode spack_encstr16(struct dynbuf *buf, const char *s)
 {
   size_t slen = strlen(s);
-  CURLcode r;
+  CURLcode result;
   if(slen > UINT16_MAX)
     return CURLE_BAD_FUNCTION_ARGUMENT;
-  r = spack_enc16(buf, (uint16_t)slen);
-  if(!r) {
-    r = curlx_dyn_addn(buf, s, slen);
+  result = spack_enc16(buf, (uint16_t)slen);
+  if(!result) {
+    result = curlx_dyn_addn(buf, s, slen);
   }
-  return r;
+  return result;
 }
 
 static CURLcode spack_decstr16(char **val, const uint8_t **src,
                                const uint8_t *end)
 {
   uint16_t slen;
-  CURLcode r;
+  CURLcode result;
 
   *val = NULL;
-  r = spack_dec16(&slen, src, end);
-  if(r)
-    return r;
+  result = spack_dec16(&slen, src, end);
+  if(result)
+    return result;
   if(end - *src < slen)
     return CURLE_READ_ERROR;
   *val = curlx_memdup0((const char *)(*src), slen);
@@ -160,26 +160,26 @@ static CURLcode spack_decstr16(char **val, const uint8_t **src,
 static CURLcode spack_encdata16(struct dynbuf *buf, const uint8_t *data,
                                 size_t data_len)
 {
-  CURLcode r;
+  CURLcode result;
   if(data_len > UINT16_MAX)
     return CURLE_BAD_FUNCTION_ARGUMENT;
-  r = spack_enc16(buf, (uint16_t)data_len);
-  if(!r) {
-    r = curlx_dyn_addn(buf, data, data_len);
+  result = spack_enc16(buf, (uint16_t)data_len);
+  if(!result) {
+    result = curlx_dyn_addn(buf, data, data_len);
   }
-  return r;
+  return result;
 }
 
 static CURLcode spack_decdata16(uint8_t **val, size_t *val_len,
                                 const uint8_t **src, const uint8_t *end)
 {
   uint16_t data_len;
-  CURLcode r;
+  CURLcode result;
 
   *val = NULL;
-  r = spack_dec16(&data_len, src, end);
-  if(r)
-    return r;
+  result = spack_dec16(&data_len, src, end);
+  if(result)
+    return result;
   if(end - *src < data_len)
     return CURLE_READ_ERROR;
   *val = curlx_memdup0((const char *)(*src), data_len);
@@ -192,48 +192,48 @@ CURLcode Curl_ssl_session_pack(struct Curl_easy *data,
                                struct Curl_ssl_session *s,
                                struct dynbuf *buf)
 {
-  CURLcode r;
+  CURLcode result;
   DEBUGASSERT(s->sdata);
   DEBUGASSERT(s->sdata_len);
 
   if(s->valid_until < 0)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
-  r = spack_enc8(buf, CURL_SPACK_VERSION);
-  if(!r)
-    r = spack_enc8(buf, CURL_SPACK_TICKET);
-  if(!r)
-    r = spack_encdata16(buf, s->sdata, s->sdata_len);
-  if(!r)
-    r = spack_enc8(buf, CURL_SPACK_IETF_ID);
-  if(!r)
-    r = spack_enc16(buf, (uint16_t)s->ietf_tls_id);
-  if(!r)
-    r = spack_enc8(buf, CURL_SPACK_VALID_UNTIL);
-  if(!r)
-    r = spack_enc64(buf, (uint64_t)s->valid_until);
-  if(!r && s->alpn) {
-    r = spack_enc8(buf, CURL_SPACK_ALPN);
-    if(!r)
-      r = spack_encstr16(buf, s->alpn);
+  result = spack_enc8(buf, CURL_SPACK_VERSION);
+  if(!result)
+    result = spack_enc8(buf, CURL_SPACK_TICKET);
+  if(!result)
+    result = spack_encdata16(buf, s->sdata, s->sdata_len);
+  if(!result)
+    result = spack_enc8(buf, CURL_SPACK_IETF_ID);
+  if(!result)
+    result = spack_enc16(buf, (uint16_t)s->ietf_tls_id);
+  if(!result)
+    result = spack_enc8(buf, CURL_SPACK_VALID_UNTIL);
+  if(!result)
+    result = spack_enc64(buf, (uint64_t)s->valid_until);
+  if(!result && s->alpn) {
+    result = spack_enc8(buf, CURL_SPACK_ALPN);
+    if(!result)
+      result = spack_encstr16(buf, s->alpn);
   }
-  if(!r && s->earlydata_max) {
+  if(!result && s->earlydata_max) {
     if(s->earlydata_max > UINT32_MAX)
-      r = CURLE_BAD_FUNCTION_ARGUMENT;
-    if(!r)
-      r = spack_enc8(buf, CURL_SPACK_EARLYDATA);
-    if(!r)
-      r = spack_enc32(buf, (uint32_t)s->earlydata_max);
+      result = CURLE_BAD_FUNCTION_ARGUMENT;
+    if(!result)
+      result = spack_enc8(buf, CURL_SPACK_EARLYDATA);
+    if(!result)
+      result = spack_enc32(buf, (uint32_t)s->earlydata_max);
   }
-  if(!r && s->quic_tp && s->quic_tp_len) {
-    r = spack_enc8(buf, CURL_SPACK_QUICTP);
-    if(!r)
-      r = spack_encdata16(buf, s->quic_tp, s->quic_tp_len);
+  if(!result && s->quic_tp && s->quic_tp_len) {
+    result = spack_enc8(buf, CURL_SPACK_QUICTP);
+    if(!result)
+      result = spack_encdata16(buf, s->quic_tp, s->quic_tp_len);
   }
 
-  if(r)
-    CURL_TRC_SSLS(data, "error packing data: %d", r);
-  return r;
+  if(result)
+    CURL_TRC_SSLS(data, "error packing data: %d", result);
+  return result;
 }
 
 CURLcode Curl_ssl_session_unpack(struct Curl_easy *data,
@@ -247,83 +247,83 @@ CURLcode Curl_ssl_session_unpack(struct Curl_easy *data,
   uint16_t val16;
   uint32_t val32;
   uint64_t val64;
-  CURLcode r;
+  CURLcode result;
 
   DEBUGASSERT(buf);
   DEBUGASSERT(buflen);
   *ps = NULL;
 
-  r = spack_dec8(&val8, &buf, end);
-  if(r)
+  result = spack_dec8(&val8, &buf, end);
+  if(result)
     goto out;
   if(val8 != CURL_SPACK_VERSION) {
-    r = CURLE_READ_ERROR;
+    result = CURLE_READ_ERROR;
     goto out;
   }
 
   s = curlx_calloc(1, sizeof(*s));
   if(!s) {
-    r = CURLE_OUT_OF_MEMORY;
+    result = CURLE_OUT_OF_MEMORY;
     goto out;
   }
 
   while(buf < end) {
-    r = spack_dec8(&val8, &buf, end);
-    if(r)
+    result = spack_dec8(&val8, &buf, end);
+    if(result)
       goto out;
 
     switch(val8) {
     case CURL_SPACK_ALPN:
-      r = spack_decstr16(&s->alpn, &buf, end);
-      if(r)
+      result = spack_decstr16(&s->alpn, &buf, end);
+      if(result)
         goto out;
       break;
     case CURL_SPACK_EARLYDATA:
-      r = spack_dec32(&val32, &buf, end);
-      if(r)
+      result = spack_dec32(&val32, &buf, end);
+      if(result)
         goto out;
       s->earlydata_max = val32;
       break;
     case CURL_SPACK_IETF_ID:
-      r = spack_dec16(&val16, &buf, end);
-      if(r)
+      result = spack_dec16(&val16, &buf, end);
+      if(result)
         goto out;
       s->ietf_tls_id = val16;
       break;
     case CURL_SPACK_QUICTP: {
-      r = spack_decdata16(&pval8, &s->quic_tp_len, &buf, end);
-      if(r)
+      result = spack_decdata16(&pval8, &s->quic_tp_len, &buf, end);
+      if(result)
         goto out;
       s->quic_tp = pval8;
       break;
     }
     case CURL_SPACK_TICKET: {
-      r = spack_decdata16(&pval8, &s->sdata_len, &buf, end);
-      if(r)
+      result = spack_decdata16(&pval8, &s->sdata_len, &buf, end);
+      if(result)
         goto out;
       s->sdata = pval8;
       break;
     }
     case CURL_SPACK_VALID_UNTIL:
-      r = spack_dec64(&val64, &buf, end);
-      if(r)
+      result = spack_dec64(&val64, &buf, end);
+      if(result)
         goto out;
       s->valid_until = (curl_off_t)val64;
       break;
     default:  /* unknown tag */
-      r = CURLE_READ_ERROR;
+      result = CURLE_READ_ERROR;
       goto out;
     }
   }
 
 out:
-  if(r) {
-    CURL_TRC_SSLS(data, "error unpacking data: %d", r);
+  if(result) {
+    CURL_TRC_SSLS(data, "error unpacking data: %d", result);
     Curl_ssl_session_destroy(s);
   }
   else
     *ps = s;
-  return r;
+  return result;
 }
 
 #endif /* USE_SSL && USE_SSLS_EXPORT */

--- a/projects/OS400/ccsidcurl.c
+++ b/projects/OS400/ccsidcurl.c
@@ -537,7 +537,7 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
 {
   va_list arg;
   void *paramp;
-  CURLcode ret;
+  CURLcode result;
   struct Curl_easy *data;
 
   /* WARNING: unlike curl_easy_getinfo(), the strings returned by this
@@ -546,9 +546,9 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
   data = (struct Curl_easy *)curl;
   va_start(arg, info);
   paramp = va_arg(arg, void *);
-  ret = Curl_getinfo(data, info, paramp);
+  result = Curl_getinfo(data, info, paramp);
 
-  if(ret == CURLE_OK) {
+  if(result == CURLE_OK) {
     unsigned int ccsid;
     char **cpp;
     struct curl_slist **slp;
@@ -565,7 +565,7 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
         *cpp = dynconvert(ccsid, *cpp, -1, ASCII_CCSID, NULL);
 
         if(!*cpp)
-          ret = CURLE_OUT_OF_MEMORY;
+          result = CURLE_OUT_OF_MEMORY;
       }
 
       break;
@@ -578,13 +578,13 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
         if(cipf) {
           cipt = (struct curl_certinfo *)malloc(sizeof(*cipt));
           if(!cipt)
-            ret = CURLE_OUT_OF_MEMORY;
+            result = CURLE_OUT_OF_MEMORY;
           else {
             cipt->certinfo =
               (struct curl_slist **)calloc(cipf->num_of_certs + 1,
                                            sizeof(struct curl_slist *));
             if(!cipt->certinfo)
-              ret = CURLE_OUT_OF_MEMORY;
+              result = CURLE_OUT_OF_MEMORY;
             else {
               int i;
 
@@ -594,13 +594,13 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
                   if(!(cipt->certinfo[i] = slist_convert(ccsid,
                                                          cipf->certinfo[i],
                                                          ASCII_CCSID))) {
-                    ret = CURLE_OUT_OF_MEMORY;
+                    result = CURLE_OUT_OF_MEMORY;
                     break;
                   }
             }
           }
 
-          if(ret != CURLE_OK) {
+          if(result != CURLE_OK) {
             curl_certinfo_free_all(cipt);
             cipt = (struct curl_certinfo *)NULL;
           }
@@ -620,7 +620,7 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
         if(*slp) {
           *slp = slist_convert(ccsid, *slp, ASCII_CCSID);
           if(!*slp)
-            ret = CURLE_OUT_OF_MEMORY;
+            result = CURLE_OUT_OF_MEMORY;
         }
         break;
       }
@@ -628,7 +628,7 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
   }
 
   va_end(arg);
-  return ret;
+  return result;
 }
 
 static int Curl_is_formadd_string(CURLformoption option)

--- a/tests/unit/unit3300.c
+++ b/tests/unit/unit3300.c
@@ -82,26 +82,26 @@ static CURLcode test_unit3300(const char *arg)
   UNITTEST_BEGIN_SIMPLE
   struct curl_thrdpool *tpool;
   struct unit3300_ctx ctx;
-  CURLcode r;
+  CURLcode result;
 
   /* pool without minimum, will not start anything */
   unit3300_ctx_init(&ctx, 10, 0);
-  r = Curl_thrdpool_create(&tpool, "unit3300a", 0, 2, 0,
-                           unit3300_take, unit3300_process, unit3300_return,
-                           &ctx);
-  fail_unless(!r, "pool-a create");
+  result = Curl_thrdpool_create(&tpool, "unit3300a", 0, 2, 0,
+                                unit3300_take, unit3300_process,
+                                unit3300_return, &ctx);
+  fail_unless(!result, "pool-a create");
   Curl_thrdpool_destroy(tpool, TRUE);
   fail_unless(!ctx.returned, "pool-a unexpected items returned");
   fail_unless(!ctx.taken, "pool-a unexpected items taken");
 
   /* pool without minimum, signal start, consumes everything */
   unit3300_ctx_init(&ctx, 10, 0);
-  r = Curl_thrdpool_create(&tpool, "unit3300b", 0, 2, 0,
-                           unit3300_take, unit3300_process, unit3300_return,
-                           &ctx);
-  fail_unless(!r, "pool-b create");
-  r = Curl_thrdpool_signal(tpool, 2);
-  fail_unless(!r, "pool-b signal");
+  result = Curl_thrdpool_create(&tpool, "unit3300b", 0, 2, 0,
+                                unit3300_take, unit3300_process,
+                                unit3300_return, &ctx);
+  fail_unless(!result, "pool-b create");
+  result = Curl_thrdpool_signal(tpool, 2);
+  fail_unless(!result, "pool-b signal");
   Curl_thrdpool_await_idle(tpool, 0);
   Curl_thrdpool_destroy(tpool, TRUE);
   fail_unless(ctx.returned == ctx.total, "pool-b items returned missing");
@@ -109,10 +109,10 @@ static CURLcode test_unit3300(const char *arg)
 
   /* pool with minimum, consumes everything without signal */
   unit3300_ctx_init(&ctx, 10, 0);
-  r = Curl_thrdpool_create(&tpool, "unit3300c", 1, 2, 0,
-                           unit3300_take, unit3300_process, unit3300_return,
-                           &ctx);
-  fail_unless(!r, "pool-c create");
+  result = Curl_thrdpool_create(&tpool, "unit3300c", 1, 2, 0,
+                                unit3300_take, unit3300_process,
+                                unit3300_return, &ctx);
+  fail_unless(!result, "pool-c create");
   Curl_thrdpool_await_idle(tpool, 0);
   Curl_thrdpool_destroy(tpool, TRUE);
   fail_unless(ctx.returned == ctx.total, "pool-c items returned missing");
@@ -120,12 +120,12 @@ static CURLcode test_unit3300(const char *arg)
 
   /* pool with many max, signal abundance, consumes everything */
   unit3300_ctx_init(&ctx, 100, 0);
-  r = Curl_thrdpool_create(&tpool, "unit3300d", 0, 50, 0,
-                           unit3300_take, unit3300_process, unit3300_return,
-                           &ctx);
-  fail_unless(!r, "pool-d create");
-  r = Curl_thrdpool_signal(tpool, 100);
-  fail_unless(!r, "pool-d signal");
+  result = Curl_thrdpool_create(&tpool, "unit3300d", 0, 50, 0,
+                                unit3300_take, unit3300_process,
+                                unit3300_return, &ctx);
+  fail_unless(!result, "pool-d create");
+  result = Curl_thrdpool_signal(tpool, 100);
+  fail_unless(!result, "pool-d signal");
   Curl_thrdpool_await_idle(tpool, 0);
   Curl_thrdpool_destroy(tpool, TRUE);
   fail_unless(ctx.returned == ctx.total, "pool-d items returned missing");
@@ -133,12 +133,12 @@ static CURLcode test_unit3300(const char *arg)
 
   /* pool with 1 max, many to take, no await, destroy without join */
   unit3300_ctx_init(&ctx, 10000000, 1);
-  r = Curl_thrdpool_create(&tpool, "unit3300e", 0, 1, 0,
-                           unit3300_take, unit3300_process, unit3300_return,
-                           &ctx);
-  fail_unless(!r, "pool-e create");
-  r = Curl_thrdpool_signal(tpool, 100);
-  fail_unless(!r, "pool-e signal");
+  result = Curl_thrdpool_create(&tpool, "unit3300e", 0, 1, 0,
+                                unit3300_take, unit3300_process,
+                                unit3300_return, &ctx);
+  fail_unless(!result, "pool-e create");
+  result = Curl_thrdpool_signal(tpool, 100);
+  fail_unless(!result, "pool-e signal");
   Curl_thrdpool_destroy(tpool, FALSE);
   fail_unless(ctx.returned < ctx.total, "pool-e returned all");
   fail_unless(ctx.taken < ctx.total, "pool-e took all");

--- a/tests/unit/unit3301.c
+++ b/tests/unit/unit3301.c
@@ -84,14 +84,14 @@ static CURLcode test_unit3301(const char *arg)
   struct curl_thrdq *tqueue;
   struct unit3301_ctx ctx;
   int i, count, nrecvd;
-  CURLcode r;
+  CURLcode result;
 
   /* create and teardown queue */
   memset(&ctx, 0, sizeof(ctx));
-  r = Curl_thrdq_create(&tqueue, "unit3301-a", 0, 0, 2, 1,
-                        unit3301_item_free, unit3301_process, unit3301_event,
-                        &ctx);
-  fail_unless(!r, "queue-a create");
+  result = Curl_thrdq_create(&tqueue, "unit3301-a", 0, 0, 2, 1,
+                             unit3301_item_free, unit3301_process,
+                             unit3301_event, &ctx);
+  fail_unless(!result, "queue-a create");
   Curl_thrdq_destroy(tqueue, TRUE);
   tqueue = NULL;
   fail_unless(!ctx.event, "queue-a unexpected done count");
@@ -99,25 +99,25 @@ static CURLcode test_unit3301(const char *arg)
   /* create queue, have it process `count` items */
   count = 10;
   memset(&ctx, 0, sizeof(ctx));
-  r = Curl_thrdq_create(&tqueue, "unit3301-b", 0, 0, 2, 1,
-                        unit3301_item_free, unit3301_process, unit3301_event,
-                        &ctx);
-  fail_unless(!r, "queue-b create");
+  result = Curl_thrdq_create(&tqueue, "unit3301-b", 0, 0, 2, 1,
+                             unit3301_item_free, unit3301_process,
+                             unit3301_event, &ctx);
+  fail_unless(!result, "queue-b create");
   for(i = 0; i < count; ++i) {
     struct unit3301_item *uitem = unit3301_item_create(i);
     fail_unless(uitem, "queue-b item create");
-    r = Curl_thrdq_send(tqueue, uitem, NULL, 0);
-    fail_unless(!r, "queue-b send");
+    result = Curl_thrdq_send(tqueue, uitem, NULL, 0);
+    fail_unless(!result, "queue-b send");
   }
 
-  r = thrdq_await_done(tqueue, 0);
-  fail_unless(!r, "queue-b await done");
+  result = thrdq_await_done(tqueue, 0);
+  fail_unless(!result, "queue-b await done");
 
   nrecvd = 0;
   for(i = 0; i < count; ++i) {
     void *item;
-    r = Curl_thrdq_recv(tqueue, &item);
-    fail_unless(!r, "queue-b recv");
+    result = Curl_thrdq_recv(tqueue, &item);
+    fail_unless(!result, "queue-b recv");
     if(item) {
       struct unit3301_item *uitem = item;
       curl_mfprintf(stderr, "received item %d\n", uitem->id);


### PR DESCRIPTION
Follow-up to 885b553545a74365f4fc2541a0829f7745e80d37 #21348
