### PR TITLE
pytest: fixes and tidy-ups to h3-proxy tests

### DIFF
--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -146,13 +146,12 @@ class TestH3Proxy:
 
     @pytest.fixture(autouse=True, scope="class")
     def _class_scope(self, env, h2o_server):
-        if not env.have_h2o():
-            pytest.skip("h2o not available")
-        env.make_data_file(indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
-        env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
+        if env.have_h2o():
+            env.make_data_file(indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024)
+            env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
+            env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
+            env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
+            env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
 
     """Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP."""
 

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -55,7 +55,6 @@ MARK_NEEDS_NGHTTPX = pytest.mark.skipif(
     condition=not Env.have_nghttpx(), reason="no nghttpx available"
 )
 
-NGTCP2_ONLY_MSG = "only supported with the ngtcp2 quic stack"
 UNSUPPORTED_OPT_MSG = "does not support this"
 H2O_HELLO_MSG = '"message": "Hello from h2o HTTP/3 server"'
 

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -305,8 +305,6 @@ class TestH3Proxy:
 
     # Guard checks for unsupported HTTP/3 proxy options.
 
-    @MARK_NEEDS_HTTPS_PROXY
-    @MARK_NEEDS_HTTP3
     @pytest.mark.skipif(
         condition=Env.curl_uses_lib("ngtcp2"),
         reason="guard only applies to non-ngtcp2 builds",

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -140,7 +140,6 @@ def _h2o_proxy_args(
 
 @MARK_NEEDS_HTTPS_PROXY
 @MARK_NEEDS_HTTP3
-@MARK_NEEDS_PROXY_HTTP3
 @MARK_NEEDS_NGHTTP3
 class TestH3Proxy:
 
@@ -155,6 +154,7 @@ class TestH3Proxy:
 
     # Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP.
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
         ["alpn_proto", "proxy_proto"],
@@ -200,6 +200,7 @@ class TestH3Proxy:
 
     # Failure matrix when proxy side does not support requested mode.
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
         ["alpn_proto", "proxy_proto", "exp_err"],
@@ -265,6 +266,7 @@ class TestH3Proxy:
 
     # Behavior checks for tunnel vs non-tunnel proxy mode selection.
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
         ["proxy_proto"],
@@ -334,6 +336,7 @@ class TestH3Proxy:
 
     # Robustness checks for shutdown and proxy loss during transfer.
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_05_graceful_shutdown(
         self, env: Env, h2o_server, h2o_proxy
@@ -361,6 +364,7 @@ class TestH3Proxy:
         ]
         assert shutdown_lines, f"No shutdown trace lines found:\n{r.stderr}"
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_06_proxy_drop_mid_transfer(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -407,6 +411,7 @@ class TestH3Proxy:
 
     # Large file transfers and multiplexing through HTTP/3 proxy.
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_07_large_download(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -419,6 +424,7 @@ class TestH3Proxy:
         r.check_response(count=1, http_status=200)
         _check_download_size(curl, 10 * 1024 * 1024)
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_08_large_upload(self, env: Env, httpd, h2o_server, h2o_proxy):
         _require_available(h2o_proxy=h2o_proxy)
@@ -435,6 +441,7 @@ class TestH3Proxy:
         )
         r.check_response(count=1, http_status=200)
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_09_parallel_downloads(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -448,6 +455,7 @@ class TestH3Proxy:
         )
         r.check_response(count=count, http_status=200)
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_10_proxy_basic_auth(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -461,6 +469,7 @@ class TestH3Proxy:
         r.check_response(count=1, http_status=200)
         _check_download_message(curl, H2O_HELLO_MSG)
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_11_connection_reuse(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -475,6 +484,7 @@ class TestH3Proxy:
             f"expected proxy connection reuse, got {r.total_connects} connects"
         )
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     @pytest.mark.skipif(condition=not Env.curl_has_feature('SSLS-EXPORT'),
                         reason='curl lacks SSL session export support')
@@ -502,6 +512,7 @@ class TestH3Proxy:
 
     # CONNECT-UDP tunnel payload size and capsule-protocol tests.
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
         "fname,fsize",
@@ -524,6 +535,7 @@ class TestH3Proxy:
         r.check_response(count=1, http_status=200)
         _check_download_size(curl, fsize)
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_NGHTTPX
     def test_60_14_udp_tunnel_capsule_absent(
         self, env: Env, httpd, nghttpx, nghttpx_fwd
@@ -545,6 +557,7 @@ class TestH3Proxy:
 
     # Timeout and protocol-mismatch edge cases.
 
+    #@MARK_NEEDS_PROXY_HTTP3
     #@MARK_NEEDS_H2O
     #def test_60_15_connect_timeout(self, env: Env, h2o_proxy):
     #    _require_available(h2o_proxy=h2o_proxy)
@@ -565,6 +578,7 @@ class TestH3Proxy:
     #        f"timeout not respected: took {r.duration.total_seconds():.1f}s"
     #    )
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     @MARK_NEEDS_NGHTTP2
     def test_60_16_h2_uses_connect_tcp_not_udp(self, env: Env, httpd, h2o_proxy):
@@ -585,6 +599,7 @@ class TestH3Proxy:
     # With the H3-PROXY filter sitting above HAPPY-EYEBALLS -> UDP, address
     # family selection to the proxy is done by happy eyeballs.
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_17_happy_eyeballs_filter_present(self, env: Env, h2o_server, h2o_proxy):
         """Verbose trace confirms HAPPY-EYEBALLS filter is in the H3 proxy chain."""
@@ -602,6 +617,7 @@ class TestH3Proxy:
             f"expected HAPPY-EYEBALLS trace for H3 proxy, got: {r.stderr}"
         )
 
+    @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     @MARK_NEEDS_NGHTTP2
     def test_60_18_happy_eyeballs_ipv4_all_proto(self, env: Env, h2o_server, h2o_proxy):

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -142,15 +142,6 @@ def _h2o_proxy_args(
 @MARK_NEEDS_NGHTTP3
 class TestH3Proxy:
 
-    @pytest.fixture(autouse=True, scope="class")
-    def _class_scope(self, env, h2o_server):
-        if env.have_h2o():
-            env.make_data_file(indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024)
-            env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
-            env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
-            env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
-            env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
-
     # Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP.
 
     @MARK_NEEDS_PROXY_HTTP3
@@ -329,15 +320,9 @@ class TestH3Proxy:
 
     # Robustness checks for shutdown and proxy loss during transfer.
 
-    @pytest.fixture(scope="class")
-    def data_proxy(self, env, h2o_server):
-        env.make_data_file(indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024)
-
     @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
-    def test_60_05_graceful_shutdown(
-        self, env: Env, h2o_server, h2o_proxy, data_proxy
-    ):
+    def test_60_05_graceful_shutdown(self, env: Env, h2o_server, h2o_proxy):
         if not env.curl_is_debug():
             pytest.skip("needs debug curl for shutdown trace lines")
         if not env.curl_is_verbose():
@@ -363,9 +348,10 @@ class TestH3Proxy:
 
     @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
-    def test_60_06_proxy_drop_mid_transfer(self, env: Env, h2o_server, h2o_proxy, data_proxy):
+    def test_60_06_proxy_drop_mid_transfer(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
 
+        env.make_data_file(indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024)
         proxy_port = h2o_proxy.port
         url = f"https://localhost:{h2o_server.port}/proxy-drop-20m"
         out_path = os.path.join(env.gen_dir, "proxy-drop.out")
@@ -412,6 +398,7 @@ class TestH3Proxy:
     @MARK_NEEDS_H2O
     def test_60_07_large_download(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
         curl = CurlClient(env=env)
         url = f"https://localhost:{h2o_server.port}/download-10m"
         proxy_args = _h2o_proxy_args(env, h2o_proxy, "h3", tunnel=True)
@@ -425,6 +412,7 @@ class TestH3Proxy:
     @MARK_NEEDS_H2O
     def test_60_08_large_upload(self, env: Env, httpd, h2o_server, h2o_proxy):
         _require_available(h2o_proxy=h2o_proxy)
+        env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
         fdata = os.path.join(env.gen_dir, "upload-2m")
         curl = CurlClient(env=env)
         url = f"https://localhost:{httpd.ports['https']}/curltest/echo?id=[0-0]"
@@ -442,6 +430,7 @@ class TestH3Proxy:
     @MARK_NEEDS_H2O
     def test_60_09_parallel_downloads(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
         count = 5
         curl = CurlClient(env=env)
         urln = f"https://localhost:{h2o_server.port}/download-1m?[0-{count - 1}]"
@@ -523,6 +512,9 @@ class TestH3Proxy:
         self, env: Env, h2o_server, h2o_proxy, fname, fsize
     ):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
         curl = CurlClient(env=env)
         url = f"https://localhost:{h2o_server.port}/{fname}"
         proxy_args = _h2o_proxy_args(env, h2o_proxy, "h3", tunnel=True)

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -153,7 +153,7 @@ class TestH3Proxy:
             env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
             env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
 
-    """Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP."""
+    # Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP.
 
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
@@ -198,7 +198,7 @@ class TestH3Proxy:
         r.check_response(count=1, http_status=200)
         _check_download_message(curl, H2O_HELLO_MSG)
 
-    """Failure matrix when proxy side does not support requested mode."""
+    # Failure matrix when proxy side does not support requested mode.
 
     @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
@@ -263,7 +263,7 @@ class TestH3Proxy:
             f"Expected protocol/proxy error but got: {r.dump_logs()}"
         )
 
-    """Behavior checks for tunnel vs non-tunnel proxy mode selection."""
+    # Behavior checks for tunnel vs non-tunnel proxy mode selection.
 
     @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
@@ -301,7 +301,7 @@ class TestH3Proxy:
             f"expected CONNECT-UDP attempt in output, got: {r.dump_logs()}"
         )
 
-    """Guard checks for unsupported HTTP/3 proxy options."""
+    # Guard checks for unsupported HTTP/3 proxy options.
 
     @MARK_NEEDS_HTTPS_PROXY
     @MARK_NEEDS_PROXY_HTTP3
@@ -335,7 +335,7 @@ class TestH3Proxy:
             f"Expected unsupported option failure but got: {r.stderr}"
         )
 
-    """Robustness checks for shutdown and proxy loss during transfer."""
+    # Robustness checks for shutdown and proxy loss during transfer.
 
     @MARK_NEEDS_H2O
     def test_60_05_graceful_shutdown(
@@ -408,7 +408,7 @@ class TestH3Proxy:
                 proc.wait(timeout=5)
             assert h2o_proxy.start(), "failed to restart h2o proxy"
 
-    """Large file transfers and multiplexing through HTTP/3 proxy."""
+    # Large file transfers and multiplexing through HTTP/3 proxy.
 
     @MARK_NEEDS_H2O
     def test_60_07_large_download(self, env: Env, h2o_server, h2o_proxy):
@@ -503,7 +503,7 @@ class TestH3Proxy:
         reuses = [line for line in r2.trace_lines if '[SSLS] took session for proxy.http.curl.se' in line]
         assert len(reuses), f'{r2.dump_logs()}'
 
-    """CONNECT-UDP tunnel payload size and capsule-protocol tests."""
+    # CONNECT-UDP tunnel payload size and capsule-protocol tests.
 
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
@@ -546,7 +546,7 @@ class TestH3Proxy:
             "expected failure: nghttpx does not support CONNECT-UDP / Capsule-Protocol"
         )
 
-    """Timeout and protocol-mismatch edge cases."""
+    # Timeout and protocol-mismatch edge cases.
 
     #@MARK_NEEDS_H2O
     #def test_60_15_connect_timeout(self, env: Env, h2o_proxy):
@@ -583,12 +583,10 @@ class TestH3Proxy:
         )
         r.check_response(count=1, http_status=200)
 
-    """
-    Verify that happy eyeballs is active for HTTP/3 proxy connections.
-
-    With the H3-PROXY filter sitting above HAPPY-EYEBALLS -> UDP, address
-    family selection to the proxy is done by happy eyeballs.
-    """
+    # Verify that happy eyeballs is active for HTTP/3 proxy connections.
+    #
+    # With the H3-PROXY filter sitting above HAPPY-EYEBALLS -> UDP, address
+    # family selection to the proxy is done by happy eyeballs.
 
     @MARK_NEEDS_H2O
     def test_60_17_happy_eyeballs_filter_present(self, env: Env, h2o_server, h2o_proxy):

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -592,7 +592,6 @@ class TestH3Proxy:
     family selection to the proxy is done by happy eyeballs.
     """
 
-    @H3_PROXY_COMMON_MARK
     @MARK_NEEDS_H2O
     def test_60_17_happy_eyeballs_filter_present(self, env: Env, h2o_server, h2o_proxy):
         """Verbose trace confirms HAPPY-EYEBALLS filter is in the H3 proxy chain."""
@@ -610,7 +609,6 @@ class TestH3Proxy:
             f"expected HAPPY-EYEBALLS trace for H3 proxy, got: {r.stderr}"
         )
 
-    @H3_PROXY_COMMON_MARK
     @MARK_NEEDS_H2O
     @MARK_NEEDS_NGHTTP2
     def test_60_18_happy_eyeballs_ipv4_all_proto(self, env: Env, h2o_server, h2o_proxy):

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -304,7 +304,6 @@ class TestH3Proxy:
     # Guard checks for unsupported HTTP/3 proxy options.
 
     @MARK_NEEDS_HTTPS_PROXY
-    @MARK_NEEDS_PROXY_HTTP3
     @pytest.mark.skipif(
         condition=Env.curl_uses_lib("ngtcp2"),
         reason="guard only applies to non-ngtcp2 builds",

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -304,12 +304,10 @@ class TestH3Proxy:
     # Guard checks for unsupported HTTP/3 proxy options.
 
     @MARK_NEEDS_HTTPS_PROXY
+    @MARK_NEEDS_HTTP3
     @pytest.mark.skipif(
         condition=Env.curl_uses_lib("ngtcp2"),
         reason="guard only applies to non-ngtcp2 builds",
-    )
-    @pytest.mark.skipif(
-        condition=not Env.curl_has_feature("HTTP3"), reason="curl lacks HTTP/3 support"
     )
     @pytest.mark.skipif(
         condition=Env.curl_has_feature("proxy-HTTP3"), reason="curl has h3 proxy support"

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -144,6 +144,16 @@ def _h2o_proxy_args(
 @MARK_NEEDS_NGHTTP3
 class TestH3Proxy:
 
+    @pytest.fixture(autouse=True, scope="class")
+    def _class_scope(self, env, h2o_server):
+        if not env.have_h2o():
+            pytest.skip("h2o not available")
+        env.make_data_file(indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
+        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
+        env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
+
     """Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP."""
 
     @MARK_NEEDS_H2O
@@ -329,15 +339,6 @@ class TestH3Proxy:
     """Robustness checks for shutdown and proxy loss during transfer."""
 
     @MARK_NEEDS_H2O
-    @pytest.fixture(autouse=True, scope="class")
-    def _class_scope(self, env, h2o_server):
-        if not env.have_h2o():
-            pytest.skip("h2o not available")
-        env.make_data_file(
-            indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024
-        )
-
-    @MARK_NEEDS_H2O
     def test_60_05_graceful_shutdown(
         self, env: Env, h2o_server, h2o_proxy
     ):
@@ -409,15 +410,6 @@ class TestH3Proxy:
             assert h2o_proxy.start(), "failed to restart h2o proxy"
 
     """Large file transfers and multiplexing through HTTP/3 proxy."""
-
-    @MARK_NEEDS_H2O
-    @pytest.fixture(autouse=True, scope="class")
-    def _class_scope(self, env, h2o_server):
-        if not env.have_h2o():
-            pytest.skip("h2o not available")
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
-        env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
 
     @MARK_NEEDS_H2O
     def test_60_07_large_download(self, env: Env, h2o_server, h2o_proxy):
@@ -513,14 +505,6 @@ class TestH3Proxy:
         assert len(reuses), f'{r2.dump_logs()}'
 
     """CONNECT-UDP tunnel payload size and capsule-protocol tests."""
-
-    @pytest.fixture(autouse=True, scope="class")
-    def _class_scope(self, env, h2o_server):
-        if not env.have_h2o():
-            return
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
 
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -306,10 +306,6 @@ class TestH3Proxy:
     # Guard checks for unsupported HTTP/3 proxy options.
 
     @pytest.mark.skipif(
-        condition=Env.curl_uses_lib("ngtcp2"),
-        reason="guard only applies to non-ngtcp2 builds",
-    )
-    @pytest.mark.skipif(
         condition=Env.curl_has_feature("proxy-HTTP3"), reason="curl has h3 proxy support"
     )
     def test_60_04_guard_proxy_http3_unsupported(self, env: Env, httpd):

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -512,9 +512,7 @@ class TestH3Proxy:
         self, env: Env, h2o_server, h2o_proxy, fname, fsize
     ):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1400", fsize=1400)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
-        env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
+        env.make_data_file(indir=h2o_server.docs_dir, fname=fname, fsize=fsize)
         curl = CurlClient(env=env)
         url = f"https://localhost:{h2o_server.port}/{fname}"
         proxy_args = _h2o_proxy_args(env, h2o_proxy, "h3", tunnel=True)

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -145,11 +145,12 @@ def _h2o_proxy_args(
     return xargs
 
 
-class TestH3ProxySuccess:
+class TestH3Proxy:
+
     """Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP."""
 
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_H2O]
-
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
         ["alpn_proto", "proxy_proto"],
         [
@@ -192,12 +193,10 @@ class TestH3ProxySuccess:
         r.check_response(count=1, http_status=200)
         _check_download_message(curl, H2O_HELLO_MSG)
 
-
-class TestH3ProxyFailure:
     """Failure matrix when proxy side does not support requested mode."""
 
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_NGHTTPX]
-
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
         ["alpn_proto", "proxy_proto", "exp_err"],
         [
@@ -260,12 +259,10 @@ class TestH3ProxyFailure:
             f"Expected protocol/proxy error but got: {r.dump_logs()}"
         )
 
-
-class TestH3ProxyModeSelection:
     """Behavior checks for tunnel vs non-tunnel proxy mode selection."""
 
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_NGHTTPX]
-
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
         ["proxy_proto"],
         [
@@ -301,19 +298,14 @@ class TestH3ProxyModeSelection:
             f"expected CONNECT-UDP attempt in output, got: {r.dump_logs()}"
         )
 
-
-class TestH3ProxyRuntimeGuards:
     """Guard checks for unsupported HTTP/3 proxy options."""
 
-    pytestmark = [
-        MARK_NEEDS_HTTPS_PROXY,
-        MARK_NEEDS_PROXY_HTTP3,
-        pytest.mark.skipif(
-            condition=Env.curl_uses_lib("ngtcp2"),
-            reason="guard only applies to non-ngtcp2 builds",
-        ),
-    ]
-
+    @MARK_NEEDS_HTTPS_PROXY
+    @MARK_NEEDS_PROXY_HTTP3
+    @pytest.mark.skipif(
+        condition=Env.curl_uses_lib("ngtcp2"),
+        reason="guard only applies to non-ngtcp2 builds",
+    )
     @pytest.mark.skipif(
         condition=not Env.curl_has_feature("HTTP3"), reason="curl lacks HTTP/3 support"
     )
@@ -340,12 +332,10 @@ class TestH3ProxyRuntimeGuards:
             f"Expected unsupported option failure but got: {r.stderr}"
         )
 
-
-class TestH3ProxyRobustness:
     """Robustness checks for shutdown and proxy loss during transfer."""
 
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_H2O]
-
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     @pytest.fixture(autouse=True, scope="class")
     def _class_scope(self, env, h2o_server):
         if not env.have_h2o():
@@ -354,6 +344,8 @@ class TestH3ProxyRobustness:
             indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024
         )
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     def test_60_05_graceful_shutdown(
         self, env: Env, h2o_server, h2o_proxy
     ):
@@ -380,6 +372,8 @@ class TestH3ProxyRobustness:
         ]
         assert shutdown_lines, f"No shutdown trace lines found:\n{r.stderr}"
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     def test_60_06_proxy_drop_mid_transfer(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
 
@@ -423,12 +417,10 @@ class TestH3ProxyRobustness:
                 proc.wait(timeout=5)
             assert h2o_proxy.start(), "failed to restart h2o proxy"
 
-
-class TestH3ProxyDataTransfer:
     """Large file transfers and multiplexing through HTTP/3 proxy."""
 
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_H2O]
-
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     @pytest.fixture(autouse=True, scope="class")
     def _class_scope(self, env, h2o_server):
         if not env.have_h2o():
@@ -437,6 +429,8 @@ class TestH3ProxyDataTransfer:
         env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
         env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     def test_60_07_large_download(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
         curl = CurlClient(env=env)
@@ -448,6 +442,8 @@ class TestH3ProxyDataTransfer:
         r.check_response(count=1, http_status=200)
         _check_download_size(curl, 10 * 1024 * 1024)
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     def test_60_08_large_upload(self, env: Env, httpd, h2o_server, h2o_proxy):
         _require_available(h2o_proxy=h2o_proxy)
         fdata = os.path.join(env.gen_dir, "upload-2m")
@@ -463,6 +459,8 @@ class TestH3ProxyDataTransfer:
         )
         r.check_response(count=1, http_status=200)
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     def test_60_09_parallel_downloads(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
         count = 5
@@ -475,12 +473,8 @@ class TestH3ProxyDataTransfer:
         )
         r.check_response(count=count, http_status=200)
 
-
-class TestH3ProxyConnectionManagement:
-    """Proxy authentication, connection reuse, and session resumption."""
-
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_H2O]
-
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     def test_60_10_proxy_basic_auth(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
         curl = CurlClient(env=env)
@@ -493,6 +487,8 @@ class TestH3ProxyConnectionManagement:
         r.check_response(count=1, http_status=200)
         _check_download_message(curl, H2O_HELLO_MSG)
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     def test_60_11_connection_reuse(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
         curl = CurlClient(env=env)
@@ -506,6 +502,8 @@ class TestH3ProxyConnectionManagement:
             f"expected proxy connection reuse, got {r.total_connects} connects"
         )
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     @pytest.mark.skipif(condition=not Env.curl_has_feature('SSLS-EXPORT'),
                         reason='curl lacks SSL session export support')
     def test_60_12_quic_session_resumption(self, env: Env, h2o_server, h2o_proxy):
@@ -530,12 +528,9 @@ class TestH3ProxyConnectionManagement:
         reuses = [line for line in r2.trace_lines if '[SSLS] took session for proxy.http.curl.se' in line]
         assert len(reuses), f'{r2.dump_logs()}'
 
-
-class TestH3ProxyUdpTunnel:
     """CONNECT-UDP tunnel payload size and capsule-protocol tests."""
 
-    pytestmark = H3_PROXY_COMMON_MARKS
-
+    @H3_PROXY_COMMON_MARKS
     @pytest.fixture(autouse=True, scope="class")
     def _class_scope(self, env, h2o_server):
         if not env.have_h2o():
@@ -544,6 +539,7 @@ class TestH3ProxyUdpTunnel:
         env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
         env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
 
+    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
         "fname,fsize",
@@ -586,11 +582,10 @@ class TestH3ProxyUdpTunnel:
         )
 
 
-class TestH3ProxyEdgeCases:
     """Timeout and protocol-mismatch edge cases."""
 
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_H2O]
-
+    #@H3_PROXY_COMMON_MARKS
+    #@MARK_NEEDS_H2O
     #def test_60_15_connect_timeout(self, env: Env, h2o_proxy):
     #    _require_available(h2o_proxy=h2o_proxy)
     #    curl = CurlClient(env=env, timeout=15)
@@ -610,6 +605,8 @@ class TestH3ProxyEdgeCases:
     #        f"timeout not respected: took {r.duration.total_seconds():.1f}s"
     #    )
 
+    @H3_PROXY_COMMON_MARKS
+    @MARK_NEEDS_H2O
     @MARK_NEEDS_NGHTTP2
     def test_60_16_h2_uses_connect_tcp_not_udp(self, env: Env, httpd, h2o_proxy):
         _require_available(httpd=httpd, h2o_proxy=h2o_proxy)
@@ -624,8 +621,6 @@ class TestH3ProxyEdgeCases:
         )
         r.check_response(count=1, http_status=200)
 
-
-class TestH3ProxyHappyEyeballs:
     """
     Verify that happy eyeballs is active for HTTP/3 proxy connections.
 
@@ -633,9 +628,9 @@ class TestH3ProxyHappyEyeballs:
     family selection to the proxy is done by happy eyeballs.
     """
 
-    pytestmark = H3_PROXY_COMMON_MARKS + [MARK_NEEDS_H2O]
-
-    def test_60_17_h3_proxy_happy_eyeballs_filter_present(self, env: Env, h2o_server, h2o_proxy):
+    @H3_PROXY_COMMON_MARK
+    @MARK_NEEDS_H2O
+    def test_60_17_happy_eyeballs_filter_present(self, env: Env, h2o_server, h2o_proxy):
         """Verbose trace confirms HAPPY-EYEBALLS filter is in the H3 proxy chain."""
         if not env.curl_is_debug():
             pytest.skip("needs debug curl for filter trace")
@@ -651,8 +646,10 @@ class TestH3ProxyHappyEyeballs:
             f"expected HAPPY-EYEBALLS trace for H3 proxy, got: {r.stderr}"
         )
 
+    @H3_PROXY_COMMON_MARK
+    @MARK_NEEDS_H2O
     @MARK_NEEDS_NGHTTP2
-    def test_60_18_h3_proxy_ipv4_all_proto(self, env: Env, h2o_server, h2o_proxy):
+    def test_60_18_happy_eyeballs_ipv4_all_proto(self, env: Env, h2o_server, h2o_proxy):
         """IPv4-forced H3 proxy works for h1/h2/h3 inner protocols."""
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
         for alpn_proto in ["http/1.1", "h2", "h3"]:

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -547,7 +547,6 @@ class TestH3Proxy:
             "expected failure: nghttpx does not support CONNECT-UDP / Capsule-Protocol"
         )
 
-
     """Timeout and protocol-mismatch edge cases."""
 
     #@MARK_NEEDS_H2O

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -55,13 +55,6 @@ MARK_NEEDS_NGHTTPX = pytest.mark.skipif(
     condition=not Env.have_nghttpx(), reason="no nghttpx available"
 )
 
-H3_PROXY_COMMON_MARKS = [
-    MARK_NEEDS_HTTPS_PROXY,
-    MARK_NEEDS_HTTP3,
-    MARK_NEEDS_PROXY_HTTP3,
-    MARK_NEEDS_NGHTTP3,
-]
-
 NGTCP2_ONLY_MSG = "only supported with the ngtcp2 quic stack"
 UNSUPPORTED_OPT_MSG = "does not support this"
 H2O_HELLO_MSG = '"message": "Hello from h2o HTTP/3 server"'
@@ -145,11 +138,14 @@ def _h2o_proxy_args(
     return xargs
 
 
+@MARK_NEEDS_HTTPS_PROXY
+@MARK_NEEDS_HTTP3
+@MARK_NEEDS_PROXY_HTTP3
+@MARK_NEEDS_NGHTTP3
 class TestH3Proxy:
 
     """Success matrix for HTTP/3 proxy CONNECT / CONNECT-UDP."""
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
         ["alpn_proto", "proxy_proto"],
@@ -195,7 +191,6 @@ class TestH3Proxy:
 
     """Failure matrix when proxy side does not support requested mode."""
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
         ["alpn_proto", "proxy_proto", "exp_err"],
@@ -261,7 +256,6 @@ class TestH3Proxy:
 
     """Behavior checks for tunnel vs non-tunnel proxy mode selection."""
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_NGHTTPX
     @pytest.mark.parametrize(
         ["proxy_proto"],
@@ -334,7 +328,6 @@ class TestH3Proxy:
 
     """Robustness checks for shutdown and proxy loss during transfer."""
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     @pytest.fixture(autouse=True, scope="class")
     def _class_scope(self, env, h2o_server):
@@ -344,7 +337,6 @@ class TestH3Proxy:
             indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024
         )
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     def test_60_05_graceful_shutdown(
         self, env: Env, h2o_server, h2o_proxy
@@ -372,7 +364,6 @@ class TestH3Proxy:
         ]
         assert shutdown_lines, f"No shutdown trace lines found:\n{r.stderr}"
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     def test_60_06_proxy_drop_mid_transfer(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -419,7 +410,6 @@ class TestH3Proxy:
 
     """Large file transfers and multiplexing through HTTP/3 proxy."""
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     @pytest.fixture(autouse=True, scope="class")
     def _class_scope(self, env, h2o_server):
@@ -429,7 +419,6 @@ class TestH3Proxy:
         env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
         env.make_data_file(indir=env.gen_dir, fname="upload-2m", fsize=2 * 1024 * 1024)
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     def test_60_07_large_download(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -442,7 +431,6 @@ class TestH3Proxy:
         r.check_response(count=1, http_status=200)
         _check_download_size(curl, 10 * 1024 * 1024)
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     def test_60_08_large_upload(self, env: Env, httpd, h2o_server, h2o_proxy):
         _require_available(h2o_proxy=h2o_proxy)
@@ -459,7 +447,6 @@ class TestH3Proxy:
         )
         r.check_response(count=1, http_status=200)
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     def test_60_09_parallel_downloads(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -473,7 +460,6 @@ class TestH3Proxy:
         )
         r.check_response(count=count, http_status=200)
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     def test_60_10_proxy_basic_auth(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -487,7 +473,6 @@ class TestH3Proxy:
         r.check_response(count=1, http_status=200)
         _check_download_message(curl, H2O_HELLO_MSG)
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     def test_60_11_connection_reuse(self, env: Env, h2o_server, h2o_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
@@ -502,7 +487,6 @@ class TestH3Proxy:
             f"expected proxy connection reuse, got {r.total_connects} connects"
         )
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     @pytest.mark.skipif(condition=not Env.curl_has_feature('SSLS-EXPORT'),
                         reason='curl lacks SSL session export support')
@@ -530,7 +514,6 @@ class TestH3Proxy:
 
     """CONNECT-UDP tunnel payload size and capsule-protocol tests."""
 
-    @H3_PROXY_COMMON_MARKS
     @pytest.fixture(autouse=True, scope="class")
     def _class_scope(self, env, h2o_server):
         if not env.have_h2o():
@@ -539,7 +522,6 @@ class TestH3Proxy:
         env.make_data_file(indir=h2o_server.docs_dir, fname="download-1m", fsize=1 * 1024 * 1024)
         env.make_data_file(indir=h2o_server.docs_dir, fname="download-10m", fsize=10 * 1024 * 1024)
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     @pytest.mark.parametrize(
         "fname,fsize",
@@ -584,7 +566,6 @@ class TestH3Proxy:
 
     """Timeout and protocol-mismatch edge cases."""
 
-    #@H3_PROXY_COMMON_MARKS
     #@MARK_NEEDS_H2O
     #def test_60_15_connect_timeout(self, env: Env, h2o_proxy):
     #    _require_available(h2o_proxy=h2o_proxy)
@@ -605,7 +586,6 @@ class TestH3Proxy:
     #        f"timeout not respected: took {r.duration.total_seconds():.1f}s"
     #    )
 
-    @H3_PROXY_COMMON_MARKS
     @MARK_NEEDS_H2O
     @MARK_NEEDS_NGHTTP2
     def test_60_16_h2_uses_connect_tcp_not_udp(self, env: Env, httpd, h2o_proxy):

--- a/tests/http/test_60_h3_proxy.py
+++ b/tests/http/test_60_h3_proxy.py
@@ -329,10 +329,14 @@ class TestH3Proxy:
 
     # Robustness checks for shutdown and proxy loss during transfer.
 
+    @pytest.fixture(scope="class")
+    def data_proxy(self, env, h2o_server):
+        env.make_data_file(indir=h2o_server.docs_dir, fname="proxy-drop-20m", fsize=20 * 1024 * 1024)
+
     @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
     def test_60_05_graceful_shutdown(
-        self, env: Env, h2o_server, h2o_proxy
+        self, env: Env, h2o_server, h2o_proxy, data_proxy
     ):
         if not env.curl_is_debug():
             pytest.skip("needs debug curl for shutdown trace lines")
@@ -359,7 +363,7 @@ class TestH3Proxy:
 
     @MARK_NEEDS_PROXY_HTTP3
     @MARK_NEEDS_H2O
-    def test_60_06_proxy_drop_mid_transfer(self, env: Env, h2o_server, h2o_proxy):
+    def test_60_06_proxy_drop_mid_transfer(self, env: Env, h2o_server, h2o_proxy, data_proxy):
         _require_available(h2o_server=h2o_server, h2o_proxy=h2o_proxy)
 
         proxy_port = h2o_proxy.port


### PR DESCRIPTION
- merge tests into a single class.
  For shorter names, to fix sort order by test number, and to align with
  other tests.
- fix preconditions to make `test_60_04_guard_proxy_http3_unsupported`
  actually run.
- replace local precondition with constant of the same effect.
- drop redundant non-`ngtcp2` requirement for
  `test_60_04_guard_proxy_http3_unsupported`.
  (seemed relevant for no longer supported openssl-quic builds.)
- drop unused `NGTCP2_ONLY_MSG` constant.
  Follow-up to e4139a73c82d2035142f5ae36196adb4e9831dae #21798
- avoid creating unnecessary test data blobs, and minimize their scopes.

Follow-up to 91facd7bb3bb366525b7cb41221f6359c5e936db #21791
Follow-up to e78b1b3eccfa6a2e367a1225ea1b66dafcdac3c4 #21153
