### PR TITLE
docs: note CURLOPT_PINNEDPUBLICKEY has no effect on legacy LDAP backend

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
@@ -54,9 +54,9 @@ The application does not have to keep the string around after setting this
 option.
 
 This option has no effect on LDAP connections when libcurl uses the legacy LDAP
-backend. That backend manages TLS through libldap independently of curl's TLS
-layer. When libcurl is built with USE_OPENLDAP, the OpenLDAP backend routes TLS
-through curl's layer and this option is honored.
+backend. That backend manages TLS independently of curl's TLS layer. When
+libcurl is built with USE_OPENLDAP, the OpenLDAP backend routes TLS through
+curl's layer and this option is honored.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
@@ -53,6 +53,11 @@ On mismatch, *CURLE_SSL_PINNEDPUBKEYNOTMATCH* is returned.
 The application does not have to keep the string around after setting this
 option.
 
+This option has no effect on LDAP connections when libcurl uses the legacy LDAP
+backend. That backend manages TLS through libldap independently of curl's TLS
+layer. When libcurl is built with USE_OPENLDAP, the OpenLDAP backend routes TLS
+through curl's layer and this option is honored.
+
 # DEFAULT
 
 NULL


### PR DESCRIPTION
The legacy LDAP backend manages TLS through libldap independently of curl's TLS layer, so this option is silently ignored for those connections. The OpenLDAP backend (USE_OPENLDAP) routes TLS through curl's layer and does honor it.