### PR TITLE
schannel: error on TLS 1.3-only with cipher list

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -654,6 +654,11 @@ static CURLcode acquire_sspi_handle(struct Curl_cfilter *cf,
 
     if(ciphers) {
       if((enabled_protocols & SP_PROT_TLS1_3_CLIENT)) {
+        if(!(enabled_protocols & ~SP_PROT_TLS1_3_CLIENT)) {
+          failf(data, "schannel: TLS 1.3 is not supported with a cipher list; "
+                "remove the cipher list or allow a lower TLS version");
+          return CURLE_SSL_CONNECT_ERROR;
+        }
         infof(data, "schannel: WARNING: This version of Schannel "
               "negotiates a less-secure TLS version than TLS 1.3 because the "
               "user set an algorithm cipher list.");


### PR DESCRIPTION
The legacy SCHANNEL_CRED path cannot negotiate TLS 1.3. When TLS 1.3 is the only enabled protocol and a cipher list is set, fail instead of silently downgrading to TLS 1.2.

Closes #21702