### PR TITLE
tidy-up: drop stray casts for allocated pointers

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1017,7 +1017,7 @@ WriteMemoryCallback(void *ptr, size_t size, size_t nmemb, void *data)
   size_t realsize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)data;
 
-  mem->memory = (char *)realloc(mem->memory, mem->size + realsize + 1);
+  mem->memory = realloc(mem->memory, mem->size + realsize + 1);
   if(mem->memory) {
     memcpy(&(mem->memory[mem->size]), ptr, realsize);
     mem->size += realsize;

--- a/docs/examples/multi-event.c
+++ b/docs/examples/multi-event.c
@@ -101,10 +101,9 @@ static struct curl_context *create_curl_context(curl_socket_t sockfd)
 {
   struct curl_context *context = malloc(sizeof(*context));
 
-  if(context) {
-    context->sockfd = sockfd;
-    context->event = event_new(base, sockfd, 0, curl_perform, context);
-  }
+  context->sockfd = sockfd;
+
+  context->event = event_new(base, sockfd, 0, curl_perform, context);
 
   return context;
 }

--- a/docs/examples/multi-event.c
+++ b/docs/examples/multi-event.c
@@ -99,13 +99,12 @@ static void curl_perform(int fd, short event, void *arg)
 
 static struct curl_context *create_curl_context(curl_socket_t sockfd)
 {
-  struct curl_context *context;
+  struct curl_context *context = malloc(sizeof(*context));
 
-  context = (struct curl_context *)malloc(sizeof(*context));
-
-  context->sockfd = sockfd;
-
-  context->event = event_new(base, sockfd, 0, curl_perform, context);
+  if(context) {
+    context->sockfd = sockfd;
+    context->event = event_new(base, sockfd, 0, curl_perform, context);
+  }
 
   return context;
 }

--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -60,13 +60,11 @@ static struct curl_context *create_curl_context(curl_socket_t sockfd,
 {
   struct curl_context *context = malloc(sizeof(*context));
 
-  if(context) {
-    context->sockfd = sockfd;
-    context->uv = uv;
+  context->sockfd = sockfd;
+  context->uv = uv;
 
-    uv_poll_init_socket(uv->loop, &context->poll_handle, sockfd);
-    context->poll_handle.data = context;
-  }
+  uv_poll_init_socket(uv->loop, &context->poll_handle, sockfd);
+  context->poll_handle.data = context;
 
   return context;
 }

--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -58,15 +58,15 @@ struct curl_context {
 static struct curl_context *create_curl_context(curl_socket_t sockfd,
                                                 struct datauv *uv)
 {
-  struct curl_context *context;
+  struct curl_context *context = malloc(sizeof(*context));
 
-  context = (struct curl_context *)malloc(sizeof(*context));
+  if(context) {
+    context->sockfd = sockfd;
+    context->uv = uv;
 
-  context->sockfd = sockfd;
-  context->uv = uv;
-
-  uv_poll_init_socket(uv->loop, &context->poll_handle, sockfd);
-  context->poll_handle.data = context;
+    uv_poll_init_socket(uv->loop, &context->poll_handle, sockfd);
+    context->poll_handle.data = context;
+  }
 
   return context;
 }

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -89,7 +89,7 @@ static voidpf zalloc_cb(voidpf opaque, unsigned int items, unsigned int size)
 {
   (void)opaque;
   /* not a typo, keep it curlx_calloc() */
-  return (voidpf)curlx_calloc(items, size);
+  return curlx_calloc(items, size);
 }
 
 static void zfree_cb(voidpf opaque, voidpf ptr)

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1202,9 +1202,7 @@ CURLcode Curl_mime_duppart(struct Curl_easy *data,
 /* Create a mime handle. */
 curl_mime *curl_mime_init(void *easy)
 {
-  curl_mime *mime;
-
-  mime = (curl_mime *)curlx_malloc(sizeof(*mime));
+  curl_mime *mime = curlx_malloc(sizeof(*mime));
 
   if(mime) {
     mime->parent = NULL;
@@ -1241,7 +1239,7 @@ curl_mimepart *curl_mime_addpart(curl_mime *mime)
   if(!mime)
     return NULL;
 
-  part = (curl_mimepart *)curlx_malloc(sizeof(*part));
+  part = curlx_malloc(sizeof(*part));
 
   if(part) {
     Curl_mime_initpart(part);

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -1938,8 +1938,8 @@ static CURLcode cf_progress_ingress(struct Curl_cfilter *cf,
     }
 
     if(ctx->tunnel_inbuf_len < max_udp_payload) {
-      unsigned char *newbuf =
-        (unsigned char *)curlx_realloc(ctx->tunnel_inbuf, max_udp_payload);
+      unsigned char *newbuf = curlx_realloc(ctx->tunnel_inbuf,
+                                            max_udp_payload);
       if(!newbuf)
         return CURLE_OUT_OF_MEMORY;
       ctx->tunnel_inbuf = newbuf;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -468,7 +468,7 @@ static CURLcode get_client_cert(struct Curl_easy *data,
 
       if(data->set.ssl.primary.key_passwd)
         pwd_len = strlen(data->set.ssl.primary.key_passwd);
-      pszPassword = (WCHAR *)curlx_malloc(sizeof(WCHAR) * (pwd_len + 1));
+      pszPassword = curlx_malloc(sizeof(WCHAR) * (pwd_len + 1));
       if(pszPassword) {
         int str_w_len = 0;
         if(pwd_len > 0)
@@ -2001,7 +2001,7 @@ static CURLcode schannel_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   /* calculate the complete message length and allocate a buffer for it */
   data_len = backend->stream_sizes.cbHeader + len +
     backend->stream_sizes.cbTrailer;
-  ptr = (unsigned char *)curlx_malloc(data_len);
+  ptr = curlx_malloc(data_len);
   if(!ptr) {
     return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -295,7 +295,7 @@ static CURLcode add_certs_file_to_store(HCERTSTORE trust_store,
     goto cleanup;
   }
 
-  ca_file_buffer = (char *)curlx_malloc(ca_file_bufsize + 1);
+  ca_file_buffer = curlx_malloc(ca_file_bufsize + 1);
   if(!ca_file_buffer) {
     result = CURLE_OUT_OF_MEMORY;
     goto cleanup;
@@ -568,7 +568,7 @@ CURLcode Curl_verify_host(struct Curl_cfilter *cf, struct Curl_easy *data)
     /* CertGetNameString guarantees that the returned name does not contain
      * embedded null bytes. This appears to be undocumented behavior.
      */
-    cert_hostname_buff = (LPTSTR)curlx_malloc(len * sizeof(TCHAR));
+    cert_hostname_buff = curlx_malloc(len * sizeof(TCHAR));
     if(!cert_hostname_buff) {
       result = CURLE_OUT_OF_MEMORY;
       goto cleanup;

--- a/projects/OS400/ccsidcurl.c
+++ b/projects/OS400/ccsidcurl.c
@@ -576,13 +576,12 @@ CURLcode curl_easy_getinfo_ccsid(CURL *curl, CURLINFO info, ...)
       case CURLINFO_CERTINFO:
         cipf = *(struct curl_certinfo **)paramp;
         if(cipf) {
-          cipt = (struct curl_certinfo *)malloc(sizeof(*cipt));
+          cipt = malloc(sizeof(*cipt));
           if(!cipt)
             result = CURLE_OUT_OF_MEMORY;
           else {
-            cipt->certinfo =
-              (struct curl_slist **)calloc(cipf->num_of_certs + 1,
-                                           sizeof(struct curl_slist *));
+            cipt->certinfo = calloc(cipf->num_of_certs + 1,
+                                    sizeof(struct curl_slist *));
             if(!cipt->certinfo)
               result = CURLE_OUT_OF_MEMORY;
             else {

--- a/projects/OS400/curlcl.c
+++ b/projects/OS400/curlcl.c
@@ -149,7 +149,7 @@ int main(int argsc, struct arguments *args)
 
   if(!exitcode) {
     /* Allocate space for parsed arguments. */
-    argv = (char **)malloc((argc + 1) * sizeof(*argv) + argsize);
+    argv = malloc((argc + 1) * sizeof(*argv) + argsize);
     if(!argv) {
       fputs("Memory allocation error\n", stderr);
       exitcode = -2;

--- a/projects/OS400/curlmain.c
+++ b/projects/OS400/curlmain.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
   }
 
   /* Allocate memory for the ASCII arguments and vector. */
-  argv = (char **)malloc((argc + 1) * sizeof(*argv) + bytecount);
+  argv = malloc((argc + 1) * sizeof(*argv) + bytecount);
 
   /* Build the vector and convert argument encoding. */
   outbuf = (char *)(argv + argc + 1);

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -105,7 +105,7 @@ static voidpf zalloc_func(voidpf opaque, unsigned int items, unsigned int size)
 {
   (void)opaque;
   /* not a typo, keep it curlx_calloc() */
-  return (voidpf)curlx_calloc(items, size);
+  return curlx_calloc(items, size);
 }
 static void zfree_func(voidpf opaque, voidpf ptr)
 {

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -213,8 +213,7 @@ static size_t win_console(intptr_t fhnd, struct OutStruct *outs,
 
     /* grow the buffer if needed */
     if(len > global->term.len) {
-      wchar_t *buf = (wchar_t *)curlx_realloc(global->term.buf,
-                                              len * sizeof(wchar_t));
+      wchar_t *buf = curlx_realloc(global->term.buf, len * sizeof(wchar_t));
       if(!buf)
         return CURL_WRITEFUNC_ERROR;
       global->term.len = len;

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -33,7 +33,7 @@
 static struct tool_mime *tool_mime_new(struct tool_mime *parent,
                                        toolmimekind kind)
 {
-  struct tool_mime *m = (struct tool_mime *)curlx_calloc(1, sizeof(*m));
+  struct tool_mime *m = curlx_calloc(1, sizeof(*m));
 
   if(m) {
     m->kind = kind;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1711,13 +1711,11 @@ static struct contextuv *create_context(curl_socket_t sockfd,
 {
   struct contextuv *c = curlx_malloc(sizeof(*c));
 
-  if(c) {
-    c->sockfd = sockfd;
-    c->uv = uv;
+  c->sockfd = sockfd;
+  c->uv = uv;
 
-    uv_poll_init_socket(uv->loop, &c->poll_handle, sockfd);
-    c->poll_handle.data = c;
-  }
+  uv_poll_init_socket(uv->loop, &c->poll_handle, sockfd);
+  c->poll_handle.data = c;
 
   return c;
 }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1709,15 +1709,15 @@ static int cb_timeout(CURLM *multi, long timeout_ms, void *userp)
 static struct contextuv *create_context(curl_socket_t sockfd,
                                         struct datauv *uv)
 {
-  struct contextuv *c;
+  struct contextuv *c = curlx_malloc(sizeof(*c));
 
-  c = (struct contextuv *)curlx_malloc(sizeof(*c));
+  if(c) {
+    c->sockfd = sockfd;
+    c->uv = uv;
 
-  c->sockfd = sockfd;
-  c->uv = uv;
-
-  uv_poll_init_socket(uv->loop, &c->poll_handle, sockfd);
-  c->poll_handle.data = c;
+    uv_poll_init_socket(uv->loop, &c->poll_handle, sockfd);
+    c->poll_handle.data = c;
+  }
 
   return c;
 }

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -102,7 +102,7 @@ static CURLcode test_lib2302(const char *URL)
   global_init(CURL_GLOBAL_ALL);
 
   memset(&ws_data, 0, sizeof(ws_data));
-  ws_data.buf = (char *)curlx_calloc(LIB2302_BUFSIZE, 1);
+  ws_data.buf = curlx_calloc(LIB2302_BUFSIZE, 1);
   if(ws_data.buf) {
     curl = curl_easy_init();
     if(curl) {


### PR DESCRIPTION
---

Initial version of this patch tried to add missing NULL checks
to three allocations touched (in example and UV debug code).
I backtracked, because later the NULL pointers were derefed
anyway.
