### PR TITLE
multi: silence gcc 16 `-Wnull-dereference`, bump CI job to test

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -574,13 +574,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'schannel +analyzer'  # mingw-w64 12.0
+          - name: 'schannel +analyzer'  # mingw-w64 13.0
             sys: 'mingw64'
             dir: 'w64devkit'
             env: 'x86_64'
-            ver: '15.1.0'
-            url: 'https://github.com/skeeto/w64devkit/releases/download/v2.2.0/w64devkit-x64-2.2.0.7z.exe'
-            SHA256: e02de30b97196329662007d64bc4509fbd7f5e14339d344075c7f1223dead4a2
+            ver: '16.1.0'
+            url: 'https://github.com/skeeto/w64devkit/releases/download/v2.8.0/w64devkit-x64-2.8.0.7z.exe'
+            SHA256: 6252bf34fe2231a55ac7f03d482b36d2c7c58697990551bba508102cfb3f342e
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DENABLE_UNIX_SOCKETS=OFF -DCURL_GCC_ANALYZER=ON'
             type: 'Release'
           - name: 'schannel'  # mingw-w64 10.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -574,7 +574,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'schannel +analyzer'  # mingw-w64 13.0
+          - name: 'schannel +analyzer'  # mingw-w64 14.0
             sys: 'mingw64'
             dir: 'w64devkit'
             env: 'x86_64'

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1707,11 +1707,12 @@ CURLMcode curl_multi_wakeup(CURLM *m)
  */
 static bool multi_ischanged(struct Curl_multi *multi, bool clear)
 {
-  bool retval;
-  DEBUGASSERT(multi);
-  retval = (bool)multi->recheckstate;
-  if(clear)
-    multi->recheckstate = FALSE;
+  bool retval = FALSE;
+  if(multi) {
+    retval = (bool)multi->recheckstate;
+    if(clear)
+      multi->recheckstate = FALSE;
+  }
   return retval;
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1707,7 +1707,9 @@ CURLMcode curl_multi_wakeup(CURLM *m)
  */
 static bool multi_ischanged(struct Curl_multi *multi, bool clear)
 {
-  bool retval = (bool)multi->recheckstate;
+  bool retval;
+  DEBUGASSERT(multi);
+  retval = (bool)multi->recheckstate;
   if(clear)
     multi->recheckstate = FALSE;
   return retval;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -4132,7 +4132,7 @@ unsigned int Curl_multi_xfers_running(struct Curl_multi *multi)
 {
   DEBUGASSERT(multi);
   if(!multi)
-    return FALSE;
+    return 0;
   return multi->xfers_alive;
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1708,6 +1708,7 @@ CURLMcode curl_multi_wakeup(CURLM *m)
 static bool multi_ischanged(struct Curl_multi *multi, bool clear)
 {
   bool retval = FALSE;
+  DEBUGASSERT(multi);
   if(multi) {
     retval = (bool)multi->recheckstate;
     if(clear)
@@ -4129,6 +4130,9 @@ struct Curl_easy *Curl_multi_get_easy(struct Curl_multi *multi,
 
 unsigned int Curl_multi_xfers_running(struct Curl_multi *multi)
 {
+  DEBUGASSERT(multi);
+  if(!multi)
+    return FALSE;
   return multi->xfers_alive;
 }
 


### PR DESCRIPTION
- GHA/windows: bump dl-mingw job from gcc 15 to 16.

- multi: silence warning while building libcurlu:
  ```
  In function 'multi_ischanged',
      inlined from 'multi_socket.isra' at D:/a/curl/curl/lib/multi.c:3282:6:
  D:/a/curl/curl/lib/multi.c:1710:17: error: null pointer dereference [-Werror=null-dereference]
   1710 |   bool retval = (bool)multi->recheckstate;
        |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
  D:/a/curl/curl/lib/multi.c:1712:25: error: null pointer dereference [-Werror=null-dereference]
   1712 |     multi->recheckstate = FALSE;
        |                         ^
  ```
  Ref: https://github.com/curl/curl/actions/runs/26217071531/job/77142119137?pr=21707

- multi: silence another `-Wnull-dereference`, popping up in libcurl
  with gcc 13 after the previous silencing:
  ```
  In function 'Curl_multi_xfers_running',
      inlined from 'multi_socket.isra' at ../../lib/multi.c:3292:28:
  ../../lib/multi.c:4132:15: error: null pointer dereference [-Werror=null-dereference]
   4132 |   return multi->xfers_alive;
        |          ~~~~~^~~~~~~~~~~~~
  ```
  Ref: https://github.com/curl/curl/actions/runs/26218822231/job/77148186045

- multi: also add `DEBUGASSERT(multi)` to the two updated functions.
