### PR TITLE
quiche: bump cloudflare/quiche to v0.29.0, update pytest workaround

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -52,7 +52,7 @@ env:
   OPENSSL_PREV_VERSION: 3.6.2
   OPENSSL_PREV_SHA256: aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
   # renovate: datasource=github-tags depName=cloudflare/quiche versioning=semver registryUrl=https://github.com
-  QUICHE_VERSION: 0.24.7
+  QUICHE_VERSION: 0.29.0
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   WOLFSSL_VERSION: 5.9.1
   # renovate: datasource=github-tags depName=ngtcp2/nghttp3 versioning=semver registryUrl=https://github.com

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -732,10 +732,6 @@ jobs:
           mkdir -p quiche-boringssl/lib
           find quiche/target/release \( -name libcrypto.a -o -name libssl.a \) -exec ln -vnf -- '{}' quiche-boringssl/lib \;
           find quiche/target/release/build/boring-sys-*/out/boringssl/src -maxdepth 1 \( -name include \) -exec ln -vsf -- '../{}' quiche-boringssl \;
-          echo '======================='
-          pwd
-          find quiche-boringssl
-          echo '======================='
 
           # include dir
           # /home/runner/quiche-boringssl/include

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -520,7 +520,7 @@ jobs:
             LDFLAGS: -Wl,-rpath,/home/runner/quiche/target/release
             PKG_CONFIG_PATH: /home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
-              --with-openssl=/home/runner/quiche/quiche/deps/boringssl/src
+              --with-openssl=/home/runner/quiche-boringssl
               --with-quiche=/home/runner/quiche/target/release
               --with-ca-fallback
               --enable-unity
@@ -528,7 +528,7 @@ jobs:
           - name: 'quiche'
             PKG_CONFIG_PATH: /home/runner/nghttp2/build/lib/pkgconfig:/home/runner/quiche/target/release
             generate: >-
-              -DOPENSSL_ROOT_DIR=/home/runner/quiche/quiche/deps/boringssl/src
+              -DOPENSSL_ROOT_DIR=/home/runner/quiche-boringssl
               -DUSE_QUICHE=ON
               -DCURL_CA_FALLBACK=ON
 
@@ -728,14 +728,15 @@ jobs:
           cd quiche
           cargo build -v --package quiche --release --features ffi,pkg-config-meta,qlog --verbose
           ln -s libquiche.so target/release/libquiche.so.0
-          mkdir -p -v quiche/deps/boringssl/src/lib
-          find target/release \( -name libcrypto.a -o -name libssl.a \) -exec ln -vnf -- '{}' quiche/deps/boringssl/src/lib \;
-          find target/release/build/boring-sys-*/out/boringssl/src -maxdepth 1 \( -name include \) -exec ln -vsf -- '../../../../{}' quiche/deps/boringssl/src \;
+          cd ..
+          mkdir -p quiche-boringssl/lib
+          find quiche/target/release \( -name libcrypto.a -o -name libssl.a \) -exec ln -vnf -- '{}' quiche-boringssl/lib \;
+          find quiche/target/release/build/boring-sys-*/out/boringssl/src -maxdepth 1 \( -name include \) -exec ln -vsf -- '../{}' quiche-boringssl \;
 
           # include dir
-          # /home/runner/quiche/quiche/deps/boringssl/src/include
+          # /home/runner/quiche-boringssl/include
           # lib dir
-          # /home/runner/quiche/quiche/deps/boringssl/src/lib
+          # /home/runner/quiche-boringssl/lib
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -728,8 +728,9 @@ jobs:
           cd quiche
           cargo build -v --package quiche --release --features ffi,pkg-config-meta,qlog --verbose
           ln -s libquiche.so target/release/libquiche.so.0
-          mkdir -v quiche/deps/boringssl/src/lib
+          mkdir -p -v quiche/deps/boringssl/src/lib
           find target/release \( -name libcrypto.a -o -name libssl.a \) -exec ln -vnf -- '{}' quiche/deps/boringssl/src/lib \;
+          find target/release/build/boring-sys-*/out/boringssl/src -maxdepth 1 \( -name include \) -exec ln -vsf -- '../../../../{}' quiche/deps/boringssl/src \;
 
           # include dir
           # /home/runner/quiche/quiche/deps/boringssl/src/include

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -726,10 +726,6 @@ jobs:
           cd ~
           git clone --quiet --depth 1 --branch "${QUICHE_VERSION}" --recursive https://github.com/cloudflare/quiche
           cd quiche
-          #### Work-around https://github.com/curl/curl/issues/7927 #######
-          #### See https://github.com/alexcrichton/cmake-rs/issues/131 ####
-          sed -i -e 's/cmake = "0.1"/cmake = "=0.1.45"/' quiche/Cargo.toml
-
           cargo build -v --package quiche --release --features ffi,pkg-config-meta,qlog --verbose
           ln -s libquiche.so target/release/libquiche.so.0
           mkdir -v quiche/deps/boringssl/src/lib

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -732,6 +732,10 @@ jobs:
           mkdir -p quiche-boringssl/lib
           find quiche/target/release \( -name libcrypto.a -o -name libssl.a \) -exec ln -vnf -- '{}' quiche-boringssl/lib \;
           find quiche/target/release/build/boring-sys-*/out/boringssl/src -maxdepth 1 \( -name include \) -exec ln -vsf -- '../{}' quiche-boringssl \;
+          echo '======================='
+          pwd
+          find quiche-boringssl
+          echo '======================='
 
           # include dir
           # /home/runner/quiche-boringssl/include

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -43,7 +43,7 @@ class TestErrors:
     @pytest.mark.parametrize("proto", Env.http_protos())
     def test_05_01_partial_1(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and env.curl_uses_lib('quiche') and \
-                not env.curl_lib_version_at_least('quiche', '0.24.8'):
+                not env.curl_lib_version_at_least('quiche', '0.29.1'):
             pytest.skip("quiche issue #2277 not fixed")
         count = 1
         curl = CurlClient(env=env)
@@ -64,7 +64,7 @@ class TestErrors:
     @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_05_02_partial_20(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and env.curl_uses_lib('quiche') and \
-                not env.curl_lib_version_at_least('quiche', '0.24.8'):
+                not env.curl_lib_version_at_least('quiche', '0.29.1'):
             pytest.skip("quiche issue #2277 not fixed")
         count = 20
         curl = CurlClient(env=env)


### PR DESCRIPTION
Also:
- drop no longer necessary quiche build workaround.
- update build for boringssl's new location (since v0.29.0, it's no
  longer vendored) within the quiche tree.
- move boringssl install dir out of quiche tree, and shorten it.

Ref: https://github.com/cloudflare/quiche/issues/2277
Ref: https://github.com/cloudflare/quiche/pull/2278
Ref: #21620
