### PR TITLE
cf-h3-proxy.c: bring back include

### DIFF
--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -28,6 +28,7 @@
   defined(USE_NGTCP2) && defined(USE_OPENSSL)
 
 #include <ngtcp2/ngtcp2.h>
+#include <ngtcp2/ngtcp2_crypto.h>
 
 #ifdef USE_OPENSSL
 #include <openssl/err.h>


### PR DESCRIPTION
Without it, it breaks regular (non-unity) builds.

Fix regression from 7e1001bcd69967707c