### PR TITLE
vtls_spack: drop redundant macro fallbacks

### DIFF
--- a/lib/vtls/vtls_spack.c
+++ b/lib/vtls/vtls_spack.c
@@ -31,13 +31,6 @@
 #include "vtls/vtls_spack.h"
 #include "curlx/strdup.h"
 
-#ifndef UINT16_MAX
-#define UINT16_MAX    0xffff
-#endif
-#ifndef UINT32_MAX
-#define UINT32_MAX    0xffffffff
-#endif
-
 #define CURL_SPACK_VERSION       0x01
 #define CURL_SPACK_IETF_ID       0x02
 #define CURL_SPACK_VALID_UNTIL   0x03


### PR DESCRIPTION
For `UINT16_MAX` and `UINT32_MAX`. They are used in other sources
without this fallback.
