### PR TITLE
build: say 'experimental' in option descriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1080,8 +1080,8 @@ if(USE_OPENSSL)
   endif()
 endif()
 
-option(USE_HTTPSRR "Enable HTTPS RR support" OFF)
-option(USE_ECH "Enable ECH support" OFF)
+option(USE_HTTPSRR "Enable HTTPS RR support (experimental)" OFF)
+option(USE_ECH "Enable ECH support (experimental)" OFF)
 if(USE_ECH)
   if(USE_OPENSSL OR USE_WOLFSSL OR USE_RUSTLS)
     # Be sure that the TLS library actually supports ECH.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -738,7 +738,7 @@ endif()
 cmake_dependent_option(CURL_USE_MBEDTLS "Enable mbedTLS for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
 cmake_dependent_option(CURL_USE_WOLFSSL "Enable wolfSSL for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
 cmake_dependent_option(CURL_USE_GNUTLS "Enable GnuTLS for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
-cmake_dependent_option(CURL_USE_RUSTLS "Enable Rustls for SSL/TLS" OFF CURL_ENABLE_SSL OFF)
+cmake_dependent_option(CURL_USE_RUSTLS "Enable Rustls for SSL/TLS (experimental)" OFF CURL_ENABLE_SSL OFF)
 
 if(WIN32 OR
    CURL_USE_SCHANNEL OR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1109,7 +1109,7 @@ if(USE_ECH)
   endif()
 endif()
 
-option(USE_SSLS_EXPORT "Enable SSL session export support" OFF)
+option(USE_SSLS_EXPORT "Enable SSL session import/export (experimental)" OFF)
 if(USE_SSLS_EXPORT)
   if(_ssl_enabled)
     message(STATUS "SSL export enabled.")
@@ -1118,7 +1118,7 @@ if(USE_SSLS_EXPORT)
   endif()
 endif()
 
-option(USE_PROXY_HTTP3 "Enable experimental HTTP/3 proxy support" OFF)
+option(USE_PROXY_HTTP3 "Enable HTTP/3 proxy support (experimental)" OFF)
 
 option(USE_NGHTTP2 "Use nghttp2 library" ON)
 if(USE_NGHTTP2)

--- a/configure.ac
+++ b/configure.ac
@@ -57,8 +57,8 @@ CURL_CHECK_OPTION_SSLS_EXPORT
 AC_MSG_CHECKING([whether to enable HTTP/3 proxy support])
 OPT_PROXY_HTTP3="default"
 AC_ARG_ENABLE(proxy-http3,
-AS_HELP_STRING([--enable-proxy-http3],[Enable experimental HTTP/3 proxy support])
-AS_HELP_STRING([--disable-proxy-http3],[Disable experimental HTTP/3 proxy support]),
+AS_HELP_STRING([--enable-proxy-http3],[Enable HTTP/3 proxy support (experimental)])
+AS_HELP_STRING([--disable-proxy-http3],[Disable HTTP/3 proxy support (experimental)]),
   OPT_PROXY_HTTP3=$enableval)
 case "$OPT_PROXY_HTTP3" in
   no)

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -250,8 +250,8 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `ENABLE_UNICODE`:                         Use the Unicode version of the Windows API functions. Default: `OFF`
 - `ENABLE_UNIX_SOCKETS`:                    Enable Unix domain sockets support. Default: `ON`
 - `USE_APPLE_IDN`:                          Use Apple built-in IDN support. Default: `OFF`
-- `USE_ECH`:                                Enable ECH support. Default: `OFF`
-- `USE_HTTPSRR`:                            Enable HTTPS RR support. Default: `OFF`
+- `USE_ECH`:                                Enable ECH support (experimental). Default: `OFF`
+- `USE_HTTPSRR`:                            Enable HTTPS RR support (experimental). Default: `OFF`
 - `USE_PROXY_HTTP3`:                        Enable HTTP/3 proxy support (experimental). Default: `OFF`
 - `USE_SSLS_EXPORT`:                        Enable SSL session import/export (experimental). Default: `OFF`
 - `USE_WIN32_IDN`:                          Use WinIDN for IDN support. Default: `OFF`
@@ -348,7 +348,7 @@ Details via CMake
 - `CURL_USE_OPENSSL`:                       Enable OpenSSL for SSL/TLS. Default: `ON` if no other TLS backend was enabled.
 - `CURL_USE_PKGCONFIG`:                     Enable `pkg-config` to detect dependencies.
                                             Default: `ON` for Unix (except Android, Apple devices), vcpkg, MinGW if not cross-compiling.
-- `CURL_USE_RUSTLS`:                        Enable Rustls for SSL/TLS. Default: `OFF`
+- `CURL_USE_RUSTLS`:                        Enable Rustls for SSL/TLS (experimental). Default: `OFF`
 - `CURL_USE_SCHANNEL`:                      Enable Windows native SSL/TLS (Schannel). Default: `OFF`
 - `CURL_USE_WOLFSSL`:                       Enable wolfSSL for SSL/TLS. Default: `OFF`
 - `CURL_ZLIB`:                              Use zlib (`ON`, `OFF` or `AUTO`). Default: `AUTO`

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -252,10 +252,10 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `USE_APPLE_IDN`:                          Use Apple built-in IDN support. Default: `OFF`
 - `USE_ECH`:                                Enable ECH support. Default: `OFF`
 - `USE_HTTPSRR`:                            Enable HTTPS RR support. Default: `OFF`
-- `USE_SSLS_EXPORT`:                        Enable experimental SSL session import/export. Default: `OFF`
+- `USE_PROXY_HTTP3`:                        Enable HTTP/3 proxy support (experimental). Default: `OFF`
+- `USE_SSLS_EXPORT`:                        Enable SSL session import/export (experimental). Default: `OFF`
 - `USE_WIN32_IDN`:                          Use WinIDN for IDN support. Default: `OFF`
 - `USE_WIN32_LDAP`:                         Use Windows LDAP implementation. Default: `ON`
-- `USE_PROXY_HTTP3`:                        Enable experimental HTTP/3 proxy support. Default: `OFF`
 
 ## Disabling features
 

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -475,8 +475,8 @@ AC_DEFUN([CURL_CHECK_OPTION_HTTPSRR], [
   AC_MSG_CHECKING([whether to enable HTTPSRR support])
   OPT_HTTPSRR="default"
   AC_ARG_ENABLE(httpsrr,
-AS_HELP_STRING([--enable-httpsrr],[Enable HTTPSRR support])
-AS_HELP_STRING([--disable-httpsrr],[Disable HTTPSRR support]),
+AS_HELP_STRING([--enable-httpsrr],[Enable HTTPSRR support (experimental)])
+AS_HELP_STRING([--disable-httpsrr],[Disable HTTPSRR support (experimental)]),
   OPT_HTTPSRR=$enableval)
   case "$OPT_HTTPSRR" in
     no)
@@ -510,8 +510,8 @@ AC_DEFUN([CURL_CHECK_OPTION_ECH], [
   AC_MSG_CHECKING([whether to enable ECH support])
   OPT_ECH="default"
   AC_ARG_ENABLE(ech,
-AS_HELP_STRING([--enable-ech],[Enable ECH support])
-AS_HELP_STRING([--disable-ech],[Disable ECH support]),
+AS_HELP_STRING([--enable-ech],[Enable ECH support (experimental)])
+AS_HELP_STRING([--disable-ech],[Disable ECH support (experimental)]),
   OPT_ECH=$enableval)
   case "$OPT_ECH" in
     no)

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -547,9 +547,9 @@ AC_DEFUN([CURL_CHECK_OPTION_SSLS_EXPORT], [
   OPT_SSLS_EXPORT="default"
   AC_ARG_ENABLE(ssls-export,
 AS_HELP_STRING([--enable-ssls-export],
-               [Enable SSL session export support])
+               [Enable SSL session export support (experimental)])
 AS_HELP_STRING([--disable-ssls-export],
-               [Disable SSL session export support]),
+               [Disable SSL session export support (experimental)]),
   OPT_SSLS_EXPORT=$enableval)
   case "$OPT_SSLS_EXPORT" in
     no)


### PR DESCRIPTION
Also:
- INSTALL-CMAKE.md: alpha-sort enable options.
- cmake: sync a description between source and docs.
