### PR TITLE
CIPHERS.md: fix the example that uses only TLS 1.3

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -188,6 +188,7 @@ mbedTLS and wolfSSL.
 ```sh
 curl \
   --tlsv1.3 \
+  --tls-max 1.3 \
   --tls13-ciphers TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256 \
   https://example.com/
 ```

--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -194,7 +194,7 @@ curl \
 ```
 
 Restrict to only TLS 1.3 with `aes128-gcm` and `chacha20` ciphers. Works with
-OpenSSL, LibreSSL, mbedTLS, wolfSSL and Schannel.
+OpenSSL, LibreSSL, mbedTLS and wolfSSL.
 
 ```sh
 curl \


### PR DESCRIPTION
- Add --tls-max 1.3 to set the maximum version to TLS 1.3.

Prior to this change the example set the minimum version to TLS 1.3 but not the maximum version to TLS 1.3.

Ref: https://github.com/curl/curl/issues/21702

Closes #xxxxx