### PR TITLE
tests: add an assert to avoid IPC blocking

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1336,6 +1336,7 @@ sub controlleripccall {
     my $margs = freeze \@_;
 
     # Send IPC call via pipe
+    length($margs) < 1000 || die "A large IPC write risks blocking on some platforms";
     my $err;
     while(! defined ($err = syswrite($controllerw{$runnerid}, (pack "L", length($margs)) . $margs)) || $err <= 0) {
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {


### PR DESCRIPTION
If so much data is being sent over the internal IPC pipe that the pipe
buffer fills and the syscall blocks, the program will hang. Add an
assert to ensure that this limit is never reached. The buffer size is
going to be different on different platforms, so choose 1KB which is
likely to be a reasonable lower bound on just about any system.
Currently, the maximum amount ever written is <100 bytes, so this should
provide plenty of headroom.

Spotted by Codex Security

Closes #21688