### PR TITLE
tool_help: rectify a bad assert

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -166,8 +166,9 @@ void inithelpscan(struct scan_ctx *ctx,
   ctx->flen = strlen(arg);
   ctx->endarg = endarg;
   ctx->elen = strlen(endarg);
-  DEBUGASSERT((ctx->elen < sizeof(ctx->rbuf)) ||
-              (ctx->flen < sizeof(ctx->rbuf)));
+  DEBUGASSERT((ctx->elen < sizeof(ctx->rbuf)) &&
+              (ctx->flen < sizeof(ctx->rbuf)) &&
+              (ctx->tlen < sizeof(ctx->rbuf)));
   ctx->show = 0;
   ctx->olen = 0;
   memset(ctx->rbuf, 0, sizeof(ctx->rbuf));


### PR DESCRIPTION
The condition was wrong, and now it also verifies 'tlen'.

Reported-by: Gao Liyou
Ref: #21825