### PR TITLE
GHA/non-native: drop DragonFlyBSD job, due to unreliable package repo updates

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -83,20 +83,7 @@ jobs:
 
       - name: 'install prereqs'
         run: |
-          if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            while [ $? = 0 ]; do
-              for i in 1 2 3; do
-                # https://github.com/DragonFlyBSD/DPorts
-                if sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2; then
-                  break 2
-                else
-                  echo "Error: wait to try again: $i"
-                  sleep 10
-                fi
-              done
-              false Too many retries
-            done
-          elif [ "${MATRIX_OS}" = 'freebsd' ]; then
+          if [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake-core ninja perl5'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -86,8 +86,18 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            # https://github.com/DragonFlyBSD/DPorts
-            sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
+            while [ $? = 0 ]; do
+              for i in 1 2 3; do
+                # https://github.com/DragonFlyBSD/DPorts
+                if sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2; then
+                  break 2
+                else
+                  echo "Error: wait to try again: $i"
+                  sleep 10
+                fi
+              done
+              false Too many retries
+            done
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -86,6 +86,7 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
+            # https://github.com/DragonFlyBSD/DPorts
             sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -54,8 +54,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests',
-              options: '--with-openssl' }
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               options: '--with-openssl --with-gssapi' }
           - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity !runtests !examples',

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -56,19 +56,19 @@ jobs:
         include:
           - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests',
               options: '--with-openssl' }
-          - { os: 'freebsd',      version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
+          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               options: '--with-openssl --with-gssapi' }
-          - { os: 'freebsd',      version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity !runtests !examples',
+          - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity !runtests !examples',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
-          - { os: 'freebsd',      version: '14.3',  build: 'autotools', arch: 'arm64' , cc: 'clang', desc: 'openssl !examples',
+          - { os: 'freebsd'     , version: '14.3',  build: 'autotools', arch: 'arm64' , cc: 'clang', desc: 'openssl !examples',
               options: '--with-openssl --with-gssapi' }
-          - { os: 'freebsd',      version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
+          - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'midnightbsd',  version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests',
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests',
               options: '-DCURL_USE_GNUTLS=ON' }
-          - { os: 'netbsd',       version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd',      version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Example:
```
Wed, 20 May 2026 09:51:48 GMT Updating Avalon repository catalogue...
Wed, 20 May 2026 09:51:48 GMT pkg: An error occurred while fetching package: No error
Wed, 20 May 2026 09:51:48 GMT pkg: An error occurred while fetching package: No error
Wed, 20 May 2026 09:51:48 GMT repository Avalon has no meta file, using default settings
Wed, 20 May 2026 09:51:48 GMT pkg: An error occurred while fetching package: No error
Wed, 20 May 2026 09:51:48 GMT pkg: An error occurred while fetching package: No error
Wed, 20 May 2026 09:51:48 GMT pkg: An error occurred while fetching package: No error
Wed, 20 May 2026 09:51:48 GMT pkg: An error occurred while fetching package: No error
Wed, 20 May 2026 09:51:48 GMT Unable to update repository Avalon
Wed, 20 May 2026 09:51:48 GMT Error updating repositories!
Wed, 20 May 2026 09:51:48 GMT Error: Process completed with exit code 3.
```

As tested over at libssh2, retrying the install command also does not
help, only repeats the same failure.

Also: fix whitespace in matrix.

Follow-up to b158d1c9f7456a8f976c74c08d2dc5a555e9cc77 #21681

---

https://github.com/curl/curl/pull/21694/files?w=1
