### PR TITLE
GHA: enable H3 proxy in CI, also enable h2o tests on Linux

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -129,7 +129,7 @@ jobs:
             cmake -B _bld2 -G Ninja -DCURL_DISABLE_TYPECHECK=ON -DCURL_WERROR=ON \
               -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR="$(brew --prefix openssl)" -DUSE_NGTCP2=ON \
               -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON \
-              -DCURL_USE_GSASL=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON
+              -DCURL_USE_GSASL=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON -DUSE_PROXY_HTTP3=ON
             cmake --build _bld2
             cmake --build _bld2 --target testdeps
             cmake --build _bld2 --target curl-examples-build

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -228,7 +228,7 @@ jobs:
             libtool autoconf automake pkgconf \
             libbrotli-dev libzstd-dev zlib1g-dev \
             libev-dev \
-            libuv1-dev libwslay-dev \
+            libuv1-dev \
             libc-ares-dev \
             libp11-kit-dev autopoint bison gperf gtk-doc-tools libtasn1-bin  # for GnuTLS
           echo 'CC=gcc-12' >> "$GITHUB_ENV"

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -63,6 +63,7 @@ env:
   NGHTTP2_VERSION: 1.69.0
   # no tagged releases
   H2O_VERSION: 11b0cfa2771e3ccad4a852e72473e4e278ab1de7
+  H2O_SHA256: 5ae1bd7b09970d7d49c41fa68193e24da04c2a7ac5581fbe2affc79200b0721f
 
 jobs:
   build-cache:
@@ -418,7 +419,7 @@ jobs:
           cd ~
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
-          sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
+          sha256sum pkg.bin | tee /dev/stderr | grep -qwF -- "${H2O_SHA256}" && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
           cmake -B . -G Ninja -DWITHOUT_LIBS=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -419,7 +419,7 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DWITH_BUNDLED_SSL=OFF -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
+          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -420,8 +420,7 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build \
-            -DCMAKE_C_FLAGS=-DSSL_get_peer_certificate=SSL_get1_peer_certificate
+          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/libressl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build \
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -196,7 +196,7 @@ jobs:
           cache-name: cache-h2o
         with:
           path: ~/h2o/build
-          key: "${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.H2O_VERSION }}-${{ env.OPENSSL_VERSION }}"
+          key: "${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.H2O_VERSION }}-${{ env.OPENSSL_PREV_VERSION }}"
 
       - id: settings
         if: >-
@@ -742,7 +742,7 @@ jobs:
           cache-name: cache-h2o
         with:
           path: ~/h2o/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.H2O_VERSION }}-${{ env.OPENSSL_VERSION }}
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.H2O_VERSION }}-${{ env.OPENSSL_PREV_VERSION }}
           fail-on-cache-miss: true
 
       - name: 'cache quiche'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -420,7 +420,7 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/libressl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build \
+          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/libressl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -126,9 +126,9 @@ jobs:
 
       - name: 'cache openssl-prev'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: cache-openssl-prev-http3-no-deprecated
+        id: cache-openssl-prev-http3
         env:
-          cache-name: cache-openssl-prev-http3-no-deprecated
+          cache-name: cache-openssl-prev-http3
         with:
           path: ~/openssl-prev/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_PREV_VERSION }}
@@ -206,7 +206,7 @@ jobs:
               !steps.cache-gnutls.outputs.cache-hit ||
               !steps.cache-libressl.outputs.cache-hit ||
               !steps.cache-openssl-http3-no-deprecated.outputs.cache-hit ||
-              !steps.cache-openssl-prev-http3-no-deprecated.outputs.cache-hit ||
+              !steps.cache-openssl-prev-http3.outputs.cache-hit ||
               !steps.cache-wolfssl.outputs.cache-hit ||
               !steps.cache-nghttp3.outputs.cache-hit ||
               !steps.cache-ngtcp2-boringssl.outputs.cache-hit ||
@@ -311,14 +311,14 @@ jobs:
           make -j1 install_sw
 
       - name: 'build openssl-prev'
-        if: ${{ !steps.cache-openssl-prev-http3-no-deprecated.outputs.cache-hit }}
+        if: ${{ !steps.cache-openssl-prev-http3.outputs.cache-hit }}
         run: |
           cd ~
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location --proto-redir =https "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_PREV_VERSION}/openssl-${OPENSSL_PREV_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin | tee /dev/stderr | grep -qwF -- "${OPENSSL_PREV_SHA256}" && tar -xzf pkg.bin && rm -f pkg.bin
           cd "openssl-${OPENSSL_PREV_VERSION}"
-          ./config --prefix=/home/runner/openssl-prev/build --libdir=lib no-makedepend no-apps no-docs no-tests no-deprecated
+          ./config --prefix=/home/runner/openssl-prev/build --libdir=lib no-makedepend no-apps no-docs no-tests
           make
           make -j1 install_sw
 
@@ -420,7 +420,7 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/boringssl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
+          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .
           cmake --install .
 
@@ -663,9 +663,9 @@ jobs:
       - name: 'cache openssl-prev'
         if: ${{ contains(matrix.build.name, 'openssl-prev') }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        id: cache-openssl-prev-http3-no-deprecated
+        id: cache-openssl-prev-http3
         env:
-          cache-name: cache-openssl-prev-http3-no-deprecated
+          cache-name: cache-openssl-prev-http3
         with:
           path: ~/openssl-prev/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_PREV_VERSION }}

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -228,6 +228,7 @@ jobs:
             libtool autoconf automake pkgconf \
             libbrotli-dev libzstd-dev zlib1g-dev \
             libev-dev \
+            libuv1-dev libwslay-dev \
             libc-ares-dev \
             libp11-kit-dev autopoint bison gperf gtk-doc-tools libtasn1-bin  # for GnuTLS
           echo 'CC=gcc-12' >> "$GITHUB_ENV"

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -62,7 +62,7 @@ env:
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
   NGHTTP2_VERSION: 1.69.0
   # no tagged releases
-  H2O_VERSION: 11b0cfa2771e3ccad4a852e72473e4e278ab1de7
+  H2O_VERSION: 11b0cfa2771e3ccad4a852e72473e4e278ab1de7 # 2026-05-28
   H2O_SHA256: 5ae1bd7b09970d7d49c41fa68193e24da04c2a7ac5581fbe2affc79200b0721f
 
 jobs:

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -420,7 +420,8 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
+          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build \
+            -DCMAKE_C_FLAGS=-DSSL_get_peer_certificate=SSL_get1_peer_certificate
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -61,6 +61,8 @@ env:
   NGTCP2_VERSION: 1.22.1
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
   NGHTTP2_VERSION: 1.69.0
+  # no greater tagged releases
+  H2O_VERSION: 2.2.6
 
 jobs:
   build-cache:
@@ -187,6 +189,15 @@ jobs:
           key: "${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.NGHTTP2_VERSION }}-${{ env.OPENSSL_VERSION }}-\
             ${{ env.NGTCP2_VERSION }}-${{ env.NGHTTP3_VERSION }}"
 
+      - name: 'cache h2o'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: cache-h2o
+        env:
+          cache-name: cache-h2o
+        with:
+          path: ~/h2o/build
+          key: "${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.H2O_VERSION }}-${{ env.OPENSSL_VERSION }}"
+
       - id: settings
         if: >-
           ${{ !steps.cache-awslc.outputs.cache-hit ||
@@ -201,7 +212,8 @@ jobs:
               !steps.cache-ngtcp2-boringssl.outputs.cache-hit ||
               !steps.cache-ngtcp2-openssl-prev.outputs.cache-hit ||
               !steps.cache-ngtcp2.outputs.cache-hit ||
-              !steps.cache-nghttp2.outputs.cache-hit }}
+              !steps.cache-nghttp2.outputs.cache-hit ||
+              !steps.cache-h2o.outputs.cache-hit }}
 
         run: echo 'needs-build=true' >> "$GITHUB_OUTPUT"
 
@@ -398,6 +410,16 @@ jobs:
             LDFLAGS=-Wl,-rpath,/home/runner/openssl/build/lib \
             --with-libbrotlienc --with-libbrotlidec
           make install
+
+      - name: 'build h2o'
+        if: ${{ !steps.cache-h2o.outputs.cache-hit }}
+        run: |
+          cd ~
+          git clone --quiet --depth 1 --branch "v${H2O_VERSION}" https://github.com/h2o/h2o
+          cd h2o
+          cmake -B . -G Ninja -DWITH_BUNDLED_SSL=OFF -DOPENSSL_ROOT_DIR=/home/runner/openssl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
+          cmake --build .
+          cmake --install .
 
   linux:
     name: ${{ matrix.build.generate && 'CM' || 'AM' }} ${{ matrix.build.name }}
@@ -710,6 +732,16 @@ jobs:
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.NGHTTP2_VERSION }}-${{ env.OPENSSL_VERSION }}-${{ env.NGTCP2_VERSION }}-${{ env.NGHTTP3_VERSION }}
           fail-on-cache-miss: true
 
+      - name: 'cache h2o'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: cache-h2o
+        env:
+          cache-name: cache-h2o
+        with:
+          path: ~/h2o/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.H2O_VERSION }}-${{ env.OPENSSL_VERSION }}
+          fail-on-cache-miss: true
+
       - name: 'cache quiche'
         if: ${{ contains(matrix.build.name, 'quiche') }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -761,6 +793,7 @@ jobs:
               -DCURL_WERROR=ON -DENABLE_DEBUG=ON \
               -DCURL_USE_LIBUV=ON -DCURL_ENABLE_NTLM=ON \
               -DTEST_NGHTTPX=/home/runner/nghttp2/build/bin/nghttpx \
+              -DH2O_NGHTTPX=/home/runner/h2o/build/bin/h2o \
               -DHTTPD_NGHTTPX=/home/runner/nghttp2/build/bin/nghttpx \
               ${MATRIX_GENERATE} ${options}
           else
@@ -768,6 +801,7 @@ jobs:
             mkdir bld && cd bld && ../configure --enable-warnings --enable-werror --enable-debug --disable-static \
               --disable-dependency-tracking --enable-option-checking=fatal \
               --with-libuv --enable-ntlm \
+              --with-test-h2o=/home/runner/h2o/build/bin/h2o \
               --with-test-nghttpx=/home/runner/nghttp2/build/bin/nghttpx \
               ${MATRIX_CONFIGURE}
           fi

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -483,7 +483,7 @@ jobs:
             LDFLAGS: -Wl,-rpath,/home/runner/openssl/build/lib
             PKG_CONFIG_PATH: /home/runner/openssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
-              --with-openssl=/home/runner/openssl/build --with-ngtcp2=/home/runner/ngtcp2/build --enable-ech --enable-ssls-export
+              --with-openssl=/home/runner/openssl/build --with-ngtcp2=/home/runner/ngtcp2/build --enable-ech --enable-ssls-export --enable-proxy-http3
 
           - name: 'openssl'
             install_steps: skipall
@@ -491,7 +491,7 @@ jobs:
             generate: >-
               -DOPENSSL_ROOT_DIR=/home/runner/openssl/build -DUSE_NGTCP2=ON
               -DCURL_DISABLE_LDAP=ON
-              -DUSE_ECH=ON
+              -DUSE_ECH=ON -DUSE_PROXY_HTTP3=ON
               -DCMAKE_UNITY_BUILD=ON
 
           - name: 'openssl-prev'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -419,7 +419,7 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DWITH_BUNDLED_SSL=OFF -DOPENSSL_ROOT_DIR=/home/runner/openssl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
+          cmake -B . -G Ninja -DWITH_BUNDLED_SSL=OFF -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -61,8 +61,8 @@ env:
   NGTCP2_VERSION: 1.22.1
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
   NGHTTP2_VERSION: 1.69.0
-  # no greater tagged releases
-  H2O_VERSION: 2.2.6
+  # no tagged releases
+  H2O_VERSION: 11b0cfa2771e3ccad4a852e72473e4e278ab1de7
 
 jobs:
   build-cache:
@@ -415,8 +415,10 @@ jobs:
         if: ${{ !steps.cache-h2o.outputs.cache-hit }}
         run: |
           cd ~
-          git clone --quiet --depth 1 --branch "v${H2O_VERSION}" https://github.com/h2o/h2o
-          cd h2o
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
+            --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
+          sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
+          cd "h2o-${H2O_VERSION}"
           cmake -B . -G Ninja -DWITH_BUNDLED_SSL=OFF -DOPENSSL_ROOT_DIR=/home/runner/openssl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .
           cmake --install .

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -796,7 +796,7 @@ jobs:
               -DCURL_WERROR=ON -DENABLE_DEBUG=ON \
               -DCURL_USE_LIBUV=ON -DCURL_ENABLE_NTLM=ON \
               -DTEST_NGHTTPX=/home/runner/nghttp2/build/bin/nghttpx \
-              -DH2O_NGHTTPX=/home/runner/h2o/build/bin/h2o \
+              -DH2O=/home/runner/h2o/build/bin/h2o \
               -DHTTPD_NGHTTPX=/home/runner/nghttp2/build/bin/nghttpx \
               ${MATRIX_GENERATE} ${options}
           else

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -420,7 +420,7 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
+          cmake -B . -G Ninja -DWITHOUT_LIBS=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl-prev/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -420,7 +420,7 @@ jobs:
             --location --proto-redir =https "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "h2o-${H2O_VERSION}"
-          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/libressl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
+          cmake -B . -G Ninja -DOPENSSL_ROOT_DIR=/home/runner/boringssl/build -DCMAKE_INSTALL_PREFIX=/home/runner/h2o/build
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -359,7 +359,7 @@ jobs:
               /home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig"
             generate: >-
               -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl -DUSE_NGTCP2=ON
-              -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DUSE_HTTPSRR=ON -DENABLE_ARES=ON
+              -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DUSE_HTTPSRR=ON -DENABLE_ARES=ON -DUSE_PROXY_HTTP3=ON
               -DCURL_DISABLE_VERBOSE_STRINGS=ON
               -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-20
 
@@ -400,7 +400,7 @@ jobs:
               /home/linuxbrew/.linuxbrew/opt/c-ares/lib/pkgconfig"
             generate: >-
               -DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl -DUSE_NGTCP2=ON
-              -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON
+              -DUSE_SSLS_EXPORT=ON -DENABLE_ARES=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'thread-sanitizer'
             install_packages: clang-20 libtsan2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -275,7 +275,7 @@ jobs:
             install_steps: pytest
             generate: >-
               -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=OFF
-              -DCMAKE_C_STANDARD=90 -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
+              -DCMAKE_C_STANDARD=90 -DCURL_ENABLE_NTLM=ON
 
           - name: 'OpenSSL SecTrust'
             compiler: clang
@@ -410,7 +410,7 @@ jobs:
           INSTALL_PACKAGES: >-
             ${{ matrix.build.generate && 'ninja' || 'automake libtool' }}
             ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') && 'nghttp2 stunnel' || '' }}
-            ${{ contains(matrix.build.install_steps, 'pytest') && 'caddy h2o httpd vsftpd' || '' }}
+            ${{ contains(matrix.build.install_steps, 'pytest') && 'caddy httpd vsftpd' || '' }}
 
         run: |
           # shellcheck disable=SC2181

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -410,7 +410,7 @@ jobs:
           INSTALL_PACKAGES: >-
             ${{ matrix.build.generate && 'ninja' || 'automake libtool' }}
             ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') && 'nghttp2 stunnel' || '' }}
-            ${{ contains(matrix.build.install_steps, 'pytest') && 'caddy httpd vsftpd' || '' }}
+            ${{ contains(matrix.build.install_steps, 'pytest') && 'caddy h2o httpd vsftpd' || '' }}
 
         run: |
           # shellcheck disable=SC2181

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -275,13 +275,13 @@ jobs:
             install_steps: pytest
             generate: >-
               -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=OFF
-              -DCMAKE_C_STANDARD=90 -DCURL_ENABLE_NTLM=ON
+              -DCMAKE_C_STANDARD=90 -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'OpenSSL SecTrust'
             compiler: clang
             install: libnghttp3 libngtcp2
             install_steps: pytest
-            configure: --enable-debug --with-openssl=/opt/homebrew/opt/openssl --with-ngtcp2 --with-apple-sectrust --enable-ntlm
+            configure: --enable-debug --with-openssl=/opt/homebrew/opt/openssl --with-ngtcp2 --with-apple-sectrust --enable-ntlm --enable-proxy-http3
 
           - name: 'OpenSSL event-based'
             compiler: clang
@@ -293,7 +293,7 @@ jobs:
             install: openssl@4 libnghttp3 libngtcp2 gsasl
             generate: >-
               -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_USE_GSASL=ON -DUSE_APPLE_IDN=ON -DUSE_NGTCP2=ON -DCURL_DISABLE_VERBOSE_STRINGS=ON
-              -DUSE_APPLE_SECTRUST=ON -DCURL_ENABLE_NTLM=ON
+              -DUSE_APPLE_SECTRUST=ON -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'MultiSSL AppleIDN clang-tidy +examples'
             image: macos-26

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -326,7 +326,7 @@ jobs:
               -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=/opt/homebrew/opt/krb5
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON
               -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/opt/homebrew/opt/llvm/bin/clang-tidy
-              -DCURL_ENABLE_NTLM=ON
+              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'LibreSSL openldap krb5 c-ares +examples'
             compiler: clang
@@ -376,22 +376,28 @@ jobs:
             compiler: clang
             install: openssl@4 libnghttp3
             install_steps: torture
-            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
             tflags: '-t --shallow=25 --min=480 1 to 500'
+            generate: >-
+              -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
+              -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'OpenSSL torture 2'
             compiler: clang
             install: openssl@4 libnghttp3
             install_steps: torture
-            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
             tflags: '-t --shallow=25 --min=730 501 to 1250'
+            generate: >-
+              -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
+              -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'OpenSSL torture 3'
             compiler: clang
             install: openssl@4 libnghttp3
             install_steps: torture
-            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
             tflags: '-t --shallow=25 --min=628 1251 to 9999'
+            generate: >-
+              -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
+              -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
     steps:
       - name: 'brew unlink openssl'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -275,7 +275,7 @@ jobs:
             install_steps: pytest
             generate: >-
               -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_NGTCP2=ON -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=OFF
-              -DCMAKE_C_STANDARD=90 -DCURL_ENABLE_NTLM=ON
+              -DCMAKE_C_STANDARD=90 -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'OpenSSL SecTrust'
             compiler: clang

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -244,7 +244,7 @@ jobs:
 
           - name: 'OpenSSL libssh'
             compiler: llvm@18
-            install: libssh libnghttp3
+            install: libssh
             generate: -DENABLE_DEBUG=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF
 
           - name: '!ssl HTTP-only c-ares'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -374,30 +374,24 @@ jobs:
 
           - name: 'OpenSSL torture 1'
             compiler: clang
-            install: openssl@4 libnghttp3
+            install: openssl@4
             install_steps: torture
+            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
             tflags: '-t --shallow=25 --min=480 1 to 500'
-            generate: >-
-              -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
-              -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'OpenSSL torture 2'
             compiler: clang
-            install: openssl@4 libnghttp3
+            install: openssl@4
             install_steps: torture
+            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
             tflags: '-t --shallow=25 --min=730 501 to 1250'
-            generate: >-
-              -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
-              -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'OpenSSL torture 3'
             compiler: clang
-            install: openssl@4 libnghttp3
+            install: openssl@4
             install_steps: torture
+            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4 -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
             tflags: '-t --shallow=25 --min=628 1251 to 9999'
-            generate: >-
-              -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@4
-              -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
     steps:
       - name: 'brew unlink openssl'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -950,7 +950,7 @@ jobs:
               -DNGTCP2_LIBRARY=/ucrt64/lib/libngtcp2.dll.a
               -DNGTCP2_CRYPTO_OSSL_LIBRARY=/ucrt64/lib/libngtcp2_crypto_ossl.dll.a
               -DCURL_CA_NATIVE=ON
-              -DCURL_ENABLE_NTLM=ON
+              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
           - name: 'schannel U'
             install-vcpkg: 'zlib libssh2[core,zlib]'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -301,7 +301,7 @@ jobs:
               install: 'mingw-w64-clang-aarch64-libssh2' }
           - { name: 'openssl', type: 'Release', chkprefill: '_chkprefill',
               build: 'cmake'    , sys: 'clang64'   , env: 'clang-x86_64' , tflags: 'skiprun'   ,
-              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON  -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON',
+              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON  -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DUSE_PROXY_HTTP3=ON',
               install: 'mingw-w64-clang-x86_64-openssl mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2 mingw-w64-clang-x86_64-libssh2' }
           - { name: 'schannel', type: 'Release', test: 'uwp',
               build: 'cmake'    , sys: 'ucrt64'    , env: 'ucrt-x86_64'  , tflags: 'skiprun'   ,


### PR DESCRIPTION
Also:
- GHA/http3-linux: enable deprecated APIs in openssl-prev local
  OpenSSL builds. Required by h2o and its vendored dependencies.
  Tried OpenSSL 4, LibreSSL 4.x, BoringSSL: all failed at one point.
- GHA/http3-linux: build h2o from source.
  libuv1-dev may not be stricly required.
  Tried installing libwslay-dev, but it wasn't recognized.
  Also disable building h2o libs for a much smaller dist directory and
  slightly faster build.
  Sadly, h2o is not versioned, so I pinned to the current latest commit
  at the master branch. It advertises itself as 2.3.0-DEV in pytest.
- drop redundant `libnghttp3` installs. Remains of openssl-quic builds.
  Follow-up to 6aaac9dd388a64d0f511544496608693e1105d13 #20226

Note GHA/macos pytests may or not not be stable with the H3 proxy tests.

Follow-up to e78b1b3eccfa6a2e367a1225ea1b66dafcdac3c4 #21153

---

- [x] merge the mergeable pieces: am, cm, CI, except actually running pytests with H3 enabled (due to ~~a list of~~ issues). → #21796 #21795
