### PR TITLE
Test runner improvements

### DIFF
--- a/docs/runtests.md
+++ b/docs/runtests.md
@@ -105,6 +105,11 @@ Dump `buildinfo.txt`.
 Provide a path to a custom curl binary to run the tests with. Default is the
 curl executable in the build tree.
 
+## `-cc \<curl-config\>`
+
+Provide a path to a custom curl-config script to run the tests with. Default
+is the curl-config script in the build tree.
+
 ## `-d`
 
 Enable protocol debug: have the servers display protocol output. If used in

--- a/docs/runtests.md
+++ b/docs/runtests.md
@@ -185,6 +185,10 @@ regression test suite.
 
 Lists all test case names.
 
+## `-ld \<logdir\>`
+
+Specify the log directory.
+
 ## `-m=[seconds]`
 
 Set timeout for curl commands in tests.

--- a/tests/data/test1013
+++ b/tests/data/test1013
@@ -23,7 +23,7 @@ Compare curl --version with curl-config --protocols
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%PERL %SRCDIR/libtest/test%TESTNUMBER.pl ../curl-config %LOGDIR/stdout%TESTNUMBER protocols
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl %CURLCONFIG %LOGDIR/stdout%TESTNUMBER protocols
 </postcheck>
 <errorcode>
 0

--- a/tests/data/test1014
+++ b/tests/data/test1014
@@ -23,7 +23,7 @@ Compare curl --version with curl-config --features
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%PERL %SRCDIR/libtest/test1013.pl ../curl-config %LOGDIR/stdout%TESTNUMBER features > %LOGDIR/result%TESTNUMBER
+%PERL %SRCDIR/libtest/test1013.pl %CURLCONFIG %LOGDIR/stdout%TESTNUMBER features > %LOGDIR/result%TESTNUMBER
 </postcheck>
 <errorcode>
 0

--- a/tests/data/test1022
+++ b/tests/data/test1022
@@ -23,7 +23,7 @@ Compare curl --version with curl-config --version
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%PERL %SRCDIR/libtest/test%TESTNUMBER.pl ../curl-config %LOGDIR/stdout%TESTNUMBER version
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl %CURLCONFIG %LOGDIR/stdout%TESTNUMBER version
 </postcheck>
 <errorcode>
 0

--- a/tests/data/test1023
+++ b/tests/data/test1023
@@ -23,7 +23,7 @@ Compare curl --version with curl-config --vernum
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-%PERL %SRCDIR/libtest/test1022.pl ../curl-config %LOGDIR/stdout%TESTNUMBER vernum
+%PERL %SRCDIR/libtest/test1022.pl %CURLCONFIG %LOGDIR/stdout%TESTNUMBER vernum
 </postcheck>
 <errorcode>
 0

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -37,6 +37,7 @@ BEGIN {
         $anyway
         $automakestyle
         $CURL
+        $CURLCONFIG
         $CURLINFO
         $CURLVERSION
         $CURLVERNUM
@@ -119,6 +120,8 @@ our $SRVDIR=dirsepadd("./server/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
 our $TESTDIR="$srcdir/data";
 our $CURL=dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
     "curl".exe_ext('TOOL'); # what curl binary to run on the tests
+our $CURLCONFIG=dirsepadd("../") .
+    "curl-config"; # what curl-config script to use on the tests
 our $CURLINFO=dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
     "curlinfo".exe_ext('TOOL'); # what curlinfo binary to run on the tests
 

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -44,7 +44,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 include Makefile.inc
 
 EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C) \
-  test307.pl test610.pl test613.pl test1013.pl test1022.pl mk-lib1521.pl
+  $(TESTS_PL) mk-lib1521.pl
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -118,3 +118,10 @@ TESTS_C = \
   lib3010.c lib3025.c lib3026.c lib3027.c lib3033.c lib3034.c \
   lib3100.c lib3101.c lib3102.c lib3103.c lib3104.c lib3105.c \
   lib3207.c lib3208.c
+
+TESTS_PL = \
+  test307.pl \
+  test610.pl \
+  test613.pl \
+  test1013.pl \
+  test1022.pl

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2505,6 +2505,11 @@ while(@ARGV) {
         # lists the test case names only
         $listonly=1;
     }
+    elsif($ARGV[0] eq "-ld") {
+        # set the log directory
+        $LOGDIR=$ARGV[1];
+        shift @ARGV;
+    }
     elsif($ARGV[0] eq "--buildinfo") {
         $buildinfo=1;
     }
@@ -2576,6 +2581,7 @@ Usage: runtests.pl [options] [test selection(s)]
   -k       keep stdout and stderr files present after tests
   -L path  require an additional perl library file to replace certain functions
   -l       list all test case names/descriptions
+  -ld      path to log directory
   -m=[seconds] set timeout for curl commands in tests
   --min=[count] minimum number of tests to run.
   -n       no valgrind

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -108,7 +108,6 @@ my %custom_skip_reasons;
 
 my $ACURL=$VCURL;  # what curl binary to use to talk to APIs (relevant for CI)
                    # ACURL is handy to set to the system one for reliability
-my $CURLCONFIG="../curl-config"; # curl-config from current build
 
 # Normally, all test cases should be run, but at times it is handy to
 # run a particular one:
@@ -2350,6 +2349,11 @@ while(@ARGV) {
         $DBGCURL=$CURL=$ARGV[1];
         shift @ARGV;
     }
+    elsif($ARGV[0] eq "-cc") {
+        # use this path to curl-config instead of default
+        $CURLCONFIG=$ARGV[1];
+        shift @ARGV;
+    }
     elsif($ARGV[0] eq "-vc") {
         # use this path to a curl used to verify servers
 
@@ -2559,6 +2563,7 @@ Usage: runtests.pl [options] [test selection(s)]
   -am      automake style output PASS/FAIL: [number] [name]
   --buildinfo dump buildinfo.txt
   -c path  use this curl executable
+  -cc path use this curl-config script
   -d       display server debug info
   -e, --test-event  event-based execution
   --test-duphandle  duplicate handles before use

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -3177,6 +3177,7 @@ sub subvariables {
 
     # misc
     $$thing =~ s/${prefix}PERL/$perlcmd/g;
+    $$thing =~ s/${prefix}CURLCONFIG/$CURLCONFIG/g;
     $$thing =~ s/${prefix}CURL/$CURL/g;
     $$thing =~ s/${prefix}LOGDIR/$LOGDIR/g;
     $$thing =~ s/${prefix}PWD/$pwd/g;


### PR DESCRIPTION
- Allow the path to `curl-config` to be specified on the command line
- Allow the log directory to be specified on the command line
- Factor out the list of Perl libtest scripts