### PR TITLE
units: drop redundant pointer check and workaround

### DIFF
--- a/tests/libtest/unitcheck.h
+++ b/tests/libtest/unitcheck.h
@@ -48,7 +48,7 @@
 
 #define verify_memory(dynamic, check, len)                                  \
   do {                                                                      \
-    if((dynamic) && memcmp(dynamic, check, len)) {                          \
+    if(memcmp(dynamic, check, len)) {                                       \
       curl_mfprintf(stderr, "%s:%d Memory buffer FAILED match size %d. "    \
                     "'%s' is not\n", __FILE__, __LINE__, len,               \
                     hexdump((const unsigned char *)(check), len));          \

--- a/tests/unit/unit1600.c
+++ b/tests/unit/unit1600.c
@@ -53,18 +53,17 @@ static CURLcode test_unit1600(const char *arg)
 #if defined(USE_NTLM) &&                                    \
   (!defined(USE_WINDOWS_SSPI) || defined(USE_WIN32_CRYPTO))
   unsigned char output[21];
-  const unsigned char *testp = output;
 
   Curl_ntlm_core_mk_nt_hash("1", output);
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\x69\x94\x3c\x5e\x63\xb4\xd2\xc1\x04\xdb"
                 "\xbc\xc1\x51\x38\xb7\x2b\x00\x00\x00\x00\x00",
                 21);
 
   Curl_ntlm_core_mk_nt_hash("hello-you-fool", output);
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\x39\xaf\x87\xa6\x75\x0a\x7a\x00\xba\xa0"
                 "\xd3\x4f\x04\x9e\xc1\xd0\x00\x00\x00\x00\x00",
                 21);
@@ -77,7 +76,7 @@ static CURLcode test_unit1600(const char *arg)
     "AAAAAAAA",
     output);
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\x36\x9d\xae\x06\x84\x7e\xe1\xc1\x4a\x94\x39\xea\x6f\x44\x8c"
                 "\x65\x00\x00\x00\x00\x00",
                 21);

--- a/tests/unit/unit1601.c
+++ b/tests/unit/unit1601.c
@@ -34,16 +34,15 @@ static CURLcode test_unit1601(const char *arg)
   static const char string1[] = "1";
   static const char string2[] = "hello-you-fool";
   unsigned char output[MD5_DIGEST_LEN];
-  const unsigned char *testp = output;
 
   Curl_md5it(output, (const unsigned char *)string1, strlen(string1));
 
-  verify_memory(testp, "\xc4\xca\x42\x38\xa0\xb9\x23\x82\x0d\xcc\x50\x9a\x6f"
+  verify_memory(output, "\xc4\xca\x42\x38\xa0\xb9\x23\x82\x0d\xcc\x50\x9a\x6f"
                 "\x75\x84\x9b", MD5_DIGEST_LEN);
 
   Curl_md5it(output, (const unsigned char *)string2, strlen(string2));
 
-  verify_memory(testp, "\x88\x67\x0b\x6d\x5d\x74\x2f\xad\xa5\xcd\xf9\xb6\x82"
+  verify_memory(output, "\x88\x67\x0b\x6d\x5d\x74\x2f\xad\xa5\xcd\xf9\xb6\x82"
                 "\x87\x5f\x22", MD5_DIGEST_LEN);
 #endif
 

--- a/tests/unit/unit1610.c
+++ b/tests/unit/unit1610.c
@@ -41,11 +41,10 @@ static CURLcode test_unit1610(const char *arg)
   static const char string1[] = "1";
   static const char string2[] = "hello-you-fool";
   unsigned char output[CURL_SHA256_DIGEST_LENGTH];
-  const unsigned char *testp = output;
 
   Curl_sha256it(output, (const unsigned char *)string1, strlen(string1));
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\x6b\x86\xb2\x73\xff\x34\xfc\xe1\x9d\x6b\x80\x4e\xff\x5a\x3f"
                 "\x57\x47\xad\xa4\xea\xa2\x2f\x1d\x49\xc0\x1e\x52\xdd\xb7\x87"
                 "\x5b\x4b",
@@ -53,7 +52,7 @@ static CURLcode test_unit1610(const char *arg)
 
   Curl_sha256it(output, (const unsigned char *)string2, strlen(string2));
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\xcb\xb1\x6a\x8a\xb9\xcb\xb9\x35\xa8\xcb\xa0\x2e\x28\xc0\x26"
                 "\x30\xd1\x19\x9c\x1f\x02\x17\xf4\x7c\x96\x20\xf3\xef\xe8\x27"
                 "\x15\xae",

--- a/tests/unit/unit1611.c
+++ b/tests/unit/unit1611.c
@@ -32,18 +32,17 @@ static CURLcode test_unit1611(const char *arg)
   static const char string1[] = "1";
   static const char string2[] = "hello-you-fool";
   unsigned char output[MD4_DIGEST_LENGTH];
-  const unsigned char *testp = output;
 
   Curl_md4it(output, (const unsigned char *)string1, strlen(string1));
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\x8b\xe1\xec\x69\x7b\x14\xad\x3a\x53\xb3\x71\x43\x61\x20\x64"
                 "\x1d",
                 MD4_DIGEST_LENGTH);
 
   Curl_md4it(output, (const unsigned char *)string2, strlen(string2));
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\xa7\x16\x1c\xad\x7e\xbe\xdb\xbc\xf8\xc7\x23\x10\x2d\x2c\xe2"
                 "\x0b",
                 MD4_DIGEST_LENGTH);

--- a/tests/unit/unit1612.c
+++ b/tests/unit/unit1612.c
@@ -36,14 +36,13 @@ static CURLcode test_unit1612(const char *arg)
   static const char string1[] = "1";
   static const char string2[] = "hello-you-fool";
   unsigned char output[HMAC_MD5_LENGTH];
-  const unsigned char *testp = output;
 
   Curl_hmacit(&Curl_HMAC_MD5,
               (const unsigned char *)password, strlen(password),
               (const unsigned char *)string1, strlen(string1),
               output);
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\xd1\x29\x75\x43\x58\xdc\xab\x78\xdf\xcd\x7f\x2b\x29\x31\x13"
                 "\x37",
                 HMAC_MD5_LENGTH);
@@ -53,7 +52,7 @@ static CURLcode test_unit1612(const char *arg)
               (const unsigned char *)string2, strlen(string2),
               output);
 
-  verify_memory(testp,
+  verify_memory(output,
                 "\x75\xf1\xa7\xb9\xf5\x40\xe5\xa4\x98\x83\x9f\x64\x5a\x27\x6d"
                 "\xd0",
                 HMAC_MD5_LENGTH);

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -108,42 +108,38 @@ static CURLcode test_unit1615(const char *arg)
   };
 
   unsigned char output_buf[CURL_SHA512_256_DIGEST_LENGTH];
-  const unsigned char *computed_hash; /* to mute compiler warning */
-
-  /* Mute compiler warnings in 'verify_memory' macros below */
-  computed_hash = output_buf;
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str1,
                     CURL_ARRAYSIZE(test_str1) - 1);
-  verify_memory(computed_hash, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str2,
                     CURL_ARRAYSIZE(test_str2) - 1);
-  verify_memory(computed_hash, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str3,
                     CURL_ARRAYSIZE(test_str3) - 1);
-  verify_memory(computed_hash, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str4,
                     CURL_ARRAYSIZE(test_str4) - 1);
-  verify_memory(computed_hash, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str5,
                     CURL_ARRAYSIZE(test_str5) - 1);
-  verify_memory(computed_hash, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str6,
                     CURL_ARRAYSIZE(test_str6) - 1);
-  verify_memory(computed_hash, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str7,
                     CURL_ARRAYSIZE(test_str7) - 1);
-  verify_memory(computed_hash, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, test_seq8,
                     CURL_ARRAYSIZE(test_seq8));
-  verify_memory(computed_hash, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
 
 #endif /* CURL_HAVE_SHA512_256 */
 

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -108,45 +108,42 @@ static CURLcode test_unit1615(const char *arg)
   };
 
   unsigned char output_buf[CURL_SHA512_256_DIGEST_LENGTH];
+  const unsigned char *computed_hash; /* to mute -Waddress GCC warning */
 
-#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Waddress"
-#endif
+  /* Mute compiler warnings in 'verify_memory' macros below */
+  computed_hash = output_buf;
+
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str1,
                     CURL_ARRAYSIZE(test_str1) - 1);
-  verify_memory(output_buf, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str2,
                     CURL_ARRAYSIZE(test_str2) - 1);
-  verify_memory(output_buf, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str3,
                     CURL_ARRAYSIZE(test_str3) - 1);
-  verify_memory(output_buf, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str4,
                     CURL_ARRAYSIZE(test_str4) - 1);
-  verify_memory(output_buf, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str5,
                     CURL_ARRAYSIZE(test_str5) - 1);
-  verify_memory(output_buf, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str6,
                     CURL_ARRAYSIZE(test_str6) - 1);
-  verify_memory(output_buf, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str7,
                     CURL_ARRAYSIZE(test_str7) - 1);
-  verify_memory(output_buf, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, test_seq8,
                     CURL_ARRAYSIZE(test_seq8));
-  verify_memory(output_buf, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
-#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+  verify_memory(computed_hash, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
 
 #endif /* CURL_HAVE_SHA512_256 */
 

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -108,7 +108,7 @@ static CURLcode test_unit1615(const char *arg)
   };
 
   unsigned char output_buf[CURL_SHA512_256_DIGEST_LENGTH];
-  const unsigned char *computed_hash; /* to mute compiler warning */
+  const unsigned char *computed_hash; /* to mute -Waddress GCC warning */
 
   /* Mute compiler warnings in 'verify_memory' macros below */
   computed_hash = output_buf;

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -108,42 +108,45 @@ static CURLcode test_unit1615(const char *arg)
   };
 
   unsigned char output_buf[CURL_SHA512_256_DIGEST_LENGTH];
-  const unsigned char *computed_hash; /* to mute -Waddress GCC warning */
 
-  /* Mute compiler warnings in 'verify_memory' macros below */
-  computed_hash = output_buf;
-
+#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress"
+#endif
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str1,
                     CURL_ARRAYSIZE(test_str1) - 1);
-  verify_memory(computed_hash, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str2,
                     CURL_ARRAYSIZE(test_str2) - 1);
-  verify_memory(computed_hash, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str3,
                     CURL_ARRAYSIZE(test_str3) - 1);
-  verify_memory(computed_hash, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str4,
                     CURL_ARRAYSIZE(test_str4) - 1);
-  verify_memory(computed_hash, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str5,
                     CURL_ARRAYSIZE(test_str5) - 1);
-  verify_memory(computed_hash, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str6,
                     CURL_ARRAYSIZE(test_str6) - 1);
-  verify_memory(computed_hash, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str7,
                     CURL_ARRAYSIZE(test_str7) - 1);
-  verify_memory(computed_hash, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, test_seq8,
                     CURL_ARRAYSIZE(test_seq8));
-  verify_memory(computed_hash, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
+#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* CURL_HAVE_SHA512_256 */
 

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -108,38 +108,42 @@ static CURLcode test_unit1615(const char *arg)
   };
 
   unsigned char output_buf[CURL_SHA512_256_DIGEST_LENGTH];
+  const unsigned char *computed_hash; /* to mute compiler warning */
+
+  /* Mute compiler warnings in 'verify_memory' macros below */
+  computed_hash = output_buf;
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str1,
                     CURL_ARRAYSIZE(test_str1) - 1);
-  verify_memory(output_buf, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str2,
                     CURL_ARRAYSIZE(test_str2) - 1);
-  verify_memory(output_buf, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str3,
                     CURL_ARRAYSIZE(test_str3) - 1);
-  verify_memory(output_buf, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str4,
                     CURL_ARRAYSIZE(test_str4) - 1);
-  verify_memory(output_buf, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str5,
                     CURL_ARRAYSIZE(test_str5) - 1);
-  verify_memory(output_buf, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str6,
                     CURL_ARRAYSIZE(test_str6) - 1);
-  verify_memory(output_buf, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str7,
                     CURL_ARRAYSIZE(test_str7) - 1);
-  verify_memory(output_buf, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, test_seq8,
                     CURL_ARRAYSIZE(test_seq8));
-  verify_memory(output_buf, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
 
 #endif /* CURL_HAVE_SHA512_256 */
 

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -108,42 +108,38 @@ static CURLcode test_unit1615(const char *arg)
   };
 
   unsigned char output_buf[CURL_SHA512_256_DIGEST_LENGTH];
-  const unsigned char *computed_hash; /* to mute -Waddress GCC warning */
-
-  /* Mute compiler warnings in 'verify_memory' macros below */
-  computed_hash = output_buf;
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str1,
                     CURL_ARRAYSIZE(test_str1) - 1);
-  verify_memory(computed_hash, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str2,
                     CURL_ARRAYSIZE(test_str2) - 1);
-  verify_memory(computed_hash, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str3,
                     CURL_ARRAYSIZE(test_str3) - 1);
-  verify_memory(computed_hash, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str4,
                     CURL_ARRAYSIZE(test_str4) - 1);
-  verify_memory(computed_hash, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str5,
                     CURL_ARRAYSIZE(test_str5) - 1);
-  verify_memory(computed_hash, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str6,
                     CURL_ARRAYSIZE(test_str6) - 1);
-  verify_memory(computed_hash, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *)test_str7,
                     CURL_ARRAYSIZE(test_str7) - 1);
-  verify_memory(computed_hash, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, test_seq8,
                     CURL_ARRAYSIZE(test_seq8));
-  verify_memory(computed_hash, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
+  verify_memory(output_buf, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
 
 #endif /* CURL_HAVE_SHA512_256 */
 


### PR DESCRIPTION
All users of the `verify_memory()` macro used a fixed-length buffer for
the test output, which then needed a workaround to silence GCC
`-Waddress` warnings.

```
tests/unit/unit1615.c: In function 'test_unit1615':
tests/libtest/unitcheck.h:51:8: error: the address of 'output_buf' will always evaluate as 'true' [-Werror=address]
   51 |     if((dynamic) && memcmp(dynamic, check, len)) {                          \
      |        ^
tests/unit/unit1615.c:114:3: note: in expansion of macro 'verify_memory'
  114 |   verify_memory(output_buf, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
      |   ^~~~~~~~~~~~~
```

Drop redundant address check and the workarounds with it.
