### PR TITLE
GHA: fix locale tests on macOS, extend to verify test 1981

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,7 +89,7 @@ jobs:
           - name: 'libressl krb5'
             image: ubuntu-24.04-arm
             install_packages: libidn2-dev libnghttp2-dev libldap-dev libkrb5-dev
-            install_steps: libressl-c-arm pytest codeset-test
+            install_steps: libressl-c-arm pytest codeset-test1
             LDFLAGS: -Wl,-rpath,/home/runner/libressl/lib
             configure: --with-openssl=/home/runner/libressl --with-gssapi --enable-debug
 
@@ -110,7 +110,7 @@ jobs:
           - name: 'libressl clang'
             image: ubuntu-24.04-arm
             install_packages: clang
-            install_steps: libressl-c-arm
+            install_steps: libressl-c-arm codeset-test2
             CC: clang
             LDFLAGS: -Wl,-rpath,/home/runner/libressl/lib
             configure: --with-openssl=/home/runner/libressl --enable-debug
@@ -953,11 +953,14 @@ jobs:
             TFLAGS+=' --buildinfo'  # only test-ci sets this by default, set it manually for test-torture
           fi
           [ -f ~/venv/bin/activate ] && source ~/venv/bin/activate
-          if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test'* ]]; then
+          if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test1'* ]]; then
             locale || true
             export LC_ALL=C
             export LC_CTYPE=C
             export LC_NUMERIC=fr_FR.UTF-8
+          elif [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test2'* ]]; then
+            locale || true
+            export LANG=fr_FR
           fi
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target "${TEST_TARGET}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -110,7 +110,7 @@ jobs:
           - name: 'libressl clang'
             image: ubuntu-24.04-arm
             install_packages: clang
-            install_steps: libressl-c-arm codeset-test2
+            install_steps: libressl-c-arm
             CC: clang
             LDFLAGS: -Wl,-rpath,/home/runner/libressl/lib
             configure: --with-openssl=/home/runner/libressl --enable-debug
@@ -958,9 +958,6 @@ jobs:
             export LC_ALL=C
             export LC_CTYPE=C
             export LC_NUMERIC=fr_FR.UTF-8
-          elif [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test2'* ]]; then
-            locale || true
-            export LANG=fr_FR
           fi
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target "${TEST_TARGET}"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -563,7 +563,6 @@ jobs:
           source ~/venv/bin/activate
           if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test1'* ]]; then
             locale || true
-            export LC_ALL=C
             export LC_CTYPE=C
             export LC_NUMERIC=fr_FR.UTF-8
           elif [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test2'* ]]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -574,7 +574,7 @@ jobs:
           elif [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test2'* ]]; then
             locale || true
             unset LC_ALL
-            export LANG=fr_FR
+            export LC_TIME=fr_FR
           fi
           rm -f ~/.curlrc
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -563,7 +563,12 @@ jobs:
           source ~/venv/bin/activate
           if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test1'* ]]; then
             locale || true
+            unset LANG
             unset LC_ALL
+            unset LC_COLLATE
+            unset LC_MESSAGES
+            unset LC_MONETARY
+            unset LC_TIME
             export LC_CTYPE=C
             export LC_NUMERIC=fr_FR.UTF-8
           elif [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test2'* ]]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -563,10 +563,12 @@ jobs:
           source ~/venv/bin/activate
           if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test1'* ]]; then
             locale || true
+            unset LC_ALL
             export LC_CTYPE=C
             export LC_NUMERIC=fr_FR.UTF-8
           elif [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test2'* ]]; then
             locale || true
+            unset LC_ALL
             export LANG=fr_FR
           fi
           rm -f ~/.curlrc

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -347,12 +347,13 @@ jobs:
           - name: 'mbedTLS !ldap brotli zstd MultiSSL AppleIDN'
             compiler: llvm@18
             install: brotli mbedtls zstd
-            install_steps: codeset-test
+            install_steps: codeset-test1
             generate: -DCURL_USE_MBEDTLS=ON -DCURL_DISABLE_LDAP=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls -DCURL_USE_OPENSSL=ON -DUSE_APPLE_IDN=ON -DCURL_ENABLE_NTLM=ON
 
           - name: 'GnuTLS !ldap krb5 +examples'
             compiler: clang
             install: gnutls nettle krb5
+            install_steps: codeset-test2
             generate: >-
               -DENABLE_DEBUG=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF
               -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=/opt/homebrew/opt/krb5
@@ -560,11 +561,14 @@ jobs:
             TFLAGS+=' --buildinfo'  # only test-ci sets this by default, set it manually for test-torture
           fi
           source ~/venv/bin/activate
-          if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test'* ]]; then
+          if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test1'* ]]; then
             locale || true
             export LC_ALL=C
             export LC_CTYPE=C
             export LC_NUMERIC=fr_FR.UTF-8
+          elif [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test2'* ]]; then
+            locale || true
+            export LANG=fr_FR
           fi
           rm -f ~/.curlrc
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -11,7 +11,7 @@ url
 # Client-side
 <client>
 <setenv>
-__LC_ALL=C.UTF-8
+LC_ALL=C.UTF-8
 </setenv>
 <features>
 file

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -11,7 +11,7 @@ url
 # Client-side
 <client>
 <setenv>
-LC_ALL=C.UTF-8
+__LC_ALL=C.UTF-8
 </setenv>
 <features>
 file


### PR DESCRIPTION
- fix macOS locale tests to clear existing variables.
  (Without this, the system-defined `LC_ALL` takes precedence, and
  the custom envs in CI are ignored.)

- trigger test 1981 issue by setting `LC_TIME` to non-English, on macOS.
  (On Linux it'd require explicitly installing a non-English locale, I
  skipped this for simplicity.)
  ```
  [...]
  -Time: 01/Aug/2025 08:31:43.037103 +0000 UTC[CR][LF]
  +Time: 01/ao%c3%bb/2025 08:31:43.037103 +0000 UTC[CR][LF]
  [...]
  FAIL 1981: '%time output with --write-out' HTTP, HTTP GET
  ```
  Follow-up to 90a7732d467eae7c5a59fc07c5a072970926f8c6 #21749

Follow-up to 1cc8a5235f76e744433cbf28ec98ecb972158387 #17988
Follow-up to c221c0ee5935497168c52686a9d8cc87b45bbca9 #17938

---

- [x] rebase on #21749
