### PR TITLE
GHA/non-native: move BSDs to a single matrix, add DragonFly and Midnight

### DIFF
--- a/.github/scripts/typos.toml
+++ b/.github/scripts/typos.toml
@@ -6,7 +6,7 @@
 extend-ignore-identifiers-re = [
   "^(ba|fo|pn|PN|UE)$",
   "^(CNA|cpy|ser)$",
-  "^(ECT0|ECT1|HELO|htpts|PASE)$",
+  "^(ECT0|ECT1|HELO|htpts|mport|PASE)$",
   "^[A-Za-z0-9_-]*(EDE|GOST)[A-Z0-9_-]*$",  # ciphers
   "^0x[0-9a-fA-F]+FUL$",  # unsigned long hex literals ending with 'F'
    "^[0-9a-zA-Z+]{64,}$",  # possibly base64

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', desc: 'openssl',
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', desc: 'openssl !runtests',
               options: '--with-openssl' }
           - { os: 'freebsd',      version: '15.0',  build: 'autotools', arch: 'x86_64', desc: 'openssl',
               options: '--with-openssl --with-gssapi' }
@@ -64,7 +64,7 @@ jobs:
               options: '--with-openssl --with-gssapi' }
           - { os: 'freebsd',      version: '14.3',  build: 'cmake'    , arch: 'arm64' , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', desc: 'gnutls',
+          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', desc: 'gnutls !runtests',
               options: '-DCURL_USE_GNUTLS=ON' }
           - { os: 'netbsd',       version: '10.1' , build: 'cmake'    , arch: 'x86_64', desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -87,11 +87,14 @@ jobs:
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
             sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
-          elif [ "${MATRIX_OS}" = 'freebsd' ] && [ "${MATRIX_BUILD}" = 'cmake' ]; then
+          elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake-core ninja perl5 pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
-          elif [ "${MATRIX_OS}" = 'freebsd' ] && [ "${MATRIX_BUILD}" = 'autotools' ]; then
-            sudo pkg install -y autoconf automake libtool pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+              tools='cmake-core ninja perl5'
+            else
+              tools='autoconf automake libtool'
+            fi
+            sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -178,12 +178,11 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            sudo pkg install -y cmake ninja perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
+            sudo pkg install -y cmake-core ninja perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport upgrade
-            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client libidn2 libnghttp2 || true
+            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client openssl-devel libidn2 libnghttp2 || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -52,6 +52,11 @@ jobs:
           operating_system: 'dragonflybsd'
           version: '6.4.2'
           run: |
+            echo '----------------'
+            echo "|$PATH|"
+            which cmake || true
+            command -v cmake || true
+            echo '----------------'
             export CURL_CI=github
             time sudo pkg install -y cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -53,7 +53,7 @@ jobs:
           version: '6.4.2'
           run: |
             export CURL_CI=github
-            time sudo pkg install -y cmake ninja perl5 \
+            time sudo pkg install -y cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2
             echo '----------------'
             echo "|$PATH|"

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,6 +37,49 @@ env:
   DO_NOT_TRACK: '1'
 
 jobs:
+  dragonflybsd:
+    name: 'DragonFlyBSD, CM clang openssl'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 'cmake'
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
+        with:
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
+          operating_system: 'dragonflybsd'
+          version: '6.4.2'
+          run: |
+            export CURL_CI=github
+            time sudo pkg install -y cmake ninja perl5 \
+              pkgconf brotli openldap26-client libidn2 libnghttp2
+            echo '----------------'
+            echo "|$PATH|"
+            which cmake || true
+            command -v cmake || true
+            echo '----------------'
+            time cmake -B bld -G Ninja \
+              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+              -DCMAKE_C_COMPILER="${CC}" \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_WERROR=ON \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+              -DCURL_USE_OPENSSL=ON \
+              -DCURL_USE_GSSAPI=ON \
+              ${MATRIX_OPTIONS} \
+              || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
+            time cmake --build bld
+            time cmake --install bld
+            bld/src/curl --disable --version
+            time cmake --build bld --target testdeps
+            echo '::group::build examples'
+            time cmake --build bld --target curl-examples-build
+            echo '::endgroup::'
+
   freebsd:
     name: "FreeBSD, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
@@ -143,6 +186,47 @@ jobs:
               fi
               echo '::endgroup::'
             fi
+
+  midnightbsd:
+    name: 'MidnightBSD, CM clang openssl'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 'cmake'
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
+        with:
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
+          operating_system: 'midnightbsd'
+          version: '4.0.4'
+          architecture: ${{ matrix.arch }}
+          run: |
+            export CURL_CI=github
+            # https://app.midnightbsd.org/
+            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
+            time doas mport -q install cmake-core ninja perl5 \
+              pkgconf brotli openldap26-client libidn2 libnghttp2 >/dev/null
+            time cmake -B bld -G Ninja \
+              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+              -DCMAKE_C_COMPILER="${CC}" \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_WERROR=ON \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+              -DCURL_USE_OPENSSL=ON \
+              -DCURL_USE_GSSAPI=ON \
+              ${MATRIX_OPTIONS} \
+              || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
+            time cmake --build bld
+            time cmake --install bld
+            bld/src/curl --disable --version
+            time cmake --build bld --target testdeps
+            echo '::group::build examples'
+            time cmake --build bld --target curl-examples-build
+            echo '::endgroup::'
 
   netbsd:
     name: 'NetBSD, CM clang openssl ${{ matrix.arch }}'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -182,7 +182,7 @@ jobs:
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client openssl-devel libidn2 libnghttp2 || true
+            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client openssl-devel libidn2 libnghttp2 | grep -E '(Downloading|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -278,6 +278,9 @@ jobs:
     name: 'OpenBSD, CM clang libressl ${{ matrix.arch }}'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: cpa.sh {0}  # zizmor: ignore[misfeature]
     strategy:
       matrix:
         arch: ['x86_64']
@@ -295,13 +298,11 @@ jobs:
           architecture: ${{ matrix.arch }}
 
       - name: 'install prereqs'
-        shell: cpa.sh {0}
         # https://openbsd.app/
         # https://www.openbsd.org/faq/faq15.html
         run: sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
 
       - name: 'configure'
-        shell: cpa.sh {0}
         run: |
           cmake -B bld -G Ninja \
             -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
@@ -315,30 +316,23 @@ jobs:
           echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
 
       - name: 'build'
-        shell: cpa.sh {0}
         run: cmake --build bld
 
       - name: 'curl -V'
-        shell: cpa.sh {0}
         run: bld/src/curl --disable --version
 
       - name: 'curl install'
-        shell: cpa.sh {0}
         run: cmake --install bld
 
       - name: 'build tests'
         if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
-        shell: cpa.sh {0}
         run: cmake --build bld --target testdeps
 
       - name: 'run tests'
         if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
-        shell: cpa.sh {0}
-        # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
-        run: TFLAGS='-j8 !2707' cmake --build bld --target test-ci
+        run: TFLAGS='-j8 !2707' cmake --build bld --target test-ci  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
 
       - name: 'build examples'
-        shell: cpa.sh {0}
         run: cmake --build bld --target curl-examples-build
 
   android:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -289,7 +289,7 @@ jobs:
           operating_system: 'openbsd'
           version: '7.7'
           architecture: ${{ matrix.arch }}
-      - name: 'cmake'
+      - name: 'build'
         run: |
           # https://openbsd.app/
           # https://www.openbsd.org/faq/faq15.html
@@ -312,6 +312,9 @@ jobs:
             export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
             time cmake --build bld --target test-ci
           fi
+
+      - name: 'examples'
+        run: |
           echo '::group::build examples'
           time cmake --build bld --target curl-examples-build
           echo '::endgroup::'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -38,25 +38,19 @@ env:
 
 jobs:
   dragonflybsd:
-    name: 'DragonFlyBSD, CM clang openssl ${{ matrix.arch }}'
+    name: 'DragonFlyBSD, CM clang openssl'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        arch: ['x86_64']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: 'cmake'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        env:
-          MATRIX_ARCH: '${{ matrix.arch }}'
         with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
           operating_system: 'dragonflybsd'
           version: '6.4.2'
-          architecture: ${{ matrix.arch }}
           run: |
             export CURL_CI=github
             # https://app.midnightbsd.org
@@ -190,29 +184,24 @@ jobs:
             fi
 
   midnightbsd:
-    name: 'MidnightBSD, CM clang openssl ${{ matrix.arch }}'
+    name: 'MidnightBSD, CM clang openssl'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        arch: ['x86_64']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: 'cmake'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        env:
-          MATRIX_ARCH: '${{ matrix.arch }}'
         with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
           operating_system: 'midnightbsd'
           version: '4.0.4'
           architecture: ${{ matrix.arch }}
           run: |
             export CURL_CI=github
             # https://app.midnightbsd.org
-            time sudo mport install cmake-core ninja perl5 \
+            time sudo mport -q install cmake-core ninja perl5 \
               pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -207,7 +207,7 @@ jobs:
             export CURL_CI=github
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            time doas mport -q install cmake-core ninja perl5 \
+            time sudo mport -q install cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2 >/dev/null
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -157,10 +157,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', arch: 'x86_64', desc: 'openssl' }
-          - { os: 'midnightbsd',  version: '4.0.4', arch: 'x86_64', desc: 'openssl' }
-          - { os: 'netbsd',       version: '10.1' , arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd',      version: '7.7'  , arch: 'x86_64', desc: 'libressl' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_OPENSSL=ON' }
+          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', desc: 'gnutls', options: '-DCURL_USE_GNUTLS=ON' }
+          - { os: 'netbsd',       version: '10.1' , build: 'cmake'    , arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
+          - { os: 'openbsd',      version: '7.7'  , build: 'cmake'    , arch: 'x86_64', desc: 'libressl', options: '-DCURL_USE_OPENSSL=ON' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -182,7 +182,7 @@ jobs:
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client openssl31 libidn2 libnghttp2 | grep -E '(Downloading|Installing)' || true
+            sudo mport -q install cmake-core ninja perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
@@ -194,14 +194,9 @@ jobs:
 
       - name: 'configure'
         run: |
-          cmake -B bld -G Ninja \
-            -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-            -DCMAKE_UNITY_BUILD=ON \
-            -DCURL_WERROR=ON \
-            -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-            -DCURL_USE_OPENSSL=ON \
-            -DCURL_ENABLE_NTLM=ON \
-            ${MATRIX_OPTIONS}
+          cmake -B bld -G Ninja -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+            -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+            -DCURL_ENABLE_NTLM=ON ${MATRIX_OPTIONS}
 
       - name: 'configure log'
         if: ${{ !cancelled() }}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -145,7 +145,7 @@ jobs:
             fi
 
   cross:
-    name: '${{ matrix.os }}, CM clang ${{ matrix.desc }} ${{ matrix.arch }}'
+    name: '${{ matrix.os }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} clang ${{ matrix.desc }} ${{ matrix.arch }}'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           persist-credentials: false
       - name: '${{ matrix.build }}'
-        uses: cross-platform-actions/action@233156312992f3f169d8d0c633c21d12a5d30455 # v1.0.0
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         env:
           CC: '${{ matrix.compiler }}'
           MATRIX_ARCH: '${{ matrix.arch }}'
@@ -156,7 +156,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'cmake'
-        uses: cross-platform-actions/action@233156312992f3f169d8d0c633c21d12a5d30455 # v1.0.0
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         env:
           MATRIX_ARCH: '${{ matrix.arch }}'
         with:
@@ -202,7 +202,7 @@ jobs:
         with:
           persist-credentials: false
       - name: 'cmake'
-        uses: cross-platform-actions/action@233156312992f3f169d8d0c633c21d12a5d30455 # v1.0.0
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         env:
           MATRIX_ARCH: '${{ matrix.arch }}'
         with:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -367,6 +367,90 @@ jobs:
       - name: 'build examples'
         run: cmake --build bld --target curl-examples-build
 
+  bsd:
+    name: '${{ matrix.os }}, CM clang ${{ matrix.info }} ${{ matrix.arch }}'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: cpa.sh {0}  # zizmor: ignore[misfeature]
+    strategy:
+      matrix:
+        include:
+          - { os: 'netbsd',  version: '10.1', arch: 'x86_64', info: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
+          - { os: 'openbsd', version: '7.7' , arch: 'x86_64', info: 'libressl' }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 'setup VM'
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
+        env:
+          MATRIX_OPTIONS: '${{ matrix.options }}'
+          MATRIX_OS: '${{ matrix.os }}'
+        with:
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_OPTIONS
+          operating_system: ${{ matrix.os }}
+          version: ${{ matrix.version }}
+          architecture: ${{ matrix.arch }}
+
+      - name: 'install prereqs'
+        run: |
+          if [ "${MATRIX_OS}" = 'netbsd' ]; then
+            # https://pkgsrc.se/
+            sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
+          elif [ "${MATRIX_OS}" = 'openbsd' ]; then
+            # https://openbsd.app/
+            # https://www.openbsd.org/faq/faq15.html
+            sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
+          fi
+
+      - name: 'configure'
+        run: |
+          cmake -B bld -G Ninja \
+            -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCURL_WERROR=ON \
+            -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+            -DCURL_USE_OPENSSL=ON \
+            -DCURL_ENABLE_NTLM=ON \
+            ${MATRIX_OPTIONS}
+
+      - name: 'configure log'
+        if: ${{ !cancelled() }}
+        run: cat bld/config.log bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+
+      - name: 'curl_config.h'
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          grep -F '#define' bld/lib/curl_config.h | sort || true
+
+      - name: 'build'
+        run: cmake --build bld
+
+      - name: 'curl -V'
+        run: bld/src/curl --disable --version
+
+      - name: 'curl install'
+        run: cmake --install bld
+
+      - name: 'build tests'
+        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        run: cmake --build bld --target testdeps
+
+      - name: 'run tests'
+        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        run: |
+          export TFLAGS='-j8'
+          if [ "${MATRIX_OS}" = 'openbsd' ]; then
+            TFLAGS+=' !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
+          fi
+          cmake --build bld --target test-ci
+
+      - name: 'build examples'
+        run: cmake --build bld --target curl-examples-build
+
   android:
     name: "Android ${{ matrix.platform }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.name }} arm64"
     runs-on: ubuntu-latest

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -61,7 +61,7 @@ jobs:
             export CURL_CI=github
             # https://app.midnightbsd.org
             time sudo pkg install -y cmake-core ninja perl5 \
-              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \
@@ -213,7 +213,7 @@ jobs:
             export CURL_CI=github
             # https://app.midnightbsd.org
             time sudo mport install cmake-core ninja perl5 \
-              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -52,14 +52,14 @@ jobs:
           operating_system: 'dragonflybsd'
           version: '6.4.2'
           run: |
+            export CURL_CI=github
+            time sudo pkg install -y cmake-core ninja perl5 \
+              pkgconf brotli openldap26-client libidn2 libnghttp2
             echo '----------------'
             echo "|$PATH|"
             which cmake || true
             command -v cmake || true
             echo '----------------'
-            export CURL_CI=github
-            time sudo pkg install -y cmake-core ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \
@@ -294,8 +294,9 @@ jobs:
           operating_system: 'openbsd'
           version: '7.7'
           architecture: ${{ matrix.arch }}
-          shell: ksh
+
       - name: 'build'
+        shell: cpa.sh {0}
         run: |
           # https://openbsd.app/
           # https://www.openbsd.org/faq/faq15.html
@@ -320,6 +321,7 @@ jobs:
           fi
 
       - name: 'examples'
+        shell: cpa.sh {0}
         run: |
           echo '::group::build examples'
           time cmake --build bld --target curl-examples-build

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -90,8 +90,12 @@ jobs:
           - { version: '15.0', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
           - { version: '14.4', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
           - { version: '14.3', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
+          - { version: '15.0', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
+          - { version: '14.4', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
           - { version: '14.3', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
           - { version: '14.3', build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
+          - { version: '15.0', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
+          - { version: '14.4', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
           - { version: '14.3', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
       fail-fast: false
     steps:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,130 +37,38 @@ env:
   DO_NOT_TRACK: '1'
 
 jobs:
-  freebsd:
-    name: "FreeBSD ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
+  cross:
+    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} clang ${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        include:
-          - { version: '15.0', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
-          - { version: '15.0', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
-          - { version: '14.3', build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
-          - { version: '14.3', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: '${{ matrix.build }}'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        env:
-          CC: '${{ matrix.compiler }}'
-          MATRIX_ARCH: '${{ matrix.arch }}'
-          MATRIX_BUILD: '${{ matrix.build }}'
-          MATRIX_DESC: '${{ matrix.desc }}'
-          MATRIX_OPTIONS: '${{ matrix.options }}'
-        with:
-          environment_variables: CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH MATRIX_BUILD MATRIX_DESC MATRIX_OPTIONS
-          operating_system: 'freebsd'
-          version: ${{ matrix.version }}
-          architecture: ${{ matrix.arch }}
-          run: |
-            export CURL_CI=github
-
-            # https://ports.freebsd.org/
-            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              time sudo pkg install -y cmake-core ninja perl5 \
-                pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
-            else
-              time sudo pkg install -y autoconf automake libtool \
-                pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
-              export MAKEFLAGS=-j3
-            fi
-
-            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              time cmake -B bld -G Ninja \
-                -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-                -DCMAKE_C_COMPILER="${CC}" \
-                -DCMAKE_UNITY_BUILD=ON \
-                -DCURL_WERROR=ON \
-                -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-                -DCURL_USE_OPENSSL=ON \
-                -DCURL_USE_GSSAPI=ON \
-                ${MATRIX_OPTIONS} \
-                || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            else
-              time autoreconf -fi
-              if [ "${MATRIX_ARCH}" != 'x86_64' ]; then
-                options='--disable-manual --disable-docs'  # Slow with autotools, skip on emulated CPU
-              fi
-              mkdir bld && cd bld
-              time ../configure --prefix="$HOME"/curl-install --enable-unity --enable-debug --enable-warnings --enable-werror --disable-static \
-                --disable-dependency-tracking --enable-option-checking=fatal \
-                --with-openssl \
-                --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 --with-gssapi \
-                ${options} \
-                ${MATRIX_OPTIONS} \
-                || { tail -n 1000 config.log; false; }
-              cd ..
-            fi
-
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-
-            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              time cmake --build bld
-              time cmake --install bld
-            else
-              time make -C bld install
-            fi
-
-            bld/src/curl --disable --version
-
-            if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
-              if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-                time cmake --build bld --target testdeps
-              else
-                time make -C bld -C tests
-              fi
-              if [ "${MATRIX_DESC#*!runtests*}" = "${MATRIX_DESC}" ]; then
-                export TFLAGS='-j8'
-                if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-                  time cmake --build bld --verbose --target test-ci
-                else
-                  time make -C bld V=1 test-ci
-                fi
-              fi
-            fi
-
-            if [ "${MATRIX_DESC#*!examples*}" = "${MATRIX_DESC}" ]; then
-              echo '::group::build examples'
-              if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-                time cmake --build bld --target curl-examples-build
-              else
-                time make -C bld examples
-              fi
-              echo '::endgroup::'
-            fi
-
-  cross:
-    name: '${{ matrix.os }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} clang ${{ matrix.desc }} ${{ matrix.arch }}'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     defaults:
       run:
         shell: cpa.sh {0}  # zizmor: ignore[misfeature]
     env:
+      CC: 'clang'
+      MAKEFLAGS: -j 3
+      MATRIX_ARCH: '${{ matrix.arch }}'
+      MATRIX_BUILD: '${{ matrix.build }}'
       MATRIX_OPTIONS: '${{ matrix.options }}'
       MATRIX_OS: '${{ matrix.os }}'
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_OPENSSL=ON' }
-          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', desc: 'gnutls', options: '-DCURL_USE_GNUTLS=ON' }
-          - { os: 'netbsd',       version: '10.1' , build: 'cmake'    , arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd',      version: '7.7'  , build: 'cmake'    , arch: 'x86_64', desc: 'libressl', options: '-DCURL_USE_OPENSSL=ON' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', desc: 'openssl',
+              options: '--with-openssl' }
+          - { os: 'freebsd',      version: '15.0',  build: 'autotools', arch: 'x86_64', desc: 'openssl',
+              options: '--with-openssl --with-gssapi' }
+          - { os: 'freebsd',      version: '15.0',  build: 'cmake'    , arch: 'x86_64', desc: 'openssl !unity !runtests !examples',
+              options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
+          - { os: 'freebsd',      version: '14.3',  build: 'autotools', arch: 'arm64' , desc: 'openssl !examples',
+              options: '--with-openssl --with-gssapi' }
+          - { os: 'freebsd',      version: '14.3',  build: 'cmake'    , arch: 'arm64' , desc: 'openssl',
+              options: '-DCURL_USE_GSSAPI=ON' }
+          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', desc: 'gnutls',
+              options: '-DCURL_USE_GNUTLS=ON' }
+          - { os: 'netbsd',       version: '10.1' , build: 'cmake'    , arch: 'x86_64', desc: 'openssl',
+              options: '-DCURL_USE_GSSAPI=ON' }
+          - { os: 'openbsd',      version: '7.7'  , build: 'cmake'    , arch: 'x86_64', desc: 'libressl' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -170,7 +78,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_OPTIONS MATRIX_OS
+          environment_variables: CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_OPTIONS MATRIX_OS
           operating_system: ${{ matrix.os }}
           version: ${{ matrix.version }}
           architecture: ${{ matrix.arch }}
@@ -179,6 +87,11 @@ jobs:
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
             sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
+          elif [ "${MATRIX_OS}" = 'freebsd' ] && [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            # https://ports.freebsd.org/
+            sudo pkg install -y cmake-core ninja perl5 pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+          elif [ "${MATRIX_OS}" = 'freebsd' ] && [ "${MATRIX_BUILD}" = 'autotools' ]; then
+            sudo pkg install -y autoconf automake libtool pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
@@ -192,11 +105,27 @@ jobs:
             sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
           fi
 
+      - name: 'autoreconf'
+        if: ${{ matrix.build == 'autotools' }}
+        run: autoreconf -fi
+
       - name: 'configure'
         run: |
-          cmake -B bld -G Ninja -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-            -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-            -DCURL_ENABLE_NTLM=ON ${MATRIX_OPTIONS}
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake -B bld -G Ninja -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+              -DCMAKE_C_COMPILER="${CC}" \
+              -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+              -DCURL_ENABLE_NTLM=ON ${MATRIX_OPTIONS}
+          else
+            if [ "${MATRIX_ARCH}" != 'x86_64' ]; then
+              options='--disable-manual --disable-docs'  # Slow with autotools, skip on emulated CPU
+            fi
+            mkdir bld && cd bld
+            ../configure --prefix="$HOME"/curl-install --enable-unity --enable-debug --enable-warnings --enable-werror --disable-static \
+              --disable-dependency-tracking --enable-option-checking=fatal \
+              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2  \
+              ${options} ${MATRIX_OPTIONS}
+          fi
 
       - name: 'configure log'
         if: ${{ !cancelled() }}
@@ -208,29 +137,54 @@ jobs:
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'build'
-        run: cmake --build bld
+        run: |
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --build bld
+          else
+            make -C bld
+          fi
 
       - name: 'curl -V'
         run: bld/src/curl --disable --version
 
       - name: 'curl install'
-        run: cmake --install bld
+        run: |
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --install bld
+          else
+            make -C bld install
+          fi
 
       - name: 'build tests'
-        if: ${{ matrix.arch == 'x86_64' && matrix.os != 'midnightbsd' }}  # Slow on emulated CPU
-        run: cmake --build bld --target testdeps
+        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        run: |
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --build bld --target testdeps
+          else
+            make -C bld -C tests
+          fi
 
       - name: 'run tests'
-        if: ${{ matrix.arch == 'x86_64' && matrix.os != 'midnightbsd' }}  # Slow on emulated CPU
+        if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, '!runtests') }}  # Slow on emulated CPU
         run: |
           export TFLAGS='-j8'
           if [ "${MATRIX_OS}" = 'openbsd' ]; then
             TFLAGS="$TFLAGS !2707"  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
           fi
-          cmake --build bld --target test-ci
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --build bld --verbose --target test-ci
+          else
+            make -C bld V=1 test-ci
+          fi
 
       - name: 'build examples'
-        run: cmake --build bld --target curl-examples-build
+        if: ${{ !contains(matrix.desc, '!examples') }}
+        run: |
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --build bld --target curl-examples-build
+          else
+            make -C bld examples
+          fi
 
   android:
     name: "Android ${{ matrix.platform }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.name }} arm64"

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -178,11 +178,11 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            sudo pkg install -y cmake-core ninja perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
+            sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client openssl-devel libidn2 libnghttp2 | grep -E '(Downloading|Installing)' || true
+            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client openssl31 libidn2 libnghttp2 | grep -E '(Downloading|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           environment_variables: CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH MATRIX_BUILD MATRIX_DESC MATRIX_OPTIONS
           operating_system: 'freebsd'
-          version: '14.3'
+          version: '14.4'
           architecture: ${{ matrix.arch }}
           run: |
             export CURL_CI=github

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -206,7 +206,7 @@ jobs:
             export CURL_CI=github
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            time sudo mport -q install cmake-core ninja perl5 \
+            time doas mport -q install cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2 >/dev/null
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
@@ -322,12 +322,12 @@ jobs:
           bld/src/curl --disable --version
 
       - name: 'build tests'
-        if: ${{ matrix.arch = 'x86_64' }}  # Slow on emulated CPU
+        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
         shell: cpa.sh {0}
         run: cmake --build bld --target testdeps
 
       - name: 'run tests'
-        if: ${{ matrix.arch = 'x86_64' }}  # Slow on emulated CPU
+        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
         shell: cpa.sh {0}
         run: |
             export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   dragonflybsd:
-    name: 'MidnightBSD, CM clang openssl ${{ matrix.arch }}'
+    name: 'DragonFlyBSD, CM clang openssl ${{ matrix.arch }}'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -374,6 +374,9 @@ jobs:
     defaults:
       run:
         shell: cpa.sh {0}  # zizmor: ignore[misfeature]
+    env:
+      MATRIX_OPTIONS: '${{ matrix.options }}'
+      MATRIX_OS: '${{ matrix.os }}'
     strategy:
       matrix:
         include:
@@ -386,11 +389,8 @@ jobs:
 
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        env:
-          MATRIX_OPTIONS: '${{ matrix.options }}'
-          MATRIX_OS: '${{ matrix.os }}'
         with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_OPTIONS
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_OPTIONS MATRIX_OS
           operating_system: ${{ matrix.os }}
           version: ${{ matrix.version }}
           architecture: ${{ matrix.arch }}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -289,7 +289,7 @@ jobs:
           operating_system: 'openbsd'
           version: '7.7'
           architecture: ${{ matrix.arch }}
-          shell: bash
+          shell: cpa.sh {0}
       - name: 'build'
         run: |
           # https://openbsd.app/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -316,10 +316,15 @@ jobs:
 
       - name: 'build'
         shell: cpa.sh {0}
-        run: |
-          cmake --build bld
-          cmake --install bld
-          bld/src/curl --disable --version
+        run: cmake --build bld
+
+      - name: 'curl -V'
+        shell: cpa.sh {0}
+        run: bld/src/curl --disable --version
+
+      - name: 'curl install'
+        shell: cpa.sh {0}
+        run: cmake --install bld
 
       - name: 'build tests'
         if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
@@ -329,9 +334,8 @@ jobs:
       - name: 'run tests'
         if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
         shell: cpa.sh {0}
-        run: |
-            export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
-            cmake --build bld --target test-ci
+        # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
+        run: TFLAGS='-j8 !2707' cmake --build bld --target test-ci
 
       - name: 'build examples'
         shell: cpa.sh {0}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,6 +37,51 @@ env:
   DO_NOT_TRACK: '1'
 
 jobs:
+  dragonflybsd:
+    name: 'MidnightBSD, CM clang openssl ${{ matrix.arch }}'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        arch: ['x86_64']
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 'cmake'
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
+        env:
+          MATRIX_ARCH: '${{ matrix.arch }}'
+        with:
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH
+          operating_system: 'dragonflybsd'
+          version: '6.4.2'
+          architecture: ${{ matrix.arch }}
+          run: |
+            export CURL_CI=github
+            # https://app.midnightbsd.org
+            time sudo pkg install -y cmake-core ninja perl5 \
+              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+            time cmake -B bld -G Ninja \
+              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+              -DCMAKE_C_COMPILER="${CC}" \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_WERROR=ON \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+              -DCURL_USE_OPENSSL=ON \
+              -DCURL_USE_GSSAPI=ON \
+              ${MATRIX_OPTIONS} \
+              || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
+            time cmake --build bld
+            time cmake --install bld
+            bld/src/curl --disable --version
+            time cmake --build bld --target testdeps
+            echo '::group::build examples'
+            time cmake --build bld --target curl-examples-build
+            echo '::endgroup::'
+
   freebsd:
     name: "FreeBSD, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -206,7 +206,7 @@ jobs:
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
             time sudo mport -q install cmake-core ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2
+              pkgconf brotli openldap26-client libidn2 libnghttp2 || true
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -438,7 +438,7 @@ jobs:
         run: |
           export TFLAGS='-j8'
           if [ "${MATRIX_OS}" = 'openbsd' ]; then
-            TFLAGS+=' !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
+            TFLAGS="$TFLAGS !2707"  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
           fi
           cmake --build bld --target test-ci
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -289,7 +289,7 @@ jobs:
           operating_system: 'openbsd'
           version: '7.7'
           architecture: ${{ matrix.arch }}
-          shell: cpa.sh {0}
+          shell: ksh
       - name: 'build'
         run: |
           # https://openbsd.app/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -201,7 +201,6 @@ jobs:
           environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
           operating_system: 'midnightbsd'
           version: '4.0.4'
-          architecture: ${{ matrix.arch }}
           run: |
             export CURL_CI=github
             # https://app.midnightbsd.org/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -368,7 +368,7 @@ jobs:
         run: cmake --build bld --target curl-examples-build
 
   bsd:
-    name: '${{ matrix.os }}, CM clang ${{ matrix.info }} ${{ matrix.arch }}'
+    name: '${{ matrix.os }}, CM clang ${{ matrix.desc }} ${{ matrix.arch }}'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -377,8 +377,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'netbsd',  version: '10.1', arch: 'x86_64', info: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd', version: '7.7' , arch: 'x86_64', info: 'libressl' }
+          - { os: 'netbsd',  version: '10.1', arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
+          - { os: 'openbsd', version: '7.7' , arch: 'x86_64', desc: 'libressl' }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,49 +37,6 @@ env:
   DO_NOT_TRACK: '1'
 
 jobs:
-  dragonflybsd:
-    name: 'DragonFlyBSD, CM clang openssl'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: 'cmake'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
-          operating_system: 'dragonflybsd'
-          version: '6.4.2'
-          run: |
-            export CURL_CI=github
-            sudo pkg install -y cmake ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2
-            echo '----------------'
-            echo "|$PATH|"
-            which cmake || true
-            command -v cmake || true
-            echo '----------------'
-            time cmake -B bld -G Ninja \
-              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_C_COMPILER="${CC}" \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-              -DCURL_USE_OPENSSL=ON \
-              -DCURL_USE_GSSAPI=ON \
-              ${MATRIX_OPTIONS} \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld
-            time cmake --install bld
-            bld/src/curl --disable --version
-            time cmake --build bld --target testdeps
-            echo '::group::build examples'
-            time cmake --build bld --target curl-examples-build
-            echo '::endgroup::'
-
   freebsd:
     name: "FreeBSD ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
@@ -187,48 +144,7 @@ jobs:
               echo '::endgroup::'
             fi
 
-  midnightbsd:
-    name: 'MidnightBSD, CM clang openssl'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: 'cmake'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
-          operating_system: 'midnightbsd'
-          version: '4.0.4'
-          run: |
-            export CURL_CI=github
-            # https://app.midnightbsd.org/
-            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport upgrade
-            sudo mport -q install cmake-core ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2 || true
-            time cmake -B bld -G Ninja \
-              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_C_COMPILER="${CC}" \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-              -DCURL_USE_OPENSSL=ON \
-              -DCURL_USE_GSSAPI=ON \
-              ${MATRIX_OPTIONS} \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld
-            time cmake --install bld
-            bld/src/curl --disable --version
-            time cmake --build bld --target testdeps
-            echo '::group::build examples'
-            time cmake --build bld --target curl-examples-build
-            echo '::endgroup::'
-
-  bsd:
+  cross:
     name: '${{ matrix.os }}, CM clang ${{ matrix.desc }} ${{ matrix.arch }}'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -241,8 +157,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'netbsd',  version: '10.1', arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd', version: '7.7' , arch: 'x86_64', desc: 'libressl' }
+          - { os: 'dragonflybsd', version: '6.4.2', arch: 'x86_64', desc: 'openssl' }
+          - { os: 'midnightbsd',  version: '4.0.4', arch: 'x86_64', desc: 'openssl' }
+          - { os: 'netbsd',       version: '10.1' , arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
+          - { os: 'openbsd',      version: '7.7'  , arch: 'x86_64', desc: 'libressl' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -259,7 +177,14 @@ jobs:
 
       - name: 'install prereqs'
         run: |
-          if [ "${MATRIX_OS}" = 'netbsd' ]; then
+          if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
+            sudo pkg install -y cmake ninja perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
+          elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
+            # https://app.midnightbsd.org/
+            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
+            sudo mport upgrade
+            sudo mport -q install cmake-core ninja perl5 pkgconf brotli openldap26-client libidn2 libnghttp2 || true
+          elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
@@ -298,11 +223,11 @@ jobs:
         run: cmake --install bld
 
       - name: 'build tests'
-        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        if: ${{ matrix.arch == 'x86_64' && matrix.os != 'midnightbsd' }}  # Slow on emulated CPU
         run: cmake --build bld --target testdeps
 
       - name: 'run tests'
-        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        if: ${{ matrix.arch == 'x86_64' && matrix.os != 'midnightbsd' }}  # Slow on emulated CPU
         run: |
           export TFLAGS='-j8'
           if [ "${MATRIX_OS}" = 'openbsd' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -55,7 +55,7 @@ jobs:
             export CURL_CI=github
             # https://app.midnightbsd.org
             time sudo pkg install -y cmake-core ninja perl5 \
-              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
+              pkgconf brotli openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \
@@ -201,8 +201,8 @@ jobs:
           run: |
             export CURL_CI=github
             # https://app.midnightbsd.org
-            time sudo mport -q install cmake-core ninja perl5 \
-              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
+            time sudo mport install -q cmake-core ninja perl5 \
+              pkgconf brotli openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \
@@ -289,6 +289,7 @@ jobs:
           operating_system: 'openbsd'
           version: '7.7'
           architecture: ${{ matrix.arch }}
+          shell: bash
       - name: 'build'
         run: |
           # https://openbsd.app/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: 'cmake'
+      - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         env:
           MATRIX_ARCH: '${{ matrix.arch }}'
@@ -289,31 +289,32 @@ jobs:
           operating_system: 'openbsd'
           version: '7.7'
           architecture: ${{ matrix.arch }}
-          run: |
-            # https://openbsd.app/
-            # https://www.openbsd.org/faq/faq15.html
-            time sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
-            time cmake -B bld -G Ninja \
-              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-              -DCURL_USE_OPENSSL=ON \
-              -DCURL_ENABLE_NTLM=ON \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld
-            time cmake --install bld
-            bld/src/curl --disable --version
-            if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
-              time cmake --build bld --target testdeps
-              export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
-              time cmake --build bld --target test-ci
-            fi
-            echo '::group::build examples'
-            time cmake --build bld --target curl-examples-build
-            echo '::endgroup::'
+      - name: 'cmake'
+        run: |
+          # https://openbsd.app/
+          # https://www.openbsd.org/faq/faq15.html
+          time sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
+          time cmake -B bld -G Ninja \
+            -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCURL_WERROR=ON \
+            -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+            -DCURL_USE_OPENSSL=ON \
+            -DCURL_ENABLE_NTLM=ON \
+            || { cat bld/CMakeFiles/CMake*.yaml; false; }
+          echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
+          time cmake --build bld
+          time cmake --install bld
+          bld/src/curl --disable --version
+          if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
+            time cmake --build bld --target testdeps
+            export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
+            time cmake --build bld --target test-ci
+          fi
+          echo '::group::build examples'
+          time cmake --build bld --target curl-examples-build
+          echo '::endgroup::'
 
   android:
     name: "Android ${{ matrix.platform }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.name }} arm64"

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -202,7 +202,7 @@ jobs:
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
             time sudo mport -q install cmake-core ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2 2>/dev/null
+              pkgconf brotli openldap26-client libidn2 libnghttp2 >/dev/null
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -264,10 +264,16 @@ jobs:
             -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
             -DCURL_USE_OPENSSL=ON \
             -DCURL_USE_GSSAPI=ON \
-            -DCURL_ENABLE_NTLM=ON \
-            || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
+            -DCURL_ENABLE_NTLM=ON
+
+      - name: 'configure log'
+        if: ${{ !cancelled() }}
+        run: cat bld/config.log bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+
+      - name: 'curl_config.h'
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'build'
         run: cmake --build bld
@@ -325,10 +331,16 @@ jobs:
             -DCURL_WERROR=ON \
             -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
             -DCURL_USE_OPENSSL=ON \
-            -DCURL_ENABLE_NTLM=ON \
-            || { cat bld/CMakeFiles/CMake*.yaml; false; }
-          echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
+            -DCURL_ENABLE_NTLM=ON
+
+      - name: 'configure log'
+        if: ${{ !cancelled() }}
+        run: cat bld/config.log bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+
+      - name: 'curl_config.h'
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'build'
         run: cmake --build bld

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -53,7 +53,7 @@ jobs:
           version: '6.4.2'
           run: |
             export CURL_CI=github
-            time sudo pkg install -y cmake-core ninja perl5 \
+            time sudo pkg install -y cmake ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2
             echo '----------------'
             echo "|$PATH|"
@@ -285,23 +285,25 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        env:
-          MATRIX_ARCH: '${{ matrix.arch }}'
         with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
           operating_system: 'openbsd'
           version: '7.7'
           architecture: ${{ matrix.arch }}
 
-      - name: 'build'
+      - name: 'install prereqs'
+        shell: cpa.sh {0}
+        # https://openbsd.app/
+        # https://www.openbsd.org/faq/faq15.html
+        run: sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
+
+      - name: 'configure'
         shell: cpa.sh {0}
         run: |
-          # https://openbsd.app/
-          # https://www.openbsd.org/faq/faq15.html
-          time sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
-          time cmake -B bld -G Ninja \
+          cmake -B bld -G Ninja \
             -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
@@ -311,21 +313,29 @@ jobs:
             || { cat bld/CMakeFiles/CMake*.yaml; false; }
           echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-          time cmake --build bld
-          time cmake --install bld
-          bld/src/curl --disable --version
-          if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
-            time cmake --build bld --target testdeps
-            export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
-            time cmake --build bld --target test-ci
-          fi
 
-      - name: 'examples'
+      - name: 'build'
         shell: cpa.sh {0}
         run: |
-          echo '::group::build examples'
-          time cmake --build bld --target curl-examples-build
-          echo '::endgroup::'
+          cmake --build bld
+          cmake --install bld
+          bld/src/curl --disable --version
+
+      - name: 'build tests'
+        if: ${{ matrix.arch = 'x86_64' }}  # Slow on emulated CPU
+        shell: cpa.sh {0}
+        run: cmake --build bld --target testdeps
+
+      - name: 'run tests'
+        if: ${{ matrix.arch = 'x86_64' }}  # Slow on emulated CPU
+        shell: cpa.sh {0}
+        run: |
+            export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
+            cmake --build bld --target test-ci
+
+      - name: 'build examples'
+        shell: cpa.sh {0}
+        run: cmake --build bld --target curl-examples-build
 
   android:
     name: "Android ${{ matrix.platform }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.name }} arm64"

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -53,7 +53,7 @@ jobs:
           version: '6.4.2'
           run: |
             export CURL_CI=github
-            time sudo pkg install -y cmake ninja perl5 \
+            sudo pkg install -y cmake ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2
             echo '----------------'
             echo "|$PATH|"
@@ -205,7 +205,8 @@ jobs:
             export CURL_CI=github
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            time sudo mport -q install cmake-core ninja perl5 \
+            sudo mport upgrade
+            sudo mport -q install cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2 || true
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
@@ -226,140 +227,6 @@ jobs:
             echo '::group::build examples'
             time cmake --build bld --target curl-examples-build
             echo '::endgroup::'
-
-  netbsd:
-    name: 'NetBSD, CM clang openssl ${{ matrix.arch }}'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    defaults:
-      run:
-        shell: cpa.sh {0}  # zizmor: ignore[misfeature]
-    strategy:
-      matrix:
-        arch: ['x86_64']
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: 'setup VM'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
-          operating_system: 'netbsd'
-          version: '10.1'
-          architecture: ${{ matrix.arch }}
-
-      - name: 'install prereqs'
-        # https://pkgsrc.se/
-        run: sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
-
-      - name: 'configure'
-        run: |
-          cmake -B bld -G Ninja \
-            -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-            -DCMAKE_UNITY_BUILD=ON \
-            -DCURL_WERROR=ON \
-            -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-            -DCURL_USE_OPENSSL=ON \
-            -DCURL_USE_GSSAPI=ON \
-            -DCURL_ENABLE_NTLM=ON
-
-      - name: 'configure log'
-        if: ${{ !cancelled() }}
-        run: cat bld/config.log bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
-
-      - name: 'curl_config.h'
-        run: |
-          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          grep -F '#define' bld/lib/curl_config.h | sort || true
-
-      - name: 'build'
-        run: cmake --build bld
-
-      - name: 'curl -V'
-        run: bld/src/curl --disable --version
-
-      - name: 'curl install'
-        run: cmake --install bld
-
-      - name: 'build tests'
-        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
-        run: cmake --build bld --target testdeps
-
-      - name: 'run tests'
-        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
-        run: TFLAGS='-j8' cmake --build bld --target test-ci
-
-      - name: 'build examples'
-        run: cmake --build bld --target curl-examples-build
-
-  openbsd:
-    name: 'OpenBSD, CM clang libressl ${{ matrix.arch }}'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    defaults:
-      run:
-        shell: cpa.sh {0}  # zizmor: ignore[misfeature]
-    strategy:
-      matrix:
-        arch: ['x86_64']
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: 'setup VM'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
-          operating_system: 'openbsd'
-          version: '7.7'
-          architecture: ${{ matrix.arch }}
-
-      - name: 'install prereqs'
-        # https://openbsd.app/
-        # https://www.openbsd.org/faq/faq15.html
-        run: sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
-
-      - name: 'configure'
-        run: |
-          cmake -B bld -G Ninja \
-            -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-            -DCMAKE_UNITY_BUILD=ON \
-            -DCURL_WERROR=ON \
-            -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-            -DCURL_USE_OPENSSL=ON \
-            -DCURL_ENABLE_NTLM=ON
-
-      - name: 'configure log'
-        if: ${{ !cancelled() }}
-        run: cat bld/config.log bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
-
-      - name: 'curl_config.h'
-        run: |
-          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          grep -F '#define' bld/lib/curl_config.h | sort || true
-
-      - name: 'build'
-        run: cmake --build bld
-
-      - name: 'curl -V'
-        run: bld/src/curl --disable --version
-
-      - name: 'curl install'
-        run: cmake --install bld
-
-      - name: 'build tests'
-        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
-        run: cmake --build bld --target testdeps
-
-      - name: 'run tests'
-        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
-        run: TFLAGS='-j8 !2707' cmake --build bld --target test-ci  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
-
-      - name: 'build examples'
-        run: cmake --build bld --target curl-examples-build
 
   bsd:
     name: '${{ matrix.os }}, CM clang ${{ matrix.desc }} ${{ matrix.arch }}'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -232,6 +232,9 @@ jobs:
     name: 'NetBSD, CM clang openssl ${{ matrix.arch }}'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: cpa.sh {0}  # zizmor: ignore[misfeature]
     strategy:
       matrix:
         arch: ['x86_64']
@@ -239,40 +242,52 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: 'cmake'
+
+      - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        env:
-          MATRIX_ARCH: '${{ matrix.arch }}'
         with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
           operating_system: 'netbsd'
           version: '10.1'
           architecture: ${{ matrix.arch }}
-          run: |
-            # https://pkgsrc.se/
-            time sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
-            time cmake -B bld -G Ninja \
-              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-              -DCURL_USE_OPENSSL=ON \
-              -DCURL_USE_GSSAPI=ON \
-              -DCURL_ENABLE_NTLM=ON \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
+
+      - name: 'install prereqs'
+        # https://pkgsrc.se/
+        run: sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
+
+      - name: 'configure'
+        run: |
+          cmake -B bld -G Ninja \
+            -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCURL_WERROR=ON \
+            -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+            -DCURL_USE_OPENSSL=ON \
+            -DCURL_USE_GSSAPI=ON \
+            -DCURL_ENABLE_NTLM=ON \
+            || { cat bld/CMakeFiles/CMake*.yaml; false; }
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld
-            time cmake --install bld
-            bld/src/curl --disable --version
-            if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
-              time cmake --build bld --target testdeps
-              export TFLAGS='-j8'
-              time cmake --build bld --target test-ci
-            fi
-            echo '::group::build examples'
-            time cmake --build bld --target curl-examples-build
-            echo '::endgroup::'
+
+      - name: 'build'
+        run: cmake --build bld
+
+      - name: 'curl -V'
+        run: bld/src/curl --disable --version
+
+      - name: 'curl install'
+        run: cmake --install bld
+
+      - name: 'build tests'
+        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        run: cmake --build bld --target testdeps
+
+      - name: 'run tests'
+        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        run: TFLAGS='-j8' cmake --build bld --target test-ci
+
+      - name: 'build examples'
+        run: cmake --build bld --target curl-examples-build
 
   openbsd:
     name: 'OpenBSD, CM clang libressl ${{ matrix.arch }}'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   cross:
-    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }}  ${{ matrix.cc }} ${{ matrix.desc }} ${{ matrix.arch }}"
+    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.cc }} ${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -53,7 +53,7 @@ jobs:
           version: '6.4.2'
           run: |
             export CURL_CI=github
-            time sudo pkg install -y cmake-core ninja perl5 \
+            time sudo pkg install -y cmake ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2
             echo '----------------'
             echo "|$PATH|"

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -53,7 +53,6 @@ jobs:
           version: '6.4.2'
           run: |
             export CURL_CI=github
-            # https://app.midnightbsd.org
             time sudo pkg install -y cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,49 +37,6 @@ env:
   DO_NOT_TRACK: '1'
 
 jobs:
-  dragonflybsd:
-    name: 'DragonFlyBSD, CM clang openssl'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: 'cmake'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
-          operating_system: 'dragonflybsd'
-          version: '6.4.2'
-          run: |
-            export CURL_CI=github
-            time sudo pkg install -y cmake ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2
-            echo '----------------'
-            echo "|$PATH|"
-            which cmake || true
-            command -v cmake || true
-            echo '----------------'
-            time cmake -B bld -G Ninja \
-              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_C_COMPILER="${CC}" \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-              -DCURL_USE_OPENSSL=ON \
-              -DCURL_USE_GSSAPI=ON \
-              ${MATRIX_OPTIONS} \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld
-            time cmake --install bld
-            bld/src/curl --disable --version
-            time cmake --build bld --target testdeps
-            echo '::group::build examples'
-            time cmake --build bld --target curl-examples-build
-            echo '::endgroup::'
-
   freebsd:
     name: "FreeBSD, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
@@ -186,47 +143,6 @@ jobs:
               fi
               echo '::endgroup::'
             fi
-
-  midnightbsd:
-    name: 'MidnightBSD, CM clang openssl'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: 'cmake'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
-        with:
-          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK
-          operating_system: 'midnightbsd'
-          version: '4.0.4'
-          architecture: ${{ matrix.arch }}
-          run: |
-            export CURL_CI=github
-            # https://app.midnightbsd.org/
-            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            time doas mport -q install cmake-core ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2 >/dev/null
-            time cmake -B bld -G Ninja \
-              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_C_COMPILER="${CC}" \
-              -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
-              -DCURL_USE_OPENSSL=ON \
-              -DCURL_USE_GSSAPI=ON \
-              ${MATRIX_OPTIONS} \
-              || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld
-            time cmake --install bld
-            bld/src/curl --disable --version
-            time cmake --build bld --target testdeps
-            echo '::group::build examples'
-            time cmake --build bld --target curl-examples-build
-            echo '::endgroup::'
 
   netbsd:
     name: 'NetBSD, CM clang openssl ${{ matrix.arch }}'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -88,14 +88,8 @@ jobs:
       matrix:
         include:
           - { version: '15.0', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
-          - { version: '14.4', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
-          - { version: '14.3', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
           - { version: '15.0', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
-          - { version: '14.4', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
-          - { version: '14.3', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
           - { version: '14.3', build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
-          - { version: '15.0', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
-          - { version: '14.4', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
           - { version: '14.3', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
       fail-fast: false
     steps:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -376,6 +376,7 @@ jobs:
         include:
           - { os: 'netbsd',  version: '10.1', arch: 'x86_64', desc: 'openssl', options: '-DCURL_USE_GSSAPI=ON' }
           - { os: 'openbsd', version: '7.7' , arch: 'x86_64', desc: 'libressl' }
+      fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -144,6 +144,51 @@ jobs:
               echo '::endgroup::'
             fi
 
+  midnightbsd:
+    name: 'MidnightBSD, CM clang openssl ${{ matrix.arch }}'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        arch: ['x86_64']
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 'cmake'
+        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
+        env:
+          MATRIX_ARCH: '${{ matrix.arch }}'
+        with:
+          environment_variables: CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH
+          operating_system: 'midnightbsd'
+          version: '4.0.4'
+          architecture: ${{ matrix.arch }}
+          run: |
+            export CURL_CI=github
+            # https://app.midnightbsd.org
+            time sudo mport install cmake-core ninja perl5 \
+              pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+            time cmake -B bld -G Ninja \
+              -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
+              -DCMAKE_C_COMPILER="${CC}" \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_WERROR=ON \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
+              -DCURL_USE_OPENSSL=ON \
+              -DCURL_USE_GSSAPI=ON \
+              ${MATRIX_OPTIONS} \
+              || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
+            time cmake --build bld
+            time cmake --install bld
+            bld/src/curl --disable --version
+            time cmake --build bld --target testdeps
+            echo '::group::build examples'
+            time cmake --build bld --target curl-examples-build
+            echo '::endgroup::'
+
   netbsd:
     name: 'NetBSD, CM clang openssl ${{ matrix.arch }}'
     runs-on: ubuntu-latest

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -81,16 +81,18 @@ jobs:
             echo '::endgroup::'
 
   freebsd:
-    name: "FreeBSD, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
+    name: "FreeBSD ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} openssl${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       matrix:
         include:
-          - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
-          - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
-          - { build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
-          - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
+          - { version: '15.0', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
+          - { version: '14.4', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
+          - { version: '14.3', build: 'autotools', arch: 'x86_64', compiler: 'clang' }
+          - { version: '14.3', build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF', desc: ' !unity !runtests !examples' }
+          - { version: '14.3', build: 'autotools', arch: 'arm64' , compiler: 'clang', desc: ' !examples' }
+          - { version: '14.3', build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -107,7 +109,7 @@ jobs:
         with:
           environment_variables: CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MATRIX_ARCH MATRIX_BUILD MATRIX_DESC MATRIX_OPTIONS
           operating_system: 'freebsd'
-          version: '14.4'
+          version: ${{ matrix.version }}
           architecture: ${{ matrix.arch }}
           run: |
             export CURL_CI=github

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -199,9 +199,10 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             export CURL_CI=github
-            # https://app.midnightbsd.org
-            time sudo mport install -q cmake-core ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2
+            # https://app.midnightbsd.org/
+            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
+            time sudo mport -q install cmake-core ninja perl5 \
+              pkgconf brotli openldap26-client libidn2 libnghttp2 2>/dev/null
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -38,14 +38,14 @@ env:
 
 jobs:
   cross:
-    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} clang ${{ matrix.desc }} ${{ matrix.arch }}"
+    name: "${{ matrix.os }} ${{ matrix.version }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }}  ${{ matrix.cc }} ${{ matrix.desc }} ${{ matrix.arch }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
       run:
         shell: cpa.sh {0}  # zizmor: ignore[misfeature]
     env:
-      CC: 'clang'
+      CC: '${{ matrix.cc }}'
       MAKEFLAGS: -j 3
       MATRIX_ARCH: '${{ matrix.arch }}'
       MATRIX_BUILD: '${{ matrix.build }}'
@@ -54,21 +54,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', desc: 'openssl !runtests',
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests',
               options: '--with-openssl' }
-          - { os: 'freebsd',      version: '15.0',  build: 'autotools', arch: 'x86_64', desc: 'openssl',
+          - { os: 'freebsd',      version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               options: '--with-openssl --with-gssapi' }
-          - { os: 'freebsd',      version: '15.0',  build: 'cmake'    , arch: 'x86_64', desc: 'openssl !unity !runtests !examples',
+          - { os: 'freebsd',      version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity !runtests !examples',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
-          - { os: 'freebsd',      version: '14.3',  build: 'autotools', arch: 'arm64' , desc: 'openssl !examples',
+          - { os: 'freebsd',      version: '14.3',  build: 'autotools', arch: 'arm64' , cc: 'clang', desc: 'openssl !examples',
               options: '--with-openssl --with-gssapi' }
-          - { os: 'freebsd',      version: '14.3',  build: 'cmake'    , arch: 'arm64' , desc: 'openssl',
+          - { os: 'freebsd',      version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', desc: 'gnutls !runtests',
+          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests',
               options: '-DCURL_USE_GNUTLS=ON' }
-          - { os: 'netbsd',       version: '10.1' , build: 'cmake'    , arch: 'x86_64', desc: 'openssl',
+          - { os: 'netbsd',       version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd',      version: '7.7'  , build: 'cmake'    , arch: 'x86_64', desc: 'libressl' }
+          - { os: 'openbsd',      version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,10 +78,10 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_OPTIONS MATRIX_OS
-          operating_system: ${{ matrix.os }}
-          version: ${{ matrix.version }}
-          architecture: ${{ matrix.arch }}
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_OPTIONS MATRIX_OS'
+          operating_system: '${{ matrix.os }}'
+          version: '${{ matrix.version }}'
+          architecture: '${{ matrix.arch }}'
 
       - name: 'install prereqs'
         run: |

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -212,7 +212,7 @@ jobs:
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
             time sudo mport -q install cmake-core ninja perl5 \
-              pkgconf brotli openldap26-client libidn2 libnghttp2 >/dev/null
+              pkgconf brotli openldap26-client libidn2 libnghttp2
             time cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
               -DCMAKE_C_COMPILER="${CC}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -93,7 +93,6 @@ jobs:
               build: 'cmake', platform: 'x86_64', tflags: '',
               config: '-DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DENABLE_THREADED_RESOLVER=OFF -DCURL_ENABLE_NTLM=ON',
               install: 'libssl-devel libssh2-devel' }
-
       fail-fast: false
     steps:
       - uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6.1


### PR DESCRIPTION
- bump cross-platform-actions to v1.1.0.
  Ref: https://github.com/cross-platform-actions/action/releases/tag/v1.1.0

- merge BSD jobs into a single matrix.

- split BSD jobs into build steps as used for other platforms.
  A new feature of cross-platform-actions v1.1.0.

- sync BSD build steps with other platforms.

- add DragonFlyBSD and MidnightBSD to the BSD matrix.
  New features of cross-platform-actions v1.1.0.
  MidnightBSD uses GnuTLS to add variation, also the preinstalled
  OpenSSL is too old (v1.1.1w) for curl.
  Stick with autotools for DragonFlyBSD; I could not figure out how
  to install cmake.
  Refs:
  https://en.wikipedia.org/wiki/DragonFly_BSD
  https://en.wikipedia.org/wiki/MidnightBSD

- bump Intel FreeBSD jobs from v14.3 to v15.0.

- fix to show `gcc` in the NetBSD job name.

All these saved 50 lines of YAML. The two new jobs take 2m15s each. The
bump to FreeBSD 15 needs and extra minute in total.

Note, the DragonFlyBSD job seems to have reliability issues. If it 
remains an issue, I'll comment it out or delete it in a future commit.
