### PR TITLE
GnuTLS, require 3.7.2 for earlydata

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -72,7 +72,7 @@ static void tls_log_func(int level, const char *str)
 #endif
 
 #undef CURL_GNUTLS_EARLY_DATA
-#if GNUTLS_VERSION_NUMBER >= 0x03060d
+#if GNUTLS_VERSION_NUMBER >= 0x030702
 #define CURL_GNUTLS_EARLY_DATA
 #endif
 

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -523,7 +523,7 @@ class Env:
     @staticmethod
     def curl_can_early_data() -> bool:
         if Env.curl_uses_lib('gnutls'):
-            return Env.curl_lib_version_at_least('gnutls', '3.6.13')
+            return Env.curl_lib_version_at_least('gnutls', '3.7.2')
         return Env.curl_uses_any_libs(['wolfssl', 'quictls', 'openssl'])
 
     @staticmethod


### PR DESCRIPTION
Since all API features we need for TLSv1.3 earlydata support do exist only from version 3.7.2 onwards, make that the minimal version required.

refs #21750