### PR TITLE
unit3303, unit3304: tidy-ups

### DIFF
--- a/tests/unit/unit3303.c
+++ b/tests/unit/unit3303.c
@@ -37,10 +37,10 @@ static CURLcode test_unit3303(const char *arg)
   struct connectdata *conn;
   struct ssl_primary_config *primary;
   char *saved;
-  static const char *alt_passwd = "wrong";
-  static const char *alt_key    = "other.key";
-  static const char *alt_ktype  = "DER";
-  static const char *alt_ctype  = "P12";
+  static char alt_passwd[] = "wrong";
+  static char alt_key[]    = "other.key";
+  static char alt_ktype[]  = "DER";
+  static char alt_ctype[]  = "P12";
 
   curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();

--- a/tests/unit/unit3303.c
+++ b/tests/unit/unit3303.c
@@ -111,7 +111,7 @@ static CURLcode test_unit3303(const char *arg)
   primary->cert_type = saved;
 
   /* All fields restored: must match again. */
-  fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn, 
+  fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
                                          FALSE),
               "restored mTLS config should match");
 

--- a/tests/unit/unit3303.c
+++ b/tests/unit/unit3303.c
@@ -33,94 +33,92 @@ static CURLcode test_unit3303(const char *arg)
   UNITTEST_BEGIN_SIMPLE
 
 #ifdef USE_SSL
-  {
-    CURL *curl;
-    struct connectdata *conn;
-    struct ssl_primary_config *primary;
-    char *saved;
-    static char alt_passwd[] = "wrong";
-    static char alt_key[]    = "other.key";
-    static char alt_ktype[]  = "DER";
-    static char alt_ctype[]  = "P12";
+  CURL *curl;
+  struct connectdata *conn;
+  struct ssl_primary_config *primary;
+  char *saved;
+  static const char *alt_passwd = "wrong";
+  static const char *alt_key    = "other.key";
+  static const char *alt_ktype  = "DER";
+  static const char *alt_ctype  = "P12";
 
-    curl_global_init(CURL_GLOBAL_ALL);
-    curl = curl_easy_init();
-    if(!curl) {
-      curl_global_cleanup();
-      goto unit_test_abort;
-    }
+  curl_global_init(CURL_GLOBAL_ALL);
+  curl = curl_easy_init();
+  if(!curl) {
+    curl_global_cleanup();
+    goto unit_test_abort;
+  }
 
-    curl_easy_setopt(curl, CURLOPT_SSLCERT, "client.pem");
-    curl_easy_setopt(curl, CURLOPT_SSLKEY, "client.key");
-    curl_easy_setopt(curl, CURLOPT_KEYPASSWD, "secret");
-    curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
-    curl_easy_setopt(curl, CURLOPT_SSLKEYTYPE, "PEM");
+  curl_easy_setopt(curl, CURLOPT_SSLCERT, "client.pem");
+  curl_easy_setopt(curl, CURLOPT_SSLKEY, "client.key");
+  curl_easy_setopt(curl, CURLOPT_KEYPASSWD, "secret");
+  curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
+  curl_easy_setopt(curl, CURLOPT_SSLKEYTYPE, "PEM");
 
-    if(Curl_ssl_easy_config_complete((struct Curl_easy *)curl)) {
-      curl_easy_cleanup(curl);
-      curl_global_cleanup();
-      goto unit_test_abort;
-    }
+  if(Curl_ssl_easy_config_complete((struct Curl_easy *)curl)) {
+    curl_easy_cleanup(curl);
+    curl_global_cleanup();
+    goto unit_test_abort;
+  }
 
-    conn = curlx_calloc(1, sizeof(*conn));
-    if(!conn || Curl_ssl_conn_config_init((struct Curl_easy *)curl, conn)) {
-      if(conn)
-        Curl_ssl_conn_config_cleanup(conn);
-      curlx_free(conn);
-      curl_easy_cleanup(curl);
-      curl_global_cleanup();
-      goto unit_test_abort;
-    }
-
-    /* Baseline: identical config must match. */
-    fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                           FALSE),
-                "identical mTLS config should match");
-
-    primary = &((struct Curl_easy *)curl)->set.ssl.primary;
-
-    /* Different key_passwd must not match. */
-    saved = primary->key_passwd;
-    primary->key_passwd = alt_passwd;
-    fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                            FALSE),
-                "different key_passwd must not reuse conn");
-    primary->key_passwd = saved;
-
-    /* Different key path must not match. */
-    saved = primary->key;
-    primary->key = alt_key;
-    fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                            FALSE),
-                "different key must not reuse conn");
-    primary->key = saved;
-
-    /* Different key type must not match. */
-    saved = primary->key_type;
-    primary->key_type = alt_ktype;
-    fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                            FALSE),
-                "different key_type must not reuse conn");
-    primary->key_type = saved;
-
-    /* Different cert type must not match. */
-    saved = primary->cert_type;
-    primary->cert_type = alt_ctype;
-    fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                            FALSE),
-                "different cert_type must not reuse conn");
-    primary->cert_type = saved;
-
-    /* All fields restored: must match again. */
-    fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                           FALSE),
-                "restored mTLS config should match");
-
-    Curl_ssl_conn_config_cleanup(conn);
+  conn = curlx_calloc(1, sizeof(*conn));
+  if(!conn || Curl_ssl_conn_config_init((struct Curl_easy *)curl, conn)) {
+    if(conn)
+      Curl_ssl_conn_config_cleanup(conn);
     curlx_free(conn);
     curl_easy_cleanup(curl);
     curl_global_cleanup();
+    goto unit_test_abort;
   }
+
+  /* Baseline: identical config must match. */
+  fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
+                                         FALSE),
+              "identical mTLS config should match");
+
+  primary = &((struct Curl_easy *)curl)->set.ssl.primary;
+
+  /* Different key_passwd must not match. */
+  saved = primary->key_passwd;
+  primary->key_passwd = alt_passwd;
+  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
+                                          FALSE),
+              "different key_passwd must not reuse conn");
+  primary->key_passwd = saved;
+
+  /* Different key path must not match. */
+  saved = primary->key;
+  primary->key = alt_key;
+  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
+                                          FALSE),
+              "different key must not reuse conn");
+  primary->key = saved;
+
+  /* Different key type must not match. */
+  saved = primary->key_type;
+  primary->key_type = alt_ktype;
+  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
+                                          FALSE),
+              "different key_type must not reuse conn");
+  primary->key_type = saved;
+
+  /* Different cert type must not match. */
+  saved = primary->cert_type;
+  primary->cert_type = alt_ctype;
+  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
+                                          FALSE),
+              "different cert_type must not reuse conn");
+  primary->cert_type = saved;
+
+  /* All fields restored: must match again. */
+  fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn, 
+                                         FALSE),
+              "restored mTLS config should match");
+
+  Curl_ssl_conn_config_cleanup(conn);
+  curlx_free(conn);
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
 #endif /* USE_SSL */
 
   UNITTEST_END_SIMPLE

--- a/tests/unit/unit3304.c
+++ b/tests/unit/unit3304.c
@@ -43,125 +43,123 @@ static CURLcode test_unit3304(const char *arg)
   UNITTEST_BEGIN_SIMPLE
 
 #ifdef USE_SSL
-  {
-    struct Curl_peer dest;
-    struct ssl_peer peer;
-    struct ssl_primary_config ssl;
-    char *key1 = NULL;
-    char *key2 = NULL;
-    static char base_hostname[] = "example.com";
-    static char base_cert[]     = "client.pem";
-    static char base_key[]      = "client.key";
-    static char base_passwd[]   = "secret";
-    static char base_ctype[]    = "PEM";
-    static char base_ktype[]    = "PEM";
-    static char alt_key[]       = "other.key";
-    static char alt_ktype[]     = "DER";
-    static char alt_ctype[]     = "P12";
-    static char lc_ctype[]      = "pem";
-    static char lc_ktype[]      = "pem";
+  struct Curl_peer dest;
+  struct ssl_peer peer;
+  struct ssl_primary_config ssl;
+  char *key1 = NULL;
+  char *key2 = NULL;
+  static const char *base_hostname = "example.com";
+  static const char *base_cert     = "client.pem";
+  static const char *base_key      = "client.key";
+  static const char *base_passwd   = "secret";
+  static const char *base_ctype    = "PEM";
+  static const char *base_ktype    = "PEM";
+  static const char *alt_key       = "other.key";
+  static const char *alt_ktype     = "DER";
+  static const char *alt_ctype     = "P12";
+  static const char *lc_ctype      = "pem";
+  static const char *lc_ktype      = "pem";
 
-    memset(&dest, 0, sizeof(dest));
-    dest.hostname = base_hostname;
-    dest.port = 443;
+  memset(&dest, 0, sizeof(dest));
+  dest.hostname = base_hostname;
+  dest.port = 443;
 
-    memset(&peer, 0, sizeof(peer));
-    peer.dest = &dest;
-    peer.transport = TRNSPRT_TCP;
+  memset(&peer, 0, sizeof(peer));
+  peer.dest = &dest;
+  peer.transport = TRNSPRT_TCP;
 
-    memset(&ssl, 0, sizeof(ssl));
-    ssl.verifypeer = TRUE;
-    ssl.verifyhost = TRUE;
-    ssl.clientcert = base_cert;
-    ssl.key        = base_key;
-    ssl.key_passwd = base_passwd;
-    ssl.cert_type  = base_ctype;
-    ssl.key_type   = base_ktype;
+  memset(&ssl, 0, sizeof(ssl));
+  ssl.verifypeer = TRUE;
+  ssl.verifyhost = TRUE;
+  ssl.clientcert = base_cert;
+  ssl.key        = base_key;
+  ssl.key_passwd = base_passwd;
+  ssl.cert_type  = base_ctype;
+  ssl.key_type   = base_ktype;
 
-    /* Baseline: same config produces same key. */
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
-                "peer key build failed");
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
-                "peer key build failed");
-    fail_unless(key1 && key2 && !strcmp(key1, key2),
-                "identical config should produce identical peer key");
-    curlx_free(key1); key1 = NULL;
-    curlx_free(key2); key2 = NULL;
+  /* Baseline: same config produces same key. */
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
+              "peer key build failed");
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
+              "peer key build failed");
+  fail_unless(key1 && key2 && !strcmp(key1, key2),
+              "identical config should produce identical peer key");
+  curlx_safefree(key1);
+  curlx_safefree(key2);
 
-    /* key_passwd is NOT in the peer key: lookup uses timing-safe comparison
-     * via cf_ssl_scache_match_auth(), same as SRP credentials. */
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
-                "peer key build failed");
-    ssl.key_passwd = NULL;
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
-                "peer key build failed");
-    fail_unless(key1 && key2 && !strcmp(key1, key2),
-                "key_passwd must not affect the peer key");
-    curlx_free(key1); key1 = NULL;
-    curlx_free(key2); key2 = NULL;
-    ssl.key_passwd = base_passwd;
+  /* key_passwd is NOT in the peer key: lookup uses timing-safe comparison
+   * via cf_ssl_scache_match_auth(), same as SRP credentials. */
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
+              "peer key build failed");
+  ssl.key_passwd = NULL;
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
+              "peer key build failed");
+  fail_unless(key1 && key2 && !strcmp(key1, key2),
+              "key_passwd must not affect the peer key");
+  curlx_safefree(key1);
+  curlx_safefree(key2);
+  ssl.key_passwd = base_passwd;
 
-    /* Different key path must produce a different peer key. */
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
-                "peer key build failed");
-    ssl.key = alt_key;
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
-                "peer key build failed");
-    fail_unless(key1 && key2 && strcmp(key1, key2),
-                "different key must produce different peer key");
-    curlx_free(key1); key1 = NULL;
-    curlx_free(key2); key2 = NULL;
-    ssl.key = base_key;
+  /* Different key path must produce a different peer key. */
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
+              "peer key build failed");
+  ssl.key = alt_key;
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
+              "peer key build failed");
+  fail_unless(key1 && key2 && strcmp(key1, key2),
+              "different key must produce different peer key");
+  curlx_safefree(key1);
+  curlx_safefree(key2);
+  ssl.key = base_key;
 
-    /* Different key_type must produce a different peer key. */
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
-                "peer key build failed");
-    ssl.key_type = alt_ktype;
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
-                "peer key build failed");
-    fail_unless(key1 && key2 && strcmp(key1, key2),
-                "different key_type must produce different peer key");
-    curlx_free(key1); key1 = NULL;
-    curlx_free(key2); key2 = NULL;
-    ssl.key_type = base_ktype;
+  /* Different key_type must produce a different peer key. */
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
+              "peer key build failed");
+  ssl.key_type = alt_ktype;
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
+              "peer key build failed");
+  fail_unless(key1 && key2 && strcmp(key1, key2),
+              "different key_type must produce different peer key");
+  curlx_safefree(key1);
+  curlx_safefree(key2);
+  ssl.key_type = base_ktype;
 
-    /* Different cert_type must produce a different peer key. */
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
-                "peer key build failed");
-    ssl.cert_type = alt_ctype;
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
-                "peer key build failed");
-    fail_unless(key1 && key2 && strcmp(key1, key2),
-                "different cert_type must produce different peer key");
-    curlx_free(key1); key1 = NULL;
-    curlx_free(key2); key2 = NULL;
-    ssl.cert_type = base_ctype;
+  /* Different cert_type must produce a different peer key. */
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
+              "peer key build failed");
+  ssl.cert_type = alt_ctype;
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
+              "peer key build failed");
+  fail_unless(key1 && key2 && strcmp(key1, key2),
+              "different cert_type must produce different peer key");
+  curlx_safefree(key1);
+  curlx_safefree(key2);
+  ssl.cert_type = base_ctype;
 
-    /* cert_type is case-insensitive: "PEM" and "pem" must produce the
-     * same peer key, consistent with the conn-reuse comparison. */
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
-                "peer key build failed");
-    ssl.cert_type = lc_ctype;
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
-                "peer key build failed");
-    fail_unless(key1 && key2 && !strcmp(key1, key2),
-                "cert_type case must not affect peer key");
-    curlx_free(key1); key1 = NULL;
-    curlx_free(key2); key2 = NULL;
-    ssl.cert_type = base_ctype;
+  /* cert_type is case-insensitive: "PEM" and "pem" must produce the
+   * same peer key, consistent with the conn-reuse comparison. */
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
+              "peer key build failed");
+  ssl.cert_type = lc_ctype;
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
+              "peer key build failed");
+  fail_unless(key1 && key2 && !strcmp(key1, key2),
+              "cert_type case must not affect peer key");
+  curlx_safefree(key1);
+  curlx_safefree(key2);
+  ssl.cert_type = base_ctype;
 
-    /* key_type is case-insensitive: "PEM" and "pem" must produce the
-     * same peer key. */
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
-                "peer key build failed");
-    ssl.key_type = lc_ktype;
-    fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
-                "peer key build failed");
-    fail_unless(key1 && key2 && !strcmp(key1, key2),
-                "key_type case must not affect peer key");
-    curlx_free(key1); key1 = NULL;
-    curlx_free(key2); key2 = NULL;
-  }
+  /* key_type is case-insensitive: "PEM" and "pem" must produce the
+   * same peer key. */
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key1),
+              "peer key build failed");
+  ssl.key_type = lc_ktype;
+  fail_unless(!Curl_ssl_peer_key_build(&ssl, &peer, NULL, "test", &key2),
+              "peer key build failed");
+  fail_unless(key1 && key2 && !strcmp(key1, key2),
+              "key_type case must not affect peer key");
+  curlx_safefree(key1);
+  curlx_safefree(key2);
 #endif /* USE_SSL */
 
   UNITTEST_END_SIMPLE

--- a/tests/unit/unit3304.c
+++ b/tests/unit/unit3304.c
@@ -48,17 +48,17 @@ static CURLcode test_unit3304(const char *arg)
   struct ssl_primary_config ssl;
   char *key1 = NULL;
   char *key2 = NULL;
-  static const char *base_hostname = "example.com";
-  static const char *base_cert     = "client.pem";
-  static const char *base_key      = "client.key";
-  static const char *base_passwd   = "secret";
-  static const char *base_ctype    = "PEM";
-  static const char *base_ktype    = "PEM";
-  static const char *alt_key       = "other.key";
-  static const char *alt_ktype     = "DER";
-  static const char *alt_ctype     = "P12";
-  static const char *lc_ctype      = "pem";
-  static const char *lc_ktype      = "pem";
+  static char base_hostname[] = "example.com";
+  static char base_cert[]     = "client.pem";
+  static char base_key[]      = "client.key";
+  static char base_passwd[]   = "secret";
+  static char base_ctype[]    = "PEM";
+  static char base_ktype[]    = "PEM";
+  static char alt_key[]       = "other.key";
+  static char alt_ktype[]     = "DER";
+  static char alt_ctype[]     = "P12";
+  static char lc_ctype[]      = "pem";
+  static char lc_ktype[]      = "pem";
 
   memset(&dest, 0, sizeof(dest));
   dest.hostname = base_hostname;


### PR DESCRIPTION
- use `curlx_safefree()`.
- drop redundant blocks.

Follow-up to 7541ae569d82fb308a5e2d94916027da4fa3ba3e #21667

---

https://github.com/curl/curl/pull/21684/files?w=1
