### PR TITLE
KNOWN_BUGS: remove stale Threads::Threads entry

### DIFF
--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -490,10 +490,6 @@ Something in the SONAME generation seems to be wrong in the cmake build.
 
 [curl issue 11158](https://github.com/curl/curl/issues/11158)
 
-## uses `-lpthread` instead of `Threads::Threads`
-
-See [curl issue 6166](https://github.com/curl/curl/issues/6166)
-
 ## generated `.pc` file contains strange entries
 
 The `Libs.private` field of the generated `.pc` file contains `-lgcc -lgcc_s


### PR DESCRIPTION
The old CMake bug about exporting -lpthread instead of Threads::Threads 
no longer matches current master. As of
2d546d239ecd455b6459e68b85ef8d4b045c0a00 ("cmake: use Threads::Threads
imported target for POSIX Threads"), the build now uses Threads::Threads
and the generated CMake package config resolves the dependency
explicitly, so this KNOWN_BUGS entry is stale.

Ref: 2d546d239ecd455b6459e68b85ef8d4b045c0a00 #21163
