### PR TITLE
http priority handling, update

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -1113,6 +1113,12 @@ CURLcode Curl_conn_ev_data_pause(struct Curl_easy *data, bool do_pause)
                       CF_CTRL_DATA_PAUSE, do_pause, NULL);
 }
 
+void Curl_conn_ev_prio_changed(struct Curl_easy *data)
+{
+  if(data->conn)
+    cf_cntrl_all(data->conn, data, TRUE, CF_CTRL_DATA_PRIO_CHANGED, 0, NULL);
+}
+
 bool Curl_conn_is_alive(struct Curl_easy *data, struct connectdata *conn,
                         bool *input_pending)
 {

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -121,6 +121,7 @@ typedef CURLcode Curl_cft_conn_keep_alive(struct Curl_cfilter *cf,
 #define CF_CTRL_DATA_PAUSE              6  /* on/off     NULL     first fail */
 #define CF_CTRL_DATA_DONE               7  /* premature  NULL     ignored */
 #define CF_CTRL_DATA_DONE_SEND          8  /* 0          NULL     ignored */
+#define CF_CTRL_DATA_PRIO_CHANGED       9  /* 0          NULL     ignored */
 /* update conn info at connection and data */
 #define CF_CTRL_CONN_INFO_UPDATE (256 + 0) /* 0          NULL     ignored */
 #define CF_CTRL_FORGET_SOCKET    (256 + 1) /* 0          NULL     ignored */
@@ -564,6 +565,9 @@ void Curl_conn_ev_data_done(struct Curl_easy *data, bool premature);
  * Notify connection filters that the transfer of data is paused/unpaused.
  */
 CURLcode Curl_conn_ev_data_pause(struct Curl_easy *data, bool do_pause);
+
+/* Notify connection filters that transfer priority changed. */
+void Curl_conn_ev_prio_changed(struct Curl_easy *data);
 
 /**
  * Check if FIRSTSOCKET's cfilter chain deems connection alive.

--- a/lib/http.c
+++ b/lib/http.c
@@ -2833,6 +2833,7 @@ typedef enum {
   H1_HD_TE,
   H1_HD_ACCEPT_ENCODING,
   H1_HD_REFERER,
+  H1_HD_PRIORITY,
 #ifndef CURL_DISABLE_PROXY
   H1_HD_PROXY_CONNECTION,
 #endif
@@ -2932,6 +2933,15 @@ static CURLcode http_add_hd(struct Curl_easy *data,
        !Curl_checkheaders(data, STRCONST("Referer")))
       result = curlx_dyn_addf(req, "Referer: %s\r\n",
                               Curl_bufref_ptr(&data->state.referer));
+    break;
+
+  case H1_HD_PRIORITY:
+    if(!Curl_http_prio_is_default(&data->set.priority) &&
+       !Curl_checkheaders(data, STRCONST("Priority"))) {
+      char buf[128];
+      Curl_http_prio_hd_val(&data->set.priority, buf, sizeof(buf));
+      result = curlx_dyn_addf(req, "Priority: %s\r\n", buf);
+    }
     break;
 
 #ifndef CURL_DISABLE_PROXY
@@ -5006,6 +5016,27 @@ void Curl_http_resp_free(struct http_resp *resp)
       Curl_http_resp_free(resp->prev);
     curlx_free(resp);
   }
+}
+
+void Curl_http_prio_init(struct http_priority *prio)
+{
+  memset(prio, 0, sizeof(*prio));
+#ifdef USE_HTTP2
+  prio->rfc7540.weight = 16; /* NGHTTP2_DEFAULT_WEIGHT */
+#endif
+  prio->urgency = 3;
+}
+
+bool Curl_http_prio_is_default(struct http_priority *prio)
+{
+  return (prio->urgency == 3) && !prio->incremental;
+}
+
+void Curl_http_prio_hd_val(struct http_priority *prio,
+                           char *buf, size_t buflen)
+{
+  curl_msnprintf(buf, buflen, "u=%u%s", prio->urgency,
+                 prio->incremental ? ", i" : "");
 }
 
 /*

--- a/lib/http.h
+++ b/lib/http.h
@@ -159,6 +159,25 @@ CURLcode Curl_http_follow(struct Curl_easy *data, const char *newurl,
    redirects. */
 #define MAX_HTTP_RESP_HEADER_COUNT 5000
 
+
+/**
+ * HTTP/2 priority information for an easy handle.
+ */
+struct http_priority {
+#ifdef USE_HTTP2
+  struct {
+    uint16_t weight;
+  } rfc7540;
+#endif
+  uint8_t urgency;
+  BIT(incremental);
+};
+
+void Curl_http_prio_init(struct http_priority *prio);
+bool Curl_http_prio_is_default(struct http_priority *prio);
+void Curl_http_prio_hd_val(struct http_priority *prio,
+                           char *buf, size_t buflen);
+
 #endif /* CURL_DISABLE_HTTP */
 
 /****************************************************************************

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -129,6 +129,7 @@ struct h2_stream_ctx {
   size_t resp_hds_len; /* amount of response header bytes in recvbuf */
   curl_off_t nrcvd_data;  /* number of DATA bytes received */
 
+  struct http_priority prio; /* priority information */
   char **push_headers;       /* allocated array */
   size_t push_headers_used;  /* number of entries filled in */
   size_t push_headers_alloc; /* number of entries allocated */
@@ -279,6 +280,7 @@ static struct h2_stream_ctx *h2_stream_ctx_create(struct cf_h2_ctx *ctx)
                   H2_STREAM_SEND_CHUNKS, BUFQ_OPT_NONE);
   Curl_h1_req_parse_init(&stream->h1, H1_PARSE_DEFAULT_MAX_LINE_LEN);
   Curl_dynhds_init(&stream->resp_trailers, 0, DYN_HTTP_REQUEST);
+  Curl_http_prio_init(&stream->prio);
   stream->bodystarted = FALSE;
   stream->status_code = -1;
   stream->closed = FALSE;
@@ -394,6 +396,7 @@ static CURLcode http2_data_setup(struct Curl_cfilter *cf,
     h2_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
+  stream->prio = data->set.priority;
 
   *pstream = stream;
   return CURLE_OK;
@@ -713,7 +716,6 @@ static struct Curl_easy *h2_duphandle(struct Curl_cfilter *cf,
   if(second) {
     struct h2_stream_ctx *second_stream;
     http2_data_setup(cf, second, &second_stream);
-    second->state.priority.weight = data->state.priority.weight;
   }
   return second;
 }
@@ -1758,39 +1760,6 @@ out:
   return result;
 }
 
-static int sweight_wanted(const struct Curl_easy *data)
-{
-  /* 0 weight is not set by user and we take the nghttp2 default one */
-  return data->set.priority.weight ?
-    data->set.priority.weight : NGHTTP2_DEFAULT_WEIGHT;
-}
-
-static int sweight_in_effect(const struct Curl_easy *data)
-{
-  /* 0 weight is not set by user and we take the nghttp2 default one */
-  return data->state.priority.weight ?
-    data->state.priority.weight : NGHTTP2_DEFAULT_WEIGHT;
-}
-
-/*
- * h2_pri_spec() fills in the pri_spec struct, used by nghttp2 to send weight
- * and dependency to the peer. It also stores the updated values in the state
- * struct.
- */
-
-static void h2_pri_spec(struct cf_h2_ctx *ctx,
-                        struct Curl_easy *data,
-                        nghttp2_priority_spec *pri_spec)
-{
-  struct Curl_data_priority *prio = &data->set.priority;
-  struct h2_stream_ctx *depstream = H2_STREAM_CTX(ctx, prio->parent);
-  int32_t depstream_id = depstream ? depstream->id : 0;
-  nghttp2_priority_spec_init(pri_spec, depstream_id,
-                             sweight_wanted(data),
-                             data->set.priority.exclusive);
-  data->state.priority = *prio;
-}
-
 /*
  * Check if there is been an update in the priority /
  * dependency settings and if so it submits a PRIORITY frame with the updated
@@ -1801,30 +1770,12 @@ static CURLcode h2_progress_egress(struct Curl_cfilter *cf,
                                    struct Curl_easy *data)
 {
   struct cf_h2_ctx *ctx = cf->ctx;
-  struct h2_stream_ctx *stream = H2_STREAM_CTX(ctx, data);
   int rv = 0;
-
-  if(stream && stream->id > 0 &&
-     ((sweight_wanted(data) != sweight_in_effect(data)) ||
-      (data->set.priority.exclusive != data->state.priority.exclusive) ||
-      (data->set.priority.parent != data->state.priority.parent))) {
-    /* send new weight and/or dependency */
-    nghttp2_priority_spec pri_spec;
-
-    h2_pri_spec(ctx, data, &pri_spec);
-    CURL_TRC_CF(data, cf, "[%d] Queuing PRIORITY", stream->id);
-    DEBUGASSERT(stream->id != -1);
-    rv = nghttp2_submit_priority(ctx->h2, NGHTTP2_FLAG_NONE,
-                                 stream->id, &pri_spec);
-    if(rv)
-      goto out;
-  }
 
   ctx->nw_out_blocked = 0;
   while(!rv && !ctx->nw_out_blocked && nghttp2_session_want_write(ctx->h2))
     rv = nghttp2_session_send(ctx->h2);
 
-out:
   if(nghttp2_is_fatal(rv)) {
     CURL_TRC_CF(data, cf, "nghttp2_session_send error (%s)%d",
                 nghttp2_strerror(rv), rv);
@@ -2122,8 +2073,6 @@ static CURLcode h2_submit(struct h2_stream_ctx **pstream,
     result = CURLE_OUT_OF_MEMORY;
     goto out;
   }
-
-  h2_pri_spec(ctx, data, &pri_spec);
   if(!nghttp2_session_check_request_allowed(ctx->h2))
     CURL_TRC_CF(data, cf, "send request NOT allowed (via nghttp2)");
 
@@ -2135,6 +2084,8 @@ static CURLcode h2_submit(struct h2_stream_ctx **pstream,
     if(result)
       goto out;
   }
+  nghttp2_priority_spec_init(&pri_spec, 0,
+                            stream->prio.rfc7540.weight, FALSE);
 
   switch(data->state.httpreq) {
   case HTTPREQ_POST:
@@ -2502,6 +2453,51 @@ out:
   return result;
 }
 
+static void cf_h2_prio_changed(struct Curl_cfilter *cf,
+                               struct Curl_easy *data)
+{
+  struct cf_h2_ctx *ctx = cf->ctx;
+  struct h2_stream_ctx *stream = H2_STREAM_CTX(ctx, data);
+  int rv = 0;
+  bool changed = FALSE;
+
+  if(!stream || (stream->id <= 0))
+    return;
+
+  if(data->set.priority.rfc7540.weight != stream->prio.rfc7540.weight) {
+    nghttp2_priority_spec pri_spec;
+
+    stream->prio.rfc7540.weight = data->set.priority.rfc7540.weight;
+    nghttp2_priority_spec_init(&pri_spec, 0,
+                               stream->prio.rfc7540.weight, FALSE);
+
+    rv = nghttp2_submit_priority(ctx->h2, NGHTTP2_FLAG_NONE,
+                                 stream->id, &pri_spec);
+    CURL_TRC_CF(data, cf, "[%d] sending PRIORITY, rfc7540 weight=%u -> %d",
+                stream->id, stream->prio.rfc7540.weight, rv);
+    changed = TRUE;
+  }
+
+  if((data->set.priority.urgency != stream->prio.urgency) ||
+     (data->set.priority.incremental != stream->prio.incremental)) {
+    char buf[128];
+
+    stream->prio.urgency = data->set.priority.urgency;
+    stream->prio.incremental = data->set.priority.incremental;
+    Curl_http_prio_hd_val(&stream->prio, buf, sizeof(buf));
+    rv = nghttp2_submit_priority_update(ctx->h2, NGHTTP2_FLAG_NONE,
+                                        stream->id,
+                                        (const uint8_t *)buf, strlen(buf));
+    CURL_TRC_CF(data, cf, "[%d] sending PRIORITY, '%s' -> %d",
+                stream->id, buf, rv);
+    changed = TRUE;
+  }
+
+  (void)rv; /* for non-verbose builds */
+  if(changed)
+    (void)h2_progress_egress(cf, data); /* best effort */
+}
+
 static CURLcode cf_h2_connect(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
                               bool *done)
@@ -2693,6 +2689,9 @@ static CURLcode cf_h2_cntrl(struct Curl_cfilter *cf,
       cf->conn->httpversion_seen = 20;
       Curl_conn_set_multiplex(cf->conn);
     }
+    break;
+  case CF_CTRL_DATA_PRIO_CHANGED:
+    cf_h2_prio_changed(cf, data);
     break;
   default:
     break;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -35,6 +35,7 @@
 
 #include "urldata.h"
 #include "url.h"
+#include "cfilters.h"
 #include "progress.h"
 #include "content_encoding.h"
 #include "strcase.h"
@@ -1108,9 +1109,11 @@ static CURLcode setopt_long_http(struct Curl_easy *data, CURLoption option,
       s->expect_100_timeout = (unsigned short)arg;
     break;
   case CURLOPT_STREAM_WEIGHT:
-#if defined(USE_HTTP2) || defined(USE_HTTP3)
-    if((arg >= 1) && (arg <= 256))
-      s->priority.weight = (int)arg;
+#ifdef USE_HTTP2
+    if((arg >= 1) && (arg <= 256)) {
+      s->priority.rfc7540.weight = (uint16_t)arg;
+      Curl_conn_ev_prio_changed(data);
+    }
     break;
 #else
     result = CURLE_NOT_BUILT_IN;
@@ -1527,13 +1530,12 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
 
 #ifdef USE_HTTP2
   case CURLOPT_STREAM_DEPENDS:
-  case CURLOPT_STREAM_DEPENDS_E: {
-    struct Curl_easy *dep = va_arg(param, struct Curl_easy *);
-    if(!dep || GOOD_EASY_HANDLE(dep))
-      return Curl_data_priority_add_child(dep, data,
-                                          option == CURLOPT_STREAM_DEPENDS_E);
+  case CURLOPT_STREAM_DEPENDS_E:
+    /* RFC 9113 deprecated HTTP/2 stream priorities and the dependencies,
+     * the most complicated parts, where optional, often not (correctly)
+     * implemented.
+     * libcurl now silently ignores any such settings. */
     break;
-  }
 #endif
 
   default:

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -505,7 +505,6 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
   data->state.authhost.want = data->set.httpauth;
   data->state.authproxy.want = data->set.proxyauth;
   curlx_safefree(data->info.wouldredirect);
-  Curl_data_priority_clear_state(data);
   if(data->set.http_auto_referer)
     Curl_bufref_free(&data->state.referer);
   if(data->set.str[STRING_SET_REFERER])

--- a/lib/url.c
+++ b/lib/url.c
@@ -119,12 +119,6 @@
 #include "smtp.h"
 #include "ws.h"
 
-#ifdef USE_NGHTTP2
-static void data_priority_cleanup(struct Curl_easy *data);
-#else
-#define data_priority_cleanup(x)
-#endif
-
 /* Some parts of the code (e.g. chunked encoding) assume this buffer has more
  * than a few bytes to play with. Do not let it become too small or bad things
  * will happen.
@@ -275,8 +269,6 @@ CURLcode Curl_close(struct Curl_easy **datap)
   curlx_safefree(data->info.contenttype);
   curlx_safefree(data->info.wouldredirect);
 
-  data_priority_cleanup(data);
-
   /* No longer a dirty share, if it exists */
   if(Curl_share_easy_unlink(data))
     DEBUGASSERT(0);
@@ -426,8 +418,8 @@ void Curl_init_userdefined(struct Curl_easy *data)
   set->conn_max_age_ms = 24 * 3600 * 1000;
   set->http09_allowed = FALSE;
   set->httpwant = CURL_HTTP_VERSION_NONE;
-#if defined(USE_HTTP2) || defined(USE_HTTP3)
-  memset(&set->priority, 0, sizeof(set->priority));
+#ifndef CURL_DISABLE_HTTP
+  Curl_http_prio_init(&data->set.priority);
 #endif
   set->quick_exit = 0L;
 #ifndef CURL_DISABLE_WEBSOCKETS
@@ -3006,105 +2998,6 @@ CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
   }
   return result;
 }
-
-#if defined(USE_HTTP2) || defined(USE_HTTP3)
-
-#ifdef USE_NGHTTP2
-
-static void priority_remove_child(struct Curl_easy *parent,
-                                  struct Curl_easy *child)
-{
-  struct Curl_data_prio_node **pnext = &parent->set.priority.children;
-  struct Curl_data_prio_node *pnode = parent->set.priority.children;
-
-  DEBUGASSERT(child->set.priority.parent == parent);
-  while(pnode && pnode->data != child) {
-    pnext = &pnode->next;
-    pnode = pnode->next;
-  }
-
-  DEBUGASSERT(pnode);
-  if(pnode) {
-    *pnext = pnode->next;
-    curlx_free(pnode);
-  }
-
-  child->set.priority.parent = 0;
-  child->set.priority.exclusive = FALSE;
-}
-
-CURLcode Curl_data_priority_add_child(struct Curl_easy *parent,
-                                      struct Curl_easy *child,
-                                      bool exclusive)
-{
-  if(child->set.priority.parent) {
-    priority_remove_child(child->set.priority.parent, child);
-  }
-
-  if(parent) {
-    struct Curl_data_prio_node **tail;
-    struct Curl_data_prio_node *pnode;
-
-    pnode = curlx_calloc(1, sizeof(*pnode));
-    if(!pnode)
-      return CURLE_OUT_OF_MEMORY;
-    pnode->data = child;
-
-    if(parent->set.priority.children && exclusive) {
-      /* exclusive: move all existing children underneath the new child */
-      struct Curl_data_prio_node *node = parent->set.priority.children;
-      while(node) {
-        node->data->set.priority.parent = child;
-        node = node->next;
-      }
-
-      tail = &child->set.priority.children;
-      while(*tail)
-        tail = &(*tail)->next;
-
-      DEBUGASSERT(!*tail);
-      *tail = parent->set.priority.children;
-      parent->set.priority.children = 0;
-    }
-
-    tail = &parent->set.priority.children;
-    while(*tail) {
-      (*tail)->data->set.priority.exclusive = FALSE;
-      tail = &(*tail)->next;
-    }
-
-    DEBUGASSERT(!*tail);
-    *tail = pnode;
-  }
-
-  child->set.priority.parent = parent;
-  child->set.priority.exclusive = exclusive;
-  return CURLE_OK;
-}
-
-#endif /* USE_NGHTTP2 */
-
-#ifdef USE_NGHTTP2
-static void data_priority_cleanup(struct Curl_easy *data)
-{
-  while(data->set.priority.children) {
-    struct Curl_easy *tmp = data->set.priority.children->data;
-    priority_remove_child(data, tmp);
-    if(data->set.priority.parent)
-      Curl_data_priority_add_child(data->set.priority.parent, tmp, FALSE);
-  }
-
-  if(data->set.priority.parent)
-    priority_remove_child(data->set.priority.parent, data);
-}
-#endif
-
-void Curl_data_priority_clear_state(struct Curl_easy *data)
-{
-  memset(&data->state.priority, 0, sizeof(data->state.priority));
-}
-
-#endif /* USE_HTTP2 || USE_HTTP3 */
 
 CURLcode Curl_conn_meta_set(struct connectdata *conn, const char *key,
                             void *meta_data, Curl_meta_dtor *meta_dtor)

--- a/lib/url.h
+++ b/lib/url.h
@@ -89,18 +89,4 @@ CURLcode Curl_conn_upkeep(struct Curl_easy *data,
  */
 CURLcode Curl_1st_fatal(CURLcode r1, CURLcode r2);
 
-#if defined(USE_HTTP2) || defined(USE_HTTP3)
-void Curl_data_priority_clear_state(struct Curl_easy *data);
-#else
-#define Curl_data_priority_clear_state(x)
-#endif /* USE_HTTP2 || USE_HTTP3 */
-
-#ifdef USE_NGHTTP2
-CURLcode Curl_data_priority_add_child(struct Curl_easy *parent,
-                                      struct Curl_easy *child,
-                                      bool exclusive);
-#else
-#define Curl_data_priority_add_child(x, y, z) CURLE_NOT_BUILT_IN
-#endif
-
 #endif /* HEADER_CURL_URL_H */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -580,29 +580,6 @@ struct auth {
                      auth multipass negotiation */
 };
 
-#ifdef USE_NGHTTP2
-struct Curl_data_prio_node {
-  struct Curl_data_prio_node *next;
-  struct Curl_easy *data;
-};
-#endif
-
-/**
- * Priority information for an easy handle in relation to others
- * on the same connection.
- */
-struct Curl_data_priority {
-#ifdef USE_NGHTTP2
-  /* tree like dependencies only implemented in nghttp2 */
-  struct Curl_easy *parent;
-  struct Curl_data_prio_node *children;
-#endif
-  int weight;
-#ifdef USE_NGHTTP2
-  BIT(exclusive);
-#endif
-};
-
 /* Timers */
 typedef enum {
   EXPIRE_100_TIMEOUT,
@@ -715,10 +692,6 @@ struct UrlState {
 
   curl_off_t infilesize; /* size of file to upload, -1 means unknown.
                             Copied from set.filesize at start of operation */
-#if defined(USE_HTTP2) || defined(USE_HTTP3)
-  struct Curl_data_priority priority; /* shallow copy of data->set */
-#endif
-
   curl_read_callback fread_func; /* read callback/function */
   void *in;                      /* CURLOPT_READDATA */
   CURLU *uh; /* URL handle for the current parsed URL */
@@ -1118,9 +1091,6 @@ struct UserDefined {
   int tcp_keepintvl;    /* seconds between TCP keepalive probes */
   int tcp_keepcnt;      /* maximum number of keepalive probes */
 
-#if defined(USE_HTTP2) || defined(USE_HTTP3)
-  struct Curl_data_priority priority;
-#endif
   curl_resolver_start_callback resolver_start; /* optional callback called
                                                   before resolver start */
   void *resolver_start_client; /* pointer to pass to resolver start callback */
@@ -1128,6 +1098,7 @@ struct UserDefined {
                                     upkeep. */
   CURLU *uh; /* URL handle for the current parsed URL */
 #ifndef CURL_DISABLE_HTTP
+  struct http_priority priority;
   void *trailer_data; /* pointer to pass to trailer data callback */
   curl_trailer_callback trailer_callback; /* trailing data callback */
 #endif


### PR DESCRIPTION
- Remove RFC 7540 priority dependency handling.
- CURLOPT_STREAM_DEPENDS and CURLOPT_STREAM_DEPENDS_E become dummies
- Add RFC 9218 priority state to easy handle
- Add signalling of priority change to connection filters
- Change http2.c to react on priority changes
- Add HTTP header "Priority: " handling in http.c

WIP, missing:

- update of documentation
- adding a CURLOPT_HTTP_PRIORITY with "urgency" and "incremental" bits