### PR TITLE
urlapi: fix redirect handling if CURLU_NO_GUESS_SCHEME is set

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1731,8 +1731,9 @@ static CURLUcode set_url(CURLU *u, const char *url, size_t part_size,
     return parseurl_and_replace(url, u, flags);
 
   /* if the old URL is incomplete (we cannot get an absolute URL in
-     'oldurl'), replace the existing with the new */
-  uc = curl_url_get(u, CURLUPART_URL, &oldurl, flags);
+     'oldurl'), replace the existing with the new.
+     Always include "scheme://" to make the URL "complete" */
+  uc = curl_url_get(u, CURLUPART_URL, &oldurl, flags& ~CURLU_NO_GUESS_SCHEME);
   if(uc == CURLUE_OUT_OF_MEMORY)
     return uc;
   else if(uc)

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -239,7 +239,7 @@ test1916 test1917 test1918 test1919 test1920 test1921 \
 test1933 test1934 test1935 test1936 test1937 test1938 test1939 test1940 \
 test1941 test1942 test1943 test1944 test1945 test1946 test1947 test1948 \
 test1955 test1956 test1957 test1958 test1959 test1960 test1964 test1965 \
-test1966 \
+test1966 test1967 \
 \
 test1970 test1971 test1972 test1973 test1974 test1975 test1976 test1977 \
 test1978 test1979 test1980 test1981 test1982 test1983 test1984 \

--- a/tests/data/test1967
+++ b/tests/data/test1967
@@ -3,20 +3,11 @@
 <info>
 <keywords>
 HTTP
-HSTS
+urlapi
 </keywords>
 </info>
 
-# Server-side
-<reply>
-</reply>
-
-# Client-side
 <client>
-<features>
-HSTS
-http
-</features>
 
 <name>
 curl_url_set() a URL without guessing a scheme

--- a/tests/data/test1967
+++ b/tests/data/test1967
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HSTS
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<features>
+HSTS
+http
+</features>
+
+<name>
+curl_url_set() a URL without guessing a scheme
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<command>
+http://%HOSTIP:%NOLISTENPORT/not-there/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<stdout mode="text">
+URL http://a.b/x
+</stdout>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -108,7 +108,7 @@ TESTS_C = \
   lib1940.c                                         lib1945.c \
   lib1947.c lib1948.c \
   lib1955.c lib1956.c lib1957.c lib1958.c lib1959.c lib1960.c \
-  lib1964.c lib1965.c                                         lib1970.c \
+  lib1964.c lib1965.c           lib1967.c                     lib1970.c \
   lib1971.c lib1972.c lib1973.c lib1974.c lib1975.c lib1977.c lib1978.c \
   lib2023.c lib2032.c lib2082.c \
   lib2301.c lib2302.c lib2304.c           lib2306.c lib2308.c lib2309.c \

--- a/tests/libtest/lib1967.c
+++ b/tests/libtest/lib1967.c
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+static CURLcode test_lib1967(const char *URL)
+{
+  CURLU *u = curl_url();
+  (void)URL;
+  if(u) {
+    char *url;
+    curl_url_set(u, CURLUPART_URL, "a.b", CURLU_GUESS_SCHEME);
+    curl_url_set(u, CURLUPART_URL, "/x", CURLU_NO_GUESS_SCHEME);
+
+    if(!curl_url_get(u, CURLUPART_URL, &url, 0)) {
+      curl_mprintf("URL %s\n", url);
+      curl_free(url);
+    }
+    curl_url_cleanup(u);
+  }
+  return CURLE_OK;
+}


### PR DESCRIPTION
Verified by test 1967

Reported-by: Joshua Rogers