### PR TITLE
Added arpa/inet.h to lib/capsule.c for the ntohs() declaration.

### DIFF
--- a/lib/capsule.c
+++ b/lib/capsule.c
@@ -26,6 +26,10 @@
 
 #if !defined(CURL_DISABLE_PROXY) && !defined(CURL_DISABLE_HTTP)
 
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h>  /* for htons() */
+#endif
+
 #include <curl/curl.h>
 #include "urldata.h"
 #include "curlx/dynbuf.h"


### PR DESCRIPTION
Some platforms require inclusion of arpa/inet.h in order to use ntohs().