### PR TITLE
vtls: more large buffer support and error checks for SHA-256

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2269,14 +2269,14 @@ static CURLcode gtls_random(struct Curl_easy *data,
   return rc ? CURLE_FAILED_INIT : CURLE_OK;
 }
 
-static CURLcode gtls_sha256sum(const unsigned char *tmp, /* input */
-                               size_t tmplen,
+static CURLcode gtls_sha256sum(const unsigned char *input,
+                               size_t len,
                                unsigned char *sha256sum, /* output */
                                size_t sha256len)
 {
   struct sha256_ctx SHA256pw;
   sha256_init(&SHA256pw);
-  sha256_update(&SHA256pw, (unsigned int)tmplen, tmp);
+  sha256_update(&SHA256pw, (unsigned int)len, input);
 #if NETTLE_VERSION_MAJOR >= 4
   (void)sha256len;
   sha256_digest(&SHA256pw, sha256sum);

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2276,7 +2276,12 @@ static CURLcode gtls_sha256sum(const unsigned char *input,
 {
   struct sha256_ctx SHA256pw;
   sha256_init(&SHA256pw);
-  sha256_update(&SHA256pw, (unsigned int)len, input);
+  do {
+    unsigned int ilen = (unsigned int)CURLMIN(len, UINT_MAX);
+    sha256_update(&SHA256pw, ilen, input);
+    len -= ilen;
+    input += ilen;
+  } while(len);
 #if NETTLE_VERSION_MAJOR >= 4
   (void)sha256len;
   sha256_digest(&SHA256pw, sha256sum);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5470,7 +5470,7 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
     return CURLE_FAILED_INIT;
   }
   if(!EVP_DigestUpdate(mdctx, input, len))
-    returun CURLE_BAD_FUNCTION_ARGUMENT;
+    return CURLE_BAD_FUNCTION_ARGUMENT;
   if(!EVP_DigestFinal_ex(mdctx, sha256sum, NULL))
     return CURLE_BAD_FUNCTION_ARGUMENT;
   EVP_MD_CTX_destroy(mdctx);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5460,7 +5460,6 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
                                size_t unused)
 {
   EVP_MD_CTX *mdctx;
-  unsigned int len = 0;
   (void)unused;
 
   mdctx = EVP_MD_CTX_create();
@@ -5471,7 +5470,7 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
     return CURLE_FAILED_INIT;
   }
   EVP_DigestUpdate(mdctx, input, tmplen);
-  EVP_DigestFinal_ex(mdctx, sha256sum, &len);
+  EVP_DigestFinal_ex(mdctx, sha256sum, NULL);
   EVP_MD_CTX_destroy(mdctx);
   return CURLE_OK;
 }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5469,8 +5469,10 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
     EVP_MD_CTX_destroy(mdctx);
     return CURLE_FAILED_INIT;
   }
-  EVP_DigestUpdate(mdctx, input, len);
-  EVP_DigestFinal_ex(mdctx, sha256sum, NULL);
+  if(!EVP_DigestUpdate(mdctx, input, len))
+    returun CURLE_BAD_FUNCTION_ARGUMENT;
+  if(!EVP_DigestFinal_ex(mdctx, sha256sum, NULL))
+    return CURLE_BAD_FUNCTION_ARGUMENT;
   EVP_MD_CTX_destroy(mdctx);
   return CURLE_OK;
 }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5455,7 +5455,7 @@ static CURLcode ossl_random(struct Curl_easy *data,
 }
 
 static CURLcode ossl_sha256sum(const unsigned char *input,
-                               size_t tmplen,
+                               size_t len,
                                unsigned char *sha256sum /* output */,
                                size_t unused)
 {
@@ -5469,7 +5469,7 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
     EVP_MD_CTX_destroy(mdctx);
     return CURLE_FAILED_INIT;
   }
-  EVP_DigestUpdate(mdctx, input, tmplen);
+  EVP_DigestUpdate(mdctx, input, len);
   EVP_DigestFinal_ex(mdctx, sha256sum, NULL);
   EVP_MD_CTX_destroy(mdctx);
   return CURLE_OK;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5454,7 +5454,7 @@ static CURLcode ossl_random(struct Curl_easy *data,
   return rc == 1 ? CURLE_OK : CURLE_FAILED_INIT;
 }
 
-static CURLcode ossl_sha256sum(const unsigned char *tmp, /* input */
+static CURLcode ossl_sha256sum(const unsigned char *input,
                                size_t tmplen,
                                unsigned char *sha256sum /* output */,
                                size_t unused)
@@ -5470,7 +5470,7 @@ static CURLcode ossl_sha256sum(const unsigned char *tmp, /* input */
     EVP_MD_CTX_destroy(mdctx);
     return CURLE_FAILED_INIT;
   }
-  EVP_DigestUpdate(mdctx, tmp, tmplen);
+  EVP_DigestUpdate(mdctx, input, tmplen);
   EVP_DigestFinal_ex(mdctx, sha256sum, &len);
   EVP_MD_CTX_destroy(mdctx);
   return CURLE_OK;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5459,6 +5459,7 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
                                unsigned char *sha256sum /* output */,
                                size_t unused)
 {
+  CURLcode result = CURLE_OK;
   EVP_MD_CTX *mdctx;
   (void)unused;
 
@@ -5466,15 +5467,15 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
   if(!mdctx)
     return CURLE_OUT_OF_MEMORY;
   if(!EVP_DigestInit(mdctx, EVP_sha256())) {
-    EVP_MD_CTX_destroy(mdctx);
-    return CURLE_FAILED_INIT;
+    result = CURLE_FAILED_INIT;
+    goto out;
   }
-  if(!EVP_DigestUpdate(mdctx, input, len))
-    return CURLE_BAD_FUNCTION_ARGUMENT;
-  if(!EVP_DigestFinal_ex(mdctx, sha256sum, NULL))
-    return CURLE_BAD_FUNCTION_ARGUMENT;
+  if(!EVP_DigestUpdate(mdctx, input, len) ||
+     !EVP_DigestFinal_ex(mdctx, sha256sum, NULL))
+    result = CURLE_BAD_FUNCTION_ARGUMENT;
+out:
   EVP_MD_CTX_destroy(mdctx);
-  return CURLE_OK;
+  return result;
 }
 
 static bool ossl_cert_status_request(void)

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2284,8 +2284,8 @@ static CURLcode wssl_random(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode wssl_sha256sum(const unsigned char *tmp, /* input */
-                               size_t tmplen,
+static CURLcode wssl_sha256sum(const unsigned char *input,
+                               size_t len,
                                unsigned char *sha256sum /* output */,
                                size_t unused)
 {
@@ -2293,7 +2293,12 @@ static CURLcode wssl_sha256sum(const unsigned char *tmp, /* input */
   (void)unused;
   if(wc_InitSha256(&SHA256pw))
     return CURLE_FAILED_INIT;
-  wc_Sha256Update(&SHA256pw, tmp, (word32)tmplen);
+  do {
+    word32 ilen = (word32)CURLMIN(len, UINT32_MAX);
+    wc_Sha256Update(&SHA256pw, input, ilen);
+    len -= ilen;
+    input += ilen;
+  } while(len);
   wc_Sha256Final(&SHA256pw, sha256sum);
   return CURLE_OK;
 }

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2295,11 +2295,13 @@ static CURLcode wssl_sha256sum(const unsigned char *input,
     return CURLE_FAILED_INIT;
   do {
     word32 ilen = (word32)CURLMIN(len, UINT32_MAX);
-    wc_Sha256Update(&SHA256pw, input, ilen);
+    if(wc_Sha256Update(&SHA256pw, input, ilen))
+      return CURLE_SSL_CIPHER;
     len -= ilen;
     input += ilen;
   } while(len);
-  wc_Sha256Final(&SHA256pw, sha256sum);
+  if(wc_Sha256Final(&SHA256pw, sha256sum))
+    return CURLE_SSL_CIPHER;
   return CURLE_OK;
 }
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2296,12 +2296,12 @@ static CURLcode wssl_sha256sum(const unsigned char *input,
   do {
     word32 ilen = (word32)CURLMIN(len, UINT32_MAX);
     if(wc_Sha256Update(&SHA256pw, input, ilen))
-      return CURLE_SSL_CIPHER;
+      return CURLE_BAD_FUNCTION_ARGUMENT;
     len -= ilen;
     input += ilen;
   } while(len);
   if(wc_Sha256Final(&SHA256pw, sha256sum))
-    return CURLE_SSL_CIPHER;
+    return CURLE_BAD_FUNCTION_ARGUMENT;
   return CURLE_OK;
 }
 


### PR DESCRIPTION
- gnutls: support 4GiB+ SHA-256 digest inputs.
- openssl: check success of low-level update/finish digest calls.
- openssl: pass NULL to `EVP_DigestFinal_ex()` instead of discarding 
  returned value.
- wolfssl: support 4GiB+ SHA-256 digest inputs.
- wolfssl: check success of low-level update/finish digest calls.
- sync and tidy up argument names in low-level sha256_sum functions.
