### PR TITLE
tests: add `cookies` feature to some tests

### DIFF
--- a/tests/data/test2015
+++ b/tests/data/test2015
@@ -66,6 +66,7 @@ HTTP with cookie with with -b and redirect to new host
 http://first.host.it.is/we/want/that/page/%TESTNUMBER -x %HOSTIP:%HTTPPORT -b "test=yes" --location
 </command>
 <features>
+cookies
 proxy
 </features>
 </client>

--- a/tests/data/test2504
+++ b/tests/data/test2504
@@ -34,6 +34,9 @@ custom Host with cookie, handle reuse, no custom Host:
 <command>
 http://%HOSTIP:%HTTPPORT
 </command>
+<features>
+cookies
+</features>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test7
+++ b/tests/data/test7
@@ -35,6 +35,9 @@ HTTP with cookie parser and header recording
 <command>
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -b none -D %LOGDIR/heads%TESTNUMBER.txt
 </command>
+<features>
+cookies
+</features>
 </client>
 
 # Verify data after the test has been "shot"


### PR DESCRIPTION
These fail without cookie support.

This fixes my autobuilds.