### PR TITLE
lib: use %zu printf flag for size_t variable

### DIFF
--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -1064,7 +1064,7 @@ static nghttp3_ssize cb_h3_read_data_for_tunnel_stream(nghttp3_conn *conn,
   }
 
   CURL_TRC_CF(data, cf, "[%" PRId64 "] read req body -> "
-              "%zd vecs%s with %zu (buffered=%zu, left=%" FMT_OFF_T ")",
+              "%zu vecs%s with %zu (buffered=%zu, left=%" FMT_OFF_T ")",
               H3_STREAM_ID(stream), nvecs,
               *pflags == NGHTTP3_DATA_FLAG_EOF ? " EOF" : "",
               nwritten, Curl_bufq_len(&stream->sendbuf),

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1602,7 +1602,7 @@ static nghttp3_ssize cb_h3_read_req_body(nghttp3_conn *conn, int64_t stream_id,
   }
 
   CURL_TRC_CF(data, cf, "[%" PRId64 "] read req body -> "
-              "%zd vecs%s with %zu (buffered=%zu, left=%" FMT_OFF_T ")",
+              "%zu vecs%s with %zu (buffered=%zu, left=%" FMT_OFF_T ")",
               stream->id, nvecs,
               *pflags == NGHTTP3_DATA_FLAG_EOF ? " EOF" : "",
               nwritten, Curl_bufq_len(&stream->sendbuf),


### PR DESCRIPTION
It is unsigned after all.

Pointed out by Codex Security