### PR TITLE
multi: handle pause in multi socket callback

### DIFF
--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -51,6 +51,9 @@ struct mev_sh_entry {
                          * libcurl application to watch out for */
   unsigned int readers; /* this many transfers want to read */
   unsigned int writers; /* this many transfers want to write */
+#ifdef DEBUGBUILD
+  unsigned int magic;
+#endif
   BIT(announced);       /* this socket has been passed to the socket
                            callback at least once */
 };
@@ -75,6 +78,9 @@ static void mev_sh_entry_dtor(void *freethis)
 {
   struct mev_sh_entry *entry = (struct mev_sh_entry *)freethis;
   Curl_uint32_spbset_destroy(&entry->xfers);
+#ifdef DEBUGBUILD
+  entry->magic = 0;
+#endif
   curlx_free(entry);
 }
 
@@ -113,7 +119,9 @@ static struct mev_sh_entry *mev_sh_entry_add(struct Curl_hash *sh,
     mev_sh_entry_dtor(check);
     return NULL; /* major failure */
   }
-
+#ifdef DEBUGBUILD
+  check->magic = SH_ENTRY_MAGIC;
+#endif
   return check; /* things are good in sockhash land */
 }
 
@@ -223,6 +231,7 @@ static CURLMcode mev_sh_entry_update(struct Curl_multi *multi,
 
   /* we should only be called when the callback exists */
   DEBUGASSERT(multi->socket_cb);
+  DEBUGASSERT(entry->magic == SH_ENTRY_MAGIC);
   if(!multi->socket_cb)
     return CURLM_OK;
 
@@ -272,12 +281,18 @@ static CURLMcode mev_sh_entry_update(struct Curl_multi *multi,
   rc = multi->socket_cb(data, s, comboaction, multi->socket_userp,
                         entry->user_data);
   mev_in_callback(multi, FALSE);
-  entry->announced = TRUE;
   if(rc == -1) {
     multi->dead = TRUE;
     return CURLM_ABORTED_BY_CALLBACK;
   }
-  entry->action = (unsigned int)comboaction;
+  /* curl_easy_pause() is documented as callable from any callback; it
+   * re-enters mev_assess() which may free this 'entry'. Re-fetch. */
+  entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+  if(entry) {
+    DEBUGASSERT(entry->magic == SH_ENTRY_MAGIC);
+    entry->announced = TRUE;
+    entry->action = (unsigned int)comboaction;
+  }
   return CURLM_OK;
 }
 

--- a/lib/multi_ev.h
+++ b/lib/multi_ev.h
@@ -30,6 +30,8 @@ struct Curl_multi;
 struct easy_pollset;
 struct uint32_bset;
 
+#define SH_ENTRY_MAGIC 0x570091d
+
 /* meta key for event pollset at easy handle or connection */
 #define CURL_META_MEV_POLLSET   "meta:mev:ps"
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -238,6 +238,7 @@ test1916 test1917 test1918 test1919 test1920 test1921 \
 \
 test1933 test1934 test1935 test1936 test1937 test1938 test1939 test1940 \
 test1941 test1942 test1943 test1944 test1945 test1946 test1947 test1948 \
+test1949 \
 test1955 test1956 test1957 test1958 test1959 test1960 test1964 test1965 \
 test1966 test1967 \
 \

--- a/tests/data/test1949
+++ b/tests/data/test1949
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK swsclose
+Date: Thu, 01 Nov 2001 14:49:00 GMT
+Content-Type: text/html
+Content-Length: 601
+
+%repeat[60 x datatosend]%
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+
+<name>
+call curl_easy_pause from within CURLMOPT_SOCKETFUNCTION
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -106,7 +106,7 @@ TESTS_C = \
   lib1915.c lib1916.c           lib1918.c lib1919.c lib1920.c lib1921.c \
   lib1933.c lib1934.c lib1935.c lib1936.c lib1937.c lib1938.c lib1939.c \
   lib1940.c                                         lib1945.c \
-  lib1947.c lib1948.c \
+  lib1947.c lib1948.c lib1949.c \
   lib1955.c lib1956.c lib1957.c lib1958.c lib1959.c lib1960.c \
   lib1964.c lib1965.c           lib1967.c                     lib1970.c \
   lib1971.c lib1972.c lib1973.c lib1974.c lib1975.c lib1977.c lib1978.c \

--- a/tests/libtest/lib1949.c
+++ b/tests/libtest/lib1949.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <pthread.h>
 #include <curl/curl.h>
 
 #define MAX_FDS 64

--- a/tests/libtest/lib1949.c
+++ b/tests/libtest/lib1949.c
@@ -1,0 +1,202 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <pthread.h>
+#include <curl/curl.h>
+
+#define MAX_FDS 64
+struct ctx {
+  CURLM         *multi;
+  int            still_running;
+  curl_socket_t  fds[MAX_FDS];
+  int            actions[MAX_FDS];
+  int            nfds;
+  int            pause_fired;
+  int            iterations;
+};
+
+static void fd_add(struct ctx *c, curl_socket_t s, int action)
+{
+  for(int i = 0; i < c->nfds; i++) {
+    if(c->fds[i] == s) { c->actions[i] = action; return; }
+  }
+  if(c->nfds < MAX_FDS) {
+    c->fds[c->nfds]     = s;
+    c->actions[c->nfds] = action;
+    c->nfds++;
+  }
+}
+
+static void fd_del(struct ctx *c, curl_socket_t s)
+{
+  for(int i = 0; i < c->nfds; i++) {
+    if(c->fds[i] == s) {
+      c->nfds--;
+      c->fds[i]     = c->fds[c->nfds];
+      c->actions[i] = c->actions[c->nfds];
+      return;
+    }
+  }
+}
+
+static int sock1949_cb(CURL *easy, curl_socket_t s, int what,
+                       void *userp, void *socketp)
+{
+  struct ctx *c = userp;
+  (void)socketp;
+  if(what == CURL_POLL_REMOVE) {
+    fd_del(c, s);
+    return 0;
+  }
+  fd_add(c, s, what);
+
+  if(!c->pause_fired && (what & CURL_POLL_IN)) {
+    /*
+     * The first POLL_IN may be the multi handle's internal wakeup pipe
+     * (admin handle, conn==NULL); curl_easy_pause() returns
+     * CURLE_BAD_FUNCTION_ARGUMENT and the re-entrant path is not taken.
+     * Leave pause_fired=0 and retry on the next POLL_IN, which will be
+     * the actual transfer socket (conn!=NULL).
+     */
+    CURLcode rc = curl_easy_pause(easy, CURLPAUSE_RECV);
+    if(rc == CURLE_OK)
+      c->pause_fired = 1;
+  }
+  return 0;
+}
+
+static int timer1949_cb(CURLM *m, long ms, void *u)
+{
+  (void)m;(void)ms;(void)u;
+  return 0;
+}
+static size_t write1949_cb(char *p, size_t sz, size_t n, void *u)
+{
+  (void)p;(void)u;
+  return sz*n;
+}
+
+static CURLcode test_lib1949(const char *URL)
+{
+  struct ctx c = {0};
+  CURL *easy = NULL;
+  curl_global_init(CURL_GLOBAL_DEFAULT);
+
+  c.multi = curl_multi_init();
+  if(!c.multi)
+    goto test_cleanup;
+  curl_multi_setopt(c.multi, CURLMOPT_SOCKETFUNCTION, sock1949_cb);
+  curl_multi_setopt(c.multi, CURLMOPT_SOCKETDATA,     &c);
+  curl_multi_setopt(c.multi, CURLMOPT_TIMERFUNCTION,  timer1949_cb);
+  curl_multi_setopt(c.multi, CURLMOPT_TIMERDATA,      &c);
+
+  easy = curl_easy_init();
+  if(!easy)
+    goto test_cleanup;
+  curl_easy_setopt(easy, CURLOPT_URL,           URL);
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write1949_cb);
+  curl_easy_setopt(easy, CURLOPT_VERBOSE,       1L);
+  curl_easy_setopt(easy, CURLOPT_TIMEOUT_MS,    500L);
+
+  curl_multi_add_handle(c.multi, easy);
+  curl_multi_socket_action(c.multi, CURL_SOCKET_TIMEOUT, 0, &c.still_running);
+
+  while(c.still_running && c.iterations < 2000) {
+    fd_set rfds, wfds;
+    struct timeval tv = { .tv_sec = 0, .tv_usec = 50000 };
+    curl_socket_t maxfd = -1;
+    int rc;
+    curl_socket_t ready_s[MAX_FDS];
+    int ready_ev[MAX_FDS];
+    int nready = 0;
+    int i;
+
+    FD_ZERO(&rfds);
+    FD_ZERO(&wfds);
+    c.iterations++;
+    for(i = 0; i < c.nfds; i++) {
+      curl_socket_t s = c.fds[i];
+      int           a = c.actions[i];
+      if(a & CURL_POLL_IN) {
+        FD_SET(s, &rfds);
+        if((int)s > maxfd)
+          maxfd = s;
+      }
+      if(a & CURL_POLL_OUT) {
+        FD_SET(s, &wfds);
+        if((int)s > maxfd)
+          maxfd = s;
+      }
+    }
+    if(c.pause_fired)
+      break;
+    if(maxfd < 0) {
+      usleep(5000);
+      curl_multi_socket_action(c.multi, CURL_SOCKET_TIMEOUT, 0,
+                               &c.still_running);
+      continue;
+    }
+    rc = select(maxfd + 1, &rfds, &wfds, NULL, &tv);
+    if(rc < 0) {
+      if(errno == SOCKEINTR)
+        continue;
+      break;
+    }
+    if(rc == 0) {
+      curl_multi_socket_action(c.multi, CURL_SOCKET_TIMEOUT, 0,
+                               &c.still_running);
+      continue;
+    }
+
+    for(i = 0; i < c.nfds && nready < MAX_FDS; i++) {
+      curl_socket_t s = c.fds[i];
+      int ev = 0;
+      if(FD_ISSET(s, &rfds))
+        ev |= CURL_CSELECT_IN;
+      if(FD_ISSET(s, &wfds))
+        ev |= CURL_CSELECT_OUT;
+      if(ev) {
+        ready_s[nready] = s;
+        ready_ev[nready] = ev;
+        nready++;
+      }
+    }
+    for(i = 0; i < nready; i++)
+      curl_multi_socket_action(c.multi, ready_s[i], ready_ev[i],
+                               &c.still_running);
+  }
+
+test_cleanup:
+  if(c.multi && easy)
+    curl_multi_remove_handle(c.multi, easy);
+  curl_easy_cleanup(easy);
+  curl_multi_cleanup(c.multi);
+  curl_global_cleanup();
+  return 0;
+}

--- a/tests/libtest/lib1949.c
+++ b/tests/libtest/lib1949.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 #include <curl/curl.h>
 
 #define MAX_FDS 64

--- a/tests/libtest/lib1949.c
+++ b/tests/libtest/lib1949.c
@@ -41,7 +41,8 @@ struct ctx {
 
 static void fd_add(struct ctx *c, curl_socket_t s, int action)
 {
-  for(int i = 0; i < c->nfds; i++) {
+  int i;
+  for(i = 0; i < c->nfds; i++) {
     if(c->fds[i] == s) { c->actions[i] = action; return; }
   }
   if(c->nfds < MAX_FDS) {
@@ -53,7 +54,8 @@ static void fd_add(struct ctx *c, curl_socket_t s, int action)
 
 static void fd_del(struct ctx *c, curl_socket_t s)
 {
-  for(int i = 0; i < c->nfds; i++) {
+  int i;
+  for(i = 0; i < c->nfds; i++) {
     if(c->fds[i] == s) {
       c->nfds--;
       c->fds[i]     = c->fds[c->nfds];
@@ -140,7 +142,7 @@ static CURLcode test_lib1949(const char *URL)
     c.iterations++;
     for(i = 0; i < c.nfds; i++) {
       curl_socket_t s = c.fds[i];
-      int           a = c.actions[i];
+      int a = c.actions[i];
       if(a & CURL_POLL_IN) {
         FD_SET(s, &rfds);
         if((int)s > maxfd)

--- a/tests/libtest/lib1949.c
+++ b/tests/libtest/lib1949.c
@@ -130,7 +130,7 @@ static CURLcode test_lib1949(const char *URL)
   while(c.still_running && c.iterations < 2000) {
     fd_set rfds, wfds;
     struct timeval tv = { 0, 50000 };
-    curl_socket_t maxfd = -1;
+    curl_socket_t maxfd = 0;
     int rc;
     curl_socket_t ready_s[MAX_FDS];
     int ready_ev[MAX_FDS];
@@ -145,24 +145,24 @@ static CURLcode test_lib1949(const char *URL)
       int a = c.actions[i];
       if(a & CURL_POLL_IN) {
         FD_SET(s, &rfds);
-        if((int)s > maxfd)
+        if(s > maxfd)
           maxfd = s;
       }
       if(a & CURL_POLL_OUT) {
         FD_SET(s, &wfds);
-        if((int)s > maxfd)
+        if(s > maxfd)
           maxfd = s;
       }
     }
     if(c.pause_fired)
       break;
-    if(maxfd < 0) {
+    if(maxfd == 0) {
       usleep(5000);
       curl_multi_socket_action(c.multi, CURL_SOCKET_TIMEOUT, 0,
                                &c.still_running);
       continue;
     }
-    rc = select(maxfd + 1, &rfds, &wfds, NULL, &tv);
+    rc = select((int)maxfd + 1, &rfds, &wfds, NULL, &tv);
     if(rc < 0) {
       if(errno == SOCKEINTR)
         continue;

--- a/tests/libtest/lib1949.c
+++ b/tests/libtest/lib1949.c
@@ -129,7 +129,7 @@ static CURLcode test_lib1949(const char *URL)
 
   while(c.still_running && c.iterations < 2000) {
     fd_set rfds, wfds;
-    struct timeval tv = { .tv_sec = 0, .tv_usec = 50000 };
+    struct timeval tv = { 0, 50000 };
     curl_socket_t maxfd = -1;
     int rc;
     curl_socket_t ready_s[MAX_FDS];


### PR DESCRIPTION
The mev_sh_entry object might be removed if curl_easy_pause() is called from within the socket callback.

Introduced a 'magic' struct field to to 'mev_sh_entry' to make it easier to programmatically detect/assert if the pointer is bad - in debug builds.

Verify by test case 1949.

Reported-by: Joshua Rogers