### PR TITLE
mailmap: cmeister2@gmail is primary for Max Dymond

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -84,8 +84,8 @@ Tobias Nyholm <tobias.nyholm@gmail.com>
 Timur Artikov <t.artikov@2gis.ru>
 Michał Antoniak <47522782+MAntoniak@users.noreply.github.com>
 Gleb Ivanovsky <gl.ivanovsky@gmail.com>
-Max Dymond <max.dymond@microsoft.com> <max.dymond@metaswitch.com>
-Max Dymond <max.dymond@microsoft.com> <cmeister2@gmail.com>
+Max Dymond <cmeister2@gmail.com> <max.dymond@metaswitch.com>
+Max Dymond <cmeister2@gmail.com> <max.dymond@microsoft.com>
 Abhinav Singh <theawless@gmail.com>
 Malik Idrees Hasan Khan <77000356+MalikIdreesHasanKhan@users.noreply.github.com>
 Yongkang Huang <hyk68691@hotmail.com>


### PR DESCRIPTION
I'd rather all my commits be attributed to cmeister2@gmail.com instead of anything else; especially not my old Microsoft email address!