### PR TITLE
urlapi: forbid '|' in host

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -471,7 +471,7 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
     return ipv6_parse(u, hostname, hlen);
   else {
     /* letters from the second string are not ok */
-    len = strcspn(hostname, " \r\n\t/:#?!@{}[]\\$\'\"^`*<>=;,+&()%");
+    len = strcspn(hostname, " \r\n\t/:#?!@{}[]\\$\'\"^`*<>=;,+&()%|");
     if(hlen != len)
       /* hostname with bad content */
       return CURLUE_BAD_HOSTNAME;

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -326,6 +326,7 @@ static const struct testcase get_parts_list[] = {
   {"https://user@example.net?he l lo",
    "https | user | [12] | [13] | example.net | [15] | / | he l lo | [17]",
    CURLU_ALLOW_SPACE, 0, CURLUE_OK},
+  {"https://exam|ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://exam{}[]ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://exam{ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://exam}ple.net", "", 0, 0, CURLUE_BAD_HOSTNAME},


### PR DESCRIPTION
Fixes #21744

Added `|` to the list of characters that cause an error in `hostname_check`, added a test to cover it.