### PR TITLE
pytest: re-enable test test_05_01 and test_05_02 for quiche 0.29.0+

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -52,7 +52,7 @@ env:
   OPENSSL_PREV_VERSION: 3.6.2
   OPENSSL_PREV_SHA256: aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
   # renovate: datasource=github-tags depName=cloudflare/quiche versioning=semver registryUrl=https://github.com
-  QUICHE_VERSION: 0.29.0
+  QUICHE_VERSION: 0.29.1
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   WOLFSSL_VERSION: 5.9.1
   # renovate: datasource=github-tags depName=ngtcp2/nghttp3 versioning=semver registryUrl=https://github.com

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -52,7 +52,7 @@ env:
   OPENSSL_PREV_VERSION: 3.6.2
   OPENSSL_PREV_SHA256: aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
   # renovate: datasource=github-tags depName=cloudflare/quiche versioning=semver registryUrl=https://github.com
-  QUICHE_VERSION: 0.29.1
+  QUICHE_VERSION: 0.29.0
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   WOLFSSL_VERSION: 5.9.1
   # renovate: datasource=github-tags depName=ngtcp2/nghttp3 versioning=semver registryUrl=https://github.com

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -43,7 +43,7 @@ class TestErrors:
     @pytest.mark.parametrize("proto", Env.http_protos())
     def test_05_01_partial_1(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and env.curl_uses_lib('quiche') and \
-                not env.curl_lib_version_at_least('quiche', '0.29.1'):
+                not env.curl_lib_version_at_least('quiche', '0.29.0'):
             pytest.skip("quiche issue #2277 not fixed")
         count = 1
         curl = CurlClient(env=env)
@@ -64,7 +64,7 @@ class TestErrors:
     @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_05_02_partial_20(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and env.curl_uses_lib('quiche') and \
-                not env.curl_lib_version_at_least('quiche', '0.29.1'):
+                not env.curl_lib_version_at_least('quiche', '0.29.0'):
             pytest.skip("quiche issue #2277 not fixed")
         count = 20
         curl = CurlClient(env=env)

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -42,9 +42,6 @@ class TestErrors:
     # download 1 file, check that we get CURLE_PARTIAL_FILE
     @pytest.mark.parametrize("proto", Env.http_protos())
     def test_05_01_partial_1(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h3' and env.curl_uses_lib('quiche') and \
-                not env.curl_lib_version_at_least('quiche', '0.29.1'):
-            pytest.skip("quiche issue #2277 not fixed")
         count = 1
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
@@ -63,9 +60,6 @@ class TestErrors:
     # download files, check that we get CURLE_PARTIAL_FILE for all
     @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_05_02_partial_20(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h3' and env.curl_uses_lib('quiche') and \
-                not env.curl_lib_version_at_least('quiche', '0.29.1'):
-            pytest.skip("quiche issue #2277 not fixed")
         count = 20
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -42,6 +42,9 @@ class TestErrors:
     # download 1 file, check that we get CURLE_PARTIAL_FILE
     @pytest.mark.parametrize("proto", Env.http_protos())
     def test_05_01_partial_1(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h3' and env.curl_uses_lib('quiche') and \
+                not env.curl_lib_version_at_least('quiche', '0.29.1'):
+            pytest.skip("quiche issue #2277 not fixed")
         count = 1
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
@@ -60,6 +63,9 @@ class TestErrors:
     # download files, check that we get CURLE_PARTIAL_FILE for all
     @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_05_02_partial_20(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h3' and env.curl_uses_lib('quiche') and \
+                not env.curl_lib_version_at_least('quiche', '0.29.1'):
+            pytest.skip("quiche issue #2277 not fixed")
         count = 20
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \


### PR DESCRIPTION
The upstream issue seems to have been fixed or mitigated in quiche
v0.29.0. Though the original upstream report and patch remain open at
the time of writing this.

Ref: https://github.com/cloudflare/quiche/issues/2277
Ref: https://github.com/cloudflare/quiche/pull/2278

Follow-up to 252b82f693574e884fb36dfde9371b409716a0fc #21730
Follow-up to 91b422d356a52d32708c02514d8ede66363e8847 #20952
Follow-up to 14478429e71ef0eee6d12b73113e9ff8e3ae9e75 #19916

---

This was a flaky issue, but previously all bumps failed, and with 0.29.1
neither the automatic bump, nor this PR failed, which makes me think
this has indeed seen an upstream fix or mitigation.

test 05_02 still failed at 0.28.0:
https://github.com/curl/curl/actions/runs/23865652425/job/69583976618
