### PR TITLE
urlapi: compare zone-id in Curl_url_same_origin()

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -2024,6 +2024,9 @@ bool Curl_url_same_origin(CURLU *base, CURLU *href)
   if(href->host) {
     if(!curl_strequal(base->host, href->host))
       return FALSE;
+    if(!curl_strequal(base->zoneid ? base->zoneid : "",
+                      href->zoneid ? href->zoneid : ""))
+      return FALSE;
     if(!curl_strequal(base->port, href->port)) {
       /* This may still match if only one has an explicit port
        * and it is the default for the scheme. */


### PR DESCRIPTION
`Curl_url_same_origin()` compares `u->host` but not `u->zoneid`.
IPv6 link-local addresses that differ only in zone-id (e.g.
`fe80::1%eth0` vs `fe80::1%eth1`) are treated as the same origin.

Add zone-id comparison immediately after the host comparison.