### PR TITLE
gtls: use the correct return code in trace output

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2249,7 +2249,8 @@ static CURLcode gtls_recv(struct Curl_cfilter *cf,
   }
 
 out:
-  CURL_TRC_CF(data, cf, "gtls_recv(len=%zu) -> 0, %zd", blen, nread);
+  CURL_TRC_CF(data, cf, "gtls_recv(len=%zu) -> %d, %zd", blen,
+              (int)result, nread);
   return result;
 }
 


### PR DESCRIPTION
Instead of using a hard-coded zero.

Spotted by Copilot