### PR TITLE
schannel: fix revoke_best_effort reading wrong ssl config

### DIFF
--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -805,7 +805,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
       DWORD dwTrustErrorMask = ~(DWORD)(CERT_TRUST_IS_NOT_TIME_NESTED);
       dwTrustErrorMask &= pSimpleChain->TrustStatus.dwErrorStatus;
 
-      if(data->set.ssl.revoke_best_effort) {
+      if(ssl_config->revoke_best_effort) {
         /* Ignore errors when root certificates are missing the revocation
          * list URL, or when the list could not be downloaded because the
          * server is currently unreachable. */


### PR DESCRIPTION
`schannel_verify.c` line 808 reads `data->set.ssl.revoke_best_effort` unconditionally, ignoring whether the connection being verified is an origin or proxy connection.

`ssl_config` is already set at line 660 via `Curl_ssl_cf_get_config()`, which returns `&data->set.proxy_ssl` for proxy cfilters and `&data->set.ssl` for origin cfilters. Lines 752 and 792 in the same function already use `ssl_config` correctly; this makes line 808 consistent.

The impact is policy bleed: when `CURLSSLOPT_REVOKE_BEST_EFFORT` differs between `CURLOPT_SSL_OPTIONS` and `CURLOPT_PROXY_SSL_OPTIONS`, the wrong revocation policy is applied during proxy certificate verification.