### PR TITLE
setopt: minor cleanup

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1667,10 +1667,10 @@ static CURLcode setopt_cptr_proxy(struct Curl_easy *data, CURLoption option,
       if(u)
         result = Curl_urldecode(u, 0, &s->str[STRING_PROXYUSERNAME], NULL,
                                 REJECT_ZERO);
+      if(p)
+        result = Curl_urldecode(p, 0, &s->str[STRING_PROXYPASSWORD], NULL,
+                                REJECT_ZERO);
     }
-    if(!result && p)
-      result = Curl_urldecode(p, 0, &s->str[STRING_PROXYPASSWORD], NULL,
-                              REJECT_ZERO);
     curlx_free(u);
     curlx_free(p);
     break;


### PR DESCRIPTION
I noticed how as part of https://github.com/curl/curl/pull/21696 the `u` branch (when `!result`) was separated but `p` branch was not, so decided to suggest making it uniform to improve readability.
