### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -116,10 +116,8 @@ jobs:
           echo '::group::raw'; cat bld-1/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld-1/lib/curl_config.h | sort || true
 
-      # when this job can get a libssh version 0.9.0 or later, this should get
-      # that enabled again
-      # when this job can get c-ares 1.16.0 or later, we can enable that
-      # again
+      # when this job can get libssh 0.9.0 or greater, this should get that enabled again
+      # when this job can get c-ares 1.16.0 or greater, this should get that enabled again
 
       - name: 'CM configure (out-of-tree, zstd, gssapi)'
         run: |

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -71,7 +71,7 @@ This release includes the following bugfixes:
  o KNOWN_BUGS: remove stale Threads::Threads entry [135]
  o ldap: fix minor leak on write callback error [24]
  o ldap: fix to not leak `attribute` on OOM (WinLDAP) [79]
- o ldap: switch of chasing referrals [114]
+ o ldap: switch off chasing referrals [114]
  o lib678: fix to not be perma-skipped [10]
  o lib: make `__STDC_VERSION__` literals `L` (where missing)
  o lib: two minor typos [16]

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -101,7 +101,7 @@ This release includes the following bugfixes:
  o setopt: gate a few proxy TLS options by checking backend support [35]
  o setopt: more careful cleanup of the HSTS cache [45]
  o show-headers.md: mention bold headers and --no-styled-output [17]
- o snpego_sspi: preserve distinction btw policy-only and uncond delegation [74]
+ o spnego_sspi: preserve distinction btw policy-only and uncond delegation [74]
  o spnego_sspi: honor CURLOPT_GSSAPI_DELEGATION for Windows SSPI [89]
  o src: fix comment typos [83]
  o SSLCERTS: document 8.19.0 default Native CA builds (Windows) [14]

--- a/configure.ac
+++ b/configure.ac
@@ -2458,7 +2458,7 @@ if test "x$OPT_LIBSSH2" != "xno"; then
   CPPFLAGS="$CPPFLAGS $CPP_SSH2"
   LIBS="$LIB_SSH2 $LIBS"
 
-  dnl check for function added in libssh2 version 1.9.0
+  dnl check for function added in libssh2 v1.9.0
   AC_CHECK_LIB(ssh2, libssh2_agent_get_identity_path)
 
   AC_CHECK_HEADER(libssh2.h,

--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -270,10 +270,10 @@ Restrict to only TLS 1.2 with the `CAMELLIA-128-GCM` cipher.
 
 ## Further reading
 
-- [OpenSSL cipher suite names documentation](https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names)
-- [wolfSSL cipher support documentation](https://www.wolfssl.com/documentation/manuals/wolfssl/chapter04.html#cipher-support)
-- [mbedTLS cipher suites reference](https://mbed-tls.readthedocs.io/projects/api/en/development/api/file/ssl__ciphersuites_8h/)
-- [Schannel cipher suites documentation](https://learn.microsoft.com/windows/win32/secauthn/cipher-suites-in-schannel)
-- [IANA cipher suites list](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4)
-- [Wikipedia cipher suite article](https://en.wikipedia.org/wiki/Cipher_suite)
 - [GnuTLS Priority Strings](https://gnutls.org/manual/html_node/Priority-Strings.html)
+- [IANA cipher suites list](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4)
+- [mbedTLS cipher suites reference](https://mbed-tls.readthedocs.io/projects/api/en/development/api/file/ssl__ciphersuites_8h/)
+- [OpenSSL cipher suite names documentation](https://docs.openssl.org/master/man1/openssl-ciphers/#cipher-suite-names)
+- [Schannel cipher suites documentation](https://learn.microsoft.com/windows/win32/secauthn/cipher-suites-in-schannel)
+- [Wikipedia cipher suite article](https://en.wikipedia.org/wiki/Cipher_suite)
+- [wolfSSL cipher support documentation](https://www.wolfssl.com/documentation/manuals/wolfssl/chapter04.html#cipher-support)

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -261,7 +261,7 @@ work.
   has already been closed.
 
 - `Ref: URL` to more information about the commit; use `Bug:` instead for a
-  reference to a bug on another bug tracker]
+  reference to a bug on another bug tracker.
 
 - `Fixes #1234` - if this fixes a GitHub issue; GitHub closes the issue once
   this commit is merged.

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -242,6 +242,7 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 ## Enabling features
 
 - `CURL_ENABLE_NTLM`:                       Enable NTLM support. Default: `OFF`
+- `CURL_ENABLE_SMB`:                        Enable SMB. Default: `OFF`
 - `CURL_ENABLE_SSL`:                        Enable SSL support. Default: `ON`
 - `CURL_WINDOWS_SSPI`:                      Enable SSPI on Windows. Default: =`CURL_USE_SCHANNEL`
 - `ENABLE_IPV6`:                            Enable IPv6 support. Default: `ON` if target supports IPv6.
@@ -296,7 +297,6 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `CURL_DISABLE_RTSP`:                      Disable RTSP. Default: `OFF`
 - `CURL_DISABLE_SHA512_256`:                Disable SHA-512/256 hash algorithm. Default: `OFF`
 - `CURL_DISABLE_SHUFFLE_DNS`:               Disable shuffle DNS feature. Default: `OFF`
-- `CURL_ENABLE_SMB`:                        Enable SMB. Default: `OFF`
 - `CURL_DISABLE_SMTP`:                      Disable SMTP. Default: `OFF`
 - `CURL_DISABLE_SOCKETPAIR`:                Disable use of socketpair for curl_multi_poll(). Default: `OFF`
 - `CURL_DISABLE_SRP`:                       Disable TLS-SRP support. Default: `OFF`

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -486,7 +486,7 @@ Examples:
 - `HTTPD`:                                  Absolute path. Default: search for `apache2`
 - `DANTED`:                                 Absolute path. Default: search for `danted`
 - `TEST_NGHTTPX`:                           Absolute path. Default: search for `nghttpx`
-- `VSFTPD`:                                 Absolute path. Default: search for `vsftps`
+- `VSFTPD`:                                 Absolute path. Default: search for `vsftpd`
 - `SSHD`:                                   Absolute path. Default: search for `sshd`
 - `SFTPD`:                                  Absolute path. Default: search for `sftp-server`
 

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -56,7 +56,7 @@ Once downloaded, build `curl` using `--with-rustls` and the path to the extracte
 Building `rustls-ffi` from source requires both a rust compiler, and the [cargo-c] cargo plugin.
 
 To install a Rust compiler, use [rustup] or your package manager to install
-the **1.73+** or newer toolchain.
+the **1.73** or newer toolchain.
 
 To install `cargo-c`, use your [package manager][cargo-c pkg], download
 [a pre-built archive][cargo-c prebuilt], or build it from source with `cargo install cargo-c`.

--- a/docs/internals/CHECKSRC.md
+++ b/docs/internals/CHECKSRC.md
@@ -40,21 +40,21 @@ warnings are:
   code style mandates the assignment to be done outside of it.
 
 - `ASTERISKNOSPACE`: A pointer was declared like `char* name` instead of the
-   more appropriate `char *name` style. The asterisk should sit next to the
-   name.
+  more appropriate `char *name` style. The asterisk should sit next to the
+  name.
 
 - `ASTERISKSPACE`: A pointer was declared like `char * name` instead of the
-   more appropriate `char *name` style. The asterisk should sit right next to
-   the name without a space in between.
+  more appropriate `char *name` style. The asterisk should sit right next to
+  the name without a space in between.
 
 - `BADCOMMAND`: There is a bad `checksrc` instruction in the code. See the
-   **Ignore certain warnings** section below for details.
+  **Ignore certain warnings** section below for details.
 
 - `BANNEDFUNC`: A banned function was used. The functions sprintf, vsprintf,
-   strcat, strncat, gets are **never** allowed in curl source code.
+  strcat, strncat, gets are **never** allowed in curl source code.
 
 - `BRACEELSE`: '} else' on the same line. The else is supposed to be on the
-   following line.
+  following line.
 
 - `BRACEPOS`: wrong position for an open brace (`{`).
 
@@ -80,8 +80,8 @@ warnings are:
   string, use it
 
 - `INDENTATION`: detected a wrong start column for code. Note that this
-   warning only checks some specific places and can certainly miss many bad
-   indentations.
+  warning only checks some specific places and can certainly miss many bad
+  indentations.
 
 - `LONGLINE`: A line is longer than 79 columns.
 
@@ -99,7 +99,7 @@ warnings are:
 - `PARENBRACE`: `){` was used without sufficient space in between.
 
 - `RETURNNOSPACE`: `return` was used without space between the keyword and the
-   following value.
+  following value.
 
 - `SEMINOSPACE`: There was no space (or newline) following a semicolon.
 
@@ -107,7 +107,7 @@ warnings are:
   `sizeof(int)` style.
 
 - `SNPRINTF` - Found use of `snprintf()`. Since we use an internal replacement
-   with a different return code etc, we prefer `curl_msnprintf()`.
+  with a different return code etc, we prefer `curl_msnprintf()`.
 
 - `SPACEAFTERPAREN`: there was a space after open parenthesis, `( text`.
 
@@ -116,7 +116,7 @@ warnings are:
 - `SPACEBEFORECOMMA`: there was a space before a comma, `one , two`.
 
 - `SPACEBEFOREPAREN`: there was a space before an open parenthesis, `if (`,
-   where one was not expected
+  where one was not expected
 
 - `SPACESEMICOLON`: there was a space before semicolon, ` ;`.
 
@@ -127,7 +127,7 @@ warnings are:
 - `TYPEDEFSTRUCT`: we frown upon (most) typedefed structs
 
 - `UNUSEDIGNORE`: a `checksrc` inlined warning ignore was asked for but not
-   used, that is an ignore that should be removed or changed to get used.
+  used, that is an ignore that should be removed or changed to get used.
 
 - `USESAFEFREE`: there was a `curlx_free(var)` call made right before assigning
   NULL to `var`. We prefer replacing that with `curlx_safefree()`, which is
@@ -144,7 +144,7 @@ so: `enable <EXTENDEDWARNING>`
 Currently these are the extended warnings which can be enabled:
 
 - `COPYRIGHTYEAR`: the current changeset has not updated the copyright year in
-   the source file
+  the source file
 
 - `STRERROR`: use of banned function strerror()
 

--- a/include/curl/curlver.h
+++ b/include/curl/curlver.h
@@ -47,7 +47,7 @@
 
    Where XX, YY and ZZ are the main version, release and patch numbers in
    hexadecimal (using 8 bits each). All three numbers are always represented
-   using two digits. 1.2 would appear as "0x010200" while version 9.11.7
+   using two digits. Version 1.2 would appear as "0x010200" while 9.11.7
    appears as "0x090b07".
 
    This 6-digit (24 bits) hexadecimal number does not show pre-release number,

--- a/lib/capsule.c
+++ b/lib/capsule.c
@@ -43,12 +43,12 @@ static uint64_t capsule_ntohll(uint64_t value)
 #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
   return value;
 #elif (defined(__GNUC__) || defined(__clang__)) && \
-      defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
   return __builtin_bswap64(value);
 #else
   union {
-      uint64_t u64;
-      uint32_t u32[2];
+    uint64_t u64;
+    uint32_t u32[2];
   } src, dst;
 
   src.u64 = value;

--- a/lib/cf-capsule.c
+++ b/lib/cf-capsule.c
@@ -238,7 +238,7 @@ CURLcode Curl_cf_capsule_insert_after(struct Curl_cfilter *cf_at,
     return CURLE_OUT_OF_MEMORY;
 
   Curl_bufq_init2(&ctx->recvbuf, CAPSULE_CHUNK_SIZE, CAPSULE_RECV_CHUNKS,
-                   BUFQ_OPT_SOFT_LIMIT);
+                  BUFQ_OPT_SOFT_LIMIT);
 
   result = Curl_cf_create(&cf, &Curl_cft_capsule, ctx);
   if(result) {

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1518,6 +1518,3 @@ out:
 }
 
 #endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_PROXY && USE_NGHTTP2 */
-
-/* Do not leak this filter's call_data accessor in unity builds. */
-#undef CF_CTX_CALL_DATA

--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -25,8 +25,8 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_PROXY) && \
-    defined(USE_PROXY_HTTP3) && defined(USE_NGHTTP3) && \
-    defined(USE_NGTCP2) && defined(USE_OPENSSL)
+  defined(USE_PROXY_HTTP3) && defined(USE_NGHTTP3) &&              \
+  defined(USE_NGTCP2) && defined(USE_OPENSSL)
 
 #include <ngtcp2/ngtcp2.h>
 #include <ngtcp2/ngtcp2_crypto.h>
@@ -90,11 +90,10 @@
 #define PROXY_H3_STREAM_SEND_CHUNKS \
   (PROXY_H3_STREAM_WINDOW_SIZE / PROXY_H3_STREAM_CHUNK_SIZE)
 
-#define PROXY_QUIC_MAX_STREAMS (256*1024)
-#define PROXY_QUIC_HANDSHAKE_TIMEOUT (10*NGTCP2_SECONDS)
+#define PROXY_QUIC_MAX_STREAMS       (256 * 1024)
+#define PROXY_QUIC_HANDSHAKE_TIMEOUT (10 * NGTCP2_SECONDS)
 
-typedef enum
-{
+typedef enum {
   H3_TUNNEL_INIT,     /* init/default/no tunnel state */
   H3_TUNNEL_CONNECT,  /* CONNECT request is being sent */
   H3_TUNNEL_RESPONSE, /* CONNECT response received completely */
@@ -104,8 +103,7 @@ typedef enum
 
 struct h3_proxy_stream_ctx;
 
-struct h3_tunnel_stream
-{
+struct h3_tunnel_stream {
   struct http_resp *resp;
   char *authority;
   struct h3_proxy_stream_ctx *stream;
@@ -252,8 +250,7 @@ struct cf_ngtcp2_proxy_ctx {
   BIT(shutdown_started);             /* queued shutdown packets */
 };
 
-struct cf_h3_proxy_ctx
-{
+struct cf_h3_proxy_ctx {
   struct cf_ngtcp2_proxy_ctx *ngtcp2_ctx;
   struct cf_call_data call_data; /* fallback before backend ctx exists */
   struct bufq inbufq;          /* network receive buffer */
@@ -266,8 +263,7 @@ struct cf_h3_proxy_ctx
 /**
  * All about the H3 internals of a stream
  */
-struct h3_proxy_stream_ctx
-{
+struct h3_proxy_stream_ctx {
   int64_t id;              /* HTTP/3 stream identifier */
   struct bufq sendbuf;          /* h3 request body */
   size_t sendbuf_len_in_flight; /* sendbuf amount "in flight" */
@@ -286,7 +282,7 @@ struct h3_proxy_stream_ctx
   BIT(quic_flow_blocked);       /* stream is blocked by QUIC flow control */
 };
 
-#define H3_PROXY_STREAM_CTX(ctx, data)                                     \
+#define H3_PROXY_STREAM_CTX(ctx, data)                                 \
   ((data) ? Curl_uint32_hash_get(&(ctx)->streams, (data)->mid) : NULL)
 
 #define H3_STREAM_ID(stream) ((stream)->id)
@@ -361,7 +357,7 @@ static void cf_ngtcp2_proxy_ctx_close(struct cf_ngtcp2_proxy_ctx *ctx)
 }
 
 static void cf_ngtcp2_proxy_setup_keep_alive(struct Curl_cfilter *cf,
-                                       struct Curl_easy *data)
+                                             struct Curl_easy *data)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
@@ -454,7 +450,7 @@ static void proxy_quic_printf(void *user_data, const char *fmt, ...)
 #endif /* DEBUG_NGTCP2 */
 
 static void proxy_qlog_callback(void *user_data, uint32_t flags,
-                          const void *data, size_t datalen)
+                                const void *data, size_t datalen)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -510,7 +506,7 @@ static void quic_settings_proxy(struct cf_ngtcp2_proxy_ctx *ctx,
 }
 
 static void cf_ngtcp2_proxy_conn_close(struct Curl_cfilter *cf,
-                                 struct Curl_easy *data);
+                                       struct Curl_easy *data);
 
 static bool cf_ngtcp2_proxy_err_is_fatal(int code)
 {
@@ -520,7 +516,7 @@ static bool cf_ngtcp2_proxy_err_is_fatal(int code)
 }
 
 static void cf_ngtcp2_proxy_err_set(struct Curl_cfilter *cf,
-                              struct Curl_easy *data, int code)
+                                    struct Curl_easy *data, int code)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
@@ -545,7 +541,7 @@ static bool cf_ngtcp2_proxy_h3_err_is_fatal(int code)
 }
 
 static void cf_ngtcp2_proxy_h3_err_set(struct Curl_cfilter *cf,
-                                 struct Curl_easy *data, int code)
+                                       struct Curl_easy *data, int code)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
@@ -590,7 +586,7 @@ static void cf_h3_proxy_ctx_free(struct cf_h3_proxy_ctx *ctx)
 }
 
 static CURLcode h3_proxy_data_setup(struct Curl_cfilter *cf,
-                              struct Curl_easy *data)
+                                    struct Curl_easy *data)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
@@ -631,8 +627,8 @@ static CURLcode h3_proxy_data_setup(struct Curl_cfilter *cf,
 }
 
 static int cb_h3_proxy_acked_req_body(nghttp3_conn *conn, int64_t stream_id,
-                                uint64_t datalen, void *user_data,
-                                void *stream_user_data)
+                                      uint64_t datalen, void *user_data,
+                                      void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -667,8 +663,8 @@ static int cb_h3_proxy_acked_req_body(nghttp3_conn *conn, int64_t stream_id,
 }
 
 static int cb_h3_proxy_stream_close(nghttp3_conn *conn, int64_t stream_id,
-                              uint64_t app_error_code, void *user_data,
-                              void *stream_user_data)
+                                    uint64_t app_error_code, void *user_data,
+                                    void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -726,8 +722,7 @@ static void cf_h3_proxy_upd_rx_win(struct Curl_cfilter *cf,
     if(!stream->rx_offset)
       return;
 
-    avail = Curl_rlimit_avail(&data->progress.dl.rlimit,
-                              Curl_pgrs_now(data));
+    avail = Curl_rlimit_avail(&data->progress.dl.rlimit, Curl_pgrs_now(data));
     if(avail <= 0) {
       /* nothing available, do not extend the rx offset */
       CURL_TRC_CF(data, cf, "[%" PRId64 "] dl rate limit exhausted (%" PRId64
@@ -762,8 +757,8 @@ static void cf_h3_proxy_upd_rx_win(struct Curl_cfilter *cf,
 }
 
 static int cb_h3_proxy_recv_data(nghttp3_conn *conn, int64_t stream3_id,
-                           const uint8_t *buf, size_t buflen,
-                           void *user_data, void *stream_user_data)
+                                 const uint8_t *buf, size_t buflen,
+                                 void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -808,8 +803,8 @@ static int cb_h3_proxy_recv_data(nghttp3_conn *conn, int64_t stream3_id,
 }
 
 static int cb_h3_proxy_deferred_consume(nghttp3_conn *conn, int64_t stream_id,
-                                  size_t consumed, void *user_data,
-                                  void *stream_user_data)
+                                        size_t consumed, void *user_data,
+                                        void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -829,9 +824,9 @@ static int cb_h3_proxy_deferred_consume(nghttp3_conn *conn, int64_t stream_id,
 }
 
 static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t sid,
-                             int32_t token, nghttp3_rcbuf *name,
-                             nghttp3_rcbuf *value, uint8_t flags,
-                             void *user_data, void *stream_user_data)
+                                   int32_t token, nghttp3_rcbuf *name,
+                                   nghttp3_rcbuf *value, uint8_t flags,
+                                   void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   int64_t stream_id = sid;
@@ -888,12 +883,11 @@ static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t sid,
   }
   else {
     /* store as an HTTP1-style header */
-    CURL_TRC_CF(data, cf, "[%" PRId64 "] header: %.*s: %.*s",
-                stream_id, (int)h3name.len, h3name.base,
-                (int)h3val.len, h3val.base);
+    CURL_TRC_CF(data, cf, "[%" PRId64 "] header: %.*s: %.*s", stream_id,
+                (int)h3name.len, h3name.base, (int)h3val.len, h3val.base);
     result = Curl_dynhds_add(&proxy_ctx->tunnel.resp->headers,
-      (const char *)h3name.base, h3name.len,
-      (const char *)h3val.base, h3val.len);
+                             (const char *)h3name.base, h3name.len,
+                             (const char *)h3val.base, h3val.len);
     if(result) {
       return -1;
     }
@@ -901,8 +895,8 @@ static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t sid,
   return 0;
 }
 
-static int cb_h3_proxy_end_headers(nghttp3_conn *conn, int64_t sid,
-                             int fin, void *user_data, void *stream_user_data)
+static int cb_h3_proxy_end_headers(nghttp3_conn *conn, int64_t sid, int fin,
+                                   void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -932,8 +926,8 @@ static int cb_h3_proxy_end_headers(nghttp3_conn *conn, int64_t sid,
   if(!stream)
     return 0;
 
-  CURL_TRC_CF(data, cf, "[%" PRId64 "] end_headers, status=%d",
-              stream_id, stream->status_code);
+  CURL_TRC_CF(data, cf, "[%" PRId64 "] end_headers, status=%d", stream_id,
+              stream->status_code);
 
   if(!proxy_ctx->tunnel.has_final_response) {
     if(stream->status_code / 100 != 1) {
@@ -950,8 +944,8 @@ static int cb_h3_proxy_end_headers(nghttp3_conn *conn, int64_t sid,
 }
 
 static int cb_h3_proxy_stop_sending(nghttp3_conn *conn, int64_t sid,
-                              uint64_t app_error_code, void *user_data,
-                              void *stream_user_data)
+                                    uint64_t app_error_code, void *user_data,
+                                    void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -973,8 +967,8 @@ static int cb_h3_proxy_stop_sending(nghttp3_conn *conn, int64_t sid,
 }
 
 static int cb_h3_proxy_reset_stream(nghttp3_conn *conn, int64_t sid,
-                              uint64_t app_error_code, void *user_data,
-                              void *stream_user_data)
+                                    uint64_t app_error_code, void *user_data,
+                                    void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -1001,11 +995,13 @@ static int cb_h3_proxy_reset_stream(nghttp3_conn *conn, int64_t sid,
   return 0;
 }
 
-static nghttp3_ssize
-cb_h3_read_data_for_tunnel_stream(nghttp3_conn *conn, int64_t stream_id,
-                                  nghttp3_vec *vec, size_t veccnt,
-                                  uint32_t *pflags, void *user_data,
-                                  void *stream_user_data)
+static nghttp3_ssize cb_h3_read_data_for_tunnel_stream(nghttp3_conn *conn,
+                                                       int64_t stream_id,
+                                                       nghttp3_vec *vec,
+                                                       size_t veccnt,
+                                                       uint32_t *pflags,
+                                                       void *user_data,
+                                                       void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
@@ -1111,8 +1107,7 @@ struct cf_ngtcp2_proxy_sfind_ctx {
   uint32_t mid;
 };
 
-static bool cf_ngtcp2_proxy_sfind(uint32_t mid, void *value,
-                                  void *user_data)
+static bool cf_ngtcp2_proxy_sfind(uint32_t mid, void *value, void *user_data)
 {
   struct cf_ngtcp2_proxy_sfind_ctx *fctx = user_data;
   struct h3_proxy_stream_ctx *stream = value;
@@ -1125,8 +1120,8 @@ static bool cf_ngtcp2_proxy_sfind(uint32_t mid, void *value,
   return TRUE; /* continue */
 }
 
-static struct h3_proxy_stream_ctx *
-cf_ngtcp2_proxy_get_stream(struct cf_ngtcp2_proxy_ctx *ctx, int64_t stream_id)
+static struct h3_proxy_stream_ctx *cf_ngtcp2_proxy_get_stream(
+  struct cf_ngtcp2_proxy_ctx *ctx, int64_t stream_id)
 {
   struct cf_ngtcp2_proxy_sfind_ctx fctx;
   fctx.stream_id = stream_id;
@@ -1135,8 +1130,8 @@ cf_ngtcp2_proxy_get_stream(struct cf_ngtcp2_proxy_ctx *ctx, int64_t stream_id)
   return fctx.stream;
 }
 #else
-static struct h3_proxy_stream_ctx *
-cf_ngtcp2_proxy_get_stream(struct cf_ngtcp2_proxy_ctx *ctx, int64_t stream_id)
+static struct h3_proxy_stream_ctx *cf_ngtcp2_proxy_get_stream(
+  struct cf_ngtcp2_proxy_ctx *ctx, int64_t stream_id)
 {
   struct Curl_easy *data =
     ngtcp2_conn_get_stream_user_data(ctx->qconn, stream_id);
@@ -1204,8 +1199,7 @@ static CURLcode cf_ngtcp2_h3conn_init(struct Curl_cfilter *cf,
   rc = nghttp3_conn_bind_qpack_streams(ctx->h3conn, qpack_enc_stream_id,
                                        qpack_dec_stream_id);
   if(rc) {
-    failf(data, "error binding HTTP/3 qpack streams: %s",
-          ngtcp2_strerror(rc));
+    failf(data, "error binding HTTP/3 qpack streams: %s", ngtcp2_strerror(rc));
     return CURLE_QUIC_CONNECT_ERROR;
   }
 
@@ -1705,8 +1699,8 @@ static CURLcode proxy_h3_progress_ingress_ngtcp2(struct Curl_cfilter *cf,
  * Return number of bytes written or -1 with *err set.
  */
 static CURLcode proxy_read_pkt_to_send(void *userp,
-                                 unsigned char *buf, size_t buflen,
-                                 size_t *pnread)
+                                       unsigned char *buf, size_t buflen,
+                                       size_t *pnread)
 {
   struct proxy_pkt_io_ctx *x = userp;
   struct cf_h3_proxy_ctx *proxy_ctx = x->cf->ctx;
@@ -1851,7 +1845,7 @@ static CURLcode proxy_h3_progress_egress_ngtcp2(struct Curl_cfilter *cf,
    */
   max_payload_size = ngtcp2_conn_get_max_tx_udp_payload_size(ctx->qconn);
   path_max_payload_size =
-      ngtcp2_conn_get_path_max_tx_udp_payload_size(ctx->qconn);
+    ngtcp2_conn_get_path_max_tx_udp_payload_size(ctx->qconn);
   send_quantum = ngtcp2_conn_get_send_quantum(ctx->qconn);
   CURL_TRC_CF(data, cf, "egress, collect and send packets, quantum=%zu",
               send_quantum);
@@ -1867,7 +1861,7 @@ static CURLcode proxy_h3_progress_egress_ngtcp2(struct Curl_cfilter *cf,
       size_t buflen = Curl_bufq_len(&ctx->q.sendbuf);
       if((buflen >= send_quantum) ||
          ((buflen + gsolen) >= ctx->q.sendbuf.chunk_size))
-         break;
+        break;
       DEBUGASSERT(nread > 0);
       ++pktcnt;
       if(pktcnt == 1) {
@@ -1918,7 +1912,7 @@ static CURLcode proxy_h3_progress_egress_ngtcp2(struct Curl_cfilter *cf,
 }
 
 static CURLcode cf_ngtcp2_proxy_shutdown(struct Curl_cfilter *cf,
-                                   struct Curl_easy *data, bool *done)
+                                         struct Curl_easy *data, bool *done)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
@@ -2020,7 +2014,7 @@ out:
 }
 
 static void cf_ngtcp2_proxy_conn_close(struct Curl_cfilter *cf,
-                                 struct Curl_easy *data)
+                                       struct Curl_easy *data)
 {
   bool done;
   cf_ngtcp2_proxy_shutdown(cf, data, &done);
@@ -2044,8 +2038,8 @@ static void cf_ngtcp2_proxy_close(struct Curl_cfilter *cf,
 }
 
 static void cf_ngtcp2_proxy_stream_close(struct Curl_cfilter *cf,
-                                   struct Curl_easy *data,
-                                   struct h3_proxy_stream_ctx  *stream)
+                                         struct Curl_easy *data,
+                                         struct h3_proxy_stream_ctx *stream)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
@@ -2136,9 +2130,9 @@ static CURLcode check_and_set_expiry_ngtcp2(struct Curl_cfilter *cf,
 }
 
 static ssize_t proxy_recv_closed_stream(struct Curl_cfilter *cf,
-                                  struct Curl_easy *data,
-                                  struct h3_proxy_stream_ctx *stream,
-                                  CURLcode *err)
+                                        struct Curl_easy *data,
+                                        struct h3_proxy_stream_ctx *stream,
+                                        CURLcode *err)
 {
   ssize_t nread = -1;
   *err = CURLE_OK;
@@ -2180,10 +2174,10 @@ out:
   return nread;
 }
 
-static struct h3_proxy_stream_ctx *
-h3_proxy_resolve_send_stream(struct cf_h3_proxy_ctx *proxy_ctx,
-                             struct cf_ngtcp2_proxy_ctx *ctx,
-                             struct Curl_easy *data)
+static struct h3_proxy_stream_ctx *h3_proxy_resolve_send_stream(
+  struct cf_h3_proxy_ctx *proxy_ctx,
+  struct cf_ngtcp2_proxy_ctx *ctx,
+  struct Curl_easy *data)
 {
   struct h3_proxy_stream_ctx *stream = H3_PROXY_STREAM_CTX(ctx, data);
 
@@ -2328,8 +2322,7 @@ static CURLcode cf_h3_proxy_recv(struct Curl_cfilter *cf,
   }
 
   if(!Curl_bufq_is_empty(&proxy_ctx->inbufq)) {
-    result = Curl_bufq_cread(&proxy_ctx->inbufq,
-                            buf, len, pnread);
+    result = Curl_bufq_cread(&proxy_ctx->inbufq, buf, len, pnread);
     if(result)
       goto out;
   }
@@ -2340,8 +2333,7 @@ static CURLcode cf_h3_proxy_recv(struct Curl_cfilter *cf,
 
   /* inbufq had nothing before, maybe after progressing ingress? */
   if(!*pnread && !Curl_bufq_is_empty(&proxy_ctx->inbufq)) {
-    result = Curl_bufq_cread(&proxy_ctx->inbufq,
-                             buf, len, pnread);
+    result = Curl_bufq_cread(&proxy_ctx->inbufq, buf, len, pnread);
     if(result) {
       CURL_TRC_CF(data, cf, "[%" PRId64 "] read inbufq(len=%zu) "
                             "-> %zd, %d",
@@ -2355,8 +2347,7 @@ static CURLcode cf_h3_proxy_recv(struct Curl_cfilter *cf,
   }
   else {
     if(stream->xfer_result) {
-      CURL_TRC_CF(data, cf, "[%" PRId64 "] xfer write failed",
-                  stream->id);
+      CURL_TRC_CF(data, cf, "[%" PRId64 "] xfer write failed", stream->id);
       cf_ngtcp2_proxy_stream_close(cf, data, stream);
       result = stream->xfer_result;
       goto out;
@@ -2668,8 +2659,9 @@ static CURLcode cf_ngtcp2_proxy_adjust_pollset(struct Curl_cfilter *cf,
     bool c_exhaust, s_exhaust;
 
     CF_DATA_SAVE(save, cf, data);
-    c_exhaust = want_send && (!ngtcp2_conn_get_cwnd_left(ctx->qconn) ||
-                !ngtcp2_conn_get_max_data_left(ctx->qconn));
+    c_exhaust = want_send &&
+                (!ngtcp2_conn_get_cwnd_left(ctx->qconn) ||
+                 !ngtcp2_conn_get_max_data_left(ctx->qconn));
     s_exhaust = want_send && stream && H3_STREAM_ID(stream) >= 0 &&
                 stream->quic_flow_blocked;
     want_recv = (want_recv || c_exhaust || s_exhaust);
@@ -2795,10 +2787,10 @@ static CURLcode cf_ngtcp2_proxy_tls_ctx_setup(struct Curl_cfilter *cf,
 }
 
 static CURLcode cf_ngtcp2_proxy_on_session_reuse(struct Curl_cfilter *cf,
-                                           struct Curl_easy *data,
-                                           struct alpn_spec *alpns,
-                                           struct Curl_ssl_session *scs,
-                                           bool *do_early_data)
+                                                 struct Curl_easy *data,
+                                                 struct alpn_spec *alpns,
+                                                 struct Curl_ssl_session *scs,
+                                                 bool *do_early_data)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
@@ -2819,8 +2811,8 @@ static CURLcode cf_ngtcp2_proxy_on_session_reuse(struct Curl_cfilter *cf,
   ctx->earlydata_max = 0;
 #endif /* WOLFSSL_EARLY_DATA */
 #endif /* USE_WOLFSSL */
-#if defined(USE_GNUTLS) || defined(USE_WOLFSSL) || \
-    (defined(USE_OPENSSL) && defined(HAVE_OPENSSL_EARLYDATA))
+#if defined(USE_GNUTLS) || defined(USE_WOLFSSL) ||          \
+  (defined(USE_OPENSSL) && defined(HAVE_OPENSSL_EARLYDATA))
   if((!ctx->earlydata_max)) {
     CURL_TRC_CF(data, cf, "SSL session does not allow earlydata");
   }
@@ -2867,7 +2859,7 @@ static CURLcode cf_h3_proxy_ctx_init(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OK;
   const struct Curl_sockaddr_ex *sockaddr = NULL;
   int qfd;
-  static const struct alpn_spec ALPN_SPEC_H3 = {{ "h3", "h3-29" }, 2};
+  static const struct alpn_spec ALPN_SPEC_H3 = { { "h3", "h3-29" }, 2 };
   struct proxy_pkt_io_ctx pktx;
 
   ctx = curlx_calloc(1, sizeof(struct cf_ngtcp2_proxy_ctx));
@@ -2913,7 +2905,7 @@ static CURLcode cf_h3_proxy_ctx_init(struct Curl_cfilter *cf,
     goto out;
   /* Get remote address from the socket filter below */
   if(cf->next->cft->query(cf->next, data, CF_QUERY_REMOTE_ADDR, NULL,
-                           CURL_UNCONST(&sockaddr)))
+                          CURL_UNCONST(&sockaddr)))
     goto out;
   if(!sockaddr)
     goto out;
@@ -2996,8 +2988,8 @@ out:
 }
 
 static CURLcode h3_submit_CONNECT(struct Curl_cfilter *cf,
-                               struct Curl_easy *data,
-                               struct h3_tunnel_stream *ts)
+                                  struct Curl_easy *data,
+                                  struct h3_tunnel_stream *ts)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   CURLcode result;
@@ -3023,10 +3015,9 @@ out:
   return result;
 }
 
-static CURLcode
-h3_proxy_inspect_response(struct Curl_cfilter *cf,
-                 struct Curl_easy *data,
-                 struct h3_tunnel_stream *ts)
+static CURLcode h3_proxy_inspect_response(struct Curl_cfilter *cf,
+                                          struct Curl_easy *data,
+                                          struct h3_tunnel_stream *ts)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   proxy_inspect_result res;
@@ -3126,8 +3117,7 @@ out:
 
     result = CURLE_COULDNT_CONNECT;
     if(cerr) {
-      CURL_TRC_CF(data, cf, "connect error, type=%d, code=%"
-                  PRIu64,
+      CURL_TRC_CF(data, cf, "connect error, type=%d, code=%" PRIu64,
                   cerr->type, (uint64_t)cerr->error_code);
       switch(cerr->type) {
       case NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION:
@@ -3242,13 +3232,11 @@ out:
   return result;
 }
 
-static CURLcode
-cf_h3_proxy_connect(struct Curl_cfilter *cf,
-                    struct Curl_easy *data,
-                    bool *done)
+static CURLcode cf_h3_proxy_connect(struct Curl_cfilter *cf,
+                                    struct Curl_easy *data, bool *done)
 {
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
-  struct cf_call_data save = {0};
+  struct cf_call_data save = { 0 };
   CURLcode result = CURLE_OK;
   timediff_t check;
   struct h3_tunnel_stream *ts = &proxy_ctx->tunnel;
@@ -3318,8 +3306,7 @@ static void h3_proxy_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   stream = H3_PROXY_STREAM_CTX(ctx, data);
   if(stream) {
-    CURL_TRC_CF(data, cf, "[%" PRId64 "] easy handle is done",
-                stream->id);
+    CURL_TRC_CF(data, cf, "[%" PRId64 "] easy handle is done", stream->id);
     cf_ngtcp2_proxy_stream_close(cf, data, stream);
     Curl_uint32_hash_remove(&ctx->streams, data->mid);
     if(!Curl_uint32_hash_count(&ctx->streams))
@@ -3420,21 +3407,21 @@ static CURLcode cf_h3_proxy_shutdown(struct Curl_cfilter *cf,
 }
 
 struct Curl_cftype Curl_cft_h3_proxy = {
-    "H3-PROXY",
-    CF_TYPE_IP_CONNECT | CF_TYPE_PROXY | CF_TYPE_SSL,
-    CURL_LOG_LVL_NONE,
-    cf_h3_proxy_destroy,
-    cf_h3_proxy_connect,
-    cf_h3_proxy_close,
-    cf_h3_proxy_shutdown,
-    cf_h3_proxy_adjust_pollset,
-    cf_h3_proxy_data_pending,
-    cf_h3_proxy_send,
-    cf_h3_proxy_recv,
-    cf_h3_proxy_cntrl,
-    cf_h3_proxy_is_alive,
-    Curl_cf_def_conn_keep_alive,
-    cf_h3_proxy_query,
+  "H3-PROXY",
+  CF_TYPE_IP_CONNECT | CF_TYPE_PROXY | CF_TYPE_SSL,
+  CURL_LOG_LVL_NONE,
+  cf_h3_proxy_destroy,
+  cf_h3_proxy_connect,
+  cf_h3_proxy_close,
+  cf_h3_proxy_shutdown,
+  cf_h3_proxy_adjust_pollset,
+  cf_h3_proxy_data_pending,
+  cf_h3_proxy_send,
+  cf_h3_proxy_recv,
+  cf_h3_proxy_cntrl,
+  cf_h3_proxy_is_alive,
+  Curl_cf_def_conn_keep_alive,
+  cf_h3_proxy_query,
 };
 
 CURLcode Curl_cf_h3_proxy_insert_after(struct Curl_cfilter *cf_at,

--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -552,7 +552,6 @@ static void cf_ngtcp2_proxy_h3_err_set(struct Curl_cfilter *cf,
 }
 
 /* How to access `call_data` from a cf_h3_proxy filter */
-#undef CF_CTX_CALL_DATA
 static struct cf_call_data *cf_h3_proxy_call_data(struct Curl_cfilter *cf)
 {
   struct cf_h3_proxy_ctx *ctx = cf ? cf->ctx : NULL;
@@ -565,6 +564,7 @@ static struct cf_call_data *cf_h3_proxy_call_data(struct Curl_cfilter *cf)
   return &ctx->call_data;
 }
 
+#undef CF_CTX_CALL_DATA
 #define CF_CTX_CALL_DATA(cf) (*cf_h3_proxy_call_data(cf))
 
 static void cf_h3_proxy_ctx_clear(struct cf_h3_proxy_ctx *ctx)
@@ -3455,6 +3455,3 @@ out:
 }
 
 #endif
-
-/* Do not leak this filter's call_data accessor in unity builds. */
-#undef CF_CTX_CALL_DATA

--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -21,7 +21,6 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_PROXY) && \
@@ -29,10 +28,10 @@
   defined(USE_NGTCP2) && defined(USE_OPENSSL)
 
 #include <ngtcp2/ngtcp2.h>
-#include <ngtcp2/ngtcp2_crypto.h>
+
 #ifdef USE_OPENSSL
 #include <openssl/err.h>
-#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 #include <ngtcp2/ngtcp2_crypto_boringssl.h>
 #elif defined(OPENSSL_QUIC_API2)
 #include <ngtcp2/ngtcp2_crypto_ossl.h>
@@ -40,11 +39,15 @@
 #include <ngtcp2/ngtcp2_crypto_quictls.h>
 #endif
 #include "vtls/openssl.h"
-#endif /* USE_OPENSSL */
+#endif
 
 #include <nghttp3/nghttp3.h>
 
 #include "urldata.h"
+#include "url.h"
+#include "uint-hash.h"
+#include "curl_trc.h"
+#include "rand.h"
 #include "hash.h"
 #include "sendf.h"
 #include "multiif.h"
@@ -57,17 +60,13 @@
 #include "dynhds.h"
 #include "http_proxy.h"
 #include "select.h"
-#include "uint-hash.h"
 #include "vquic/vquic.h"
 #include "vquic/vquic_int.h"
 #include "vquic/vquic-tls.h"
 #include "vtls/vtls.h"
 #include "vtls/vtls_scache.h"
-#include "curl_trc.h"
 #include "cf-h3-proxy.h"
-#include "url.h"
 #include "capsule.h"
-#include "rand.h"
 
 /* A stream window is the maximum amount we need to buffer for
  * each active transfer. We use HTTP/3 flow control and only ACK
@@ -79,7 +78,7 @@
 
 /* The pool keeps spares around and half of a full stream window
  * seems good. More does not seem to improve performance.
- * The benefit of the pool is that stream buffer to not keep
+ * The benefit of the pool is that stream buffers do not keep
  * spares. Memory consumption goes down when streams run empty,
  * have a large upload done, etc. */
 #define PROXY_H3_STREAM_POOL_SPARES \
@@ -216,7 +215,7 @@ struct cf_ngtcp2_proxy_ctx {
   struct curl_tls_ctx tls;
 #ifdef OPENSSL_QUIC_API2
   ngtcp2_crypto_ossl_ctx *ossl_ctx;
-#endif /* OPENSSL_QUIC_API2 */
+#endif
   ngtcp2_path connected_path;
   ngtcp2_conn *qconn;
   ngtcp2_cid dcid;
@@ -229,32 +228,31 @@ struct cf_ngtcp2_proxy_ctx {
   struct cf_call_data call_data;
   nghttp3_conn *h3conn;
   nghttp3_settings h3settings;
-  struct curltime started_at;        /* time the current attempt started */
-  struct curltime handshake_at;      /* time connect handshake finished */
-  struct bufc_pool stream_bufcp;     /* chunk pool for streams */
-  struct dynbuf scratch;             /* temp buffer for header construction */
-  struct uint_hash streams;
-                            /* hash `data->mid` to `h3_proxy_stream_ctx` */
-  uint64_t used_bidi_streams;        /* bidi streams we have opened */
-  uint64_t max_bidi_streams;         /* max bidi streams we can open */
-  size_t earlydata_max;              /* max amount of early data supported by
-                                        server on session reuse */
-  size_t earlydata_skip;             /* sending bytes to skip when earlydata
-                                        is accepted by peer */
-  CURLcode tls_vrfy_result;          /* result of TLS peer verification */
+  struct curltime started_at;       /* time the current attempt started */
+  struct curltime handshake_at;     /* time connect handshake finished */
+  struct bufc_pool stream_bufcp;    /* chunk pool for streams */
+  struct dynbuf scratch;            /* temp buffer for header construction */
+  struct uint_hash streams;         /* hash data->mid to h3_proxy_stream_ctx */
+  uint64_t used_bidi_streams;       /* bidi streams we have opened */
+  uint64_t max_bidi_streams;        /* max bidi streams we can open */
+  size_t earlydata_max;             /* max amount of early data supported by
+                                       server on session reuse */
+  size_t earlydata_skip;            /* sending bytes to skip when earlydata
+                                       is accepted by peer */
+  CURLcode tls_vrfy_result;         /* result of TLS peer verification */
   int qlogfd;
   BIT(initialized);
-  BIT(tls_handshake_complete);       /* TLS handshake is done */
-  BIT(use_earlydata);                /* Using 0RTT data */
-  BIT(earlydata_accepted);           /* 0RTT was accepted by server */
-  BIT(shutdown_started);             /* queued shutdown packets */
+  BIT(tls_handshake_complete);      /* TLS handshake is done */
+  BIT(use_earlydata);               /* Using 0RTT data */
+  BIT(earlydata_accepted);          /* 0RTT was accepted by server */
+  BIT(shutdown_started);            /* queued shutdown packets */
 };
 
 struct cf_h3_proxy_ctx {
   struct cf_ngtcp2_proxy_ctx *ngtcp2_ctx;
-  struct cf_call_data call_data; /* fallback before backend ctx exists */
-  struct bufq inbufq;          /* network receive buffer */
-  struct Curl_peer *dest; /* where to tunnel to */
+  struct cf_call_data call_data;  /* fallback before backend ctx exists */
+  struct bufq inbufq;             /* network receive buffer */
+  struct Curl_peer *dest;         /* where to tunnel to */
   struct h3_tunnel_stream tunnel; /* our tunnel CONNECT stream */
   BIT(connected);
   BIT(udp_tunnel);
@@ -264,10 +262,10 @@ struct cf_h3_proxy_ctx {
  * All about the H3 internals of a stream
  */
 struct h3_proxy_stream_ctx {
-  int64_t id;              /* HTTP/3 stream identifier */
+  int64_t id;                   /* HTTP/3 stream identifier */
   struct bufq sendbuf;          /* h3 request body */
   size_t sendbuf_len_in_flight; /* sendbuf amount "in flight" */
-  uint64_t error3;         /* HTTP/3 stream error code */
+  uint64_t error3;              /* HTTP/3 stream error code */
   curl_off_t upload_left;       /* number of request bytes left to upload */
   curl_off_t tun_data_recvd;    /* number of bytes received over tunnel */
   uint64_t rx_offset;           /* current receive offset */
@@ -352,7 +350,7 @@ static void cf_ngtcp2_proxy_ctx_close(struct cf_ngtcp2_proxy_ctx *ctx)
     ngtcp2_crypto_ossl_ctx_del(ctx->ossl_ctx);
     ctx->ossl_ctx = NULL;
   }
-#endif /* OPENSSL_QUIC_API2 */
+#endif
   ctx->call_data = save;
 }
 
@@ -389,8 +387,8 @@ static void cf_ngtcp2_proxy_setup_keep_alive(struct Curl_cfilter *cf,
     ngtcp2_conn_set_keep_alive_timeout(ctx->qconn, keep_ns);
     CURL_TRC_CF(data, cf, "peer idle timeout is %" PRIu64 "ms, "
                 "set keep-alive to %" PRIu64 " ms.",
-                (uint64_t)(rp->max_idle_timeout / NGTCP2_MILLISECONDS),
-                (uint64_t)(keep_ns / NGTCP2_MILLISECONDS));
+                rp->max_idle_timeout / NGTCP2_MILLISECONDS,
+                keep_ns / NGTCP2_MILLISECONDS);
   }
 }
 
@@ -447,7 +445,7 @@ static void proxy_quic_printf(void *user_data, const char *fmt, ...)
   va_end(ap);
   curl_mfprintf(stderr, "\n");
 }
-#endif /* DEBUG_NGTCP2 */
+#endif
 
 static void proxy_qlog_callback(void *user_data, uint32_t flags,
                                 const void *data, size_t datalen)
@@ -479,7 +477,7 @@ static void quic_settings_proxy(struct cf_ngtcp2_proxy_ctx *ctx,
   s->log_printf = proxy_quic_printf;
 #else
   s->log_printf = NULL;
-#endif /* DEBUG_NGTCP2 */
+#endif
 
   s->initial_ts = pktx->ts;
   s->handshake_timeout = (data->set.connecttimeout > 0) ?
@@ -492,7 +490,7 @@ static void quic_settings_proxy(struct cf_ngtcp2_proxy_ctx *ctx,
   /* try ten times the ngtcp2 defaults here for problems with Caddy */
   s->glitch_ratelim_burst = 1000 * 10;
   s->glitch_ratelim_rate = 33 * 10;
-#endif /* NGTCP2_SETTINGS_V3 */
+#endif
   t->initial_max_data = 10 * PROXY_H3_STREAM_WINDOW_SIZE;
   t->initial_max_stream_data_bidi_local = PROXY_H3_STREAM_WINDOW_SIZE;
   t->initial_max_stream_data_bidi_remote = PROXY_H3_STREAM_WINDOW_SIZE;
@@ -1090,14 +1088,14 @@ static nghttp3_callbacks ngh3_proxy_callbacks = {
   cb_h3_proxy_reset_stream,
   NULL, /* shutdown */
   NULL, /* recv_settings (deprecated) */
-#ifdef NGHTTP3_CALLBACKS_V2 /* nghttp3 v1.11.0+ */
+#ifdef NGHTTP3_CALLBACKS_V2  /* nghttp3 v1.11.0+ */
   NULL, /* recv_origin */
   NULL, /* end_origin */
   NULL, /* rand */
-#endif /* NGHTTP3_CALLBACKS_V2 */
+#endif
 #ifdef NGHTTP3_CALLBACKS_V3  /* nghttp3 v1.14.0+ */
   NULL, /* recv_settings2 */
-#endif /* NGHTTP3_CALLBACKS_V3 */
+#endif
 };
 
 #if NGTCP2_VERSION_NUM < 0x011100
@@ -1254,7 +1252,7 @@ static int cb_ngtcp2_proxy_handshake_completed(ngtcp2_conn *tconn,
 #ifdef USE_GNUTLS
     int flags = gnutls_session_get_flags(ctx->tls.gtls.session);
     ctx->earlydata_accepted = !!(flags & GNUTLS_SFLAGS_EARLY_DATA);
-#endif /* USE_GNUTLS */
+#endif
 #ifdef USE_WOLFSSL
 #ifdef WOLFSSL_EARLY_DATA
     ctx->earlydata_accepted =
@@ -1264,7 +1262,7 @@ static int cb_ngtcp2_proxy_handshake_completed(ngtcp2_conn *tconn,
     DEBUGASSERT(0); /* should not come here if ED is disabled. */
     ctx->earlydata_accepted = FALSE;
 #endif /* WOLFSSL_EARLY_DATA */
-#endif /* USE_WOLFSSL */
+#endif
     CURL_TRC_CF(data, cf, "server did%s accept %zu bytes of early data",
                 ctx->earlydata_accepted ? "" : " not", ctx->earlydata_skip);
     Curl_pgrsEarlyData(data, ctx->earlydata_accepted ?
@@ -1292,7 +1290,7 @@ static int cb_ngtcp2_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
-  int64_t stream_id = (int64_t)sid;
+  int64_t stream_id = sid;
   nghttp3_ssize nconsumed;
   int fin = (flags & NGTCP2_STREAM_DATA_FLAG_FIN) ? 1 : 0;
   struct Curl_easy *data = stream_user_data;
@@ -1320,9 +1318,8 @@ static int cb_ngtcp2_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
    * including QPACK HEADERS. In other words, it does not consume payload of
    * DATA frame. */
   if(nconsumed) {
-    ngtcp2_conn_extend_max_stream_offset(tconn, stream_id,
-                                         (uint64_t)nconsumed);
-    ngtcp2_conn_extend_max_offset(tconn, (uint64_t)nconsumed);
+    ngtcp2_conn_extend_max_stream_offset(tconn, stream_id, nconsumed);
+    ngtcp2_conn_extend_max_offset(tconn, nconsumed);
   }
 
   return 0;
@@ -1360,7 +1357,7 @@ static int cb_ngtcp2_stream_close(ngtcp2_conn *tconn, uint32_t flags,
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
   struct Curl_easy *data = stream_user_data;
-  int64_t stream_id = (int64_t)sid;
+  int64_t stream_id = sid;
   int rv;
 
   (void)tconn;
@@ -1376,8 +1373,7 @@ static int cb_ngtcp2_stream_close(ngtcp2_conn *tconn, uint32_t flags,
 
   rv = nghttp3_conn_close_stream(ctx->h3conn, stream_id, app_error_code);
   CURL_TRC_CF(data, cf, "[%" PRId64 "] quic close(app_error=%"
-              PRIu64 ") -> %d", stream_id, (uint64_t)app_error_code,
-              rv);
+              PRIu64 ") -> %d", stream_id, app_error_code, rv);
   if(rv && rv != NGHTTP3_ERR_STREAM_NOT_FOUND) {
     cf_ngtcp2_proxy_h3_err_set(cf, data, rv);
     return NGTCP2_ERR_CALLBACK_FAILURE;
@@ -1397,9 +1393,8 @@ static int cb_ngtcp2_extend_max_local_streams_bidi(ngtcp2_conn *tconn,
   (void)tconn;
   ctx->max_bidi_streams = max_streams;
   if(data)
-    CURL_TRC_CF(data, cf, "max bidi streams now %" PRIu64
-                ", used %" PRIu64, (uint64_t)ctx->max_bidi_streams,
-                (uint64_t)ctx->used_bidi_streams);
+    CURL_TRC_CF(data, cf, "max bidi streams now %" PRIu64 ", used %" PRIu64,
+                ctx->max_bidi_streams, ctx->used_bidi_streams);
   return 0;
 }
 
@@ -1467,7 +1462,7 @@ static int cb_ngtcp2_stream_reset(ngtcp2_conn *tconn, int64_t sid,
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
-  int64_t stream_id = (int64_t)sid;
+  int64_t stream_id = sid;
   struct Curl_easy *data = stream_user_data;
   int rv;
   (void)tconn;
@@ -1508,7 +1503,7 @@ static int cb_ngtcp2_extend_max_stream_data(ngtcp2_conn *tconn,
   stream = H3_PROXY_STREAM_CTX(ctx, s_data);
   if(stream && stream->quic_flow_blocked) {
     CURL_TRC_CF(s_data, cf, "[%" PRId64 "] unblock quic flow",
-                (int64_t)stream_id);
+                stream_id);
     stream->quic_flow_blocked = FALSE;
     Curl_multi_mark_dirty(s_data);
   }
@@ -1605,13 +1600,13 @@ static ngtcp2_callbacks ngtcp2_proxy_callbacks = {
   NULL, /* early_data_rejected */
 #ifdef NGTCP2_CALLBACKS_V2  /* ngtcp2 v1.14.0+ */
   NULL, /* begin_path_validation */
-#endif /* NGTCP2_CALLBACKS_V2 */
+#endif
 #ifdef NGTCP2_CALLBACKS_V3  /* ngtcp2 v1.22.0+ */
   NULL, /* recv_stateless_reset2 */
   cb_ngtcp2_get_new_connection_id2, /* get_new_connection_id2 */
   NULL, /* dcid_status2 */
   ngtcp2_crypto_get_path_challenge_data2_cb, /* get_path_challenge_data2 */
-#endif /* NGTCP2_CALLBACKS_V3 */
+#endif
 };
 
 #if defined(_MSC_VER) && defined(_DLL)
@@ -1636,7 +1631,7 @@ static CURLcode cf_ngtcp2_recv_pkts_proxy(const unsigned char *buf,
     CURL_TRC_CF(pktx->data, pktx->cf, "vquic_recv(len=%zu, gso=%zu, ecn=%x)",
                 buflen, gso_size, ecn);
   ngtcp2_addr_init(&path.local, (struct sockaddr *)&ctx->q.local_addr,
-                   (socklen_t)ctx->q.local_addrlen);
+                   ctx->q.local_addrlen);
   ngtcp2_addr_init(&path.remote, (struct sockaddr *)remote_addr,
                    remote_addrlen);
   pi.ecn = (uint8_t)ecn;
@@ -1751,11 +1746,11 @@ static CURLcode proxy_read_pkt_to_send(void *userp,
     else if(n < 0) {
       switch(n) {
       case NGTCP2_ERR_STREAM_DATA_BLOCKED: {
-        struct h3_proxy_stream_ctx *stream = NULL;
+        struct h3_proxy_stream_ctx *stream;
         DEBUGASSERT(ndatalen == -1);
         nghttp3_conn_block_stream(ctx->h3conn, stream_id);
         CURL_TRC_CF(x->data, x->cf, "[%" PRId64 "] block quic flow",
-                    (int64_t)stream_id);
+                    stream_id);
         stream = cf_ngtcp2_proxy_get_stream(ctx, stream_id);
         if(stream) /* it might be not one of our h3 streams? */
           stream->quic_flow_blocked = TRUE;
@@ -1963,7 +1958,7 @@ static CURLcode cf_ngtcp2_proxy_shutdown(struct Curl_cfilter *cf,
       &ctx->last_error, pktx.ts);
     CURL_TRC_CF(data, cf, "start shutdown(err_type=%d, err_code=%"
                 PRIu64 ") -> %zd", ctx->last_error.type,
-                (uint64_t)ctx->last_error.error_code, (ssize_t)nwritten);
+                ctx->last_error.error_code, (ssize_t)nwritten);
     /* there are cases listed in ngtcp2 documentation where this call
      * may fail. Since we are doing a connection shutdown as graceful
      * as we can, such an error is ignored here. */
@@ -2442,7 +2437,7 @@ static void proxy_h3_submit(int64_t *pstream_id,
       *err = CURLE_SEND_ERROR;
       goto out;
     }
-    stream->id = (int64_t)sid;
+    stream->id = sid;
     ++ctx->used_bidi_streams;
 
     /* Set stream user data in ngtcp2 connection for callbacks */
@@ -2718,8 +2713,8 @@ static int proxy_quic_ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
 {
   ngtcp2_crypto_conn_ref *cref;
   struct Curl_cfilter *cf;
-  struct cf_h3_proxy_ctx *proxy_ctx;
   struct cf_ngtcp2_proxy_ctx *ctx;
+  struct cf_h3_proxy_ctx *proxy_ctx;
   struct Curl_easy *data;
 
   cref = (ngtcp2_crypto_conn_ref *)SSL_get_app_data(ssl);
@@ -2743,7 +2738,7 @@ static int proxy_quic_ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
       quic_tp = (unsigned char *)tpbuf;
       quic_tp_len = (size_t)tplen;
     }
-#endif /* HAVE_OPENSSL_EARLYDATA */
+#endif
     Curl_ossl_add_session(cf, data, ctx->peer.scache_key, ssl_sessionid,
                           SSL_version(ssl), "h3", quic_tp, quic_tp_len);
   }
@@ -2758,7 +2753,7 @@ static CURLcode cf_ngtcp2_proxy_tls_ctx_setup(struct Curl_cfilter *cf,
   struct curl_tls_ctx *ctx = user_data;
 
 #ifdef USE_OPENSSL
-#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
   if(ngtcp2_crypto_boringssl_configure_client_context(ctx->ossl.ssl_ctx)
      != 0) {
     failf(data, "ngtcp2_crypto_boringssl_configure_client_context failed");
@@ -2771,7 +2766,7 @@ static CURLcode cf_ngtcp2_proxy_tls_ctx_setup(struct Curl_cfilter *cf,
     failf(data, "ngtcp2_crypto_quictls_configure_client_context failed");
     return CURLE_FAILED_INIT;
   }
-#endif
+#endif /* !OPENSSL_IS_AWSLC && !OPENSSL_IS_BORINGSSL */
   if(Curl_ssl_scache_use(cf, data)) {
     SSL_CTX_set_session_cache_mode(ctx->ossl.ssl_ctx,
                                    SSL_SESS_CACHE_CLIENT |
@@ -2803,24 +2798,24 @@ static CURLcode cf_ngtcp2_proxy_on_session_reuse(struct Curl_cfilter *cf,
 #ifdef USE_GNUTLS
   ctx->earlydata_max =
     gnutls_record_get_max_early_data_size(ctx->tls.gtls.session);
-#endif /* USE_GNUTLS */
+#endif
 #ifdef USE_WOLFSSL
 #ifdef WOLFSSL_EARLY_DATA
   ctx->earlydata_max = scs->earlydata_max;
 #else
   ctx->earlydata_max = 0;
 #endif /* WOLFSSL_EARLY_DATA */
-#endif /* USE_WOLFSSL */
-#if defined(USE_GNUTLS) || defined(USE_WOLFSSL) ||          \
+#endif
+#if defined(USE_GNUTLS) || defined(USE_WOLFSSL) || \
   (defined(USE_OPENSSL) && defined(HAVE_OPENSSL_EARLYDATA))
-  if((!ctx->earlydata_max)) {
+  if(!ctx->earlydata_max) {
     CURL_TRC_CF(data, cf, "SSL session does not allow earlydata");
   }
   else if(!Curl_alpn_contains_proto(alpns, scs->alpn)) {
     CURL_TRC_CF(data, cf, "SSL session from different ALPN, no early data");
   }
   else if(!scs->quic_tp || !scs->quic_tp_len) {
-    CURL_TRC_CF(data, cf, "no 0RTT transport parameters, no early data, ");
+    CURL_TRC_CF(data, cf, "no 0RTT transport parameters, no early data");
   }
   else {
     int rv;
@@ -3118,7 +3113,7 @@ out:
     result = CURLE_COULDNT_CONNECT;
     if(cerr) {
       CURL_TRC_CF(data, cf, "connect error, type=%d, code=%" PRIu64,
-                  cerr->type, (uint64_t)cerr->error_code);
+                  cerr->type, cerr->error_code);
       switch(cerr->type) {
       case NGTCP2_CCERR_TYPE_VERSION_NEGOTIATION:
         CURL_TRC_CF(data, cf, "error in version negotiation");

--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -821,13 +821,12 @@ static int cb_h3_proxy_deferred_consume(nghttp3_conn *conn, int64_t stream_id,
   return 0;
 }
 
-static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t sid,
+static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t stream_id,
                                    int32_t token, nghttp3_rcbuf *name,
                                    nghttp3_rcbuf *value, uint8_t flags,
                                    void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
-  int64_t stream_id = sid;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
   nghttp3_vec h3name = nghttp3_rcbuf_get_buf(name);
@@ -893,14 +892,14 @@ static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t sid,
   return 0;
 }
 
-static int cb_h3_proxy_end_headers(nghttp3_conn *conn, int64_t sid, int fin,
-                                   void *user_data, void *stream_user_data)
+static int cb_h3_proxy_end_headers(nghttp3_conn *conn, int64_t stream_id,
+                                   int fin, void *user_data,
+                                   void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
   struct Curl_easy *data = stream_user_data;
-  int64_t stream_id = sid;
   struct h3_proxy_stream_ctx *stream;
   (void)conn;
   (void)stream_id;
@@ -941,7 +940,7 @@ static int cb_h3_proxy_end_headers(nghttp3_conn *conn, int64_t sid, int fin,
   return 0;
 }
 
-static int cb_h3_proxy_stop_sending(nghttp3_conn *conn, int64_t sid,
+static int cb_h3_proxy_stop_sending(nghttp3_conn *conn, int64_t stream_id,
                                     uint64_t app_error_code, void *user_data,
                                     void *stream_user_data)
 {
@@ -953,7 +952,7 @@ static int cb_h3_proxy_stop_sending(nghttp3_conn *conn, int64_t sid,
   (void)stream_user_data;
 
   if(ctx) {
-    int rv = ngtcp2_conn_shutdown_stream_read(ctx->qconn, 0, sid,
+    int rv = ngtcp2_conn_shutdown_stream_read(ctx->qconn, 0, stream_id,
                                               app_error_code);
 
     if(rv && rv != NGTCP2_ERR_STREAM_NOT_FOUND) {
@@ -964,7 +963,7 @@ static int cb_h3_proxy_stop_sending(nghttp3_conn *conn, int64_t sid,
   return 0;
 }
 
-static int cb_h3_proxy_reset_stream(nghttp3_conn *conn, int64_t sid,
+static int cb_h3_proxy_reset_stream(nghttp3_conn *conn, int64_t stream_id,
                                     uint64_t app_error_code, void *user_data,
                                     void *stream_user_data)
 {
@@ -972,7 +971,6 @@ static int cb_h3_proxy_reset_stream(nghttp3_conn *conn, int64_t sid,
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
   struct Curl_easy *data = stream_user_data;
-  int64_t stream_id = sid;
   int rv;
   (void)conn;
 
@@ -1283,14 +1281,13 @@ static int cb_ngtcp2_proxy_handshake_completed(ngtcp2_conn *tconn,
 }
 
 static int cb_ngtcp2_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
-                                      int64_t sid, uint64_t offset,
+                                      int64_t stream_id, uint64_t offset,
                                       const uint8_t *buf, size_t buflen,
                                       void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
-  int64_t stream_id = sid;
   nghttp3_ssize nconsumed;
   int fin = (flags & NGTCP2_STREAM_DATA_FLAG_FIN) ? 1 : 0;
   struct Curl_easy *data = stream_user_data;
@@ -1350,14 +1347,13 @@ static int cb_ngtcp2_acked_stream_data_offset(ngtcp2_conn *tconn,
 }
 
 static int cb_ngtcp2_stream_close(ngtcp2_conn *tconn, uint32_t flags,
-                                  int64_t sid, uint64_t app_error_code,
+                                  int64_t stream_id, uint64_t app_error_code,
                                   void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
   struct Curl_easy *data = stream_user_data;
-  int64_t stream_id = sid;
   int rv;
 
   (void)tconn;
@@ -1455,14 +1451,13 @@ static int cb_ngtcp2_get_new_connection_id2(ngtcp2_conn *tconn,
 }
 #endif
 
-static int cb_ngtcp2_stream_reset(ngtcp2_conn *tconn, int64_t sid,
+static int cb_ngtcp2_stream_reset(ngtcp2_conn *tconn, int64_t stream_id,
                                   uint64_t final_size, uint64_t app_error_code,
                                   void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct cf_h3_proxy_ctx *proxy_ctx = cf->ctx;
   struct cf_ngtcp2_proxy_ctx *ctx = proxy_ctx->ngtcp2_ctx;
-  int64_t stream_id = sid;
   struct Curl_easy *data = stream_user_data;
   int rv;
   (void)tconn;

--- a/lib/cf-h3-proxy.h
+++ b/lib/cf-h3-proxy.h
@@ -27,8 +27,8 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_PROXY) && \
-    defined(USE_PROXY_HTTP3) && defined(USE_NGHTTP3) && \
-    defined(USE_NGTCP2) && defined(USE_OPENSSL)
+  defined(USE_PROXY_HTTP3) && defined(USE_NGHTTP3) &&              \
+  defined(USE_NGTCP2) && defined(USE_OPENSSL)
 
 CURLcode Curl_cf_h3_proxy_insert_after(struct Curl_cfilter *cf_at,
                                        struct Curl_easy *data,

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -168,8 +168,8 @@ static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *context)
   /* Use a larger buffer to work around a bug in NetBSD:
      https://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=58039 */
   unsigned char tmp_digest[CURL_SHA512_256_DIGEST_SIZE * 2];
-  result = EVP_DigestFinal_ex(*ctx,
-                           tmp_digest, NULL) ? CURLE_OK : CURLE_SSL_CIPHER;
+  result = EVP_DigestFinal_ex(*ctx, tmp_digest, NULL) ?
+    CURLE_OK : CURLE_SSL_CIPHER;
   if(result == CURLE_OK)
     memcpy(digest, tmp_digest, CURL_SHA512_256_DIGEST_SIZE);
   curlx_memzero(tmp_digest, sizeof(tmp_digest));

--- a/lib/http.c
+++ b/lib/http.c
@@ -338,7 +338,6 @@ static CURLcode http_output_bearer(struct Curl_easy *data)
 fail:
   return result;
 }
-
 #endif
 
 #endif

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -3021,6 +3021,3 @@ char *curl_pushheader_byname(struct curl_pushheaders *h, const char *name)
 }
 
 #endif /* !CURL_DISABLE_HTTP && USE_NGHTTP2 */
-
-/* Do not leak this filter's call_data accessor in unity builds. */
-#undef CF_CTX_CALL_DATA

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -121,7 +121,7 @@ static void my_md5_final(unsigned char *digest, void *ctx)
 }
 
 #elif defined(USE_MBEDTLS) && \
-  defined(PSA_WANT_ALG_MD5) && PSA_WANT_ALG_MD5  /* mbedTLS 4+ */
+  defined(PSA_WANT_ALG_MD5) && PSA_WANT_ALG_MD5  /* mbedTLS 3+ */
 #include <psa/crypto.h>
 
 typedef psa_hash_operation_t my_md5_ctx;

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -121,7 +121,7 @@ static void my_md5_final(unsigned char *digest, void *ctx)
 }
 
 #elif defined(USE_MBEDTLS) && \
-  defined(PSA_WANT_ALG_MD5) && PSA_WANT_ALG_MD5  /* mbedTLS 3+ */
+  defined(PSA_WANT_ALG_MD5) && PSA_WANT_ALG_MD5
 #include <psa/crypto.h>
 
 typedef psa_hash_operation_t my_md5_ctx;

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -46,8 +46,7 @@
 
 
 /* .netrc is not really a standard. The GNU definition can be found here:
- * https://www.gnu.org/software/inetutils/manual/\
- *            html_node/The-_002enetrc-file.html
+ * https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
  * This gives grammar like:
  *
  * LITERAL := \S+ | QUOTED
@@ -81,8 +80,8 @@
 #define NETRC_DEBUG   0
 
 /* convert a dynbuf call CURLcode error to a NETRCcode error */
-#define curl2netrc(r)                     \
-  ((!(r)) ? NETRC_OK : (((r) == CURLE_OUT_OF_MEMORY) ?         \
+#define curl2netrc(r)                                  \
+  ((!(r)) ? NETRC_OK : (((r) == CURLE_OUT_OF_MEMORY) ? \
    NETRC_OUT_OF_MEMORY : NETRC_SYNTAX_ERROR))
 
 typedef enum {
@@ -132,7 +131,6 @@ static const char *netrc_tokenstr(curl_netrc_token token)
     return "[???]";
   }
 }
-
 #endif
 
 static void netrc_lexer_init(struct netrc_lexer *lexer,

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -141,7 +141,7 @@ static void my_sha256_final(unsigned char *digest, void *ctx)
 }
 
 #elif defined(USE_MBEDTLS) && \
-  defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256  /* mbedTLS 4+ */
+  defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256  /* mbedTLS 3+ */
 #include <psa/crypto.h>
 
 typedef psa_hash_operation_t my_sha256_ctx;

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -141,7 +141,7 @@ static void my_sha256_final(unsigned char *digest, void *ctx)
 }
 
 #elif defined(USE_MBEDTLS) && \
-  defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256  /* mbedTLS 3+ */
+  defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256
 #include <psa/crypto.h>
 
 typedef psa_hash_operation_t my_sha256_ctx;

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -958,13 +958,13 @@ static CURLproxycode socks5_recv_resp1(struct socks_ctx *sx,
      +----+-----+-------+------+----------+----------+
      |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
      +----+-----+-------+------+----------+----------+
-     | 1  |  1  | X'00' |  1   | Variable |    2     |
+     | 1  |  1  | 0x00  |  1   | Variable |    2     |
      +----+-----+-------+------+----------+----------+
 
      ATYP:
-     o  IPv4 address: X'01', BND.ADDR = 4 byte
-     o  domain name:  X'03', BND.ADDR = [ 1 byte length, string ]
-     o  IPv6 address: X'04', BND.ADDR = 16 byte
+     o IPv4 address: 0x01, BND.ADDR = 4 byte
+     o domain name:  0x03, BND.ADDR = [ 1 byte length, string ]
+     o IPv6 address: 0x04, BND.ADDR = 16 byte
   */
   if(resp[0] != 5) { /* version */
     failf(data, "SOCKS5 reply has wrong version, version should be 5.");

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -962,9 +962,9 @@ static CURLproxycode socks5_recv_resp1(struct socks_ctx *sx,
      +----+-----+-------+------+----------+----------+
 
      ATYP:
-     o  IP v4 address: X'01', BND.ADDR = 4 byte
-     o  domain name:   X'03', BND.ADDR = [ 1 byte length, string ]
-     o  IP v6 address: X'04', BND.ADDR = 16 byte
+     o  IPv4 address: X'01', BND.ADDR = 4 byte
+     o  domain name:  X'03', BND.ADDR = [ 1 byte length, string ]
+     o  IPv6 address: X'04', BND.ADDR = 16 byte
   */
   if(resp[0] != 5) { /* version */
     failf(data, "SOCKS5 reply has wrong version, version should be 5.");

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -88,7 +88,7 @@
 
 /* The pool keeps spares around and half of a full stream windows
  * seems good. More does not seem to improve performance.
- * The benefit of the pool is that stream buffer to not keep
+ * The benefit of the pool is that stream buffers do not keep
  * spares. Memory consumption goes down when streams run empty,
  * have a large upload done, etc. */
 #define H3_STREAM_POOL_SPARES      2
@@ -1680,7 +1680,7 @@ static CURLcode h3_stream_open(struct Curl_cfilter *cf,
 
   rc = ngtcp2_conn_open_bidi_stream(ctx->qconn, &sid, data);
   if(rc) {
-    failf(data, "can get bidi streams");
+    failf(data, "cannot open bidi streams");
     result = CURLE_SEND_ERROR;
     goto out;
   }
@@ -2657,7 +2657,7 @@ static CURLcode cf_ngtcp2_on_session_reuse(struct Curl_cfilter *cf,
     CURL_TRC_CF(data, cf, "SSL session from different ALPN, no early data");
   }
   else if(!scs->quic_tp || !scs->quic_tp_len) {
-    CURL_TRC_CF(data, cf, "no 0RTT transport parameters, no early data, ");
+    CURL_TRC_CF(data, cf, "no 0RTT transport parameters, no early data");
   }
   else {
     int rv;

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -24,8 +24,8 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_NGTCP2) && defined(USE_NGHTTP3)
+
 #include <ngtcp2/ngtcp2.h>
-#include <nghttp3/nghttp3.h>
 
 #ifdef USE_OPENSSL
 #include <openssl/err.h>
@@ -44,6 +44,8 @@
 #include <ngtcp2/ngtcp2_crypto_wolfssl.h>
 #include "vtls/wolfssl.h"
 #endif
+
+#include <nghttp3/nghttp3.h>
 
 #include "urldata.h"
 #include "url.h"
@@ -86,7 +88,7 @@
 #error H3_STREAM_CHUNK_SIZE smaller than NGTCP2_MAX_UDP_PAYLOAD_SIZE
 #endif
 
-/* The pool keeps spares around and half of a full stream windows
+/* The pool keeps spares around and half of a full stream window
  * seems good. More does not seem to improve performance.
  * The benefit of the pool is that stream buffers do not keep
  * spares. Memory consumption goes down when streams run empty,
@@ -128,26 +130,26 @@ struct cf_ngtcp2_ctx {
   struct cf_call_data call_data;
   nghttp3_conn *h3conn;
   nghttp3_settings h3settings;
-  struct curltime started_at;        /* time the current attempt started */
-  struct curltime handshake_at;      /* time connect handshake finished */
-  struct bufc_pool stream_bufcp;     /* chunk pool for streams */
-  struct dynbuf scratch;             /* temp buffer for header construction */
-  struct uint_hash streams;          /* hash `data->mid` to `h3_stream_ctx` */
-  uint64_t used_bidi_streams;        /* bidi streams we have opened */
-  uint64_t max_bidi_streams;         /* max bidi streams we can open */
-  size_t earlydata_max;              /* max amount of early data supported by
-                                        server on session reuse */
-  size_t earlydata_skip;             /* sending bytes to skip when earlydata
-                                        is accepted by peer */
-  CURLcode tls_vrfy_result;          /* result of TLS peer verification */
+  struct curltime started_at;       /* time the current attempt started */
+  struct curltime handshake_at;     /* time connect handshake finished */
+  struct bufc_pool stream_bufcp;    /* chunk pool for streams */
+  struct dynbuf scratch;            /* temp buffer for header construction */
+  struct uint_hash streams;         /* hash data->mid to h3_stream_ctx */
+  uint64_t used_bidi_streams;       /* bidi streams we have opened */
+  uint64_t max_bidi_streams;        /* max bidi streams we can open */
+  size_t earlydata_max;             /* max amount of early data supported by
+                                       server on session reuse */
+  size_t earlydata_skip;            /* sending bytes to skip when earlydata
+                                       is accepted by peer */
+  CURLcode tls_vrfy_result;         /* result of TLS peer verification */
   int qlogfd;
-  unsigned char *tunnel_inbuf;       /* ingress buffer for tunneled packets */
+  unsigned char *tunnel_inbuf;      /* ingress buffer for tunneled packets */
   size_t tunnel_inbuf_len;
   BIT(initialized);
-  BIT(tls_handshake_complete);       /* TLS handshake is done */
-  BIT(use_earlydata);                /* Using 0RTT data */
-  BIT(earlydata_accepted);           /* 0RTT was accepted by server */
-  BIT(shutdown_started);             /* queued shutdown packets */
+  BIT(tls_handshake_complete);      /* TLS handshake is done */
+  BIT(use_earlydata);               /* Using 0RTT data */
+  BIT(earlydata_accepted);          /* 0RTT was accepted by server */
+  BIT(shutdown_started);            /* queued shutdown packets */
 };
 
 /* How to access `call_data` from a cf_ngtcp2 filter */
@@ -432,11 +434,8 @@ static ngtcp2_conn *get_conn(ngtcp2_crypto_conn_ref *conn_ref)
 #ifdef DEBUG_NGTCP2
 static void quic_printf(void *user_data, const char *fmt, ...)
 {
-  struct Curl_cfilter *cf = user_data;
-  struct cf_ngtcp2_ctx *ctx = cf->ctx;
-
-  (void)ctx;  /* need an easy handle to infof() message */
   va_list ap;
+  (void)user_data;
   va_start(ap, fmt);
   curl_mvfprintf(stderr, fmt, ap);
   va_end(ap);
@@ -1052,7 +1051,7 @@ static int cb_h3_stream_close(nghttp3_conn *conn, int64_t stream_id,
 static void h3_xfer_write_resp_hd(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
                                   struct h3_stream_ctx *stream,
-                                  const char *buf, size_t blen, bool eos)
+                                  const char *buf, size_t buflen, bool eos)
 {
   /* This function returns no error intentionally, but records
    * the result at the stream, skipping further writes once the
@@ -1061,17 +1060,17 @@ static void h3_xfer_write_resp_hd(struct Curl_cfilter *cf,
    * send/recv callbacks. Closing the stream here leads to SEND/RECV
    * errors in other places that then overwrite the transfer's result. */
   if(!stream->xfer_result) {
-    stream->xfer_result = Curl_xfer_write_resp_hd(data, buf, blen, eos);
+    stream->xfer_result = Curl_xfer_write_resp_hd(data, buf, buflen, eos);
     if(stream->xfer_result)
       CURL_TRC_CF(data, cf, "[%" PRId64 "] error %d writing %zu "
-                  "bytes of headers", stream->id, stream->xfer_result, blen);
+                  "bytes of headers", stream->id, stream->xfer_result, buflen);
   }
 }
 
 static void h3_xfer_write_resp(struct Curl_cfilter *cf,
                                struct Curl_easy *data,
                                struct h3_stream_ctx *stream,
-                               const char *buf, size_t blen, bool eos)
+                               const char *buf, size_t buflen, bool eos)
 {
   /* This function returns no error intentionally, but records
    * the result at the stream, skipping further writes once the
@@ -1080,11 +1079,11 @@ static void h3_xfer_write_resp(struct Curl_cfilter *cf,
    * send/recv callbacks. Closing the stream here leads to SEND/RECV
    * errors in other places that then overwrite the transfer's result. */
   if(!stream->xfer_result) {
-    stream->xfer_result = Curl_xfer_write_resp(data, buf, blen, eos);
+    stream->xfer_result = Curl_xfer_write_resp(data, buf, buflen, eos);
     /* If the transfer write is errored, we do not want any more data */
     if(stream->xfer_result) {
       CURL_TRC_CF(data, cf, "[%" PRId64 "] error %d writing %zu bytes of data",
-                  stream->id, stream->xfer_result, blen);
+                  stream->id, stream->xfer_result, buflen);
     }
   }
 }
@@ -1135,7 +1134,7 @@ static void cf_ngtcp2_upd_rx_win(struct Curl_cfilter *cf,
 }
 
 static int cb_h3_recv_data(nghttp3_conn *conn, int64_t stream3_id,
-                           const uint8_t *buf, size_t blen,
+                           const uint8_t *buf, size_t buflen,
                            void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
@@ -1149,15 +1148,15 @@ static int cb_h3_recv_data(nghttp3_conn *conn, int64_t stream3_id,
   if(!stream)
     return NGHTTP3_ERR_CALLBACK_FAILURE;
 
-  h3_xfer_write_resp(cf, data, stream, (const char *)buf, blen, FALSE);
+  h3_xfer_write_resp(cf, data, stream, (const char *)buf, buflen, FALSE);
 
-  ngtcp2_conn_extend_max_offset(ctx->qconn, blen);
-  stream->rx_offset += blen;
+  ngtcp2_conn_extend_max_offset(ctx->qconn, buflen);
+  stream->rx_offset += buflen;
   if(stream->rx_offset_max < stream->rx_offset)
     stream->rx_offset_max = stream->rx_offset;
 
   CURL_TRC_CF(data, cf, "[%" PRId64 "] DATA len=%zu, rx win=%" PRIu64,
-              stream->id, blen, stream->rx_offset_max - stream->rx_offset);
+              stream->id, buflen, stream->rx_offset_max - stream->rx_offset);
   cf_ngtcp2_upd_rx_win(cf, data, stream);
   return 0;
 }
@@ -1442,7 +1441,7 @@ static CURLcode recv_closed_stream(struct Curl_cfilter *cf,
 
 /* incoming data frames on the h3 stream */
 static CURLcode cf_ngtcp2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
-                               char *buf, size_t blen, size_t *pnread)
+                               char *buf, size_t buflen, size_t *pnread)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
@@ -1453,7 +1452,7 @@ static CURLcode cf_ngtcp2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   (void)ctx;
   (void)buf;
-  NOVERBOSE((void)blen);
+  NOVERBOSE((void)buflen);
 
   CF_DATA_SAVE(save, cf, data);
   DEBUGASSERT(cf->connected);
@@ -1508,8 +1507,8 @@ out:
   if(ctx->tls_vrfy_result)
     result = ctx->tls_vrfy_result;
 denied:
-  CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_recv(blen=%zu) -> %d, %zu",
-              stream ? stream->id : -1, blen, result, *pnread);
+  CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_recv(buflen=%zu) -> %d, %zu",
+              stream ? stream->id : -1, buflen, result, *pnread);
   CF_DATA_RESTORE(cf, save);
   return result;
 }

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -3164,6 +3164,3 @@ out:
 }
 
 #endif
-
-/* Do not leak this filter's call_data accessor in unity builds. */
-#undef CF_CTX_CALL_DATA

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -529,10 +529,9 @@ static int cb_ngtcp2_handshake_completed(ngtcp2_conn *tconn, void *user_data)
     rp = ngtcp2_conn_get_remote_transport_params(ctx->qconn);
     CURL_TRC_CF(data, cf, "handshake complete after %" FMT_TIMEDIFF_T
                 "ms, remote transport[max_udp_payload=%" PRIu64
-                ", initial_max_data=%" PRIu64
-                "]",
-               curlx_ptimediff_ms(&ctx->handshake_at, &ctx->started_at),
-               rp->max_udp_payload_size, rp->initial_max_data);
+                ", initial_max_data=%" PRIu64 "]",
+                curlx_ptimediff_ms(&ctx->handshake_at, &ctx->started_at),
+                rp->max_udp_payload_size, rp->initial_max_data);
   }
 #endif
 
@@ -822,7 +821,8 @@ static int cb_get_new_connection_id(ngtcp2_conn *tconn, ngtcp2_cid *cid,
 }
 
 #ifdef NGTCP2_CALLBACKS_V3  /* ngtcp2 v1.22.0+ */
-static int cb_get_new_connection_id2(ngtcp2_conn *tconn, ngtcp2_cid *cid,
+static int cb_get_new_connection_id2(
+  ngtcp2_conn *tconn, ngtcp2_cid *cid,
   struct ngtcp2_stateless_reset_token *token, size_t cidlen, void *user_data)
 {
   CURLcode result;
@@ -1104,8 +1104,7 @@ static void cf_ngtcp2_upd_rx_win(struct Curl_cfilter *cf,
     if(!stream->rx_offset)
       return;
 
-    avail = Curl_rlimit_avail(&data->progress.dl.rlimit,
-                              Curl_pgrs_now(data));
+    avail = Curl_rlimit_avail(&data->progress.dl.rlimit, Curl_pgrs_now(data));
     if(avail <= 0) {
       /* nothing available, do not extend the rx offset */
       CURL_TRC_CF(data, cf, "[%" PRId64 "] dl rate limit exhausted (%" PRId64
@@ -1397,8 +1396,7 @@ static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
   rc = nghttp3_conn_bind_qpack_streams(ctx->h3conn, qpack_enc_stream_id,
                                        qpack_dec_stream_id);
   if(rc) {
-    failf(data, "error binding HTTP/3 qpack streams: %s",
-          ngtcp2_strerror(rc));
+    failf(data, "error binding HTTP/3 qpack streams: %s", ngtcp2_strerror(rc));
     return CURLE_QUIC_CONNECT_ERROR;
   }
 
@@ -1958,8 +1956,7 @@ static CURLcode cf_progress_ingress(struct Curl_cfilter *cf,
         return CURLE_OK;
       }
       if(result) {
-        CURL_TRC_CF(data, cf, "ingress, recv from tunnel failed: %d",
-                    result);
+        CURL_TRC_CF(data, cf, "ingress, recv from tunnel failed: %d", result);
         return result;
       }
       if(nread == 0) {
@@ -2742,15 +2739,15 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
     /* Direct UDP socket - get local address for ngtcp2 */
     ctx->q.local_addrlen = sizeof(ctx->q.local_addr);
     rv = getsockname(ctx->q.sockfd, (struct sockaddr *)&ctx->q.local_addr,
-                    &ctx->q.local_addrlen);
+                     &ctx->q.local_addrlen);
     if(rv == -1)
       return CURLE_QUIC_CONNECT_ERROR;
 
     ngtcp2_addr_init(&ctx->connected_path.local,
-                    (struct sockaddr *)&ctx->q.local_addr,
-                    ctx->q.local_addrlen);
+                     (struct sockaddr *)&ctx->q.local_addr,
+                     ctx->q.local_addrlen);
     ngtcp2_addr_init(&ctx->connected_path.remote,
-                    &sockaddr->curl_sa_addr, (socklen_t)sockaddr->addrlen);
+                     &sockaddr->curl_sa_addr, (socklen_t)sockaddr->addrlen);
 
     rc = ngtcp2_conn_client_new(&ctx->qconn, &ctx->dcid, &ctx->scid,
                                 &ctx->connected_path,

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -255,8 +255,8 @@ static CURLcode send_packet_no_gso(struct Curl_cfilter *cf,
     VERBOSE(++calls);
   }
 out:
-  CURL_TRC_CF(data, cf, "vquic_%s(len=%zu, gso=%zu, calls=%zu)"
-              " -> %d, sent=%zu",
+  CURL_TRC_CF(data, cf,
+              "vquic_%s(len=%zu, gso=%zu, calls=%zu) -> %d, sent=%zu",
               VQUIC_SEND_METHOD, pktlen, gsolen, calls, result, *psent);
   return result;
 }
@@ -293,8 +293,8 @@ static CURLcode send_packet_no_gso_cf(struct Curl_cfilter *cf,
   }
 
 out:
-  CURL_TRC_CF(data, cf, "vquic_cf_send(len=%zu, gso=%zu, calls=%zu)"
-              " -> %d, sent=%zu",
+  CURL_TRC_CF(data, cf,
+              "vquic_cf_send(len=%zu, gso=%zu, calls=%zu) -> %d, sent=%zu",
               pktlen, gsolen, calls, result, *psent);
   return result;
 }
@@ -323,8 +323,8 @@ static CURLcode vquic_send_packets(struct Curl_cfilter *cf,
   }
   else {
     result = do_sendmsg(cf, data, qctx, pkt, pktlen, gsolen, psent);
-    CURL_TRC_CF(data, cf, "vquic_%s(len=%zu, gso=%zu, calls=1)"
-                " -> %d, sent=%zu",
+    CURL_TRC_CF(data, cf,
+                "vquic_%s(len=%zu, gso=%zu, calls=1) -> %d, sent=%zu",
                 VQUIC_SEND_METHOD, pktlen, gsolen, result, *psent);
   }
   if(!result)
@@ -499,7 +499,7 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
       }
       curlx_strerror(SOCKERRNO, errstr, sizeof(errstr));
       failf(data, "QUIC: recvmmsg() unexpectedly returned %d (errno=%d; %s)",
-                  mcount, SOCKERRNO, errstr);
+            mcount, SOCKERRNO, errstr);
       result = CURLE_RECV_ERROR;
       goto out;
     }
@@ -526,8 +526,9 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
 
 out:
   if(total_nread || result)
-    CURL_TRC_CF(data, cf, "vquic_recvmmsg(len=%zu, packets=%zu, calls=%zu)"
-                " -> %d", total_nread, pkts, calls, result);
+    CURL_TRC_CF(data, cf,
+                "vquic_recvmmsg(len=%zu, packets=%zu, calls=%zu) -> %d",
+                total_nread, pkts, calls, result);
   Curl_multi_xfer_sockbuf_release(data, sockbuf);
   return result;
 }
@@ -607,8 +608,9 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
 
 out:
   if(total_nread || result)
-    CURL_TRC_CF(data, cf, "vquic_recvmsg(len=%zu, packets=%zu, calls=%zu)"
-                " -> %d", total_nread, pkts, calls, result);
+    CURL_TRC_CF(data, cf,
+                "vquic_recvmsg(len=%zu, packets=%zu, calls=%zu) -> %d",
+                total_nread, pkts, calls, result);
   return result;
 }
 
@@ -671,8 +673,9 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
 
 out:
   if(total_nread || result)
-    CURL_TRC_CF(data, cf, "vquic_recvfrom(len=%zu, packets=%zu, calls=%zu)"
-                " -> %d", total_nread, pkts, calls, result);
+    CURL_TRC_CF(data, cf,
+                "vquic_recvfrom(len=%zu, packets=%zu, calls=%zu) -> %d",
+                total_nread, pkts, calls, result);
   return result;
 }
 #endif /* !HAVE_SENDMMSG && !HAVE_SENDMSG */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -26,7 +26,7 @@
  * but vtls.c should ever call or use these functions.
  *
  * Note: do not use the GnuTLS' *_t variable type names in this source code,
- * since they were not present in 1.0.X.
+ * since they were not present in 1.0.x.
  */
 #include "curl_setup.h"
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1563,7 +1563,7 @@ static CURLcode mbedtls_sha256sum(const unsigned char *input,
                                   unsigned char *sha256sum,
                                   size_t sha256len)
 {
-#if defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256  /* mbedTLS 4+ */
+#if defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256  /* mbedTLS 3+ */
   psa_status_t status;
   size_t sha256len_actual;
   status = psa_hash_compute(PSA_ALG_SHA_256, input, inputlen,

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1563,7 +1563,7 @@ static CURLcode mbedtls_sha256sum(const unsigned char *input,
                                   unsigned char *sha256sum,
                                   size_t sha256len)
 {
-#if defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256  /* mbedTLS 3+ */
+#if defined(PSA_WANT_ALG_SHA_256) && PSA_WANT_ALG_SHA_256
   psa_status_t status;
   size_t sha256len_actual;
   status = psa_hash_compute(PSA_ALG_SHA_256, input, inputlen,

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -720,15 +720,15 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
 
           if(ca_info_blob) {
             result = add_certs_data_to_store(trust_store,
-                                              (const char *)ca_info_blob->data,
-                                              ca_info_blob->len,
-                                              "(memory blob)",
-                                              data);
+                                             (const char *)ca_info_blob->data,
+                                             ca_info_blob->len,
+                                             "(memory blob)",
+                                             data);
           }
           else {
             result = add_certs_file_to_store(trust_store,
-                                              conn_config->CAfile,
-                                              data);
+                                             conn_config->CAfile,
+                                             data);
           }
           if(result == CURLE_OK) {
             if(Curl_schannel_set_cached_cert_store(cf, data, trust_store)) {

--- a/projects/vms/build_gnv_curl_pcsi_desc.com
+++ b/projects/vms/build_gnv_curl_pcsi_desc.com
@@ -134,7 +134,7 @@ $ write pdsc "   end if;"
 $!
 $write pdsc "   software VMSPORTS ''base' ZLIB ;"
 $write pdsc -
-    "   if (not <software VMSPORTS ''base' ZLIB version minimum V1.2-8>) ;"
+    "   if (not <software VMSPORTS ''base' ZLIB version minimum v1.2-8>) ;"
 $write pdsc "      error NEED_ZLIB;"
 $write pdsc "   end if;"
 $!

--- a/projects/vms/build_vms.com
+++ b/projects/vms/build_vms.com
@@ -38,7 +38,7 @@ $!              Always link a debug image.
 $!    NOIEEE    Do not use IEEE floating point.  (Alpha/I64)
 $!              VAX must always use DFLOAT
 $!    NOLARGE   Disable large-file support if large file support available.
-$!              (Non-VAX, VMS >= V7.2.)
+$!              (Non-VAX, VMS >= v7.2.)
 $!    NOLDAP    Disable LDAP support if LDAP is available.
 $!    NOKERBEROS   Disable Kerberos support if Kerberos is available.
 $!    LIST      Create C compiler listings and linker maps.

--- a/projects/vms/curl_gnv_build_steps.txt
+++ b/projects/vms/curl_gnv_build_steps.txt
@@ -20,7 +20,7 @@ Currently building curl using GNV takes longer than building curl via DCL.
 The GNV procedure actually uses the same configure and makefiles that
 Unix builds use.
 
-Building curl on OpenVMS using GNV requires GNV V2.1-2 or the updated
+Building curl on OpenVMS using GNV requires GNV v2.1-2 or the updated
 images that are available via anonymous FTP at encompasserve.org in the gnv
 directory.  It also requires the GNV Bash 4.2.45 kit as an update from the
 same location or from the sourceforge.net GNV project.

--- a/projects/vms/readme
+++ b/projects/vms/readme
@@ -19,9 +19,9 @@ curl_gnv_build_steps.txt and other useful information.
 
 Prerequisites:
 
-OpenVMS V7.0 or later (any platform)
-DECC V6.5 or later
-OpenSSL or hp SSL, if you want SSL support
+OpenVMS v7.0 or later (any platform)
+DECC v6.5 or later
+OpenSSL or HP SSL, if you want SSL support
 
 What is Here:
 

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -58,7 +58,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
   long sts;
   short chan;
 
-  /* iosbdef.h was not in VAX V7.2 or CC 6.4 */
+  /* iosbdef.h was not in VAX v7.2 or CC 6.4 */
   struct _isb {
     short int iosb$w_status; /* status */
     short int iosb$w_bcnt;   /* byte count */

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -176,7 +176,7 @@ class TestWebsockets:
         r.check_exit_code(0)
 
     # Send large frames and simulate send blocking on 8192 bytes chunks
-    # Simlates error reported in #15865
+    # Simulates error reported in #15865
     @pytest.mark.parametrize("model", [
         pytest.param(1, id='multi_perform'),
         pytest.param(2, id='curl_ws_send+recv'),

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -433,7 +433,7 @@ class EnvConfig:
         return self._h2o_version
 
     @property
-    def tcpdmp(self) -> Optional[str]:
+    def tcpdump(self) -> Optional[str]:
         return self._tcpdump
 
     def clear_locks(self):
@@ -677,7 +677,7 @@ class Env:
 
     @staticmethod
     def tcpdump() -> Optional[str]:
-        return Env.CONFIG.tcpdmp
+        return Env.CONFIG.tcpdump
 
     def __init__(self, pytestconfig=None, env_config=None):
         if env_config:

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -205,7 +205,7 @@ static const struct testcase get_parts_list[] = {
     "http://-atest/",
     "http | [11] | [12] | [13] | -atest | [15] | / | [16] | [17]",
     0, 0, CURLUE_OK },
-  { /* Multiple trailing dots is not okey */
+  { /* Multiple trailing dots is not okay */
     "http://example.com../",
     "",
     0, 0, CURLUE_BAD_HOSTNAME },

--- a/tests/libtest/lib1648.c
+++ b/tests/libtest/lib1648.c
@@ -51,11 +51,11 @@ init_failed:
   return result; /* failure */
 }
 
-static CURLcode run1648(CURL *curl, const char *url, const char *userpwd)
+static CURLcode run1648(CURL *curl, const char *url, const char *proxy)
 {
   CURLcode result = CURLE_OK;
 
-  result = init1648(curl, url, userpwd);
+  result = init1648(curl, url, proxy);
   if(result)
     return result;
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -441,9 +441,9 @@ static curl_socket_t sockit(curl_socket_t fd)
     return CURL_SOCKET_BAD;
   }
   /* ATYP:
-     o  IP V4 address: X'01'
+     o  IPv4 address: X'01'
      o  DOMAINNAME: X'03'
-     o  IP V6 address: X'04'
+     o  IPv6 address: X'04'
   */
   type = buffer[SOCKS5_ATYP];
   address = &buffer[SOCKS5_DSTADDR];

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -44,7 +44,7 @@
  * "password [string]" - the password that must match (if method is 2)
  * "backend [IPv4]" - numerical IPv4 address of backend to connect to
  * "backendport [number:0]" - TCP port of backend to connect to. 0 means use
-                              the client's specified port number.
+ *                            the client's specified port number.
  * "method [number: 0]" - connect method to respond with:
  *                        0 - no auth
  *                        1 - GSSAPI (not supported)
@@ -164,9 +164,9 @@ static void socksd_getconfig(void)
           logmsg("password [%s] set", s_config.password);
         }
         /* Methods:
-           o  X'00' NO AUTHENTICATION REQUIRED
-           o  X'01' GSSAPI
-           o  X'02' USERNAME/PASSWORD
+           o  0x00 NO AUTHENTICATION REQUIRED
+           o  0x01 GSSAPI
+           o  0x02 USERNAME/PASSWORD
         */
         else if(!strcmp(key, "method")) {
           pval = value;
@@ -441,9 +441,9 @@ static curl_socket_t sockit(curl_socket_t fd)
     return CURL_SOCKET_BAD;
   }
   /* ATYP:
-     o  IPv4 address: X'01'
-     o  DOMAINNAME: X'03'
-     o  IPv6 address: X'04'
+     o  IPv4 address: 0x01
+     o  domain name:  0x03
+     o  IPv6 address: 0x04
   */
   type = buffer[SOCKS5_ATYP];
   address = &buffer[SOCKS5_DSTADDR];
@@ -522,17 +522,17 @@ static curl_socket_t sockit(curl_socket_t fd)
   response[SOCKS5_VERSION] = s_config.responseversion;
 
   /*
-    o  REP    Reply field:
-    o  X'00' succeeded
-    o  X'01' general SOCKS server failure
-    o  X'02' connection not allowed by ruleset
-    o  X'03' Network unreachable
-    o  X'04' Host unreachable
-    o  X'05' Connection refused
-    o  X'06' TTL expired
-    o  X'07' Command not supported
-    o  X'08' Address type not supported
-    o  X'09' to X'FF' unassigned
+    o  REP  Reply field:
+    o  0x00 succeeded
+    o  0x01 general SOCKS server failure
+    o  0x02 connection not allowed by ruleset
+    o  0x03 Network unreachable
+    o  0x04 Host unreachable
+    o  0x05 Connection refused
+    o  0x06 TTL expired
+    o  0x07 Command not supported
+    o  0x08 Address type not supported
+    o  0x09 to 0xFF unassigned
   */
   response[SOCKS5_REP] = rep;
   response[SOCKS5_RESERVED] = 0; /* must be zero */


### PR DESCRIPTION
- H3 proxy: re-sync code with original source `curl_ngtcp2.c` to reduce
  differences, and to apply missed minor fixes. Also apply clang-format.
  Drop redundant `#undef`s, casts, `#endif` comments, includes, drop
  intermediate variables, sync include and macro order.
  Follow-up to e78b1b3eccfa6a2e367a1225ea1b66dafcdac3c4 #21153
- INSTALL-CMAKE.md: move `CURL_ENABLE_SMB` to the enable section.
- tests/http/env: rename `tcpdmp` to `tcpdump` to match object variable.
- mbedtls: drop incorrect `mbedTLS 4+` comments.
  (features are also supported by 3+, meaning it's always supported.)
- lib1648: rename a variable to match purpose.
- CIPHERS.md: alpha-sort link list.
- replace rare `X''` hex markup with `0x`.
- `IP v4/6` → `IPv4/6`.
- 'version X.Y' → 'vX.Y', where sensible.
- 'VX.Y' → 'vX.Y', where sensible.
- fix indents, casing, newlines, typos.

---

https://github.com/curl/curl/pull/21772/files?w=1
