### PR TITLE
GHA/windows: bump windows-2025 runners to windows-2025-vs2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -311,7 +311,7 @@ jobs:
           #   build: 'autotools', sys: 'ucrt64'    , env: 'ucrt-x86_64'  , tflags: 'skiprun'   ,
           #   config: '--without-debug --with-schannel --disable-static',
           #   install: 'mingw-w64-ucrt-x86_64-libssh2' }
-          - { name: 'schannel dev debug', type: 'Debug', cppflags: '-DCURL_SCHANNEL_DEV_DEBUG', image: 'windows-2025',
+          - { name: 'schannel dev debug', type: 'Debug', cppflags: '-DCURL_SCHANNEL_DEV_DEBUG', image: 'windows-2025-vs2026',
               build: 'cmake'    , sys: 'mingw64'   , env: 'x86_64'       , tflags: 'skiprun'   ,
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCMAKE_VERBOSE_MAKEFILE=ON',
               install: 'mingw-w64-x86_64-libssh2' }
@@ -899,7 +899,7 @@ jobs:
             env: 'ucrt-x86_64'
             plat: 'uwp'
             type: 'Debug'
-            image: 'windows-2025'
+            image: 'windows-2025-vs2026'
             tflags: 'skiprun'
             config: >-
               -DENABLE_DEBUG=ON


### PR DESCRIPTION
To silence:
```
NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by June 15, 2026
```