### PR TITLE
schannel: check `schannel_sha256sum()` success, and more

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2674,7 +2674,7 @@ static CURLcode schannel_checksum(const unsigned char *input,
 
   off = 0;
   while(off < inputlen) {
-    DWORD chunk = (DWORD)CURLMIN(inputlen - off, (size_t)0xffffffffUL);
+    DWORD chunk = (DWORD)CURLMIN(inputlen - off, 0xffffffffUL);
     if(!CryptHashData(hHash, input + off, chunk, 0))
       goto out;
     off += chunk;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2804,7 +2804,6 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   struct schannel_cert_share *share;
   unsigned char digest[CURL_SHA256_DIGEST_LENGTH];
-  size_t CAinfo_blob_size = 0;
   char *CAfile = NULL;
 
   DEBUGASSERT(multi);
@@ -2853,12 +2852,13 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
 
   if(ca_info_blob) {
     memcpy(share->CAinfo_blob_digest, digest, sizeof(digest));
-    CAinfo_blob_size = ca_info_blob->len;
+    share->CAinfo_blob_size = ca_info_blob->len;
   }
+  else
+    share->CAinfo_blob_size = 0;
 
   share->time = curlx_now();
   share->cert_store = cert_store;
-  share->CAinfo_blob_size = CAinfo_blob_size;
   share->CAfile = CAfile;
   return TRUE;
 }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2640,15 +2640,21 @@ static CURLcode schannel_random(struct Curl_easy *data,
   return Curl_win32_random(entropy, length);
 }
 
-static void schannel_checksum(const unsigned char *input,
-                              size_t inputlen,
-                              unsigned char *checksum,
-                              size_t checksumlen,
-                              DWORD provType,
-                              const unsigned int algId)
+static CURLcode schannel_checksum(const unsigned char *input,
+                                  size_t inputlen,
+                                  unsigned char *checksum,
+                                  size_t checksumlen,
+                                  DWORD provType,
+                                  const unsigned int algId)
 {
+  CURLcode result = CURLE_BAD_FUNCTION_ARGUMENT;
+
   HCRYPTPROV hProv = 0;
   HCRYPTHASH hHash = 0;
+
+  DWORD cbHashSize = 0;
+  DWORD dwHashSizeLen;
+  DWORD dwChecksumLen;
 
   /* since this can fail in multiple ways, zero memory first so we never
    * return old data
@@ -2657,37 +2663,38 @@ static void schannel_checksum(const unsigned char *input,
 
   if(!CryptAcquireContext(&hProv, NULL, NULL, provType,
                           CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
-    return; /* failed */
+    goto out;
 
-  do {
-    DWORD cbHashSize = 0;
-    DWORD dwHashSizeLen = (DWORD)sizeof(cbHashSize);
-    DWORD dwChecksumLen = (DWORD)checksumlen;
+  dwHashSizeLen = (DWORD)sizeof(cbHashSize);
+  dwChecksumLen = (DWORD)checksumlen;
 
-    if(!CryptCreateHash(hProv, algId, 0, 0, &hHash))
-      break; /* failed */
+  if(!CryptCreateHash(hProv, algId, 0, 0, &hHash))
+    goto out;
 
-    if(!CryptHashData(hHash, input, (DWORD)inputlen, 0))
-      break; /* failed */
+  if(!CryptHashData(hHash, input, (DWORD)inputlen, 0))
+    goto out;
 
-    /* get hash size */
-    if(!CryptGetHashParam(hHash, HP_HASHSIZE, (BYTE *)&cbHashSize,
-                          &dwHashSizeLen, 0))
-      break; /* failed */
+  /* get hash size */
+  if(!CryptGetHashParam(hHash, HP_HASHSIZE, (BYTE *)&cbHashSize,
+                        &dwHashSizeLen, 0))
+    goto out;
 
-    /* check hash size */
-    if(checksumlen < cbHashSize)
-      break; /* failed */
+  /* check hash size */
+  if(checksumlen < cbHashSize)
+    goto out;
 
-    if(CryptGetHashParam(hHash, HP_HASHVAL, checksum, &dwChecksumLen, 0))
-      break; /* failed */
-  } while(0);
+  if(CryptGetHashParam(hHash, HP_HASHVAL, checksum, &dwChecksumLen, 0) &&
+     checksumlen == dwChecksumLen)
+    result = CURLE_OK;
 
+out:
   if(hHash)
     CryptDestroyHash(hHash);
 
   if(hProv)
     CryptReleaseContext(hProv, 0);
+
+  return result;
 }
 
 static CURLcode schannel_sha256sum(const unsigned char *input,
@@ -2695,9 +2702,8 @@ static CURLcode schannel_sha256sum(const unsigned char *input,
                                    unsigned char *sha256sum,
                                    size_t sha256len)
 {
-  schannel_checksum(input, inputlen, sha256sum, sha256len,
-                    PROV_RSA_AES, CALG_SHA_256);
-  return CURLE_OK;
+  return schannel_checksum(input, inputlen, sha256sum, sha256len,
+                           PROV_RSA_AES, CALG_SHA_256);
 }
 
 static void *schannel_get_internals(struct ssl_connect_data *connssl,
@@ -2755,10 +2761,11 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
     if(share->CAinfo_blob_size != ca_info_blob->len) {
       return NULL;
     }
-    schannel_sha256sum((const unsigned char *)ca_info_blob->data,
-                       ca_info_blob->len,
-                       info_blob_digest,
-                       CURL_SHA256_DIGEST_LENGTH);
+    if(schannel_sha256sum((const unsigned char *)ca_info_blob->data,
+                          ca_info_blob->len,
+                          info_blob_digest,
+                          CURL_SHA256_DIGEST_LENGTH))
+      return NULL;
     if(memcmp(share->CAinfo_blob_digest, info_blob_digest,
               CURL_SHA256_DIGEST_LENGTH)) {
       return NULL;
@@ -2823,10 +2830,13 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   }
 
   if(ca_info_blob) {
-    schannel_sha256sum((const unsigned char *)ca_info_blob->data,
-                       ca_info_blob->len,
-                       share->CAinfo_blob_digest,
-                       CURL_SHA256_DIGEST_LENGTH);
+    if(schannel_sha256sum((const unsigned char *)ca_info_blob->data,
+                          ca_info_blob->len,
+                          share->CAinfo_blob_digest,
+                          CURL_SHA256_DIGEST_LENGTH)) {
+      curlx_free(share);
+      return FALSE;
+    }
     CAinfo_blob_size = ca_info_blob->len;
   }
   else {

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2830,13 +2830,12 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   }
 
   if(ca_info_blob) {
+    unsigned char digest[CURL_SHA256_DIGEST_LENGTH];
     if(schannel_sha256sum((const unsigned char *)ca_info_blob->data,
-                          ca_info_blob->len,
-                          share->CAinfo_blob_digest,
-                          CURL_SHA256_DIGEST_LENGTH)) {
-      curlx_free(share);
+                          ca_info_blob->len, digest, sizeof(digest))) {
       return FALSE;
     }
+    memcpy(share->CAinfo_blob_digest, digest, sizeof(digest));
     CAinfo_blob_size = ca_info_blob->len;
   }
   else {

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2652,6 +2652,8 @@ static CURLcode schannel_checksum(const unsigned char *input,
   HCRYPTPROV hProv = 0;
   HCRYPTHASH hHash = 0;
 
+  size_t off;
+
   DWORD cbHashSize;
   DWORD dwHashSizeLen;
   DWORD dwChecksumLen;
@@ -2668,8 +2670,13 @@ static CURLcode schannel_checksum(const unsigned char *input,
   if(!CryptCreateHash(hProv, algId, 0, 0, &hHash))
     goto out;
 
-  if(!CryptHashData(hHash, input, (DWORD)inputlen, 0))
-    goto out;
+  off = 0;
+  while(off < inputlen) {
+    DWORD chunk = (DWORD)CURLMIN(inputlen - off, (size_t)0xffffffffUL);
+    if(!CryptHashData(hHash, input + off, chunk, 0))
+      goto out;
+    off += chunk;
+  }
 
   /* get hash size */
   cbHashSize = 0;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2683,8 +2683,7 @@ static CURLcode schannel_checksum(const unsigned char *input,
   if(checksumlen < cbHashSize)
     goto out;
 
-  if(CryptGetHashParam(hHash, HP_HASHVAL, checksum, &dwChecksumLen, 0) &&
-     checksumlen == dwChecksumLen)
+  if(CryptGetHashParam(hHash, HP_HASHVAL, checksum, &dwChecksumLen, 0))
     result = CURLE_OK;
 
 out:

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2652,7 +2652,7 @@ static CURLcode schannel_checksum(const unsigned char *input,
   HCRYPTPROV hProv = 0;
   HCRYPTHASH hHash = 0;
 
-  DWORD cbHashSize = 0;
+  DWORD cbHashSize;
   DWORD dwHashSizeLen;
   DWORD dwChecksumLen;
 
@@ -2665,9 +2665,6 @@ static CURLcode schannel_checksum(const unsigned char *input,
                           CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
     goto out;
 
-  dwHashSizeLen = (DWORD)sizeof(cbHashSize);
-  dwChecksumLen = (DWORD)checksumlen;
-
   if(!CryptCreateHash(hProv, algId, 0, 0, &hHash))
     goto out;
 
@@ -2675,15 +2672,19 @@ static CURLcode schannel_checksum(const unsigned char *input,
     goto out;
 
   /* get hash size */
+  cbHashSize = 0;
+  dwHashSizeLen = (DWORD)sizeof(cbHashSize);
   if(!CryptGetHashParam(hHash, HP_HASHSIZE, (BYTE *)&cbHashSize,
                         &dwHashSizeLen, 0))
     goto out;
 
-  /* check hash size */
+  /* check if hash fits into the return buffer */
   if(checksumlen < cbHashSize)
     goto out;
 
-  if(CryptGetHashParam(hHash, HP_HASHVAL, checksum, &dwChecksumLen, 0))
+  dwChecksumLen = (DWORD)checksumlen;
+  if(CryptGetHashParam(hHash, HP_HASHVAL, checksum, &dwChecksumLen, 0) &&
+     dwChecksumLen == cbHashSize)
     result = CURLE_OK;
 
 out:

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2803,6 +2803,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   struct Curl_multi *multi = data->multi;
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   struct schannel_cert_share *share;
+  unsigned char digest[CURL_SHA256_DIGEST_LENGTH];
   size_t CAinfo_blob_size = 0;
   char *CAfile = NULL;
 
@@ -2812,12 +2813,26 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
     return FALSE;
   }
 
+  if(ca_info_blob) {
+    if(schannel_sha256sum((const unsigned char *)ca_info_blob->data,
+                          ca_info_blob->len, digest, sizeof(digest))) {
+      return FALSE;
+    }
+  }
+  else if(conn_config->CAfile) {
+    CAfile = curlx_strdup(conn_config->CAfile);
+    if(!CAfile) {
+      return FALSE;
+    }
+  }
+
   share = Curl_hash_pick(&multi->proto_hash,
                          CURL_UNCONST(MPROTO_SCHANNEL_CERT_SHARE_KEY),
                          sizeof(MPROTO_SCHANNEL_CERT_SHARE_KEY) - 1);
   if(!share) {
     share = curlx_calloc(1, sizeof(*share));
     if(!share) {
+      curlx_free(CAfile);
       return FALSE;
     }
     if(!Curl_hash_add2(&multi->proto_hash,
@@ -2825,25 +2840,8 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
                        sizeof(MPROTO_SCHANNEL_CERT_SHARE_KEY) - 1,
                        share, schannel_cert_share_free)) {
       curlx_free(share);
+      curlx_free(CAfile);
       return FALSE;
-    }
-  }
-
-  if(ca_info_blob) {
-    unsigned char digest[CURL_SHA256_DIGEST_LENGTH];
-    if(schannel_sha256sum((const unsigned char *)ca_info_blob->data,
-                          ca_info_blob->len, digest, sizeof(digest))) {
-      return FALSE;
-    }
-    memcpy(share->CAinfo_blob_digest, digest, sizeof(digest));
-    CAinfo_blob_size = ca_info_blob->len;
-  }
-  else {
-    if(conn_config->CAfile) {
-      CAfile = curlx_strdup(conn_config->CAfile);
-      if(!CAfile) {
-        return FALSE;
-      }
     }
   }
 
@@ -2852,6 +2850,11 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
     CertCloseStore(share->cert_store, 0);
   }
   curlx_free(share->CAfile);
+
+  if(ca_info_blob) {
+    memcpy(share->CAinfo_blob_digest, digest, sizeof(digest));
+    CAinfo_blob_size = ca_info_blob->len;
+  }
 
   share->time = curlx_now();
   share->cert_store = cert_store;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2647,7 +2647,7 @@ static CURLcode schannel_checksum(const unsigned char *input,
                                   DWORD provType,
                                   const unsigned int algId)
 {
-  CURLcode result = CURLE_BAD_FUNCTION_ARGUMENT;
+  CURLcode result = CURLE_FAILED_INIT;
 
   HCRYPTPROV hProv = 0;
   HCRYPTHASH hHash = 0;
@@ -2669,6 +2669,8 @@ static CURLcode schannel_checksum(const unsigned char *input,
 
   if(!CryptCreateHash(hProv, algId, 0, 0, &hHash))
     goto out;
+
+  result = CURLE_BAD_FUNCTION_ARGUMENT;
 
   off = 0;
   while(off < inputlen) {


### PR DESCRIPTION
Also:
- support 4GiB+ SHA-256 digest inputs.
- check `CryptGetHashParam()` output size.
- avoid overwriting existing digest when new digest calculation fails.
- avoid adding digest hash element on failure.

---

https://github.com/curl/curl/pull/21739/files?w=1
