### PR TITLE
ntlm: fix integer overflow in type2 target info bounds check

### DIFF
--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -267,7 +267,7 @@ static CURLcode ntlm_decode_type2_target(struct Curl_easy *data,
     target_info_offset = Curl_read32_le(&type2[44]);
     if(target_info_len > 0) {
       if((target_info_offset > type2len) ||
-         (target_info_offset + target_info_len) > type2len ||
+         (target_info_len > type2len - target_info_offset) ||
          target_info_offset < 48) {
         infof(data, "NTLM handshake failure (bad type-2 message). "
               "Target Info Offset Len is set incorrect by the peer");


### PR DESCRIPTION
The bounds check in `ntlm_decode_type2_target()` computes `target_info_offset + target_info_len` in 32-bit unsigned arithmetic before comparing against `type2len`. Both values come from the network.
A malicious server can send values whose sum wraps to zero, bypassing the check and causing an out-of-bounds heap read in `curlx_memdup`.

Fix: replace addition with subtraction, which cannot overflow since the
prior check guarantees `target_info_offset <= type2len`.