### PR TITLE
libssh2: terminate readdir_filename after REALPATH and READLINK

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1819,6 +1819,8 @@ static CURLcode ssh_state_sftp_realpath(struct Curl_easy *data,
 
   myssh_to(data, sshc, SSH_STOP);
   if(rc > 0) {
+    /* libssh2_sftp_symlink_ex() does not NUL-terminate the buffer */
+    sshp->readdir_filename[rc] = '\0';
     curlx_free(sshc->homedir);
     sshc->homedir = curlx_strdup(sshp->readdir_filename);
     if(!sshc->homedir)
@@ -2256,6 +2258,9 @@ static CURLcode ssh_state_sftp_readdir_link(struct Curl_easy *data,
 
   if(rc < 0)
     return CURLE_OUT_OF_MEMORY;
+
+  /* libssh2_sftp_symlink_ex() does not NUL-terminate the buffer */
+  sshp->readdir_filename[rc] = '\0';
 
   /* append filename and extra output */
   result = curlx_dyn_addf(&sshp->readdir, " -> %s", sshp->readdir_filename);


### PR DESCRIPTION
Noticed sftp_readdir() NUL-terminates readdir_filename with the byte count returned by libssh2, but the REALPATH and READLINK paths read the same buffer as a string without doing so. libssh2_sftp_symlink_ex() only returns the length and leaves the buffer unterminated.

Since the buffer is reused across entries, a symlink target shorter than the previous entry leaves stale bytes that get appended to the target in the listing. Terminate at [rc] in both spots, like the readdir code already does.