### PR TITLE
Bindings.md uses archive.org for hURL even though the site is up and running

### DIFF
--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -61,7 +61,7 @@ Go: [go-curl](https://github.com/andelf/go-curl) by ShuYu Wang
 
 [Haskell](https://hackage.haskell.org/package/curl) Written by Galois, Inc
 
-[Hollywood](https://web.archive.org/web/20250116185836/www.hollywood-mal.com/download.html) hURL by Andreas Falkenhahn
+[Hollywood](https://www.hollywood-mal.com/download.html) hURL by Andreas Falkenhahn
 
 [Java](https://github.com/covers1624/curl4j)
 


### PR DESCRIPTION
No need to use archive.org ... the site is up and running