### PR TITLE
cf-socket: set scope_id for IPv6 link-local addresses

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -321,7 +321,7 @@ static uint32_t get_scope_id(struct Curl_easy *data,
      * NOTE: On multi-homed hosts with several interfaces having
      * link-local addresses, this picks the first one found, which
      * may not be the correct outgoing interface. */
-#ifdef HAVE_GETIFADDRS
+#if defined(HAVE_GETIFADDRS) && defined(HAVE_NET_IF_H)
     struct ifaddrs *ifa, *ifa_list;
     if(getifaddrs(&ifa_list) == 0) {
       for(ifa = ifa_list; ifa; ifa = ifa->ifa_next) {
@@ -341,7 +341,7 @@ static uint32_t get_scope_id(struct Curl_easy *data,
       }
       freeifaddrs(ifa_list);
     }
-#endif /* HAVE_GETIFADDRS */
+#endif /* HAVE_GETIFADDRS && HAVE_NET_IF_H */
   }
   return scope_id;
 }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -44,6 +44,12 @@
 #include <arpa/inet.h>
 #endif
 
+#ifdef HAVE_IFADDRS_H
+#include <ifaddrs.h>
+#endif
+#ifdef HAVE_NET_IF_H
+#include <net/if.h>
+#endif
 #ifdef __VMS
 #include <in.h>
 #include <inet.h>
@@ -367,9 +373,42 @@ static CURLcode socket_open(struct Curl_easy *data,
 #endif
 
 #if defined(USE_IPV6) && defined(HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID)
-  if(data->conn->scope_id && (addr->family == AF_INET6)) {
+  if(addr->family == AF_INET6) {
     struct sockaddr_in6 * const sa6 = (void *)&addr->curl_sa_addr;
-    sa6->sin6_scope_id = data->conn->scope_id;
+    uint32_t scope_id = 0;
+    /* sa6 was initialized via memcpy in Curl_socket_addr_from_ai,
+       but clang static analyzer cannot see that across the call */
+    if(data->conn->scope_id)
+      scope_id = data->conn->scope_id;
+    else {
+      /* NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Assign) */
+      scope_id = sa6->sin6_scope_id;
+      if(!scope_id &&
+         IN6_IS_ADDR_LINKLOCAL(&sa6->sin6_addr)) {
+        /* The resolver did not set scope_id for this link-local address.
+         * Try to determine it from the system's network interfaces.
+         * Without a scope_id, connect() to a link-local address fails
+         * with EINVAL on Linux. */
+#ifdef HAVE_GETIFADDRS
+        struct ifaddrs *ifa, *ifa_list;
+        if(getifaddrs(&ifa_list) == 0) {
+          for(ifa = ifa_list; ifa; ifa = ifa->ifa_next) {
+            if(ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6 &&
+               (ifa->ifa_flags & IFF_UP) &&
+               !(ifa->ifa_flags & IFF_LOOPBACK)) {
+              struct sockaddr_in6 *s6 = (void *)ifa->ifa_addr;
+              if(IN6_IS_ADDR_LINKLOCAL(&s6->sin6_addr) && s6->sin6_scope_id) {
+                scope_id = s6->sin6_scope_id;
+                break;
+              }
+            }
+          }
+          freeifaddrs(ifa_list);
+        }
+#endif /* HAVE_GETIFADDRS */
+      }
+    }
+    sa6->sin6_scope_id = scope_id;
   }
 #endif
   return CURLE_OK;
@@ -1091,6 +1130,15 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   else
 #endif
     infof(data, "  Trying %s:%d...", ctx->ip.remote_ip, ctx->ip.remote_port);
+#if defined(USE_IPV6) && defined(HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID)
+  if(ctx->addr.family == AF_INET6) {
+    struct sockaddr_in6 *sa6 = (void *)&ctx->addr.curl_sa_addr;
+    if(sa6->sin6_scope_id)
+      infof(data, "connect to [%s]:%d scope_id=%lu",
+            ctx->ip.remote_ip, ctx->ip.remote_port,
+            (unsigned long)sa6->sin6_scope_id);
+  }
+#endif
 
 #ifdef USE_IPV6
   is_tcp = (ctx->addr.family == AF_INET ||

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -304,6 +304,49 @@ int Curl_sock_nosigpipe(curl_socket_t sockfd)
 }
 #endif /* USE_SO_NOSIGPIPE */
 
+#if defined(USE_IPV6) && defined(HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID)
+static uint32_t get_scope_id(struct Curl_easy *data,
+                             struct sockaddr_in6 *sa6)
+{
+  uint32_t scope_id = 0;
+  if(data->conn->scope_id)
+    return data->conn->scope_id;
+  /* NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Assign) */
+  scope_id = sa6->sin6_scope_id;
+  if(!scope_id && IN6_IS_ADDR_LINKLOCAL(&sa6->sin6_addr)) {
+    /* The resolver did not set scope_id for this link-local address.
+     * Try to determine it from the system's network interfaces.
+     * Without a scope_id, connect() to a link-local address fails
+     * with EINVAL on Linux.
+     * NOTE: On multi-homed hosts with several interfaces having
+     * link-local addresses, this picks the first one found, which
+     * may not be the correct outgoing interface. */
+#ifdef HAVE_GETIFADDRS
+    struct ifaddrs *ifa, *ifa_list;
+    if(getifaddrs(&ifa_list) == 0) {
+      for(ifa = ifa_list; ifa; ifa = ifa->ifa_next) {
+        if(ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6 &&
+           (ifa->ifa_flags & IFF_UP) &&
+           !(ifa->ifa_flags & IFF_LOOPBACK)) {
+          struct sockaddr_in6 *s6 = (void *)ifa->ifa_addr;
+          if(IN6_IS_ADDR_LINKLOCAL(&s6->sin6_addr) && s6->sin6_scope_id) {
+            scope_id = s6->sin6_scope_id;
+            infof(data,
+                  "determined scope_id=%lu for link-local address "
+                  "from local interface",
+                  (unsigned long)scope_id);
+            break;
+          }
+        }
+      }
+      freeifaddrs(ifa_list);
+    }
+#endif /* HAVE_GETIFADDRS */
+  }
+  return scope_id;
+}
+#endif
+
 static CURLcode socket_open(struct Curl_easy *data,
                             struct Curl_sockaddr_ex *addr,
                             curl_socket_t *sockfd)
@@ -375,40 +418,7 @@ static CURLcode socket_open(struct Curl_easy *data,
 #if defined(USE_IPV6) && defined(HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID)
   if(addr->family == AF_INET6) {
     struct sockaddr_in6 * const sa6 = (void *)&addr->curl_sa_addr;
-    uint32_t scope_id = 0;
-    /* sa6 was initialized via memcpy in Curl_socket_addr_from_ai,
-       but clang static analyzer cannot see that across the call */
-    if(data->conn->scope_id)
-      scope_id = data->conn->scope_id;
-    else {
-      /* NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Assign) */
-      scope_id = sa6->sin6_scope_id;
-      if(!scope_id &&
-         IN6_IS_ADDR_LINKLOCAL(&sa6->sin6_addr)) {
-        /* The resolver did not set scope_id for this link-local address.
-         * Try to determine it from the system's network interfaces.
-         * Without a scope_id, connect() to a link-local address fails
-         * with EINVAL on Linux. */
-#ifdef HAVE_GETIFADDRS
-        struct ifaddrs *ifa, *ifa_list;
-        if(getifaddrs(&ifa_list) == 0) {
-          for(ifa = ifa_list; ifa; ifa = ifa->ifa_next) {
-            if(ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET6 &&
-               (ifa->ifa_flags & IFF_UP) &&
-               !(ifa->ifa_flags & IFF_LOOPBACK)) {
-              struct sockaddr_in6 *s6 = (void *)ifa->ifa_addr;
-              if(IN6_IS_ADDR_LINKLOCAL(&s6->sin6_addr) && s6->sin6_scope_id) {
-                scope_id = s6->sin6_scope_id;
-                break;
-              }
-            }
-          }
-          freeifaddrs(ifa_list);
-        }
-#endif /* HAVE_GETIFADDRS */
-      }
-    }
-    sa6->sin6_scope_id = scope_id;
+    sa6->sin6_scope_id = get_scope_id(data, sa6);
   }
 #endif
   return CURLE_OK;
@@ -1125,20 +1135,24 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
     (void)setsockopt(ctx->sock, IPPROTO_IPV6, IPV6_V6ONLY,
                      (void *)&on, sizeof(on));
 #endif
-    infof(data, "  Trying [%s]:%d...", ctx->ip.remote_ip, ctx->ip.remote_port);
+#ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+    {
+      struct sockaddr_in6 *sa6 = (void *)&ctx->addr.curl_sa_addr;
+      if(sa6->sin6_scope_id)
+        infof(data, "  Trying [%s]:%d scope_id=%lu...",
+              ctx->ip.remote_ip, ctx->ip.remote_port,
+              (unsigned long)sa6->sin6_scope_id);
+      else
+#endif
+        infof(data, "  Trying [%s]:%d...",
+              ctx->ip.remote_ip, ctx->ip.remote_port);
+#ifdef HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+    }
+#endif
   }
   else
 #endif
     infof(data, "  Trying %s:%d...", ctx->ip.remote_ip, ctx->ip.remote_port);
-#if defined(USE_IPV6) && defined(HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID)
-  if(ctx->addr.family == AF_INET6) {
-    struct sockaddr_in6 *sa6 = (void *)&ctx->addr.curl_sa_addr;
-    if(sa6->sin6_scope_id)
-      infof(data, "connect to [%s]:%d scope_id=%lu",
-            ctx->ip.remote_ip, ctx->ip.remote_port,
-            (unsigned long)sa6->sin6_scope_id);
-  }
-#endif
 
 #ifdef USE_IPV6
   is_tcp = (ctx->addr.family == AF_INET ||


### PR DESCRIPTION
Running `curl http://mydevice.local` on a network where the device resolves to an IPv6 link-local address fails with EINVAL since 8.20.0. The `connect()` syscall gets `sin6_scope_id=0` which is invalid for link-local addresses.

Traced this through the code and the scope_id from getaddrinfo is preserved correctly through the addrinfo chain. The issue is that the threaded resolver now splits A and AAAA queries into separate getaddrinfo calls. The AAAA-only call uses PF_INET6, which on some resolver configurations (notably systemd-resolved with mDNS) does not set sin6_scope_id in the result, while the old PF_UNSPEC call did.

The fix: in socket_open(), when we detect an IPv6 link-local address with scope_id still at 0, use getifaddrs() to find a non-loopback interface with a link-local address and use its scope_id. This is a fallback for when the resolver doesn't provide the scope_id.

Also added scope_id to the verbose connect output (`curl -v`) so this value is visible in logs for future debugging.

Built and tested on Linux. checksrc passes. Hard to write an automated test for this since it requires a specific network setup with mDNS and link-local addresses, but I verified the code path is reached by building with `CURL_DEBUG` and checking that the getifaddrs enumeration works correctly for the link-local case.

Let me know if I missed anything.

Closes #21669