### PR TITLE
lib505: tidy up slist pointer use

### DIFF
--- a/tests/libtest/lib505.c
+++ b/tests/libtest/lib505.c
@@ -38,9 +38,8 @@ static CURLcode test_lib505(const char *URL)
   FILE *hd_src;
   int hd;
   curlx_struct_stat file_info;
-  struct curl_slist *hl;
-
-  struct curl_slist *headerlist = NULL;
+  struct curl_slist *headerlist;
+  struct curl_slist *temp;
 
   static const char *buf_1 = "RNFR 505";
   static const char *buf_2 = "RNTO 505-forreal";
@@ -92,24 +91,24 @@ static CURLcode test_lib505(const char *URL)
 
   /* build a list of commands to pass to libcurl */
 
-  hl = curl_slist_append(headerlist, buf_1);
-  if(!hl) {
-    curl_mfprintf(stderr, "curl_slist_append() failed\n");
-    curl_easy_cleanup(curl);
-    curl_global_cleanup();
-    curlx_fclose(hd_src);
-    return TEST_ERR_MAJOR_BAD;
-  }
-  headerlist = curl_slist_append(hl, buf_2);
+  headerlist = curl_slist_append(NULL, buf_1);
   if(!headerlist) {
     curl_mfprintf(stderr, "curl_slist_append() failed\n");
-    curl_slist_free_all(hl);
     curl_easy_cleanup(curl);
     curl_global_cleanup();
     curlx_fclose(hd_src);
     return TEST_ERR_MAJOR_BAD;
   }
-  headerlist = hl;
+  temp = curl_slist_append(headerlist, buf_2);
+  if(!temp) {
+    curl_mfprintf(stderr, "curl_slist_append() failed\n");
+    curl_slist_free_all(headerlist);
+    curl_easy_cleanup(curl);
+    curl_global_cleanup();
+    curlx_fclose(hd_src);
+    return TEST_ERR_MAJOR_BAD;
+  }
+  headerlist = temp;
 
   /* enable uploading */
   test_setopt(curl, CURLOPT_UPLOAD, 1L);


### PR DESCRIPTION
Bring code closer to `curl_slist_append()` man page and clarify variable
names.

---

Pointed out by GitHub Code Quality, but the actual claim of an issue is
a false positive.

"`headerlist` is set to the result of appending both `buf_1` and `buf_2` on line 103, but then immediately overwritten with `hl` (which only contains `buf_1`) on line 112. This means the second command is silently dropped and only `buf_1` is passed to `CURLOPT_POSTQUOTE`. The line `headerlist = hl;` should be removed so `headerlist` retains the full two-element list."
