### PR TITLE
ldap: switch off chasing referrals

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -315,6 +315,9 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 #endif
   ldap_set_option(server, LDAP_OPT_PROTOCOL_VERSION, &ldap_proto);
 
+  /* Do not chase referrals. */
+  ldap_set_option(server, LDAP_OPT_REFERRALS, LDAP_OPT_OFF);
+
   if(ldap_ssl) {
 #ifdef HAVE_LDAP_SSL
 #ifdef USE_WIN32_LDAP


### PR DESCRIPTION
It is switched off in the OpenLDAP backend, so we should do the same here.

Not an LDAP expert here: someone could rely on the libldap version to work like that. But I still think that both ldap implementations should behave the same in this regard.