### PR TITLE
unit3400: repair after capsule_encap_udp_hdr went static

### DIFF
--- a/lib/capsule.c
+++ b/lib/capsule.c
@@ -141,9 +141,13 @@ static CURLcode capsule_decode_varint_at(struct bufq *recvbufq,
  * @param hdrlen      Size of `hdr` in bytes
  * @param payload_len Length of the UDP payload that follows
  * @return Number of header bytes written, or 0 on error
+ *
+ * @unittest 3400
  */
-static size_t capsule_encap_udp_hdr(uint8_t *hdr, size_t hdrlen,
-                                    size_t payload_len)
+UNITTEST size_t capsule_encap_udp_hdr(uint8_t *hdr, size_t hdrlen,
+                                      size_t payload_len);
+UNITTEST size_t capsule_encap_udp_hdr(uint8_t *hdr, size_t hdrlen,
+                                      size_t payload_len)
 {
   size_t off = 0;
   DEBUGASSERT(hdrlen >= HTTP_CAPSULE_HEADER_MAX_SIZE);

--- a/lib/capsule.h
+++ b/lib/capsule.h
@@ -46,7 +46,6 @@
 CURLcode Curl_capsule_encap_udp_datagram(struct dynbuf *dyn,
                                          const void *buf, size_t blen);
 
-
 struct Curl_easy;
 struct Curl_cfilter;
 

--- a/lib/capsule.h
+++ b/lib/capsule.h
@@ -46,6 +46,10 @@
 CURLcode Curl_capsule_encap_udp_datagram(struct dynbuf *dyn,
                                          const void *buf, size_t blen);
 
+
+struct Curl_easy;
+struct Curl_cfilter;
+
 /**
  * Process one UDP capsule from buffer into raw datagram payload bytes.
  * @param cf        Connection filter

--- a/tests/unit/unit3400.c
+++ b/tests/unit/unit3400.c
@@ -48,7 +48,7 @@ static void check_capsule_hdr(size_t payload_len,
   size_t hdr_len;
 
   memset(hdr, 0xA5, sizeof(hdr));
-  hdr_len = Curl_capsule_encap_udp_hdr(hdr, sizeof(hdr), payload_len);
+  hdr_len = capsule_encap_udp_hdr(hdr, sizeof(hdr), payload_len);
   fail_unless(hdr_len == expected_len, "capsule header length mismatch");
   fail_unless(!memcmp(hdr, expected, expected_len),
               "capsule header bytes mismatch");


### PR DESCRIPTION
Access the static function with UNITTEST as designed.

Follow-up to 73c2b4b4355aab3156