### PR TITLE
gtls: verify OCSP response signature in gtls_verify_ocsp_status

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1429,6 +1429,9 @@ static CURLcode gtls_verify_ocsp_status(struct Curl_easy *data,
 {
   gnutls_ocsp_resp_t ocsp_resp = NULL;
   gnutls_datum_t status_request;
+  gnutls_certificate_credentials_t creds = NULL;
+  gnutls_x509_trust_list_t tlist = NULL;
+  unsigned int verify_status = 0;
   gnutls_ocsp_cert_status_t status = GNUTLS_OCSP_CERT_UNKNOWN;
   gnutls_x509_crl_reason_t reason;
   CURLcode result = CURLE_OK;
@@ -1461,13 +1464,23 @@ static CURLcode gtls_verify_ocsp_status(struct Curl_easy *data,
     goto out;
   }
 
-  rc = gnutls_ocsp_resp_get_single(ocsp_resp, 0, NULL, NULL, NULL, NULL,
-                                   &status, NULL, NULL, NULL, &reason);
-  if(rc < 0) {
-    failf(data, "Invalid OCSP response received");
+  if(!gnutls_credentials_get(session, GNUTLS_CRD_CERTIFICATE,
+                             (void **)&creds))
+    gnutls_certificate_get_trust_list(creds, &tlist);
+  if(!tlist) {
+    failf(data, "OCSP response signature verification failed");
     result = CURLE_SSL_INVALIDCERTSTATUS;
     goto out;
   }
+  rc = gnutls_ocsp_resp_verify(ocsp_resp, tlist, &verify_status, 0);
+  if(rc < 0 || verify_status) {
+    failf(data, "OCSP response signature verification failed");
+    result = CURLE_SSL_INVALIDCERTSTATUS;
+    goto out;
+  }
+
+  (void)gnutls_ocsp_resp_get_single(ocsp_resp, 0, NULL, NULL, NULL, NULL,
+                                    &status, NULL, NULL, NULL, &reason);
 
   switch(status) {
   case GNUTLS_OCSP_CERT_GOOD:


### PR DESCRIPTION
## Background

Since `aeb1a281ca` ("gtls: fix OCSP stapling management"), `gtls_verify_ocsp_status` parses the stapled OCSP response and reads the certificate status via `gnutls_ocsp_resp_get_single()`, but never calls `gnutls_ocsp_resp_verify()` or `gnutls_ocsp_resp_verify_direct()`. A response with a forged or corrupted signature is accepted without question.

Before `aeb1a281ca`, the code called `gnutls_ocsp_status_request_is_checked(session, 0)`, which only returns non-zero after GnuTLS has internally verified the OCSP response during the handshake. The refactor replaced this with manual parsing that omitted the verification step.

## Fix

Call `gnutls_ocsp_resp_verify()` against the trust list obtained from the session credentials immediately after `gnutls_ocsp_resp_import()`. This handles both directly-signed responses and delegated OCSP responders without requiring the issuer certificate to be present in the peer chain.

## Scope

The missing check only affects the `CURLOPT_SSL_VERIFYSTATUS` code path when `CURLOPT_SSL_VERIFYPEER` is **disabled**. With peer verification enabled, `gnutls_certificate_verify_peers2()` independently catches an invalid OCSP response via `GNUTLS_CERT_INVALID_OCSP_STATUS` before `gtls_verify_ocsp_status()` is reached.

Because a caller that has disabled peer verification has already abandoned certificate chain trust, there is no attack scenario enabled by the missing check that is not already trivially achievable by other means. This is a correctness and backend-consistency fix (the OpenSSL path calls `OCSP_basic_verify()` unconditionally), not a security vulnerability.