### PR TITLE
os400sys: fix theoretical length overflows

### DIFF
--- a/projects/OS400/os400sys.c
+++ b/projects/OS400/os400sys.c
@@ -446,8 +446,13 @@ Curl_gss_init_sec_context_a(OM_uint32 *minor_status,
   if(inp) {
     if(inp->length && inp->value) {
       unsigned int i;
-      if(inp->length >= UINT_MAX)
+      if(inp->length >= UINT_MAX) {
+        if(minor_status)
+          /* !checksrc! disable ERRNOVAR 1 */
+          *minor_status = ENOMEM;
+
         return GSS_S_FAILURE;
+      }
       i = (unsigned int)inp->length;
       in.value = malloc(i + 1);
       if(!in.value) {

--- a/projects/OS400/os400sys.c
+++ b/projects/OS400/os400sys.c
@@ -445,8 +445,10 @@ Curl_gss_init_sec_context_a(OM_uint32 *minor_status,
 
   if(inp) {
     if(inp->length && inp->value) {
-      unsigned int i = inp->length;
-
+      unsigned int i;
+      if(inp->length >= UINT_MAX)
+        return GSS_S_FAILURE;
+      i = (unsigned int)inp->length;
       in.value = malloc(i + 1);
       if(!in.value) {
         if(minor_status)

--- a/projects/OS400/os400sys.c
+++ b/projects/OS400/os400sys.c
@@ -370,6 +370,10 @@ static int Curl_gss_convert_in_place(OM_uint32 *minor_status, gss_buffer_t buf)
   return 0;
 }
 
+/* Max string input length is a precaution against abuse and to detect junk
+   input easier and better. */
+#define CURL_MAX_INPUT_LENGTH 8000000
+
 OM_uint32 Curl_gss_import_name_a(OM_uint32 *minor_status, gss_buffer_t in_name,
                                  gss_OID in_name_type, gss_name_t *out_name)
 {
@@ -381,7 +385,14 @@ OM_uint32 Curl_gss_import_name_a(OM_uint32 *minor_status, gss_buffer_t in_name,
     return gss_import_name(minor_status, in_name, in_name_type, out_name);
 
   memcpy((char *)&in, (char *)in_name, sizeof(in));
-  i = in.length;
+  if(in.length > CURL_MAX_INPUT_LENGTH) {
+    if(minor_status)
+      /* !checksrc! disable ERRNOVAR 1 */
+      *minor_status = ENOMEM;
+
+    return GSS_S_FAILURE;
+  }
+  i = (unsigned int)in.length;
 
   in.value = malloc(i + 1);
   if(!in.value) {
@@ -446,7 +457,7 @@ Curl_gss_init_sec_context_a(OM_uint32 *minor_status,
   if(inp) {
     if(inp->length && inp->value) {
       unsigned int i;
-      if(inp->length >= UINT_MAX) {
+      if(inp->length > CURL_MAX_INPUT_LENGTH) {
         if(minor_status)
           /* !checksrc! disable ERRNOVAR 1 */
           *minor_status = ENOMEM;


### PR DESCRIPTION
When converting a `size_t` to `unsigned int`.

Another instance spotted by Copilot.

Reported-by: Gao Liyou
Ref: #21825
