### PR TITLE
fix content encoding limit failure message

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -750,9 +750,10 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
         return CURLE_OK;
       }
 
-      if(Curl_cwriter_count(data, phase) + 1 >= MAX_ENCODE_STACK) {
-        failf(data, "Reject response due to more than %d content encodings",
-              MAX_ENCODE_STACK);
+      if(Curl_cwriter_count(data, phase) >= MAX_ENCODE_STACK) {
+        failf(data, "Reject response exceeding limit of %d %s encodings",
+              MAX_ENCODE_STACK,
+              is_transfer ? "transfer" : "content");
         return CURLE_BAD_CONTENT_ENCODING;
       }
 

--- a/tests/data/test387
+++ b/tests/data/test387
@@ -51,7 +51,7 @@ Connection: TE
 61
 </errorcode>
 <stderr mode="text">
-curl: (61) Reject response due to more than 5 content encodings
+curl: (61) Reject response exceeding limit of 5 transfer encodings
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test418
+++ b/tests/data/test418
@@ -59,7 +59,7 @@ Connection: TE
 61
 </errorcode>
 <stderr mode="text">
-curl: (61) Reject response due to more than 5 content encodings
+curl: (61) Reject response exceeding limit of 5 transfer encodings
 </stderr>
 </verify>
 </testcase>


### PR DESCRIPTION
The message triggered earlier than intended and did not take the transfer/content type into account.

refs #21603