### PR TITLE
curl_sha512_256: fix result code on error

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -145,7 +145,7 @@ static CURLcode Curl_sha512_256_update(void *context,
   Curl_sha512_256_ctx * const ctx = (Curl_sha512_256_ctx *)context;
 
   if(!EVP_DigestUpdate(*ctx, data, length))
-    return CURLE_SSL_CIPHER;
+    return CURLE_BAD_FUNCTION_ARGUMENT;
 
   return CURLE_OK;
 }
@@ -169,13 +169,13 @@ static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *context)
      https://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=58039 */
   unsigned char tmp_digest[CURL_SHA512_256_DIGEST_SIZE * 2];
   result = EVP_DigestFinal_ex(*ctx, tmp_digest, NULL) ?
-    CURLE_OK : CURLE_SSL_CIPHER;
+    CURLE_OK : CURLE_BAD_FUNCTION_ARGUMENT;
   if(result == CURLE_OK)
     memcpy(digest, tmp_digest, CURL_SHA512_256_DIGEST_SIZE);
   curlx_memzero(tmp_digest, sizeof(tmp_digest));
 #else /* !NEED_NETBSD_SHA512_256_WORKAROUND */
   result = EVP_DigestFinal_ex(*ctx, digest, NULL) ?
-    CURLE_OK : CURLE_SSL_CIPHER;
+    CURLE_OK : CURLE_BAD_FUNCTION_ARGUMENT;
 #endif /* NEED_NETBSD_SHA512_256_WORKAROUND */
 
   EVP_MD_CTX_destroy(*ctx);
@@ -206,7 +206,7 @@ static CURLcode Curl_sha512_256_update(void *ctx,
   do {
     word32 ilen = (word32)CURLMIN(length, UINT_MAX);
     if(wc_Sha512_256Update(ctx, data, ilen))
-      return CURLE_SSL_CIPHER;
+      return CURLE_BAD_FUNCTION_ARGUMENT;
     length -= ilen;
     data += ilen;
   } while(length);
@@ -216,7 +216,7 @@ static CURLcode Curl_sha512_256_update(void *ctx,
 static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *ctx)
 {
   if(wc_Sha512_256Final(ctx, digest))
-    return CURLE_SSL_CIPHER;
+    return CURLE_BAD_FUNCTION_ARGUMENT;
   return CURLE_OK;
 }
 


### PR DESCRIPTION
Replace result code `CURLE_SSL_CIPHER` with
`CURLE_BAD_FUNCTION_ARGUMENT` in case of a low-level digest function
fails. Functionality is related to vauth, not SSL, and the operation is
a digest, not a cipher.

Also fix a indentation.

Follow-up to 05268cf801a193b68411cfa298413c3e5ca79d4f #13070
