### PR TITLE
Dockerfile: fix typo in variable name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
 
 ARG UID=1000 GID=1000
 
-RUN groupadd --gid $UID dev && \
+RUN groupadd --gid $GID dev && \
     useradd --uid $UID --gid dev --shell /bin/bash --create-home dev
 
 USER dev:dev


### PR DESCRIPTION
Did not cause an actual issue.

Spotted by GitHub Code Quality

Follow-up to 41c03b4c98dbc639a32d32486ed5146be2e73ee1 #13250
