### PR TITLE
GHA/checksrc: add auditor-level zizmor (warning-only)

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -165,6 +165,13 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           zizmor --persona pedantic .github/workflows/*.yml .github/dependabot.yml
 
+      - name: 'zizmor GHA (auditor, warning-only)'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          zizmor --persona auditor .github/workflows/*.yml .github/dependabot.yml || true
+
       - name: 'actionlint'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"


### PR DESCRIPTION
CI time cost is 1s.

It may replace existing pedantic check, if this level isn't bringing
false-positives or annoyance. Officially it's not meant for CI, but curl
has been passing this in the last couple of months when checked locally.
