### PR TITLE
m4: drop redundant conditions in TLS library detections

### DIFF
--- a/m4/curl-amissl.m4
+++ b/m4/curl-amissl.m4
@@ -63,5 +63,4 @@ if test "$HAVE_PROTO_BSDSOCKET_H" = "1"; then
 else
   AC_MSG_RESULT(no)
 fi
-
 ])

--- a/m4/curl-gnutls.m4
+++ b/m4/curl-gnutls.m4
@@ -133,7 +133,7 @@ if test "x$OPT_GNUTLS" != "xno"; then
   fi
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
-fi dnl GNUTLS not disabled
+fi dnl GnuTLS not disabled
 
 dnl
 dnl Check which crypto backend GnuTLS uses

--- a/m4/curl-gnutls.m4
+++ b/m4/curl-gnutls.m4
@@ -30,114 +30,110 @@ AC_DEFUN([CURL_WITH_GNUTLS], [
 if test "x$OPT_GNUTLS" != "xno"; then
   ssl_msg=
 
-  if test "x$OPT_GNUTLS" != "xno"; then
+  addld=""
+  addlib=""
+  gtlslib=""
+  version=""
+  addcflags=""
 
-    addld=""
-    addlib=""
-    gtlslib=""
-    version=""
-    addcflags=""
+  if test "x$OPT_GNUTLS" = "xyes"; then
+    dnl this is with no particular path given
+    CURL_CHECK_PKGCONFIG(gnutls)
 
-    if test "x$OPT_GNUTLS" = "xyes"; then
-      dnl this is with no particular path given
-      CURL_CHECK_PKGCONFIG(gnutls)
-
-      if test "$PKGCONFIG" != "no"; then
-        addlib=`$PKGCONFIG --libs-only-l gnutls`
-        addld=`$PKGCONFIG --libs-only-L gnutls`
-        addcflags=`$PKGCONFIG --cflags-only-I gnutls`
-        version=`$PKGCONFIG --modversion gnutls`
-        gtlslib=`echo $addld | $SED -e 's/^-L//'`
-      else
-        dnl without pkg-config, we try libgnutls-config as that was how it
-        dnl used to be done
-        check=`libgnutls-config --version 2>/dev/null`
-        if test -n "$check"; then
-          addlib=`libgnutls-config --libs`
-          addcflags=`libgnutls-config --cflags`
-          version=`libgnutls-config --version`
-          gtlslib=`libgnutls-config --prefix`/lib$libsuff
-        fi
-      fi
+    if test "$PKGCONFIG" != "no"; then
+      addlib=`$PKGCONFIG --libs-only-l gnutls`
+      addld=`$PKGCONFIG --libs-only-L gnutls`
+      addcflags=`$PKGCONFIG --cflags-only-I gnutls`
+      version=`$PKGCONFIG --modversion gnutls`
+      gtlslib=`echo $addld | $SED -e 's/^-L//'`
     else
-      dnl this is with a given path, first check if there is a libgnutls-config
-      dnl there and if not, make an educated guess
-      cfg=$OPT_GNUTLS/bin/libgnutls-config
-      check=`$cfg --version 2>/dev/null`
+      dnl without pkg-config, we try libgnutls-config as that was how it
+      dnl used to be done
+      check=`libgnutls-config --version 2>/dev/null`
       if test -n "$check"; then
-        addlib=`$cfg --libs`
-        addcflags=`$cfg --cflags`
-        version=`$cfg --version`
-        gtlslib=`$cfg --prefix`/lib$libsuff
-      else
-        dnl without pkg-config and libgnutls-config, we guess a lot!
-        addlib=-lgnutls
-        addld=-L$OPT_GNUTLS/lib$libsuff
-        addcflags=-I$OPT_GNUTLS/include
-        dnl we just do not know
-        version=""
-        gtlslib=$OPT_GNUTLS/lib$libsuff
+        addlib=`libgnutls-config --libs`
+        addcflags=`libgnutls-config --cflags`
+        version=`libgnutls-config --version`
+        gtlslib=`libgnutls-config --prefix`/lib$libsuff
       fi
     fi
+  else
+    dnl this is with a given path, first check if there is a libgnutls-config
+    dnl there and if not, make an educated guess
+    cfg=$OPT_GNUTLS/bin/libgnutls-config
+    check=`$cfg --version 2>/dev/null`
+    if test -n "$check"; then
+      addlib=`$cfg --libs`
+      addcflags=`$cfg --cflags`
+      version=`$cfg --version`
+      gtlslib=`$cfg --prefix`/lib$libsuff
+    else
+      dnl without pkg-config and libgnutls-config, we guess a lot!
+      addlib=-lgnutls
+      addld=-L$OPT_GNUTLS/lib$libsuff
+      addcflags=-I$OPT_GNUTLS/include
+      dnl we just do not know
+      version=""
+      gtlslib=$OPT_GNUTLS/lib$libsuff
+    fi
+  fi
 
-    if test -z "$version"; then
-      dnl lots of efforts, still no go
-      version="unknown"
+  if test -z "$version"; then
+    dnl lots of efforts, still no go
+    version="unknown"
+  fi
+
+  if test -n "$addlib"; then
+
+    CLEANLIBS="$LIBS"
+    CLEANCPPFLAGS="$CPPFLAGS"
+    CLEANLDFLAGS="$LDFLAGS"
+    CLEANLDFLAGSPC="$LDFLAGSPC"
+
+    LIBS="$addlib $LIBS"
+    LDFLAGS="$LDFLAGS $addld"
+    LDFLAGSPC="$LDFLAGSPC $addld"
+    if test "$addcflags" != "-I/usr/include"; then
+      CPPFLAGS="$CPPFLAGS $addcflags"
     fi
 
-    if test -n "$addlib"; then
+    dnl this function is selected since it was introduced in 3.1.10
+    AC_CHECK_LIB(gnutls, gnutls_x509_crt_get_dn2,
+    [
+      AC_DEFINE(USE_GNUTLS, 1, [if GnuTLS is enabled])
+      GNUTLS_ENABLED=1
+      USE_GNUTLS="yes"
+      ssl_msg="GnuTLS"
+      QUIC_ENABLED=yes
+      test "gnutls" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
+    ],
+    [
+      LIBS="$CLEANLIBS"
+      CPPFLAGS="$CLEANCPPFLAGS"
+      LDFLAGS="$CLEANLDFLAGS"
+      LDFLAGSPC="$CLEANLDFLAGSPC"
+    ])
 
-      CLEANLIBS="$LIBS"
-      CLEANCPPFLAGS="$CPPFLAGS"
-      CLEANLDFLAGS="$LDFLAGS"
-      CLEANLDFLAGSPC="$LDFLAGSPC"
-
-      LIBS="$addlib $LIBS"
-      LDFLAGS="$LDFLAGS $addld"
-      LDFLAGSPC="$LDFLAGSPC $addld"
-      if test "$addcflags" != "-I/usr/include"; then
-        CPPFLAGS="$CPPFLAGS $addcflags"
-      fi
-
-      dnl this function is selected since it was introduced in 3.1.10
-      AC_CHECK_LIB(gnutls, gnutls_x509_crt_get_dn2,
-      [
-        AC_DEFINE(USE_GNUTLS, 1, [if GnuTLS is enabled])
-        GNUTLS_ENABLED=1
-        USE_GNUTLS="yes"
-        ssl_msg="GnuTLS"
-        QUIC_ENABLED=yes
-        test "gnutls" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
-      ],
-      [
-        LIBS="$CLEANLIBS"
-        CPPFLAGS="$CLEANCPPFLAGS"
-        LDFLAGS="$CLEANLDFLAGS"
-        LDFLAGSPC="$CLEANLDFLAGSPC"
-      ])
-
-      if test "$USE_GNUTLS" = "yes"; then
-        AC_MSG_NOTICE([detected GnuTLS version $version])
-        check_for_ca_bundle=1
-        if test -n "$gtlslib"; then
-          dnl when shared libs were found in a path that the runtime
-          dnl linker does not search through, we need to add it to
-          dnl CURL_LIBRARY_PATH to prevent further configure tests to fail
-          dnl due to this
-          if test "$cross_compiling" != "yes"; then
-            CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$gtlslib"
-            export CURL_LIBRARY_PATH
-            AC_MSG_NOTICE([Added $gtlslib to CURL_LIBRARY_PATH])
-          fi
+    if test "$USE_GNUTLS" = "yes"; then
+      AC_MSG_NOTICE([detected GnuTLS version $version])
+      check_for_ca_bundle=1
+      if test -n "$gtlslib"; then
+        dnl when shared libs were found in a path that the runtime
+        dnl linker does not search through, we need to add it to
+        dnl CURL_LIBRARY_PATH to prevent further configure tests to fail
+        dnl due to this
+        if test "$cross_compiling" != "yes"; then
+          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$gtlslib"
+          export CURL_LIBRARY_PATH
+          AC_MSG_NOTICE([Added $gtlslib to CURL_LIBRARY_PATH])
         fi
-        LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE gnutls"
       fi
+      LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE gnutls"
     fi
-
-  fi dnl GNUTLS not disabled
+  fi
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
-fi
+fi dnl GNUTLS not disabled
 
 dnl
 dnl Check which crypto backend GnuTLS uses

--- a/m4/curl-mbedtls.m4
+++ b/m4/curl-mbedtls.m4
@@ -33,90 +33,86 @@ if test "x$OPT_MBEDTLS" != "xno"; then
   _ldflagspc=$LDFLAGSPC
   ssl_msg=
 
-  if test "x$OPT_MBEDTLS" != "xno"; then
+  if test "x$OPT_MBEDTLS" = "xyes"; then
+    OPT_MBEDTLS=""
+  fi
 
-    if test "x$OPT_MBEDTLS" = "xyes"; then
-      OPT_MBEDTLS=""
+  if test -z "$OPT_MBEDTLS"; then
+    dnl check for lib first without setting any new path
+
+    AC_CHECK_LIB(mbedtls, mbedtls_ssl_init,
+    dnl libmbedtls found, set the variable
+    [
+      AC_DEFINE(USE_MBEDTLS, 1, [if mbedTLS is enabled])
+      MBEDTLS_ENABLED=1
+      USE_MBEDTLS="yes"
+      ssl_msg="mbedTLS"
+      test "mbedtls" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
+    ], [], -lmbedx509 -lmbedcrypto)
+  fi
+
+  addld=""
+  addlib=""
+  addcflags=""
+  mbedtlslib=""
+
+  if test "$USE_MBEDTLS" != "yes" && test -n "$OPT_MBEDTLS"; then
+    dnl add the path and test again
+    addld=-L$OPT_MBEDTLS/lib$libsuff
+    addcflags=-I$OPT_MBEDTLS/include
+    mbedtlslib=$OPT_MBEDTLS/lib$libsuff
+
+    LDFLAGS="$LDFLAGS $addld"
+    LDFLAGSPC="$LDFLAGSPC $addld"
+    if test "$addcflags" != "-I/usr/include"; then
+      CPPFLAGS="$CPPFLAGS $addcflags"
     fi
 
-    if test -z "$OPT_MBEDTLS"; then
-      dnl check for lib first without setting any new path
-
-      AC_CHECK_LIB(mbedtls, mbedtls_ssl_init,
-      dnl libmbedtls found, set the variable
+    AC_CHECK_LIB(mbedtls, mbedtls_ssl_init,
       [
-        AC_DEFINE(USE_MBEDTLS, 1, [if mbedTLS is enabled])
-        MBEDTLS_ENABLED=1
-        USE_MBEDTLS="yes"
-        ssl_msg="mbedTLS"
-        test "mbedtls" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
-      ], [], -lmbedx509 -lmbedcrypto)
-    fi
+      AC_DEFINE(USE_MBEDTLS, 1, [if mbedTLS is enabled])
+      MBEDTLS_ENABLED=1
+      USE_MBEDTLS="yes"
+      ssl_msg="mbedTLS"
+      test "mbedtls" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
+      ],
+      [
+        CPPFLAGS=$_cppflags
+        LDFLAGS=$_ldflags
+        LDFLAGSPC=$_ldflagspc
+      ], -lmbedx509 -lmbedcrypto)
+  fi
 
-    addld=""
-    addlib=""
-    addcflags=""
-    mbedtlslib=""
+  if test "$USE_MBEDTLS" = "yes"; then
+    AC_MSG_NOTICE([detected mbedTLS])
+    check_for_ca_bundle=1
 
-    if test "$USE_MBEDTLS" != "yes" && test -n "$OPT_MBEDTLS"; then
-      dnl add the path and test again
-      addld=-L$OPT_MBEDTLS/lib$libsuff
-      addcflags=-I$OPT_MBEDTLS/include
-      mbedtlslib=$OPT_MBEDTLS/lib$libsuff
+    LIBS="-lmbedtls -lmbedx509 -lmbedcrypto $LIBS"
 
-      LDFLAGS="$LDFLAGS $addld"
-      LDFLAGSPC="$LDFLAGSPC $addld"
-      if test "$addcflags" != "-I/usr/include"; then
-        CPPFLAGS="$CPPFLAGS $addcflags"
-      fi
-
-      AC_CHECK_LIB(mbedtls, mbedtls_ssl_init,
-        [
-        AC_DEFINE(USE_MBEDTLS, 1, [if mbedTLS is enabled])
-        MBEDTLS_ENABLED=1
-        USE_MBEDTLS="yes"
-        ssl_msg="mbedTLS"
-        test "mbedtls" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
-        ],
-        [
-          CPPFLAGS=$_cppflags
-          LDFLAGS=$_ldflags
-          LDFLAGSPC=$_ldflagspc
-        ], -lmbedx509 -lmbedcrypto)
-    fi
-
-    if test "$USE_MBEDTLS" = "yes"; then
-      AC_MSG_NOTICE([detected mbedTLS])
-      check_for_ca_bundle=1
-
-      LIBS="-lmbedtls -lmbedx509 -lmbedcrypto $LIBS"
-
-      if test -n "$mbedtlslib"; then
-        dnl when shared libs were found in a path that the runtime
-        dnl linker does not search through, we need to add it to
-        dnl CURL_LIBRARY_PATH to prevent further configure tests to fail
-        dnl due to this
-        if test "$cross_compiling" != "yes"; then
-          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$mbedtlslib"
-          export CURL_LIBRARY_PATH
-          AC_MSG_NOTICE([Added $mbedtlslib to CURL_LIBRARY_PATH])
-        fi
-      fi
-      dnl FIXME: Enable when mbedTLS was detected via pkg-config
-      if false; then
-        LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE mbedtls mbedx509 mbedcrypto"
-      fi
-
-      dnl Check DES support in mbedTLS <4.
-      AC_CHECK_FUNCS(mbedtls_des_crypt_ecb)
-      if test "$ac_cv_func_mbedtls_des_crypt_ecb" = 'yes'; then
-        HAVE_MBEDTLS_DES_CRYPT_ECB=1
+    if test -n "$mbedtlslib"; then
+      dnl when shared libs were found in a path that the runtime
+      dnl linker does not search through, we need to add it to
+      dnl CURL_LIBRARY_PATH to prevent further configure tests to fail
+      dnl due to this
+      if test "$cross_compiling" != "yes"; then
+        CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$mbedtlslib"
+        export CURL_LIBRARY_PATH
+        AC_MSG_NOTICE([Added $mbedtlslib to CURL_LIBRARY_PATH])
       fi
     fi
+    dnl FIXME: Enable when mbedTLS was detected via pkg-config
+    if false; then
+      LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE mbedtls mbedx509 mbedcrypto"
+    fi
 
-  fi dnl mbedTLS not disabled
+    dnl Check DES support in mbedTLS <4.
+    AC_CHECK_FUNCS(mbedtls_des_crypt_ecb)
+    if test "$ac_cv_func_mbedtls_des_crypt_ecb" = 'yes'; then
+      HAVE_MBEDTLS_DES_CRYPT_ECB=1
+    fi
+  fi
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
-fi
+fi dnl mbedTLS not disabled
 
 ])

--- a/m4/curl-mbedtls.m4
+++ b/m4/curl-mbedtls.m4
@@ -114,5 +114,4 @@ if test "x$OPT_MBEDTLS" != "xno"; then
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 fi dnl mbedTLS not disabled
-
 ])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -333,7 +333,7 @@ if test "x$OPT_OPENSSL" != "xno"; then
   fi
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
-fi
+fi dnl OpenSSL not disabled
 
 if test "$OPENSSL_ENABLED" = "1"; then
   dnl ---

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -390,6 +390,5 @@ AS_HELP_STRING([--disable-openssl-auto-load-config],[Disable automatic loading o
       AC_DEFINE(CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG, 1, [if the OpenSSL configuration is not loaded automatically])
     fi
   ])
-
 fi
 ])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -330,14 +330,13 @@ if test "x$OPT_OPENSSL" != "xno"; then
     fi
   fi
 
-  test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
-fi
+  if test "$OPENSSL_ENABLED" != "1"; then
+    AC_MSG_NOTICE([OPT_OPENSSL: $OPT_OPENSSL])
+    AC_MSG_NOTICE([OPENSSL_ENABLED: $OPENSSL_ENABLED])
+    AC_MSG_ERROR([--with-openssl was given but OpenSSL could not be detected])
+  fi
 
-if test "x$OPT_OPENSSL" != "xno" &&
-   test "$OPENSSL_ENABLED" != "1"; then
-  AC_MSG_NOTICE([OPT_OPENSSL: $OPT_OPENSSL])
-  AC_MSG_NOTICE([OPENSSL_ENABLED: $OPENSSL_ENABLED])
-  AC_MSG_ERROR([--with-openssl was given but OpenSSL could not be detected])
+  test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 fi
 
 if test "$OPENSSL_ENABLED" = "1"; then

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -220,10 +220,6 @@ if test "x$OPT_OPENSSL" != "xno"; then
 
     if test "$OPENSSL_ENABLED" != "1"; then
       LIBS="$CLEANLIBS"
-    fi
-
-    if test "x$OPT_OPENSSL" != "xoff" &&
-       test "$OPENSSL_ENABLED" != "1"; then
       AC_MSG_ERROR([OpenSSL libs and/or directories were not found where specified!])
     fi
   fi

--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -192,5 +192,3 @@ if test "x$OPT_RUSTLS" != "xno"; then
   fi
 fi
 ])
-
-RUSTLS_ENABLED

--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -185,8 +185,7 @@ if test "x$OPT_RUSTLS" != "xno"; then
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 
-  if test "x$OPT_RUSTLS" != "xno" &&
-    test "$RUSTLS_ENABLED" != "1"; then
+  if test "$RUSTLS_ENABLED" != "1"; then
     AC_MSG_NOTICE([OPT_RUSTLS: $OPT_RUSTLS])
     AC_MSG_NOTICE([RUSTLS_ENABLED: $RUSTLS_ENABLED])
     AC_MSG_ERROR([--with-rustls was given but Rustls could not be detected])

--- a/m4/curl-schannel.m4
+++ b/m4/curl-schannel.m4
@@ -26,8 +26,7 @@ AC_DEFUN([CURL_WITH_SCHANNEL], [
 AC_MSG_CHECKING([whether to enable Windows native SSL/TLS])
 if test "x$OPT_SCHANNEL" != "xno"; then
   ssl_msg=
-  if test "x$OPT_SCHANNEL" != "xno" &&
-     test "$curl_cv_native_windows" = "yes"; then
+  if test "$curl_cv_native_windows" = "yes"; then
     if test "$curl_cv_winuwp" = "yes"; then
       AC_MSG_ERROR([UWP does not support Schannel.])
     fi

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -168,5 +168,4 @@ if test "$OPT_WOLFSSL" != "no"; then
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
 fi dnl wolfSSL not disabled
-
 ])

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -43,134 +43,130 @@ if test "$OPT_WOLFSSL" != "no"; then
 
   ssl_msg=
 
-  if test "$OPT_WOLFSSL" != "no"; then
+  if test "$OPT_WOLFSSL" = "yes"; then
+    OPT_WOLFSSL=""
+  fi
 
-    if test "$OPT_WOLFSSL" = "yes"; then
-      OPT_WOLFSSL=""
+  dnl try pkg-config magic
+  CURL_CHECK_PKGCONFIG(wolfssl, [$wolfpkg])
+  AC_MSG_NOTICE([Check directory $wolfpkg])
+
+  addld=""
+  addlib=""
+  addcflags=""
+  if test "$PKGCONFIG" != "no"; then
+    addlib=`CURL_EXPORT_PCDIR([$wolfpkg])
+      $PKGCONFIG --libs-only-l wolfssl`
+    addld=`CURL_EXPORT_PCDIR([$wolfpkg])
+      $PKGCONFIG --libs-only-L wolfssl`
+    addcflags=`CURL_EXPORT_PCDIR([$wolfpkg])
+      $PKGCONFIG --cflags-only-I wolfssl`
+    version=`CURL_EXPORT_PCDIR([$wolfpkg])
+      $PKGCONFIG --modversion wolfssl`
+    wolfssllibpath=`echo $addld | $SED -e 's/^-L//'`
+  else
+    addlib=-lwolfssl
+    dnl use system defaults if user does not supply a path
+    if test -n "$OPT_WOLFSSL"; then
+      addld=-L$OPT_WOLFSSL/lib$libsuff
+      addcflags=-I$OPT_WOLFSSL/include
+      wolfssllibpath=$OPT_WOLFSSL/lib$libsuff
+    fi
+  fi
+
+  if test "$curl_cv_apple" = "yes"; then
+    addlib="$addlib -framework Security -framework CoreFoundation"
+  else
+    addlib="$addlib -lm"
+  fi
+
+  if test "$USE_WOLFSSL" != "yes"; then
+    CPPFLAGS="$CPPFLAGS -DWOLFSSL_OPTIONS_IGNORE_SYS"
+
+    LDFLAGS="$LDFLAGS $addld"
+    LDFLAGSPC="$LDFLAGSPC $addld"
+    AC_MSG_NOTICE([Add $addld to LDFLAGS])
+    if test "$addcflags" != "-I/usr/include"; then
+      CPPFLAGS="$CPPFLAGS $addcflags"
+      AC_MSG_NOTICE([Add $addcflags to CPPFLAGS])
     fi
 
-    dnl try pkg-config magic
-    CURL_CHECK_PKGCONFIG(wolfssl, [$wolfpkg])
-    AC_MSG_NOTICE([Check directory $wolfpkg])
+    my_ac_save_LIBS="$LIBS"
+    LIBS="$addlib $LIBS"
+    AC_MSG_NOTICE([Add $addlib to LIBS])
 
-    addld=""
-    addlib=""
-    addcflags=""
-    if test "$PKGCONFIG" != "no"; then
-      addlib=`CURL_EXPORT_PCDIR([$wolfpkg])
-        $PKGCONFIG --libs-only-l wolfssl`
-      addld=`CURL_EXPORT_PCDIR([$wolfpkg])
-        $PKGCONFIG --libs-only-L wolfssl`
-      addcflags=`CURL_EXPORT_PCDIR([$wolfpkg])
-        $PKGCONFIG --cflags-only-I wolfssl`
-      version=`CURL_EXPORT_PCDIR([$wolfpkg])
-        $PKGCONFIG --modversion wolfssl`
-      wolfssllibpath=`echo $addld | $SED -e 's/^-L//'`
-    else
-      addlib=-lwolfssl
-      dnl use system defaults if user does not supply a path
-      if test -n "$OPT_WOLFSSL"; then
-        addld=-L$OPT_WOLFSSL/lib$libsuff
-        addcflags=-I$OPT_WOLFSSL/include
-        wolfssllibpath=$OPT_WOLFSSL/lib$libsuff
-      fi
+    AC_MSG_CHECKING([for wolfSSL_Init in -lwolfssl])
+    AC_LINK_IFELSE([
+      AC_LANG_PROGRAM([[
+        #include <wolfssl/options.h>
+        #include <wolfssl/ssl.h>
+      ]],[[
+        return wolfSSL_Init();
+      ]])
+    ],[
+      AC_MSG_RESULT(yes)
+      AC_DEFINE(USE_WOLFSSL, 1, [if wolfSSL is enabled])
+      WOLFSSL_ENABLED=1
+      USE_WOLFSSL="yes"
+      ssl_msg="wolfSSL"
+      test "wolfssl" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
+    ],
+    [
+      AC_MSG_RESULT(no)
+      CPPFLAGS=$_cppflags
+      LDFLAGS=$_ldflags
+      LDFLAGSPC=$_ldflagspc
+      wolfssllibpath=""
+    ])
+    LIBS="$my_ac_save_LIBS"
+  fi
+
+  if test "$USE_WOLFSSL" = "yes"; then
+    AC_MSG_NOTICE([detected wolfSSL])
+    check_for_ca_bundle=1
+
+    LIBS="$addlib $LIBS"
+
+    dnl is this wolfSSL providing the original QUIC API?
+    AC_CHECK_FUNCS([wolfSSL_set_quic_use_legacy_codepoint], [QUIC_ENABLED=yes])
+
+    dnl wolfSSL needs configure --enable-opensslextra to have *get_peer*
+    dnl wc_Des_EcbEncrypt is needed for NTLM support.
+    dnl if wolfSSL_BIO_set_shutdown is present, we have the full BIO feature set
+    AC_CHECK_FUNCS(wolfSSL_get_peer_certificate \
+                   wolfSSL_UseALPN \
+                   wolfSSL_BIO_new \
+                   wolfSSL_BIO_set_shutdown \
+                   wc_Des_EcbEncrypt)
+
+    dnl if this symbol is present, we want the include path to include the
+    dnl OpenSSL API root as well
+    if test "$ac_cv_func_wc_Des_EcbEncrypt" = "yes"; then
+      HAVE_WC_DES_ECBENCRYPT=1
     fi
 
-    if test "$curl_cv_apple" = "yes"; then
-      addlib="$addlib -framework Security -framework CoreFoundation"
-    else
-      addlib="$addlib -lm"
+    dnl if this symbol is present, we can make use of BIO filter chains
+    if test "$ac_cv_func_wolfSSL_BIO_new" = "yes"; then
+      HAVE_WOLFSSL_BIO_NEW=1
     fi
 
-    if test "$USE_WOLFSSL" != "yes"; then
-      CPPFLAGS="$CPPFLAGS -DWOLFSSL_OPTIONS_IGNORE_SYS"
-
-      LDFLAGS="$LDFLAGS $addld"
-      LDFLAGSPC="$LDFLAGSPC $addld"
-      AC_MSG_NOTICE([Add $addld to LDFLAGS])
-      if test "$addcflags" != "-I/usr/include"; then
-        CPPFLAGS="$CPPFLAGS $addcflags"
-        AC_MSG_NOTICE([Add $addcflags to CPPFLAGS])
+    if test -n "$wolfssllibpath"; then
+      dnl when shared libs were found in a path that the runtime
+      dnl linker does not search through, we need to add it to
+      dnl CURL_LIBRARY_PATH to prevent further configure tests to fail
+      dnl due to this
+      if test "$cross_compiling" != "yes"; then
+        CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$wolfssllibpath"
+        export CURL_LIBRARY_PATH
+        AC_MSG_NOTICE([Added $wolfssllibpath to CURL_LIBRARY_PATH])
       fi
-
-      my_ac_save_LIBS="$LIBS"
-      LIBS="$addlib $LIBS"
-      AC_MSG_NOTICE([Add $addlib to LIBS])
-
-      AC_MSG_CHECKING([for wolfSSL_Init in -lwolfssl])
-      AC_LINK_IFELSE([
-        AC_LANG_PROGRAM([[
-          #include <wolfssl/options.h>
-          #include <wolfssl/ssl.h>
-        ]],[[
-          return wolfSSL_Init();
-        ]])
-      ],[
-        AC_MSG_RESULT(yes)
-        AC_DEFINE(USE_WOLFSSL, 1, [if wolfSSL is enabled])
-        WOLFSSL_ENABLED=1
-        USE_WOLFSSL="yes"
-        ssl_msg="wolfSSL"
-        test "wolfssl" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
-      ],
-      [
-        AC_MSG_RESULT(no)
-        CPPFLAGS=$_cppflags
-        LDFLAGS=$_ldflags
-        LDFLAGSPC=$_ldflagspc
-        wolfssllibpath=""
-      ])
-      LIBS="$my_ac_save_LIBS"
     fi
-
-    if test "$USE_WOLFSSL" = "yes"; then
-      AC_MSG_NOTICE([detected wolfSSL])
-      check_for_ca_bundle=1
-
-      LIBS="$addlib $LIBS"
-
-      dnl is this wolfSSL providing the original QUIC API?
-      AC_CHECK_FUNCS([wolfSSL_set_quic_use_legacy_codepoint], [QUIC_ENABLED=yes])
-
-      dnl wolfSSL needs configure --enable-opensslextra to have *get_peer*
-      dnl wc_Des_EcbEncrypt is needed for NTLM support.
-      dnl if wolfSSL_BIO_set_shutdown is present, we have the full BIO feature set
-      AC_CHECK_FUNCS(wolfSSL_get_peer_certificate \
-                     wolfSSL_UseALPN \
-                     wolfSSL_BIO_new \
-                     wolfSSL_BIO_set_shutdown \
-                     wc_Des_EcbEncrypt)
-
-      dnl if this symbol is present, we want the include path to include the
-      dnl OpenSSL API root as well
-      if test "$ac_cv_func_wc_Des_EcbEncrypt" = "yes"; then
-        HAVE_WC_DES_ECBENCRYPT=1
-      fi
-
-      dnl if this symbol is present, we can make use of BIO filter chains
-      if test "$ac_cv_func_wolfSSL_BIO_new" = "yes"; then
-        HAVE_WOLFSSL_BIO_NEW=1
-      fi
-
-      if test -n "$wolfssllibpath"; then
-        dnl when shared libs were found in a path that the runtime
-        dnl linker does not search through, we need to add it to
-        dnl CURL_LIBRARY_PATH to prevent further configure tests to fail
-        dnl due to this
-        if test "$cross_compiling" != "yes"; then
-          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$wolfssllibpath"
-          export CURL_LIBRARY_PATH
-          AC_MSG_NOTICE([Added $wolfssllibpath to CURL_LIBRARY_PATH])
-        fi
-      fi
-      LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE wolfssl"
-    else
-      AC_MSG_ERROR([--with-wolfssl but wolfSSL was not found or does not work])
-    fi
-
-  fi dnl wolfSSL not disabled
+    LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE wolfssl"
+  else
+    AC_MSG_ERROR([--with-wolfssl but wolfSSL was not found or does not work])
+  fi
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
-fi
+fi dnl wolfSSL not disabled
 
 ])


### PR DESCRIPTION
Omit checking `OPT_<BACKEND>` against `no` twice.

Also:
- openssl: drop stray `OPT_OPENSSL=off` check. 
  Follow-up to 68d89f242cf9f6326e3b2f6fe119b7c74ef41c66 #6897
- rustls: drop no-op line.
  Follow-up to 9c4209837094781d5eef69ae6bcad0e86b64bf99 #13202
- gnutls: fix casing in comment.
- merge `if` branches where possible after these changes.

---

https://github.com/curl/curl/pull/21781/files?w=1
