### PR TITLE
h3-proxy: fix callback return values, and a typo in tests

### DIFF
--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -1218,7 +1218,7 @@ static int cb_ngtcp2_proxy_handshake_completed(ngtcp2_conn *tconn,
   data = CF_DATA_CURRENT(cf);
   DEBUGASSERT(data);
   if(!ctx || !data)
-    return NGHTTP3_ERR_CALLBACK_FAILURE;
+    return NGTCP2_ERR_CALLBACK_FAILURE;
 
   ctx->handshake_at = *Curl_pgrs_now(data);
   ctx->tls_handshake_complete = TRUE;
@@ -1274,7 +1274,7 @@ static int cb_ngtcp2_proxy_handshake_completed(ngtcp2_conn *tconn,
     CURLcode result = cf_ngtcp2_h3conn_init(cf, data);
     if(result) {
       CURL_TRC_CF(data, cf, "HTTP/3 initialization failed: %d", result);
-      return NGHTTP3_ERR_CALLBACK_FAILURE;
+      return NGTCP2_ERR_CALLBACK_FAILURE;
     }
   }
 

--- a/lib/cf-h3-proxy.c
+++ b/lib/cf-h3-proxy.c
@@ -888,7 +888,7 @@ static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t stream_id,
                              (const char *)h3name.base, h3name.len,
                              (const char *)h3val.base, h3val.len);
     if(result) {
-      return -1;
+      return NGHTTP3_ERR_CALLBACK_FAILURE;
     }
   }
   return 0;

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -571,7 +571,7 @@ class TestH3ProxyUdpTunnel:
         self, env: Env, httpd, nghttpx, nghttpx_fwd
     ):
         _require_available(
-            httpd=httpd, nghttpx=nghttpx, nghttps_fwd=nghttpx_fwd
+            httpd=httpd, nghttpx=nghttpx, nghttpx_fwd=nghttpx_fwd
         )
         curl = CurlClient(env=env)
         url = f"https://localhost:{httpd.ports['https']}/data.json"


### PR DESCRIPTION
- replace literal -1 with `NGHTTP3_ERR_CALLBACK_FAILURE` in nghttp3 
  callback.
- replace `NGHTTP3_ERR_CALLBACK_FAILURE` with 
  `NGTCP2_ERR_CALLBACK_FAILURE` in ngtcp2 callbacks. 
- test_60_h3_proxy: fix non-critical typo in symbol.

Spotted by GitHub Code Quality

Follow-up to e78b1b3eccfa6a2e367a1225ea1b66dafcdac3c4 #21153
