### PR TITLE
http: prefer chunked encoding over Content-Length: 0

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -4171,6 +4171,17 @@ static CURLcode http_on_response(struct Curl_easy *data,
       goto out;
   }
 
+  /* final response without error, prepare to receive the body */
+  result = http_firstwrite(data);
+  if(result)
+    goto out;
+
+  /* This is the last response that we get for the current request. Check on
+   * the body size and determine if the response is complete. */
+  result = http_size(data);
+  if(result)
+    goto out;
+
   /* If we requested a "no body", this is a good time to get
    * out and return home.
    */
@@ -4183,14 +4194,6 @@ static CURLcode http_on_response(struct Curl_easy *data,
      this, we keep reading until we close the stream. */
   if((k->maxdownload == 0) && (k->httpversion_sent < 20))
     k->download_done = TRUE;
-
-  /* final response without error, prepare to receive the body */
-  result = http_firstwrite(data);
-
-  if(!result)
-    /* This is the last response that we get for the current request. Check on
-     * the body size and determine if the response is complete. */
-    result = http_size(data);
 
 out:
   if(last_hd)

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -222,7 +222,7 @@ test1650 test1651 test1652 test1653 test1654 test1655 test1656 test1657 \
 test1658 test1659 test1660 test1661 test1662 test1663 test1664 test1665 \
 test1666 test1667 test1668 test1669 \
 \
-test1670 test1671 test1672 test1673 test1674 test1675 test1676 \
+test1670 test1671 test1672 test1673 test1674 test1675 test1676 test1677 \
 \
 test1680 test1681 test1682 test1683 test1684 test1685 \
 \

--- a/tests/data/test1677
+++ b/tests/data/test1677
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+chunked Transfer-Encoding
+Content-Length
+</keywords>
+</info>
+
+# Regression test for bug where curl stops reading chunked response
+# when both Content-Length: 0 and Transfer-Encoding: chunked headers
+# are present. Per RFC 7230 Section 3.3.3, Transfer-Encoding should
+# take precedence and Content-Length should be ignored.
+# The writedelay simulates the timing issue where chunks arrive in
+# separate packets.
+
+# Server-side
+<reply>
+<servercmd>
+writedelay: 500
+</servercmd>
+<data nocheck="yes" crlf="headers">
+HTTP/1.1 200 OK
+content-type: text/json
+connection: keep-alive
+content-length: 0
+transfer-encoding: chunked
+
+1a
+random data in first chunk
+1d
+ another data in second chunk
+15
+ third and last chunk
+0
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP POST response with both Transfer-Encoding chunked and Content-Length 0
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -d "testdata"
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol nonewline="yes" crlf="headers">
+POST /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 8
+Content-Type: application/x-www-form-urlencoded
+
+testdata
+</protocol>
+<stdout nonewline="yes" crlf="headers">
+HTTP/1.1 200 OK
+content-type: text/json
+connection: keep-alive
+content-length: 0
+transfer-encoding: chunked
+
+random data in first chunk another data in second chunk third and last chunk
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
Call http_size() before checking the request for empty body to prefer Transfer-Encoding: chunked even if Content-Length is 0.

http_size() sets `k->maxdownload` to `-1` if both headers are present to ignore content-length so it must be called before following code:

```  
if((k->maxdownload == 0) && (k->httpversion_sent < 20))
     k->download_done = TRUE;
```

Current ordering causes that with `Content-Length : 0` is ` k->download_done` set to `True` preventing remaining chunked data from being read.
