### PR TITLE
h3-proxy: rename feature 'Proxy/PROXY-HTTP3' to 'proxy-HTTP3'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2062,7 +2062,7 @@ curl_add_if("NTLM"          CURL_ENABLE_NTLM AND
 curl_add_if("TLS-SRP"       USE_TLS_SRP)
 curl_add_if("HTTP2"         USE_NGHTTP2)
 curl_add_if("HTTP3"         USE_NGTCP2 OR USE_QUICHE)
-curl_add_if("PROXY-HTTP3"   USE_PROXY_HTTP3)
+curl_add_if("proxy-HTTP3"   USE_PROXY_HTTP3)
 curl_add_if("MultiSSL"      CURL_WITH_MULTI_SSL)
 curl_add_if("HTTPS-proxy"   NOT CURL_DISABLE_PROXY AND _ssl_enabled AND (USE_OPENSSL OR USE_GNUTLS
                             OR USE_SCHANNEL OR USE_RUSTLS OR USE_MBEDTLS OR

--- a/configure.ac
+++ b/configure.ac
@@ -5086,7 +5086,7 @@ if test "$want_proxy_http3" = "yes"; then
     AC_DEFINE(USE_PROXY_HTTP3, 1, [if HTTP/3 proxy support is available])
     USE_PROXY_HTTP3=1
     AC_MSG_RESULT([yes])
-    experimental="$experimental PROXY-HTTP3"
+    experimental="$experimental proxy-HTTP3"
   fi
 fi
 
@@ -5204,7 +5204,7 @@ if test "$curl_psl_msg" = "enabled"; then
 fi
 
 if test "$USE_PROXY_HTTP3" = "1"; then
-  SUPPORT_FEATURES="$SUPPORT_FEATURES PROXY-HTTP3"
+  SUPPORT_FEATURES="$SUPPORT_FEATURES proxy-HTTP3"
 fi
 
 if test "$curl_gsasl_msg" = "enabled"; then
@@ -5551,7 +5551,7 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   HTTP1:            ${curl_h1_msg}
   HTTP2:            ${curl_h2_msg}
   HTTP3:            ${curl_h3_msg}
-  Proxy-HTTP3:      ${curl_proxy_http3_msg}
+  proxy-HTTP3:      ${curl_proxy_http3_msg}
   ECH:              ${curl_ech_msg}
   HTTPS RR:         ${curl_httpsrr_msg}
   SSLS-EXPORT:      ${curl_ssls_export_msg}

--- a/docs/libcurl/curl_version_info.md
+++ b/docs/libcurl/curl_version_info.md
@@ -298,7 +298,7 @@ supports HTTP NTLM
 libcurl was built with support for NTLM delegation to a winbind helper. This
 feature was removed from curl in 8.8.0.
 
-## `PROXY-HTTP3`
+## `proxy-HTTP3`
 
 *features* mask bit: non-existent
 

--- a/lib/version.c
+++ b/lib/version.c
@@ -492,7 +492,7 @@ static const struct feat features_table[] = {
   FEATURE("NTLM",        NULL,                CURL_VERSION_NTLM),
 #endif
 #ifdef USE_PROXY_HTTP3
-  FEATURE("PROXY-HTTP3", NULL,                0),
+  FEATURE("proxy-HTTP3", NULL,                0),
 #endif
 #ifdef USE_LIBPSL
   FEATURE("PSL",         NULL,                CURL_VERSION_PSL),

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -39,7 +39,7 @@ MARK_NEEDS_HTTP3 = pytest.mark.skipif(
     condition=not Env.curl_has_feature("HTTP3"), reason="curl lacks HTTP/3 support"
 )
 MARK_NEEDS_PROXY_HTTP3 = pytest.mark.skipif(
-    condition=not Env.curl_has_feature("PROXY-HTTP3"),
+    condition=not Env.curl_has_feature("proxy-HTTP3"),
     reason="curl lacks experimental HTTP/3 proxy support"
 )
 MARK_NEEDS_NGHTTP3 = pytest.mark.skipif(
@@ -340,7 +340,7 @@ class TestH3ProxyRuntimeGuards:
         r = curl.http_download(
             urls=[url], alpn_proto="http/1.1", with_stats=True, extra_args=proxy_args
         )
-        if not env.curl_has_feature("PROXY-HTTP3"):
+        if not env.curl_has_feature("proxy-HTTP3"):
             r.check_exit_code(2)
             assert UNSUPPORTED_OPT_MSG in r.stderr.lower(), (
                 f"Expected unsupported option failure but got: {r.stderr}"


### PR DESCRIPTION
For consistency and to follow existing 'HTTPS-proxy' (with lowercase
'proxy') feature tag more closely.

Follow-up to e78b1b3eccfa6a2e367a1225ea1b66dafcdac3c4 #21153
