### PR TITLE
KNOWN_BUGS.md: remove fixed GnuTLS <-> OpenSSL incompat bug

### DIFF
--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -25,14 +25,6 @@ instead seems to trigger a crash.
 
 See [curl issue 17626](https://github.com/curl/curl/issues/17626)
 
-## Client cert handling with Issuer `DN` differs between backends
-
-When the specified client certificate does not match any of the
-server-specified `DN` fields, the OpenSSL and GnuTLS backends behave
-differently. The GitHub discussion may contain a solution.
-
-See [curl issue 1411](https://github.com/curl/curl/issues/1411)
-
 ## Client cert (MTLS) issues with Schannel
 
 See [curl issue 3145](https://github.com/curl/curl/issues/3145)


### PR DESCRIPTION
The entry is about GnuTLS not sending the client cert when it doesn't match the `DN` the server requested.  OpenSSL does the opposite.

The issue was already fixed by #4958 and removed from KNOWN_BUGS, but it was added back to the list by #16677, seemingly by mistake.

The issue is still fixed for GnuTLS >= 3.5.0.
As curl only supports GnuTLS >= 3.6.5, remove the bug entry from KNOWN_BUGS.md

Fixes #21720