### PR TITLE
cmake: add basic way to select pytests to run

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,7 +110,7 @@ function(curl_add_pytests _targetname _test_flags)
   endif()
   string(REPLACE " " ";" _test_flags_list "${_test_flags}")
   add_custom_target(${_targetname}
-    COMMAND pytest ${_test_flags_list} "${CMAKE_CURRENT_SOURCE_DIR}/http"
+    COMMAND pytest ${_test_flags_list} "${CMAKE_CURRENT_SOURCE_DIR}/http${_CURL_PYTEST}"
     DEPENDS "${_depends}"
     VERBATIM USES_TERMINAL
   )


### PR DESCRIPTION
Not documented and experimental, example:
`-D_CURL_PYTEST=/test_60_h3_proxy.py`

Ideally, this should be an env like `TFLAGS` and it should allow
selecting any test ID or a group of them, but so far could not figure
out how even a basic env could work.
