### PR TITLE
tidy-up: apply clang-format fixes

### DIFF
--- a/lib/arpa_telnet.h
+++ b/lib/arpa_telnet.h
@@ -35,6 +35,7 @@
 #define CURL_TELOPT_NAWS        31  /* Negotiate About Window Size */
 #define CURL_TELOPT_XDISPLOC    35  /* X DISPlay LOCation */
 #define CURL_TELOPT_NEW_ENVIRON 39  /* NEW ENVIRONment variables */
+
 #define CURL_NEW_ENV_VAR   0
 #define CURL_NEW_ENV_VALUE 1
 

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -281,8 +281,8 @@ CURLcode Curl_async_take_result(struct Curl_easy *data,
   if(ares->ares_status == ARES_SUCCESS && !result) {
     struct Curl_dns_entry *dns =
       Curl_dnscache_mk_entry2(data, async->dns_queries,
-                             &ares->res_AAAA, &ares->res_A,
-                             async->hostname, async->port);
+                              &ares->res_AAAA, &ares->res_A,
+                              async->hostname, async->port);
     if(!dns) {
       result = CURLE_OUT_OF_MEMORY;
       goto out;

--- a/lib/cf-capsule.c
+++ b/lib/cf-capsule.c
@@ -153,8 +153,7 @@ static CURLcode capsule_cf_send(struct Curl_cfilter *cf,
       curlx_dyn_free(&dyn);
       return CURLE_OUT_OF_MEMORY;
     }
-    memcpy(ctx->pending,
-           curlx_dyn_ptr(&dyn) + nwritten, remaining);
+    memcpy(ctx->pending, curlx_dyn_ptr(&dyn) + nwritten, remaining);
     ctx->pending_len = remaining;
     ctx->pending_offset = 0;
     ctx->pending_payload = len;

--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -1498,8 +1498,7 @@ static int cb_ngtcp2_extend_max_stream_data(ngtcp2_conn *tconn,
   }
   stream = H3_PROXY_STREAM_CTX(ctx, s_data);
   if(stream && stream->quic_flow_blocked) {
-    CURL_TRC_CF(s_data, cf, "[%" PRId64 "] unblock quic flow",
-                stream_id);
+    CURL_TRC_CF(s_data, cf, "[%" PRId64 "] unblock quic flow", stream_id);
     stream->quic_flow_blocked = FALSE;
     Curl_multi_mark_dirty(s_data);
   }

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -824,7 +824,7 @@ CURLcode Curl_cf_https_setup(struct Curl_easy *data,
 
   if((conn->scheme->protocol != CURLPROTO_HTTPS) ||
      !conn->bits.tls_enable_alpn)
-     goto out;
+    goto out;
 
   result = cf_hc_add(data, conn, sockindex, conn->transport_wanted);
 

--- a/lib/cf-ip-happy.h
+++ b/lib/cf-ip-happy.h
@@ -53,7 +53,7 @@ CURLcode cf_ip_happy_insert_after(struct Curl_cfilter *cf_at,
                                   uint8_t transport);
 
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3) && \
-    defined(USE_PROXY_HTTP3)
+  defined(USE_PROXY_HTTP3)
 /* For H3 proxy: create happy eyeballs that races IPv4/IPv6 using raw UDP
    sockets with TRNSPRT_QUIC transport so the socket is connected to the
    proxy peer. H3-PROXY manages its own ngtcp2 QUIC stack on top. */

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -81,8 +81,7 @@ static void tcpnodelay(struct Curl_cfilter *cf,
   int level = IPPROTO_TCP;
   VERBOSE(char buffer[STRERROR_LEN]);
 
-  if(setsockopt(sockfd, level, TCP_NODELAY,
-                (void *)&onoff, sizeof(onoff)) < 0)
+  if(setsockopt(sockfd, level, TCP_NODELAY, (void *)&onoff, sizeof(onoff)) < 0)
     CURL_TRC_CF(data, cf, "Could not set TCP_NODELAY: %s",
                 curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));
 #else
@@ -92,8 +91,8 @@ static void tcpnodelay(struct Curl_cfilter *cf,
 #endif
 }
 
-#if defined(USE_WINSOCK) || defined(TCP_KEEPIDLE) || \
-  defined(TCP_KEEPALIVE) || defined(TCP_KEEPALIVE_THRESHOLD) || \
+#if defined(USE_WINSOCK) || defined(TCP_KEEPIDLE) ||               \
+  defined(TCP_KEEPALIVE) || defined(TCP_KEEPALIVE_THRESHOLD) ||    \
   defined(TCP_KEEPINTVL) || defined(TCP_KEEPALIVE_ABORT_THRESHOLD)
 #if defined(USE_WINSOCK) || \
   (defined(__sun) && !defined(TCP_KEEPIDLE)) || \

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -1028,8 +1028,8 @@ const char *Curl_conn_cf_get_alpn_negotiated(struct Curl_cfilter *cf,
   return NULL;
 }
 
-static const struct Curl_sockaddr_ex *
-cf_get_remote_addr(struct Curl_cfilter *cf, struct Curl_easy *data)
+static const struct Curl_sockaddr_ex *cf_get_remote_addr(
+  struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   const struct Curl_sockaddr_ex *remote_addr = NULL;
   if(cf &&
@@ -1067,8 +1067,8 @@ curl_socket_t Curl_conn_get_first_socket(struct Curl_easy *data)
   return data->conn->sock[FIRSTSOCKET];
 }
 
-const struct Curl_sockaddr_ex *
-Curl_conn_get_remote_addr(struct Curl_easy *data, int sockindex)
+const struct Curl_sockaddr_ex *Curl_conn_get_remote_addr(
+  struct Curl_easy *data, int sockindex)
 {
   struct Curl_cfilter *cf =
     (data->conn && CONN_SOCK_IDX_VALID(sockindex)) ?

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -305,9 +305,9 @@ static struct cpool_bundle *cpool_add_bundle(struct cpool *cpool,
   return bundle;
 }
 
-static struct connectdata *
-cpool_bundle_get_oldest_idle(struct cpool_bundle *bundle,
-                             const struct curltime *pnow)
+static struct connectdata *cpool_bundle_get_oldest_idle(
+  struct cpool_bundle *bundle,
+  const struct curltime *pnow)
 {
   struct Curl_llist_node *curr;
   timediff_t highscore = -1;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -366,9 +366,9 @@ static CURLcode cf_setup_add_http_proxy(struct Curl_cfilter *cf,
     }
   }
   else {
-    if(IS_HTTPS_PROXY(cf->conn->http_proxy.proxytype)
-      && !Curl_conn_is_ssl(cf->conn, cf->sockindex)
-      && !IS_QUIC_PROXY(cf->conn->http_proxy.proxytype)) {
+    if(IS_HTTPS_PROXY(cf->conn->http_proxy.proxytype) &&
+       !Curl_conn_is_ssl(cf->conn, cf->sockindex) &&
+       !IS_QUIC_PROXY(cf->conn->http_proxy.proxytype)) {
       result = Curl_cf_ssl_proxy_insert_after(cf, data);
       if(result)
         return result;
@@ -427,7 +427,7 @@ connect_sub_chain:
   if(ctx->state < CF_SETUP_CNNCT_EYEBALLS) {
 #ifndef CURL_DISABLE_PROXY
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3) && \
-    defined(USE_PROXY_HTTP3)
+  defined(USE_PROXY_HTTP3)
     if(IS_QUIC_PROXY(cf->conn->http_proxy.proxytype) &&
        cf->conn->bits.tunnel_proxy) {
       /* For HTTPS3 proxy tunnels, H3-PROXY manages the QUIC connection
@@ -447,8 +447,8 @@ connect_sub_chain:
        the underlying conn to the proxy is TCP. */
     else
 #endif /* !CURL_DISABLE_HTTP && USE_HTTP3 && USE_PROXY_HTTP3 */
-    if(ctx->transport == TRNSPRT_QUIC && cf->conn->bits.httpproxy
-       && !IS_QUIC_PROXY(cf->conn->http_proxy.proxytype))
+    if(ctx->transport == TRNSPRT_QUIC && cf->conn->bits.httpproxy &&
+       !IS_QUIC_PROXY(cf->conn->http_proxy.proxytype))
       result = cf_ip_happy_insert_after(cf, data, TRNSPRT_TCP);
     else
 #endif /* !CURL_DISABLE_PROXY */
@@ -521,7 +521,7 @@ connect_sub_chain:
   /* Adding Curl_cf_quic_insert_after() because now we
      need the next filter to be QUIC/HTTP/3 (which has SSL) */
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3) && \
-    defined(USE_PROXY_HTTP3)
+  defined(USE_PROXY_HTTP3)
   if(ctx->transport == TRNSPRT_QUIC && cf->conn->bits.httpproxy &&
      cf->conn->bits.tunnel_proxy &&
      (data->state.http_neg.wanted == CURL_HTTP_V3x)) {
@@ -540,9 +540,9 @@ connect_sub_chain:
     if(ctx->state < CF_SETUP_CNNCT_SSL) {
 #ifdef USE_SSL
       if((ctx->ssl_mode == CURL_CF_SSL_ENABLE ||
-         (ctx->ssl_mode != CURL_CF_SSL_DISABLE &&
-          cf->conn->scheme->flags & PROTOPT_SSL)) /* we want SSL */
-          && !Curl_conn_is_ssl(cf->conn, cf->sockindex)) { /* it is missing */
+          (ctx->ssl_mode != CURL_CF_SSL_DISABLE &&
+           cf->conn->scheme->flags & PROTOPT_SSL)) && /* we want SSL */
+         !Curl_conn_is_ssl(cf->conn, cf->sockindex)) { /* it is missing */
         result = Curl_cf_ssl_insert_after(cf, data);
         if(result)
           return result;

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -87,9 +87,9 @@ bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
  * when the connection will close.
  */
 
-#define CONNCTRL_KEEP 0 /* undo a marked closure */
+#define CONNCTRL_KEEP       0 /* undo a marked closure */
 #define CONNCTRL_CONNECTION 1
-#define CONNCTRL_STREAM 2
+#define CONNCTRL_STREAM     2
 
 void Curl_conncontrol(struct connectdata *conn,
                       int ctrl
@@ -100,12 +100,12 @@ void Curl_conncontrol(struct connectdata *conn,
 
 #if defined(DEBUGBUILD) && defined(CURLVERBOSE)
 #define streamclose(x, y) Curl_conncontrol(x, CONNCTRL_STREAM, y)
-#define connclose(x, y) Curl_conncontrol(x, CONNCTRL_CONNECTION, y)
-#define connkeep(x, y) Curl_conncontrol(x, CONNCTRL_KEEP, y)
+#define connclose(x, y)   Curl_conncontrol(x, CONNCTRL_CONNECTION, y)
+#define connkeep(x, y)    Curl_conncontrol(x, CONNCTRL_KEEP, y)
 #else /* !DEBUGBUILD || !CURLVERBOSE */
 #define streamclose(x, y) Curl_conncontrol(x, CONNCTRL_STREAM)
-#define connclose(x, y) Curl_conncontrol(x, CONNCTRL_CONNECTION)
-#define connkeep(x, y) Curl_conncontrol(x, CONNCTRL_KEEP)
+#define connclose(x, y)   Curl_conncontrol(x, CONNCTRL_CONNECTION)
+#define connkeep(x, y)    Curl_conncontrol(x, CONNCTRL_KEEP)
 #endif
 
 CURLcode Curl_cf_setup_insert_after(struct Curl_cfilter *cf_at,

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -101,8 +101,7 @@ static void zfree_cb(voidpf opaque, voidpf ptr)
 static CURLcode process_zlib_error(struct Curl_easy *data, z_stream *z)
 {
   if(z->msg)
-    failf(data, "Error while processing content unencoding: %s",
-          z->msg);
+    failf(data, "Error while processing content unencoding: %s", z->msg);
   else
     failf(data, "Error while processing content unencoding: "
           "Unknown failure within decompression software.");
@@ -166,7 +165,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
   /* because the buffer size is fixed, iteratively decompress and transfer to
      the client via next_write function. */
   while(!done) {
-    int status;                   /* zlib status */
+    int status; /* zlib status */
     done = TRUE;
 
     if(++i > (1024 * 1024 / DECOMPRESS_BUFFER_SIZE)) {
@@ -187,7 +186,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
     /* Flush output data if some. */
     if(z->avail_out != DECOMPRESS_BUFFER_SIZE) {
       if(status == Z_OK || status == Z_STREAM_END) {
-        zp->zlib_init = started;      /* Data started. */
+        zp->zlib_init = started; /* Data started. */
         result = Curl_cwriter_write(data, writer->next, type, zp->buffer,
                                     DECOMPRESS_BUFFER_SIZE - z->avail_out);
         if(result) {
@@ -221,7 +220,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
           done = FALSE;
           break;
         }
-        zp->zlib_init = ZLIB_UNINIT;    /* inflateEnd() already called. */
+        zp->zlib_init = ZLIB_UNINIT; /* inflateEnd() already called. */
       }
       result = exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
       break;
@@ -235,7 +234,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
      again. If we are in a state that would wrongly allow restart in raw mode
      at the next call, assume output has already started. */
   if(nread && zp->zlib_init == ZLIB_INIT)
-    zp->zlib_init = started;      /* Cannot restart anymore. */
+    zp->zlib_init = started; /* Cannot restart anymore. */
 
   return result;
 }
@@ -245,7 +244,7 @@ static CURLcode deflate_do_init(struct Curl_easy *data,
                                 struct Curl_cwriter *writer)
 {
   struct zlib_writer *zp = (struct zlib_writer *)writer;
-  z_stream *z = &zp->z;     /* zlib state structure */
+  z_stream *z = &zp->z; /* zlib state structure */
 
   /* Initialize zlib */
   z->zalloc = (alloc_func)zalloc_cb;
@@ -262,7 +261,7 @@ static CURLcode deflate_do_write(struct Curl_easy *data,
                                  const char *buf, size_t nbytes)
 {
   struct zlib_writer *zp = (struct zlib_writer *)writer;
-  z_stream *z = &zp->z;     /* zlib state structure */
+  z_stream *z = &zp->z; /* zlib state structure */
 
   if(!(type & CLIENTWRITE_BODY) || !nbytes)
     return Curl_cwriter_write(data, writer->next, type, buf, nbytes);
@@ -282,7 +281,7 @@ static void deflate_do_close(struct Curl_easy *data,
                              struct Curl_cwriter *writer)
 {
   struct zlib_writer *zp = (struct zlib_writer *)writer;
-  z_stream *z = &zp->z;     /* zlib state structure */
+  z_stream *z = &zp->z; /* zlib state structure */
 
   exit_zlib(data, z, &zp->zlib_init, CURLE_OK);
 }
@@ -304,7 +303,7 @@ static CURLcode gzip_do_init(struct Curl_easy *data,
                              struct Curl_cwriter *writer)
 {
   struct zlib_writer *zp = (struct zlib_writer *)writer;
-  z_stream *z = &zp->z;     /* zlib state structure */
+  z_stream *z = &zp->z; /* zlib state structure */
 
   /* Initialize zlib */
   z->zalloc = (alloc_func)zalloc_cb;
@@ -322,7 +321,7 @@ static CURLcode gzip_do_write(struct Curl_easy *data,
                               const char *buf, size_t nbytes)
 {
   struct zlib_writer *zp = (struct zlib_writer *)writer;
-  z_stream *z = &zp->z;     /* zlib state structure */
+  z_stream *z = &zp->z; /* zlib state structure */
 
   if(!(type & CLIENTWRITE_BODY) || !nbytes)
     return Curl_cwriter_write(data, writer->next, type, buf, nbytes);
@@ -343,7 +342,7 @@ static void gzip_do_close(struct Curl_easy *data,
                           struct Curl_cwriter *writer)
 {
   struct zlib_writer *zp = (struct zlib_writer *)writer;
-  z_stream *z = &zp->z;     /* zlib state structure */
+  z_stream *z = &zp->z; /* zlib state structure */
 
   exit_zlib(data, z, &zp->zlib_init, CURLE_OK);
 }
@@ -364,7 +363,7 @@ static const struct Curl_cwtype gzip_encoding = {
 struct brotli_writer {
   struct Curl_cwriter super;
   char buffer[DECOMPRESS_BUFFER_SIZE];
-  BrotliDecoderState *br;    /* State structure for brotli. */
+  BrotliDecoderState *br; /* State structure for brotli. */
 };
 
 static CURLcode brotli_map_error(BrotliDecoderErrorCode be)
@@ -429,7 +428,7 @@ static CURLcode brotli_do_write(struct Curl_easy *data,
     return Curl_cwriter_write(data, writer->next, type, buf, nbytes);
 
   if(!bp->br)
-    return CURLE_WRITE_ERROR;  /* Stream already ended. */
+    return CURLE_WRITE_ERROR; /* Stream already ended. */
 
   while((nbytes || r == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) &&
         result == CURLE_OK) {
@@ -495,7 +494,7 @@ static const struct Curl_cwtype brotli_encoding = {
 /* Zstd writer. */
 struct zstd_writer {
   struct Curl_cwriter super;
-  ZSTD_DStream *zds;    /* State structure for zstd. */
+  ZSTD_DStream *zds; /* State structure for zstd. */
   char buffer[DECOMPRESS_BUFFER_SIZE];
 };
 
@@ -817,7 +816,7 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       }
 
       if(!cwt)
-        cwt = &error_writer;  /* Defer error at use. */
+        cwt = &error_writer; /* Defer error at use. */
 
       result = Curl_cwriter_create(&writer, data, cwt, phase);
       CURL_TRC_WRITE(data, "added %s decoder %s -> %d",

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1153,7 +1153,7 @@ static CURLcode cookie_load(struct Curl_easy *data, const char *file,
       curlx_fclose(handle);
   }
   data->state.cookie_engine = TRUE;
-  ci->running = TRUE;          /* now, we are running */
+  ci->running = TRUE; /* now, we are running */
 
   return result;
 }

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -60,7 +60,7 @@
  * any function call which actually allocates a Curl_addrinfo struct.
  */
 
-#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER == 910) && \
+#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER == 910) &&     \
   defined(__OPTIMIZE__) && defined(__unix__) && defined(__i386__)
   /* workaround icc 9.1 optimizer issue */
 #  define vqualifier volatile
@@ -447,43 +447,43 @@ bool Curl_is_ipaddr(const char *address)
 bool Curl_looks_like_ipv6(const char *s, size_t len, bool maybe_url_encoded,
                           struct Curl_str *host, struct Curl_str *zone)
 {
-    const char *zonep = NULL;
-    size_t i = 0, hlen = 0, zlen = 0;
+  const char *zonep = NULL;
+  size_t i = 0, hlen = 0, zlen = 0;
 
-    if(host)
-      memset(host, 0, sizeof(*host));
-    if(zone)
-      memset(zone, 0, sizeof(*zone));
+  if(host)
+    memset(host, 0, sizeof(*host));
+  if(zone)
+    memset(zone, 0, sizeof(*zone));
 
-    for(i = 0; i < len; ++i, ++hlen) {
-      if(!s[i] || !(ISXDIGIT(s[i]) || (s[i] == ':') || (s[i] == '.')))
+  for(i = 0; i < len; ++i, ++hlen) {
+    if(!s[i] || !(ISXDIGIT(s[i]) || (s[i] == ':') || (s[i] == '.')))
+      break;
+  }
+
+  if((i < len) && (s[i] == '%')) { /* address followed by a zone? */
+    i += 1;
+    if(maybe_url_encoded && !strncmp("25", s + i, 2))
+      i += 2;
+    zonep = s + i;
+    for(; i < len; ++i, ++zlen) {
+      /* Allow unreserved characters as defined in RFC 3986 */
+      if(!s[i] || !(ISALPHA(s[i]) || ISXDIGIT(s[i]) || (s[i] == '-') ||
+                    (s[i] == '.') || (s[i] == '_') || (s[i] == '~')))
         break;
     }
+  }
 
-    if((i < len) && (s[i] == '%')) { /* address followed by a zone? */
-      i += 1;
-      if(maybe_url_encoded && !strncmp("25", s + i, 2))
-        i += 2;
-      zonep = s + i;
-      for(; i < len; ++i, ++zlen) {
-        /* Allow unreserved characters as defined in RFC 3986 */
-        if(!s[i] || !(ISALPHA(s[i]) || ISXDIGIT(s[i]) || (s[i] == '-') ||
-                      (s[i] == '.') || (s[i] == '_') || (s[i] == '~')))
-          break;
-      }
-    }
-
-    if(i != len)
-      return FALSE; /* invalid chars in zone */
-    if(host && hlen) {
-      host->str = s;
-      host->len = hlen;
-    }
-    if(zone && zlen) {
-      zone->str = zonep;
-      zone->len = zlen;
-    }
-    return TRUE;
+  if(i != len)
+    return FALSE; /* invalid chars in zone */
+  if(host && hlen) {
+    host->str = s;
+    host->len = hlen;
+  }
+  if(zone && zlen) {
+    zone->str = zonep;
+    zone->len = zlen;
+  }
+  return TRUE;
 }
 
 #ifdef USE_UNIX_SOCKETS

--- a/lib/curl_fopen.c
+++ b/lib/curl_fopen.c
@@ -42,13 +42,13 @@
 */
 
 #ifdef _WIN32
-#define PATHSEP "\\"
+#define PATHSEP   "\\"
 #define IS_SEP(x) (((x) == '/') || ((x) == '\\'))
 #elif defined(MSDOS) || defined(OS2)
-#define PATHSEP "\\"
+#define PATHSEP   "\\"
 #define IS_SEP(x) ((x) == '\\')
 #else
-#define PATHSEP "/"
+#define PATHSEP   "/"
 #define IS_SEP(x) ((x) == '/')
 #endif
 

--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -24,26 +24,26 @@
  *
  ***************************************************************************/
 
-#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI)) ||      \
-  !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH) ||   \
+#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI)) ||    \
+  !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH) || \
   defined(USE_LIBSSH2) || defined(USE_SSL)
 
 #define HMAC_MD5_LENGTH 16
 
 typedef CURLcode (*HMAC_hinit)(void *context);
-typedef void    (*HMAC_hupdate)(void *context,
-                                const unsigned char *data,
-                                unsigned int len);
-typedef void    (*HMAC_hfinal)(unsigned char *result, void *context);
+typedef void (*HMAC_hupdate)(void *context,
+                             const unsigned char *data,
+                             unsigned int len);
+typedef void (*HMAC_hfinal)(unsigned char *result, void *context);
 
 /* Per-hash function HMAC parameters. */
 struct HMAC_params {
-  HMAC_hinit       hinit;     /* Initialize context procedure. */
-  HMAC_hupdate     hupdate;   /* Update context with data. */
-  HMAC_hfinal      hfinal;    /* Get final result procedure. */
-  unsigned int     ctxtsize;  /* Context structure size. */
-  unsigned int     maxkeylen; /* Maximum key length (bytes). */
-  unsigned int     resultlen; /* Result length (bytes). */
+  HMAC_hinit  hinit;       /* Initialize context procedure. */
+  HMAC_hupdate hupdate;    /* Update context with data. */
+  HMAC_hfinal hfinal;      /* Get final result procedure. */
+  unsigned int ctxtsize;   /* Context structure size. */
+  unsigned int maxkeylen;  /* Maximum key length (bytes). */
+  unsigned int resultlen;  /* Result length (bytes). */
 };
 
 /* HMAC computation context. */
@@ -66,7 +66,6 @@ CURLcode Curl_hmacit(const struct HMAC_params *hashparams,
                      const unsigned char *key, const size_t keylen,
                      const unsigned char *data, size_t datalen,
                      unsigned char *output);
-
 #endif
 
 #endif /* HEADER_CURL_HMAC_H */

--- a/lib/curl_md5.h
+++ b/lib/curl_md5.h
@@ -38,16 +38,16 @@ typedef void (*Curl_MD5_update_func)(void *context,
 typedef void (*Curl_MD5_final_func)(unsigned char *result, void *context);
 
 struct MD5_params {
-  Curl_MD5_init_func     md5_init_func;   /* Initialize context procedure */
-  Curl_MD5_update_func   md5_update_func; /* Update context with data */
-  Curl_MD5_final_func    md5_final_func;  /* Get final result procedure */
-  unsigned int           md5_ctxtsize;  /* Context structure size */
-  unsigned int           md5_resultlen; /* Result length (bytes) */
+  Curl_MD5_init_func md5_init_func;     /* Initialize context procedure */
+  Curl_MD5_update_func md5_update_func; /* Update context with data */
+  Curl_MD5_final_func md5_final_func;   /* Get final result procedure */
+  unsigned int md5_ctxtsize;            /* Context structure size */
+  unsigned int md5_resultlen;           /* Result length (bytes) */
 };
 
 struct MD5_context {
-  const struct MD5_params *md5_hash;    /* Hash function definition */
-  void                  *md5_hashctx;   /* Hash function context */
+  const struct MD5_params *md5_hash;  /* Hash function definition */
+  void *md5_hashctx;                  /* Hash function context */
 };
 
 extern const struct MD5_params Curl_DIGEST_MD5;

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -30,7 +30,7 @@
 struct ntlmdata;
 
 /* Helpers to generate function byte arguments in little endian order */
-#define SHORTPAIR(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff))
+#define SHORTPAIR(x)   ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff))
 #define LONGQUARTET(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff)), \
   ((int)(((x) >> 16) & 0xff)), ((int)(((x) >> 24) & 0xff))
 

--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -35,7 +35,7 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_IMAP) || !defined(CURL_DISABLE_SMTP) || \
-  !defined(CURL_DISABLE_POP3) || \
+  !defined(CURL_DISABLE_POP3) ||                                  \
   (!defined(CURL_DISABLE_LDAP) && defined(USE_OPENLDAP))
 
 #include "urldata.h"

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -498,14 +498,10 @@ static void Curl_sha512_256_transform(uint64_t H[SHA512_256_HASH_SIZE_WORDS],
 
   /* Four 'Sigma' macro functions.
      See FIPS PUB 180-4 formulae 4.10, 4.11, 4.12, 4.13. */
-#define SIG0(x)                                                  \
-  (Curl_rotr64(x, 28) ^ Curl_rotr64(x, 34) ^ Curl_rotr64(x, 39))
-#define SIG1(x)                                                  \
-  (Curl_rotr64(x, 14) ^ Curl_rotr64(x, 18) ^ Curl_rotr64(x, 41))
-#define sig0(x)                                                  \
-  (Curl_rotr64(x,  1) ^ Curl_rotr64(x,  8) ^ ((x) >> 7))
-#define sig1(x)                                                  \
-  (Curl_rotr64(x, 19) ^ Curl_rotr64(x, 61) ^ ((x) >> 6))
+#define SIG0(x) (Curl_rotr64(x, 28) ^ Curl_rotr64(x, 34) ^ Curl_rotr64(x, 39))
+#define SIG1(x) (Curl_rotr64(x, 14) ^ Curl_rotr64(x, 18) ^ Curl_rotr64(x, 41))
+#define sig0(x) (Curl_rotr64(x,  1) ^ Curl_rotr64(x,  8) ^ ((x) >> 7))
+#define sig1(x) (Curl_rotr64(x, 19) ^ Curl_rotr64(x, 61) ^ ((x) >> 6))
 
   if(1) {
     unsigned int t;
@@ -715,7 +711,7 @@ static CURLcode Curl_sha512_256_update(void *context,
 static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *context)
 {
   struct Curl_sha512_256ctx * const ctx = (struct Curl_sha512_256ctx *)context;
-  uint64_t num_bits;   /* Number of processed bits */
+  uint64_t num_bits; /* Number of processed bits */
   unsigned int bytes_have; /* Number of bytes in the context buffer */
   /* the void pointer here is required to mute Intel compiler warning */
   void * const ctx_buf = ctx->buffer;

--- a/lib/curl_share.h
+++ b/lib/curl_share.h
@@ -81,9 +81,9 @@ CURLSHcode Curl_share_lock(struct Curl_easy *data, curl_lock_data type,
 CURLSHcode Curl_share_unlock(struct Curl_easy *data, curl_lock_data type);
 
 /* convenience macro to check if this handle is using a shared SSL spool */
-#define CURL_SHARE_ssl_scache(data) ((data)->share &&                    \
-                                    ((data)->share->specifier &          \
-                                     (1 << CURL_LOCK_DATA_SSL_SESSION)))
+#define CURL_SHARE_ssl_scache(data)                                \
+  ((data)->share &&                                                \
+   ((data)->share->specifier & (1 << CURL_LOCK_DATA_SSL_SESSION)))
 
 CURLcode Curl_share_easy_unlink(struct Curl_easy *data);
 CURLcode Curl_share_easy_link(struct Curl_easy *data,

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -78,8 +78,8 @@
 #include "easy_lock.h"
 
 /* true globals -- for curl_global_init() and curl_global_cleanup() */
-static unsigned int  initialized;
-static long          easy_init_flags;
+static unsigned int initialized;
+static long easy_init_flags;
 
 #ifdef GLOBAL_INIT_IS_THREADSAFE
 

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1188,8 +1188,7 @@ static CURLcode ftp_port_bind_socket(struct Curl_easy *data,
           curlx_strerror(SOCKERRNO, buffer, sizeof(buffer)));
     return CURLE_FTP_PORT_FAILED;
   }
-  CURL_TRC_FTP(data, "ftp_port_bind_socket(), socket bound to port %d",
-               port);
+  CURL_TRC_FTP(data, "ftp_port_bind_socket(), socket bound to port %d", port);
   return CURLE_OK;
 }
 
@@ -1276,8 +1275,7 @@ static CURLcode ftp_port_send_command(struct Curl_easy *data,
        * EPRT |2|1080::8:800:200C:417A|5282|
        */
       result = Curl_pp_sendf(data, &ftpc->pp, "%s |%d|%s|%hu|", mode[fcmd],
-                             sa->sa_family == AF_INET ? 1 : 2,
-                             myhost, port);
+                             sa->sa_family == AF_INET ? 1 : 2, myhost, port);
       if(result) {
         failf(data, "Failure sending EPRT command: %s",
               curl_easy_strerror(result));

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -617,8 +617,7 @@ CURLcode Curl_hsts_loadfiles(struct Curl_easy *data)
 
 bool Curl_hsts_applies(struct hsts *h, const struct Curl_peer *dest)
 {
-  return !!hsts_check(h, dest->hostname,
-                      strlen(dest->hostname), TRUE);
+  return !!hsts_check(h, dest->hostname, strlen(dest->hostname), TRUE);
 }
 
 #if defined(DEBUGBUILD) || defined(UNITTESTS)

--- a/lib/http.c
+++ b/lib/http.c
@@ -1132,9 +1132,9 @@ static void http_switch_to_get(struct Curl_easy *data, int code)
   Curl_creader_set_rewind(data, FALSE);
 }
 
-#define HTTPREQ_IS_POST(data)                           \
-  ((data)->state.httpreq == HTTPREQ_POST ||             \
-   (data)->state.httpreq == HTTPREQ_POST_FORM ||        \
+#define HTTPREQ_IS_POST(data)                    \
+  ((data)->state.httpreq == HTTPREQ_POST ||      \
+   (data)->state.httpreq == HTTPREQ_POST_FORM || \
    (data)->state.httpreq == HTTPREQ_POST_MIME)
 
 CURLcode Curl_http_follow(struct Curl_easy *data, const char *newurl,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1701,12 +1701,12 @@ static CURLcode http2_handle_stream_close(struct Curl_cfilter *cf,
       return CURLE_RECV_ERROR; /* trigger Curl_retry_request() later */
     }
     else if(stream->resp_hds_complete && data->req.no_body) {
-        CURL_TRC_CF(data, cf, "[%d] error after response headers, but we did "
-                    "not want a body anyway, ignore: %s (err %u)",
-                    stream->id, nghttp2_http2_strerror(stream->error),
-                    stream->error);
-        stream->close_handled = TRUE;
-        return CURLE_OK;
+      CURL_TRC_CF(data, cf, "[%d] error after response headers, but we did "
+                  "not want a body anyway, ignore: %s (err %u)",
+                  stream->id, nghttp2_http2_strerror(stream->error),
+                  stream->error);
+      stream->close_handled = TRUE;
+      return CURLE_OK;
     }
     failf(data, "HTTP/2 stream %d reset by %s (error 0x%x %s)",
           stream->id, stream->reset_by_server ? "server" : "curl",

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -366,7 +366,7 @@ static CURLcode http_proxy_create_CONNECTUDP(struct httpreq **preq,
 
   /* If user is not overriding Host: header, we add for HTTP/1.x */
   if(ver == PROXY_HTTP_V1 &&
-      !Curl_checkProxyheaders(data, cf->conn, STRCONST("Host"))) {
+     !Curl_checkProxyheaders(data, cf->conn, STRCONST("Host"))) {
     result = Curl_dynhds_cadd(&req->headers, "Host", authority);
     if(result)
       goto out;
@@ -380,8 +380,8 @@ static CURLcode http_proxy_create_CONNECTUDP(struct httpreq **preq,
   }
 
   if(ver == PROXY_HTTP_V1 &&
-    !Curl_checkProxyheaders(data, cf->conn, STRCONST("User-Agent")) &&
-      data->set.str[STRING_USERAGENT] && *data->set.str[STRING_USERAGENT]) {
+     !Curl_checkProxyheaders(data, cf->conn, STRCONST("User-Agent")) &&
+     data->set.str[STRING_USERAGENT] && *data->set.str[STRING_USERAGENT]) {
     result = Curl_dynhds_cadd(&req->headers, "User-Agent",
                               data->set.str[STRING_USERAGENT]);
     if(result)
@@ -389,7 +389,7 @@ static CURLcode http_proxy_create_CONNECTUDP(struct httpreq **preq,
   }
 
   if(ver == PROXY_HTTP_V1 &&
-      !Curl_checkProxyheaders(data, cf->conn, STRCONST("Proxy-Connection"))) {
+     !Curl_checkProxyheaders(data, cf->conn, STRCONST("Proxy-Connection"))) {
     result = Curl_dynhds_cadd(&req->headers, "Proxy-Connection", "Keep-Alive");
     if(result)
       goto out;
@@ -557,7 +557,7 @@ static CURLcode http_proxy_cf_connect(struct Curl_cfilter *cf,
 {
   struct cf_proxy_ctx *ctx = cf->ctx;
   CURLcode result;
-  const char *tunnel_type;  /* Determine tunnel type once and reuse */
+  const char *tunnel_type; /* Determine tunnel type once and reuse */
 
   tunnel_type = ctx->udp_tunnel ? "CONNECT-UDP" : "CONNECT";
 
@@ -608,7 +608,7 @@ connect_sub:
     if(!strcmp(alpn, "http/1.0")) {
       CURL_TRC_CF(data, cf, "installing subfilter for HTTP/1.0");
       result = Curl_cf_h1_proxy_insert_after(cf, data, ctx->dest, 10,
-                                              (bool)ctx->udp_tunnel);
+                                             (bool)ctx->udp_tunnel);
       if(result)
         goto out;
     }
@@ -617,7 +617,7 @@ connect_sub:
       CURL_TRC_CF(data, cf, "installing subfilter for HTTP/1.%d",
                   httpversion % 10);
       result = Curl_cf_h1_proxy_insert_after(cf, data, ctx->dest, httpversion,
-                                              (bool)ctx->udp_tunnel);
+                                             (bool)ctx->udp_tunnel);
       if(result)
         goto out;
     }
@@ -625,13 +625,13 @@ connect_sub:
     else if(!strcmp(alpn, "h2")) {
       CURL_TRC_CF(data, cf, "installing subfilter for HTTP/2");
       result = Curl_cf_h2_proxy_insert_after(cf, data, ctx->dest,
-                                              (bool)ctx->udp_tunnel);
+                                             (bool)ctx->udp_tunnel);
       if(result)
         goto out;
     }
 #endif /* USE_NGHTTP2 */
 #if defined(USE_PROXY_HTTP3) && defined(USE_NGHTTP3) && \
-    defined(USE_NGTCP2) && defined(USE_OPENSSL)
+  defined(USE_NGTCP2) && defined(USE_OPENSSL)
     else if(!strcmp(alpn, "h3")) {
       CURL_TRC_CF(data, cf, "installing subfilter for HTTP/3");
       result = Curl_cf_h3_proxy_insert_after(cf, data, ctx->dest,

--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -76,9 +76,10 @@ extern struct Curl_cftype Curl_cft_http_proxy;
 
 #endif /* !CURL_DISABLE_PROXY && !CURL_DISABLE_HTTP */
 
-#define IS_HTTPS_PROXY(t) (((t) == CURLPROXY_HTTPS) ||  \
-                           ((t) == CURLPROXY_HTTPS2) || \
-                           ((t) == CURLPROXY_HTTPS3))
+#define IS_HTTPS_PROXY(t)       \
+  (((t) == CURLPROXY_HTTPS) ||  \
+   ((t) == CURLPROXY_HTTPS2) || \
+   ((t) == CURLPROXY_HTTPS3))
 
 #define IS_QUIC_PROXY(t) ((t) == CURLPROXY_HTTPS3)
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -910,12 +910,12 @@ static CURLcode imap_perform_append(struct Curl_easy *data,
   if(data->set.upload_flags) {
     int i;
     struct ulbits ulflag[] = {
-      {CURLULFLAG_ANSWERED, "Answered"},
-      {CURLULFLAG_DELETED, "Deleted"},
-      {CURLULFLAG_DRAFT, "Draft"},
-      {CURLULFLAG_FLAGGED, "Flagged"},
-      {CURLULFLAG_SEEN, "Seen"},
-      {0, NULL}
+      { CURLULFLAG_ANSWERED, "Answered" },
+      { CURLULFLAG_DELETED, "Deleted" },
+      { CURLULFLAG_DRAFT, "Draft" },
+      { CURLULFLAG_FLAGGED, "Flagged" },
+      { CURLULFLAG_SEEN, "Seen" },
+      { 0, NULL }
     };
 
     result = CURLE_OUT_OF_MEMORY;
@@ -1043,7 +1043,7 @@ static CURLcode imap_state_capability_resp(struct Curl_easy *data,
 
       /* Extract the word */
       for(wordlen = 0; line[wordlen] && !ISBLANK(line[wordlen]) &&
-            !ISNEWLINE(line[wordlen]);)
+                       !ISNEWLINE(line[wordlen]);)
         wordlen++;
 
       /* Does the server support the STARTTLS capability? */

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1073,9 +1073,8 @@ static int formatf(void *userp, /* untouched by format(), sent to the
       /* Answer the count of characters written. */
       if(p.flags & FLAGS_LONGLONG)
         *(int64_t *)iptr->val.ptr = (int64_t)done;
-      else
-        if(p.flags & FLAGS_LONG)
-          *(long *)iptr->val.ptr = (long)done;
+      else if(p.flags & FLAGS_LONG)
+        *(long *)iptr->val.ptr = (long)done;
       else if(!(p.flags & FLAGS_SHORT))
         *(int *)iptr->val.ptr = done;
       else

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -656,8 +656,7 @@ static CURLproxycode socks5_check_resp0(struct socks_ctx *sx,
       sxstate(sx, cf, data, SOCKS5_ST_GSSAPI_INIT);
       return CURLPX_OK;
     }
-    failf(data,
-          "SOCKS5 GSSAPI per-message authentication is not enabled.");
+    failf(data, "SOCKS5 GSSAPI per-message authentication is not enabled.");
     return CURLPX_GSSAPI_PERMSG;
   case 2:
     /* regular name + password authentication */
@@ -712,8 +711,7 @@ static CURLproxycode socks5_auth_init(struct Curl_cfilter *cf,
   if(result || (nwritten != 2))
     return CURLPX_SEND_REQUEST;
   if(ulen) {
-    result = Curl_bufq_cwrite(&sx->iobuf, sx->creds->user, ulen,
-                              &nwritten);
+    result = Curl_bufq_cwrite(&sx->iobuf, sx->creds->user, ulen, &nwritten);
     if(result || (nwritten != ulen))
       return CURLPX_SEND_REQUEST;
   }
@@ -722,8 +720,7 @@ static CURLproxycode socks5_auth_init(struct Curl_cfilter *cf,
   if(result || (nwritten != 1))
     return CURLPX_SEND_REQUEST;
   if(plen) {
-    result = Curl_bufq_cwrite(&sx->iobuf, sx->creds->passwd, plen,
-                              &nwritten);
+    result = Curl_bufq_cwrite(&sx->iobuf, sx->creds->passwd, plen, &nwritten);
     if(result || (nwritten != plen))
       return CURLPX_SEND_REQUEST;
   }
@@ -1086,8 +1083,7 @@ process_state:
     sxstate(sx, cf, data, SOCKS5_ST_REQ1_INIT);
     goto process_state;
 #else
-    failf(data,
-          "SOCKS5 GSSAPI per-message authentication is not supported.");
+    failf(data, "SOCKS5 GSSAPI per-message authentication is not supported.");
     return socks_failed(sx, cf, data, CURLPX_GSSAPI_PERMSG);
 #endif
   }

--- a/lib/uint-bset.c
+++ b/lib/uint-bset.c
@@ -179,10 +179,10 @@ uint32_t Curl_popcount64(uint64_t x)
   /* Compute the "Hamming Distance" between 'x' and 0,
    * which is the number of set bits in 'x'.
    * See: https://en.wikipedia.org/wiki/Hamming_weight */
-  const uint64_t m1  = 0x5555555555555555LL; /* 0101+ */
-  const uint64_t m2  = 0x3333333333333333LL; /* 00110011+ */
-  const uint64_t m4  = 0x0f0f0f0f0f0f0f0fLL; /* 00001111+ */
-   /* 1 + 256^1 + 256^2 + 256^3 + ... + 256^7 */
+  const uint64_t m1 = 0x5555555555555555LL; /* 0101+ */
+  const uint64_t m2 = 0x3333333333333333LL; /* 00110011+ */
+  const uint64_t m4 = 0x0f0f0f0f0f0f0f0fLL; /* 00001111+ */
+  /* 1 + 256^1 + 256^2 + 256^3 + ... + 256^7 */
   const uint64_t h01 = 0x0101010101010101LL;
   x -= (x >> 1) & m1;             /* replace every 2 bits with bits present */
   x = (x & m2) + ((x >> 2) & m2); /* replace every nibble with bits present */

--- a/lib/uint-bset.c
+++ b/lib/uint-bset.c
@@ -157,7 +157,7 @@ bool Curl_uint32_bset_next(struct uint32_bset *bset, uint32_t last,
     /* shift away the bits we already iterated in this slot */
     x = (bset->slots[islot] >> (last % 64));
     if(x) {
-      /* more bits set, next is `last` + trailing0s of the shifted slot */
+      /* more bits set, next is `last` + trailing 0s of the shifted slot */
       *pnext = last + CURL_CTZ64(x);
       return TRUE;
     }

--- a/lib/uint-spbset.c
+++ b/lib/uint-spbset.c
@@ -203,7 +203,7 @@ static bool uint32_spbset_chunk_next(struct uint32_spbset_chunk *chunk,
     if(i < CURL_UINT32_SPBSET_CH_SLOTS) {
       x = (chunk->slots[i] >> (last % 64));
       if(x) {
-        /* more bits set, next is `last` + trailing0s of the shifted slot */
+        /* more bits set, next is `last` + trailing 0s of the shifted slot */
         *pnext = last + CURL_CTZ64(x);
         return TRUE;
       }

--- a/lib/url.c
+++ b/lib/url.c
@@ -1014,8 +1014,8 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
          that can be reused and "upgraded" to NTLM if it does
          not have any auth ongoing. */
 #ifdef USE_SPNEGO
-      if((conn->http_ntlm_state == NTLMSTATE_NONE)
-         && (conn->http_negotiate_state == GSS_AUTHNONE)) {
+      if((conn->http_ntlm_state == NTLMSTATE_NONE) &&
+         (conn->http_negotiate_state == GSS_AUTHNONE)) {
 #else
       if(conn->http_ntlm_state == NTLMSTATE_NONE) {
 #endif

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -476,8 +476,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
 
     if(Curl_creds_has_user(creds)) {
       /* Populate our identity structure */
-      if(Curl_create_sspi_identity(creds->user, creds->passwd,
-                                   &identity)) {
+      if(Curl_create_sspi_identity(creds->user, creds->passwd, &identity)) {
         curlx_free(output_token);
         return CURLE_OUT_OF_MEMORY;
       }
@@ -557,11 +556,12 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
 
     /* Generate our response message */
     status = Curl_pSecFn->InitializeSecurityContext(&credentials, NULL,
-                                                  spn,
-                                                  ISC_REQ_USE_HTTP_STYLE, 0, 0,
-                                                  &chlg_desc, 0,
-                                                  digest->http_context,
-                                                  &resp_desc, &attrs, NULL);
+                                                    spn,
+                                                    ISC_REQ_USE_HTTP_STYLE,
+                                                    0, 0,
+                                                    &chlg_desc, 0,
+                                                    digest->http_context,
+                                                    &resp_desc, &attrs, NULL);
     curlx_free(spn);
 
     if(status == SEC_I_COMPLETE_NEEDED ||

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -317,8 +317,7 @@ struct negotiatedata {
   BIT(havemultiplerequests);
 };
 
-struct negotiatedata *
-Curl_auth_nego_get(struct connectdata *conn, bool proxy);
+struct negotiatedata *Curl_auth_nego_get(struct connectdata *conn, bool proxy);
 
 /* This is used to decode a base64 encoded SPNEGO (Negotiate) challenge
    message */

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1918,7 +1918,7 @@ static CURLcode cf_progress_ingress(struct Curl_cfilter *cf,
   if(ctx->q.sockfd != CURL_SOCKET_BAD) {
     /* Direct UDP socket (via happy eyeballs) */
     return vquic_recv_packets(cf, data, &ctx->q, 1000,
-                            cf_ngtcp2_recv_pkts, &rctx);
+                              cf_ngtcp2_recv_pkts, &rctx);
   }
   else {
     /* Tunneled QUIC (CONNECT-UDP through proxy) */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -323,12 +323,12 @@ static gnutls_x509_crt_fmt_t gnutls_do_file_type(const char *type)
   "+GROUP-SECP256R1:+GROUP-X25519:+GROUP-SECP384R1:+GROUP-SECP521R1:" \
   "%DISABLE_TLS13_COMPAT_MODE"
 
-static CURLcode
-gnutls_set_ssl_version_min_max(struct Curl_easy *data,
-                               struct ssl_peer *peer,
-                               struct ssl_primary_config *conn_config,
-                               const char **prioritylist,
-                               bool tls13support)
+static CURLcode gnutls_set_ssl_version_min_max(
+  struct Curl_easy *data,
+  struct ssl_peer *peer,
+  struct ssl_primary_config *conn_config,
+  const char **prioritylist,
+  bool tls13support)
 {
   long ssl_version = conn_config->version;
   long ssl_version_max = conn_config->version_max;

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -102,9 +102,10 @@ bool Curl_tls_keylog_write_line(const char *line)
   return TRUE;
 }
 
-bool Curl_tls_keylog_write(const char *label,
-                         const unsigned char client_random[CLIENT_RANDOM_SIZE],
-                         const unsigned char *secret, size_t secretlen)
+bool Curl_tls_keylog_write(
+  const char *label,
+  const unsigned char client_random[CLIENT_RANDOM_SIZE],
+  const unsigned char *secret, size_t secretlen)
 {
   size_t pos, i;
   unsigned char line[KEYLOG_LABEL_MAXLEN + 1 +

--- a/lib/vtls/keylog.h
+++ b/lib/vtls/keylog.h
@@ -61,9 +61,10 @@ const char *Curl_tls_keylog_file_name(void);
  * Appends a key log file entry.
  * Returns true iff the key log file is open and a valid entry was provided.
  */
-bool Curl_tls_keylog_write(const char *label,
-                         const unsigned char client_random[CLIENT_RANDOM_SIZE],
-                         const unsigned char *secret, size_t secretlen);
+bool Curl_tls_keylog_write(
+  const char *label,
+  const unsigned char client_random[CLIENT_RANDOM_SIZE],
+  const unsigned char *secret, size_t secretlen);
 
 /*
  * Appends a line to the key log file, ensure it is terminated by an LF.

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -179,10 +179,10 @@ static int mbedtls_bio_cf_read(void *bio, unsigned char *buf, size_t blen)
 #define PUB_DER_MAX_BYTES   (RSA_PUB_DER_MAX_BYTES > ECP_PUB_DER_MAX_BYTES ? \
                              RSA_PUB_DER_MAX_BYTES : ECP_PUB_DER_MAX_BYTES)
 
-static CURLcode
-mbed_set_ssl_version_min_max(struct Curl_easy *data,
-                             struct mbed_ssl_backend_data *backend,
-                             struct ssl_primary_config *conn_config)
+static CURLcode mbed_set_ssl_version_min_max(
+  struct Curl_easy *data,
+  struct mbed_ssl_backend_data *backend,
+  struct ssl_primary_config *conn_config)
 {
   mbedtls_ssl_protocol_version ver_min =
 #ifdef MBEDTLS_SSL_PROTO_TLS1_2
@@ -275,15 +275,15 @@ static uint16_t mbed_cipher_suite_walk_str(const char **str, const char **end)
   return id;
 }
 #else
-#define mbed_cipher_suite_get_str Curl_cipher_suite_get_str
+#define mbed_cipher_suite_get_str  Curl_cipher_suite_get_str
 #define mbed_cipher_suite_walk_str Curl_cipher_suite_walk_str
 #endif
 
-static CURLcode
-mbed_set_selected_ciphers(struct Curl_easy *data,
-                          struct mbed_ssl_backend_data *backend,
-                          const char *ciphers12,
-                          const char *ciphers13)
+static CURLcode mbed_set_selected_ciphers(
+  struct Curl_easy *data,
+  struct mbed_ssl_backend_data *backend,
+  const char *ciphers12,
+  const char *ciphers13)
 {
   const char *ciphers = ciphers12;
   const int *supported;
@@ -745,7 +745,7 @@ static CURLcode mbed_load_privkey(struct Curl_cfilter *cf,
 }
 
 static CURLcode mbed_load_crl(struct Curl_cfilter *cf,
-                               struct Curl_easy *data)
+                              struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3324,13 +3324,13 @@ CURLcode Curl_ssl_setup_x509_store(struct Curl_cfilter *cf,
   return result;
 }
 
-static CURLcode
-ossl_init_session_and_alpns(struct ossl_ctx *octx,
-                            struct Curl_cfilter *cf,
-                            struct Curl_easy *data,
-                            struct ssl_peer *peer,
-                            const struct alpn_spec *alpns_requested,
-                            Curl_ossl_init_session_reuse_cb *sess_reuse_cb)
+static CURLcode ossl_init_session_and_alpns(
+  struct ossl_ctx *octx,
+  struct Curl_cfilter *cf,
+  struct Curl_easy *data,
+  struct ssl_peer *peer,
+  const struct alpn_spec *alpns_requested,
+  Curl_ossl_init_session_reuse_cb *sess_reuse_cb)
 {
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   struct ssl_primary_config *conn_cfg = Curl_ssl_cf_get_primary_config(cf);

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -107,12 +107,12 @@ struct Curl_ssl_session;
 /* Struct to hold a curl OpenSSL instance */
 struct ossl_ctx {
   /* these ones requires specific SSL-types */
-  SSL_CTX* ssl_ctx;
-  SSL*     ssl;
+  SSL_CTX *ssl_ctx;
+  SSL *ssl;
   BIO_METHOD *bio_method;
   CURLcode io_result;       /* result of last BIO cfilter operation */
   /* blocked writes need to retry with same length, remember it */
-  int      blocked_ssl_write_len;
+  int blocked_ssl_write_len;
 #if !defined(HAVE_KEYLOG_UPSTREAM) && !defined(HAVE_KEYLOG_CALLBACK)
   /* Set to true once a valid keylog entry has been created to avoid dupes.
      This is a bool and not a bitfield because it is passed by address. */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1908,8 +1908,8 @@ bool Curl_ssl_cf_is_proxy(struct Curl_cfilter *cf)
   return (cf->cft->flags & CF_TYPE_SSL) && (cf->cft->flags & CF_TYPE_PROXY);
 }
 
-struct ssl_config_data *
-Curl_ssl_cf_get_config(struct Curl_cfilter *cf, struct Curl_easy *data)
+struct ssl_config_data *Curl_ssl_cf_get_config(struct Curl_cfilter *cf,
+                                               struct Curl_easy *data)
 {
 #ifdef CURL_DISABLE_PROXY
   (void)cf;
@@ -1919,8 +1919,8 @@ Curl_ssl_cf_get_config(struct Curl_cfilter *cf, struct Curl_easy *data)
 #endif
 }
 
-struct ssl_primary_config *
-Curl_ssl_cf_get_primary_config(struct Curl_cfilter *cf)
+struct ssl_primary_config *Curl_ssl_cf_get_primary_config(
+  struct Curl_cfilter *cf)
 {
 #ifdef CURL_DISABLE_PROXY
   return &cf->conn->ssl_config;

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -241,8 +241,8 @@ struct ssl_config_data *Curl_ssl_cf_get_config(struct Curl_cfilter *cf,
 /**
  * Get the primary config relevant for the filter from its connection.
  */
-struct ssl_primary_config *
-  Curl_ssl_cf_get_primary_config(struct Curl_cfilter *cf);
+struct ssl_primary_config *Curl_ssl_cf_get_primary_config(
+  struct Curl_cfilter *cf);
 
 extern struct Curl_cftype Curl_cft_ssl;
 #ifndef CURL_DISABLE_PROXY

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -38,20 +38,20 @@ struct Curl_ssl_session;
 
 /* see https://www.iana.org/assignments/tls-extensiontype-values/ */
 #define ALPN_HTTP_1_0_LENGTH 8
-#define ALPN_HTTP_1_0 "http/1.0"
+#define ALPN_HTTP_1_0        "http/1.0"
 #define ALPN_HTTP_1_1_LENGTH 8
-#define ALPN_HTTP_1_1 "http/1.1"
-#define ALPN_H2_LENGTH 2
-#define ALPN_H2 "h2"
-#define ALPN_H3_LENGTH 2
-#define ALPN_H3 "h3"
+#define ALPN_HTTP_1_1        "http/1.1"
+#define ALPN_H2_LENGTH       2
+#define ALPN_H2              "h2"
+#define ALPN_H3_LENGTH       2
+#define ALPN_H3              "h3"
 
 /* conservative sizes on the ALPN entries and count we are handling,
  * we can increase these if we ever feel the need or have to accommodate
  * ALPN strings from the "outside". */
-#define ALPN_NAME_MAX     10
-#define ALPN_ENTRIES_MAX  3
-#define ALPN_PROTO_BUF_MAX   (ALPN_ENTRIES_MAX * (ALPN_NAME_MAX + 1))
+#define ALPN_NAME_MAX      10
+#define ALPN_ENTRIES_MAX   3
+#define ALPN_PROTO_BUF_MAX (ALPN_ENTRIES_MAX * (ALPN_NAME_MAX + 1))
 
 struct alpn_spec {
   char entries[ALPN_ENTRIES_MAX][ALPN_NAME_MAX];

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -495,15 +495,14 @@ static void cf_ssl_cache_peer_update(struct Curl_ssl_scache_peer *peer)
                        cf_ssl_peer_key_is_global(peer->ssl_peer_key)));
 }
 
-static CURLcode
-cf_ssl_scache_peer_init(struct Curl_ssl_scache_peer *peer,
-                        const char *ssl_peer_key,
-                        const char *clientcert,
-                        const char *key_passwd,
-                        const char *srp_username,
-                        const char *srp_password,
-                        const unsigned char *salt,
-                        const unsigned char *hmac)
+static CURLcode cf_ssl_scache_peer_init(struct Curl_ssl_scache_peer *peer,
+                                        const char *ssl_peer_key,
+                                        const char *clientcert,
+                                        const char *key_passwd,
+                                        const char *srp_username,
+                                        const char *srp_password,
+                                        const unsigned char *salt,
+                                        const unsigned char *hmac)
 {
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
@@ -758,8 +757,8 @@ out:
   return result;
 }
 
-static struct Curl_ssl_scache_peer *
-cf_ssl_get_free_peer(struct Curl_ssl_scache *scache)
+static struct Curl_ssl_scache_peer *cf_ssl_get_free_peer(
+  struct Curl_ssl_scache *scache)
 {
   struct Curl_ssl_scache_peer *peer = NULL;
   size_t i;
@@ -1107,11 +1106,10 @@ static CURLcode cf_ssl_scache_peer_set_hmac(struct Curl_ssl_scache_peer *peer)
   return result;
 }
 
-static CURLcode
-cf_ssl_find_peer_by_hmac(struct Curl_ssl_scache *scache,
-                         const unsigned char *salt,
-                         const unsigned char *hmac,
-                         struct Curl_ssl_scache_peer **ppeer)
+static CURLcode cf_ssl_find_peer_by_hmac(struct Curl_ssl_scache *scache,
+                                         const unsigned char *salt,
+                                         const unsigned char *hmac,
+                                         struct Curl_ssl_scache_peer **ppeer)
 {
   size_t i;
   CURLcode result = CURLE_OK;
@@ -1255,7 +1253,7 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
   for(i = 0; scache && i < scache->peer_count; i++) {
     peer = &scache->peers[i];
     if(!peer->ssl_peer_key && !peer->hmac_set)
-      continue;  /* skip free entry */
+      continue; /* skip free entry */
     if(!peer->exportable)
       continue;
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -316,7 +316,7 @@ static int wssl_bio_cf_out_write(WOLFSSL_BIO *bio, const char *buf, int blen)
      * sending during shutdown. */
     CURL_TRC_CF(data, cf, "bio_write, shutdown restrict send of %d"
                 " to %d bytes", blen, wssl->io_send_blocked_len);
-    skiplen = (ssize_t)(blen - wssl->io_send_blocked_len);
+    skiplen = (size_t)(blen - wssl->io_send_blocked_len);
     blen = wssl->io_send_blocked_len;
   }
   result = Curl_conn_cf_send(cf->next, data,

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -81,7 +81,7 @@
    options.h. */
 #ifndef KEEP_PEER_CERT
 #if defined(HAVE_WOLFSSL_GET_PEER_CERTIFICATE) || \
-    (defined(OPENSSL_EXTRA) && !defined(NO_CERTS))
+  (defined(OPENSSL_EXTRA) && !defined(NO_CERTS))
 #define KEEP_PEER_CERT
 #endif
 #endif
@@ -221,7 +221,7 @@ static int wssl_do_file_type(const char *type)
 #ifdef WOLFSSL_HAVE_KYBER
 struct group_name_map {
   const word16 group;
-  const char   *name;
+  const char *name;
 };
 
 static const struct group_name_map gnm[] = {
@@ -517,13 +517,13 @@ static CURLcode wssl_on_session_reuse(struct Curl_cfilter *cf,
                                connssl->earlydata_max);
 }
 
-static CURLcode
-wssl_setup_session(struct Curl_cfilter *cf,
-                   struct Curl_easy *data,
-                   struct wssl_ctx *wss,
-                   struct alpn_spec *alpns,
-                   const char *ssl_peer_key,
-                   Curl_wssl_init_session_reuse_cb *sess_reuse_cb)
+static CURLcode wssl_setup_session(
+  struct Curl_cfilter *cf,
+  struct Curl_easy *data,
+  struct wssl_ctx *wss,
+  struct alpn_spec *alpns,
+  const char *ssl_peer_key,
+  Curl_wssl_init_session_reuse_cb *sess_reuse_cb)
 {
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   struct Curl_ssl_session *scs = NULL;
@@ -1172,18 +1172,18 @@ static CURLcode wssl_init_curves(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static CURLcode wssl_init_ssl_handle(struct wssl_ctx *wctx,
-                                     struct Curl_cfilter *cf,
-                                     struct Curl_easy *data,
-                                     struct ssl_peer *peer,
-                                     struct alpn_spec *alpns,
-                                     void *ssl_user_data,
-                                     unsigned char transport,
+static CURLcode wssl_init_ssl_handle(
+  struct wssl_ctx *wctx,
+  struct Curl_cfilter *cf,
+  struct Curl_easy *data,
+  struct ssl_peer *peer,
+  struct alpn_spec *alpns,
+  void *ssl_user_data,
+  unsigned char transport,
 #ifdef WOLFSSL_HAVE_KYBER
-                                     word16 pqkem,
+  word16 pqkem,
 #endif
-                                     Curl_wssl_init_session_reuse_cb
-                                       *sess_reuse_cb)
+  Curl_wssl_init_session_reuse_cb *sess_reuse_cb)
 {
   /* Let's make an SSL structure */
   wctx->ssl = wolfSSL_new(wctx->ssl_ctx);
@@ -1206,8 +1206,7 @@ static CURLcode wssl_init_ssl_handle(struct wssl_ctx *wctx,
 
 #ifdef WOLFSSL_HAVE_KYBER
   if(pqkem) {
-    if(wolfSSL_UseKeyShare(wctx->ssl, pqkem) !=
-       WOLFSSL_SUCCESS) {
+    if(wolfSSL_UseKeyShare(wctx->ssl, pqkem) != WOLFSSL_SUCCESS) {
       failf(data, "unable to use PQ KEM");
     }
   }

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2210,7 +2210,7 @@ static CURLcode wssl_connect(struct Curl_cfilter *cf,
       wssl->hs_result = result;
       goto out;
     }
-    /* handhshake was done without errors */
+    /* handshake was done without errors */
 #ifdef HAVE_ALPN
     if(connssl->alpn) {
       int rc;

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1537,10 +1537,8 @@ static int set_url(void)
                         __FILE__, __LINE__, rc, curl_url_strerror(rc));
           error++;
         }
-        else {
-          if(checkurl(set_url_list[i].in, url, set_url_list[i].out)) {
-            error++;
-          }
+        else if(checkurl(set_url_list[i].in, url, set_url_list[i].out)) {
+          error++;
         }
         curl_free(url);
       }
@@ -1640,7 +1638,6 @@ static int set_parts(void)
       if(!uc) {
         /* only do this if it worked */
         rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
-
         if(rc) {
           curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
                         __FILE__, __LINE__, rc, curl_url_strerror(rc));
@@ -1680,17 +1677,14 @@ static int get_url(bool has_utf8)
       if(!rc) {
         char *url = NULL;
         rc = curl_url_get(urlp, CURLUPART_URL, &url, get_url_list[i].getflags);
-
         if(rc) {
           curl_mfprintf(stderr, "%s:%d returned %d (%s). URL: '%s'\n",
                         __FILE__, __LINE__, rc, curl_url_strerror(rc),
                         get_url_list[i].in);
           error++;
         }
-        else {
-          if(checkurl(get_url_list[i].in, url, get_url_list[i].out)) {
-            error++;
-          }
+        else if(checkurl(get_url_list[i].in, url, get_url_list[i].out)) {
+          error++;
         }
         curl_free(url);
       }

--- a/tests/unit/unit3400.c
+++ b/tests/unit/unit3400.c
@@ -220,8 +220,7 @@ static void test_capsule_decode_paths(void)
   fail_unless(err == CURLE_RECV_ERROR,
               "expected RECV_ERROR for short output buffer");
   fail_unless(nread == 0, "expected zero read on short output buffer");
-  fail_unless(Curl_bufq_is_empty(&q),
-              "oversized capsule must be discarded");
+  fail_unless(Curl_bufq_is_empty(&q), "oversized capsule must be discarded");
 
   /* zero-length UDP payload is accepted and consumed */
   Curl_bufq_reset(&q);
@@ -249,8 +248,6 @@ static void test_capsule_decode_paths(void)
 static CURLcode test_unit3400(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
-
-  (void)arg;
 
 #if defined(USE_PROXY_HTTP3) && \
   !defined(CURL_DISABLE_PROXY) && !defined(CURL_DISABLE_HTTP)


### PR DESCRIPTION
To lib, vtls/vauth, vtls/vquic, lib/vtls.

Also:
- unit3400: drop redundant `(void)arg`.
  Follow-up to e78b1b3eccfa6a2e367a1225ea1b66dafcdac3c4 #21153
- fix comment typos.
