### PR TITLE
GHA: verify tarball downloads

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -393,7 +393,7 @@ jobs:
 
           for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              --output pkg.bin "https://curl.se/download/curl-${CURL_VERSION}${suffix}"
+              --output pkg.bin "https://curl.se/download/curl-${CURL_VERSION}${suffix}" \
               --output pkg.sig "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc"
             gpg $gpg_opts --verify-options show-primary-uid-only --verify pkg.sig pkg.bin
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -393,7 +393,7 @@ jobs:
 
           for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              "https://curl.se/download/curl-${CURL_VERSION}${suffix}" --output pkg.bin
-              "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc" --output pkg.sig
+              --output pkg.bin "https://curl.se/download/curl-${CURL_VERSION}${suffix}"
+              --output pkg.sig "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc"
             gpg $gpg_opts --verify-options show-primary-uid-only --verify pkg.sig pkg.bin
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -384,7 +384,7 @@ jobs:
             echo "--- Downloading from ${keyserver}..."
             if curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
                "${keyserver}pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}" \
-               | gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --import --status-fd 1; then
+               | gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --import --status-fd 1 2>&1; then
               break
             fi
           done
@@ -402,6 +402,6 @@ jobs:
               --output pkg.sig "https://curl.se/download/curl-${curl_version}${suffix}.asc"
             echo "--- Verifying ${curl_version} ${suffix}..."
             gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --verify-options show-primary-uid-only \
-              --verify pkg.sig pkg.bin
+              --verify pkg.sig pkg.bin 2>&1
             echo '---'
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -390,14 +390,17 @@ jobs:
 
       - name: 'download and verify tarballs'
         run: |
+          echo "--- Detecting latest curl tarball version..."
           curl_version="$(curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused https://curl.se/download.html \
             | grep -o -E 'curl [0-9]+\.[0-9]+\.[0-9]+' | cut -c 6-)"
 
           for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
-            echo "--- Verifyfing ${curl_version} ${suffix}:"
+            echo "--- Downloading ${curl_version} ${suffix}..."
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --output pkg.bin "https://curl.se/download/curl-${curl_version}${suffix}" \
               --output pkg.sig "https://curl.se/download/curl-${curl_version}${suffix}.asc"
+            echo "--- Verifying ${curl_version} ${suffix}..."
             gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --verify-options show-primary-uid-only \
               --verify pkg.sig pkg.bin
+            echo '---'
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -378,9 +378,9 @@ jobs:
           CURL_GPG_ID: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2
         run: |
           for keyserver in \
-              https://keyserver.ubuntu.com/ \
-              https://pgpkeys.eu/ \
-            ; do
+            https://keyserver.ubuntu.com/ \
+            https://pgpkeys.eu/ \
+          ; do
             echo "--- Downloading from ${keyserver}..."
             if curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
                "${keyserver}pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}" \

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -372,11 +372,10 @@ jobs:
     name: 'Verify tarball downloads'
     runs-on: ubuntu-slim
     timeout-minutes: 2
-    env:
-      CURL_GPG_ID: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2
-      CURL_VERSION: 8.20.0
     steps:
       - name: 'download and import GPG key'
+        env:
+          CURL_GPG_ID: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2
         run: |
           for keyserver in \
               https://keyserver.ubuntu.com/ \
@@ -389,19 +388,14 @@ jobs:
             fi
           done
 
-      - name: 'download tarballs'
-        run: |
-          for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
-            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              --output pkg.bin "https://curl.se/download/curl-${CURL_VERSION}${suffix}" \
-              --output pkg.sig "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc"
-          done
-
-      - name: 'verify tarball signatures'
+      - name: 'download and verify tarballs'
         env:
+          CURL_VERSION: 8.20.0
         run: |
           for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
             echo "--- Verifyfing ${CURL_VERSION} ${suffix}:"
-            gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --verify-options show-primary-uid-only \
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+              --output pkg.bin "https://curl.se/download/curl-${CURL_VERSION}${suffix}" \
+              --output pkg.sig "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc"
               --verify pkg.sig pkg.bin
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -372,28 +372,36 @@ jobs:
     name: 'Verify live tarball downloads'
     runs-on: ubuntu-slim
     timeout-minutes: 2
+    env:
+      CURL_GPG_ID: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2
+      CURL_VERSION: 8.20.0
     steps:
-      - name: 'via find_package OpenSSL (old cmake)'
-        env:
-          CURL_GPG_ID: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2
-          CURL_VERSION: 8.20.0
+      - name: 'download and import GPG key'
         run: |
-          gpg_opts='--batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong'
-
-          req="pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}"
           for keyserver in \
-              https://pgpkeys.eu/ \
               https://keyserver.ubuntu.com/ \
+              https://pgpkeys.eu/ \
             ; do
-            if curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused "${keyserver}${req}" | \
-               gpg $gpg_opts --import --status-fd 1; then
+            if curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+               "${keyserver}pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}" | \
+               gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --import --status-fd 1; then
               break
             fi
           done
 
+      - name: 'download tarballs'
+        run: |
           for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --output pkg.bin "https://curl.se/download/curl-${CURL_VERSION}${suffix}" \
               --output pkg.sig "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc"
-            gpg $gpg_opts --verify-options show-primary-uid-only --verify pkg.sig pkg.bin
+          done
+
+      - name: 'verify tarball signatures'
+        env:
+        run: |
+          for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
+            echo "--- Verifyfing ${CURL_VERSION} ${suffix}:"
+            gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --verify-options show-primary-uid-only \
+              --verify pkg.sig pkg.bin
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -382,20 +382,21 @@ jobs:
               https://pgpkeys.eu/ \
             ; do
             if curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-               "${keyserver}pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}" | \
-               gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --import --status-fd 1; then
+               "${keyserver}pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}" \
+               | gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --import --status-fd 1; then
               break
             fi
           done
 
       - name: 'download and verify tarballs'
-        env:
-          CURL_VERSION: 8.20.0
         run: |
+          curl_version="$(curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused https://curl.se/download.html \
+            | grep -o -E 'curl [0-9]+\.[0-9]+\.[0-9]+' | cut -c 6-)"
+
           for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
-            echo "--- Verifyfing ${CURL_VERSION} ${suffix}:"
+            echo "--- Verifyfing ${curl_version} ${suffix}:"
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
-              --output pkg.bin "https://curl.se/download/curl-${CURL_VERSION}${suffix}" \
-              --output pkg.sig "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc"
+              --output pkg.bin "https://curl.se/download/curl-${curl_version}${suffix}" \
+              --output pkg.sig "https://curl.se/download/curl-${curl_version}${suffix}.asc"
               --verify pkg.sig pkg.bin
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -397,6 +397,7 @@ jobs:
             echo "--- Verifyfing ${curl_version} ${suffix}:"
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --output pkg.bin "https://curl.se/download/curl-${curl_version}${suffix}" \
-              --output pkg.sig "https://curl.se/download/curl-${curl_version}${suffix}.asc" \
+              --output pkg.sig "https://curl.se/download/curl-${curl_version}${suffix}.asc"
+            gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --verify-options show-primary-uid-only \
               --verify pkg.sig pkg.bin
           done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -381,6 +381,7 @@ jobs:
               https://keyserver.ubuntu.com/ \
               https://pgpkeys.eu/ \
             ; do
+            echo "--- Downloading from ${keyserver}..."
             if curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
                "${keyserver}pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}" \
                | gpg --batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong --import --status-fd 1; then

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -367,3 +367,33 @@ jobs:
             export TEST_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
           fi
           ./tests/cmake/test.sh find_package ${TESTOPTS} -DCURL_USE_OPENSSL=ON
+
+  verify-live-downloads:
+    name: 'Verify live tarball downloads'
+    runs-on: ubuntu-slim
+    timeout-minutes: 2
+    steps:
+      - name: 'via find_package OpenSSL (old cmake)'
+        env:
+          CURL_GPG_ID: 27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2
+          CURL_VERSION: 8.20.0
+        run: |
+          gpg_opts='--batch --keyserver-options timeout=15 --display-charset utf-8 --keyid-format 0xlong'
+
+          req="pks/lookup?op=get&options=mr&exact=on&search=0x${CURL_GPG_ID}"
+          for keyserver in \
+              https://pgpkeys.eu/ \
+              https://keyserver.ubuntu.com/ \
+            ; do
+            if curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused "${keyserver}${req}" | \
+               gpg $gpg_opts --import --status-fd 1; then
+              break
+            fi
+          done
+
+          for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+              "https://curl.se/download/curl-${CURL_VERSION}${suffix}" --output pkg.bin
+              "https://curl.se/download/curl-${CURL_VERSION}${suffix}.asc" --output pkg.sig
+            gpg $gpg_opts --verify-options show-primary-uid-only --verify pkg.sig pkg.bin
+          done

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -368,8 +368,8 @@ jobs:
           fi
           ./tests/cmake/test.sh find_package ${TESTOPTS} -DCURL_USE_OPENSSL=ON
 
-  verify-live-downloads:
-    name: 'Verify live tarball downloads'
+  verify-tarball-downloads:
+    name: 'Verify tarball downloads'
     runs-on: ubuntu-slim
     timeout-minutes: 2
     env:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -397,6 +397,6 @@ jobs:
             echo "--- Verifyfing ${curl_version} ${suffix}:"
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --output pkg.bin "https://curl.se/download/curl-${curl_version}${suffix}" \
-              --output pkg.sig "https://curl.se/download/curl-${curl_version}${suffix}.asc"
+              --output pkg.sig "https://curl.se/download/curl-${curl_version}${suffix}.asc" \
               --verify pkg.sig pkg.bin
           done


### PR DESCRIPTION
Detect latest tarball version via the https://curl.se/downloads.html
page, download the signing key from a public keyserver then verify
source download signatures.

To ensure that public downloads are intact.
