### PR TITLE
badwords: exclude wordlist input file from search

### DIFF
--- a/scripts/badwords
+++ b/scripts/badwords
@@ -318,7 +318,7 @@ sub file {
 }
 
 my @filemasks = @ARGV;
-open(my $git_ls_files, '-|', 'git', 'ls-files', '--', @filemasks) or die "Failed running git ls-files: $!";
+open(my $git_ls_files, '-|', 'git', 'ls-files', '--', ":!:$file", @filemasks) or die "Failed running git ls-files: $!";
 my @files;
 while(my $each = <$git_ls_files>) {
     chomp $each;


### PR DESCRIPTION
To avoid hitting all lines in it. It doesn't happen in curl at the
moment, but may happen in the future or in other projects using this 
script.
