### PR TITLE
cookie: simplify the cookie length check in parse_cookie_header

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -479,9 +479,7 @@ static CURLcode parse_cookie_header(
          * combination of name + contents. Chrome and Firefox support 4095 or
          * 4096 bytes combo
          */
-        if(curlx_strlen(&name) >= (MAX_NAME - 1) ||
-           curlx_strlen(&val) >= (MAX_NAME - 1) ||
-           ((curlx_strlen(&name) + curlx_strlen(&val)) > MAX_NAME)) {
+        if((curlx_strlen(&name) + curlx_strlen(&val)) > MAX_NAME) {
           infof(data, "oversized cookie dropped, name/val %zu + %zu bytes",
                 curlx_strlen(&name), curlx_strlen(&val));
           return CURLE_OK;


### PR DESCRIPTION
Since the name and value lengths are never very big, there is no risk for overflow and we can check the total size only to catch too big fields and avoid the individual checks.