### PR TITLE
[ON-HOLD] GHA/non-native: drop MidnightBSD due to package install issues

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -62,8 +62,6 @@ jobs:
               options: '--with-openssl --with-gssapi' }
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests',
-              options: '-DCURL_USE_GNUTLS=ON' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
@@ -91,10 +89,6 @@ jobs:
               tools='autoconf automake libtool'
             fi
             sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
-          elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
-            # https://app.midnightbsd.org/
-            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport -q install cmake-core ninja perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket


### PR DESCRIPTION
Package manager no longer seems to be installing packages.

Example:
```
Pseudo-terminal will not be allocated because stdin is not a terminal.
Downloading index.db.zst (100.00%)
Downloading index.db.zst.sha256 (100.00%)
[...]
/bin/sh: cmake: not found
Error: Process completed with exit code 127.
```
Ref: https://github.com/curl/curl/actions/runs/26718364286/job/78740875142

Last known good: https://github.com/curl/curl/actions/runs/26715985856/job/78734543839#step:4:37

Follow-up to b158d1c9f7456a8f976c74c08d2dc5a555e9cc77 #21681
