### PR TITLE
units: tidy up begin/end blocks

### DIFF
--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -109,8 +109,8 @@ static CURLcode test_unit1609(const char *arg)
     bool problem = false;
     easy = curl_easy_init();
     if(!easy) {
-      curl_global_cleanup();
-      return CURLE_OUT_OF_MEMORY;
+      result = CURLE_OUT_OF_MEMORY;
+      goto unit_test_abort;
     }
     /* create a multi handle and add the easy handle to it so that the
        hostcache is setup */

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -109,8 +109,8 @@ static CURLcode test_unit1609(const char *arg)
     bool problem = false;
     easy = curl_easy_init();
     if(!easy) {
-      result = CURLE_OUT_OF_MEMORY;
-      goto unit_test_abort;
+      curl_global_cleanup();
+      return CURLE_OUT_OF_MEMORY;
     }
     /* create a multi handle and add the easy handle to it so that the
        hostcache is setup */

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -97,7 +97,7 @@ static CURLcode test_unit1609(const char *arg)
   struct curl_slist *list = NULL;
 
   /* important: we setup cache outside of the loop
-     and also clean cache after the loop. In contrast,for example,
+     and also clean cache after the loop. In contrast, for example,
      test 1607 sets up and cleans cache on each iteration. */
 
   for(i = 0; i < CURL_ARRAYSIZE(tests); ++i) {

--- a/tests/unit/unit1625.c
+++ b/tests/unit/unit1625.c
@@ -36,6 +36,8 @@ struct check1625 {
 
 static CURLcode test_unit1625(const char *arg)
 {
+  UNITTEST_BEGIN_SIMPLE
+
   size_t i;
   static const struct check1625 list[] = {
     /* basic case */
@@ -101,7 +103,6 @@ static CURLcode test_unit1625(const char *arg)
     /* hyphenated second token */
     { "Encoding: extra-good, super-nice", "Encoding:", "super-nice", TRUE },
   };
-  (void)arg;
 
   for(i = 0; i < CURL_ARRAYSIZE(list); i++) {
     bool check = Curl_compareheader(list[i].in,
@@ -123,12 +124,12 @@ static CURLcode test_unit1625(const char *arg)
   if(i != CURL_ARRAYSIZE(list))
     return CURLE_FAILED_INIT;
 
-  return CURLE_OK;
+  UNITTEST_END_SIMPLE
 }
 #else /* CURL_DISABLE_HTTP */
 static CURLcode test_unit1625(const char *arg)
 {
-  (void)arg;
-  return CURLE_OK;
+  UNITTEST_BEGIN_SIMPLE
+  UNITTEST_END_SIMPLE
 }
 #endif

--- a/tests/unit/unit1626.c
+++ b/tests/unit/unit1626.c
@@ -34,6 +34,8 @@ struct check1626 {
 
 static CURLcode test_unit1626(const char *arg)
 {
+  UNITTEST_BEGIN_SIMPLE
+
   size_t i;
   static const struct check1626 list[] = {
     /* basic */
@@ -94,8 +96,6 @@ static CURLcode test_unit1626(const char *arg)
     { "Header :    value", "value" },
   };
 
-  (void)arg;
-
   for(i = 0; i < CURL_ARRAYSIZE(list); i++) {
     bool ok;
     char *get = Curl_copy_header_value(list[i].in);
@@ -117,13 +117,13 @@ static CURLcode test_unit1626(const char *arg)
   if(i != CURL_ARRAYSIZE(list))
     return CURLE_FAILED_INIT;
 
-  return CURLE_OK;
+  UNITTEST_END_SIMPLE
 }
 #else
 /* for HTTP-disabled builds */
 static CURLcode test_unit1626(const char *arg)
 {
-  (void)arg;
-  return CURLE_OK;
+  UNITTEST_BEGIN_SIMPLE
+  UNITTEST_END_SIMPLE
 }
 #endif

--- a/tests/unit/unit1627.c
+++ b/tests/unit/unit1627.c
@@ -28,6 +28,8 @@
 
 static CURLcode test_unit1627(const char *arg)
 {
+  UNITTEST_BEGIN_SIMPLE
+
   size_t i, j;
   /* existing schemes in different cases */
   static const char *okay[] = {
@@ -65,8 +67,6 @@ static CURLcode test_unit1627(const char *arg)
     "GhJk", "LzXc", "VbNm"
   };
 
-  (void)arg;
-
   for(i = 0; i < CURL_ARRAYSIZE(okay); i++) {
     char buffer[32];
     const struct Curl_scheme *get = Curl_get_scheme(okay[i]);
@@ -96,10 +96,9 @@ static CURLcode test_unit1627(const char *arg)
 
   curl_mprintf("%zu invokes\n", i + j);
 
-  if(i != CURL_ARRAYSIZE(okay))
-    return CURLE_FAILED_INIT;
-  if(j != CURL_ARRAYSIZE(notokay))
+  if(i != CURL_ARRAYSIZE(okay) ||
+     j != CURL_ARRAYSIZE(notokay))
     return CURLE_FAILED_INIT;
 
-  return CURLE_OK;
+  UNITTEST_END_SIMPLE
 }

--- a/tests/unit/unit1636.c
+++ b/tests/unit/unit1636.c
@@ -76,7 +76,7 @@ static CURLcode test_unit1636(const char *arg)
 #else /* CURL_DISABLE_PROGRESS_METER */
 static CURLcode test_unit1636(const char *arg)
 {
-  (void)arg;
-  return CURLE_OK;
+  UNITTEST_BEGIN_SIMPLE
+  UNITTEST_END_SIMPLE
 }
 #endif

--- a/tests/unit/unit1636.c
+++ b/tests/unit/unit1636.c
@@ -27,49 +27,49 @@
 static CURLcode test_unit1636(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
-  {
-    char buffer[9];
-    curl_off_t secs;
-    int i;
-    static const curl_off_t check[] = {
-      /* bytes to check */
-      131072,
-      12645826,
-      1073741824,
-      12938588979,
-      1099445657078333,
-      0 /* end of list */
-    };
 
-    puts("time2str");
-    for(i = 0, secs = 0; i < 63; i++) {
-      time2str(buffer, sizeof(buffer), secs);
-      curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
-      if(strlen(buffer) != 7) {
-        curl_mprintf("^^ was too long!\n");
-      }
-      secs *= 2;
-      secs++;
+  char buffer[9];
+  curl_off_t secs;
+  int i;
+  static const curl_off_t check[] = {
+    /* bytes to check */
+    131072,
+    12645826,
+    1073741824,
+    12938588979,
+    1099445657078333,
+    0 /* end of list */
+  };
+
+  puts("time2str");
+  for(i = 0, secs = 0; i < 63; i++) {
+    time2str(buffer, sizeof(buffer), secs);
+    curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
+    if(strlen(buffer) != 7) {
+      curl_mprintf("^^ was too long!\n");
     }
-    puts("max6out");
-    for(i = 0, secs = 0; i < 63; i++) {
-      max6out(secs, buffer, sizeof(buffer));
-      curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
-      if(strlen(buffer) != 6) {
-        curl_mprintf("^^ was too long!\n");
-      }
-      secs *= 2;
-      secs++;
+    secs *= 2;
+    secs++;
+  }
+  puts("max6out");
+  for(i = 0, secs = 0; i < 63; i++) {
+    max6out(secs, buffer, sizeof(buffer));
+    curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
+    if(strlen(buffer) != 6) {
+      curl_mprintf("^^ was too long!\n");
     }
-    for(i = 0; check[i]; i++) {
-      secs = check[i];
-      max6out(secs, buffer, sizeof(buffer));
-      curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
-      if(strlen(buffer) != 6) {
-        curl_mprintf("^^ was too long!\n");
-      }
+    secs *= 2;
+    secs++;
+  }
+  for(i = 0; check[i]; i++) {
+    secs = check[i];
+    max6out(secs, buffer, sizeof(buffer));
+    curl_mprintf("%20" FMT_OFF_T " - %s\n", secs, buffer);
+    if(strlen(buffer) != 6) {
+      curl_mprintf("^^ was too long!\n");
     }
   }
+
   UNITTEST_END(curl_global_cleanup())
 }
 

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -27,7 +27,6 @@
 
 static CURLcode test_unit1675(const char *arg)
 {
-  (void)arg;
   UNITTEST_BEGIN_SIMPLE
 
     /* Test ipv4_normalize */

--- a/tests/unit/unit3300.c
+++ b/tests/unit/unit3300.c
@@ -156,7 +156,7 @@ static CURLcode test_unit3300(const char *arg)
 #else
 static CURLcode test_unit3300(const char *arg)
 {
-  (void)arg;
-  return CURLE_OK;
+  UNITTEST_BEGIN_SIMPLE
+  UNITTEST_END_SIMPLE
 }
 #endif /* USE_THREADS */

--- a/tests/unit/unit3300.c
+++ b/tests/unit/unit3300.c
@@ -154,11 +154,9 @@ static CURLcode test_unit3300(const char *arg)
 }
 
 #else
-
 static CURLcode test_unit3300(const char *arg)
 {
-  UNITTEST_BEGIN_SIMPLE
   (void)arg;
-  UNITTEST_END_SIMPLE
+  return CURLE_OK;
 }
 #endif /* USE_THREADS */

--- a/tests/unit/unit3301.c
+++ b/tests/unit/unit3301.c
@@ -134,11 +134,9 @@ static CURLcode test_unit3301(const char *arg)
 }
 
 #else
-
 static CURLcode test_unit3301(const char *arg)
 {
-  UNITTEST_BEGIN_SIMPLE
   (void)arg;
-  UNITTEST_END_SIMPLE
+  return CURLE_OK;
 }
 #endif /* USE_THREADS */

--- a/tests/unit/unit3301.c
+++ b/tests/unit/unit3301.c
@@ -136,7 +136,7 @@ static CURLcode test_unit3301(const char *arg)
 #else
 static CURLcode test_unit3301(const char *arg)
 {
-  (void)arg;
-  return CURLE_OK;
+  UNITTEST_BEGIN_SIMPLE
+  UNITTEST_END_SIMPLE
 }
 #endif /* USE_THREADS */


### PR DESCRIPTION
- use `UNITTEST_BEGIN_SIMPLE`/`UNITTEST_END_SIMPLE` where missing.
- drop redundant `(void)arg;` where using `UNITTEST_BEGIN*`.
- unit1636: drop redundant block after `UNITTEST_BEGIN*`.
- unit1609: fix typo in comment.
- unit1627: merge to `if`s.

---

https://github.com/curl/curl/pull/21715/files?w=1
