### PR TITLE
libssh2: use non-deprecated `libssh2_knownhost_addc()`

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -427,12 +427,13 @@ static CURLcode ssh_knownhost(struct Curl_easy *data,
       if(keycheck != LIBSSH2_KNOWNHOST_CHECK_MATCH) {
         /* the found host+key did not match but has been told to be fine
            anyway so we add it in memory */
-        int addrc = libssh2_knownhost_add(sshc->kh,
-                                          conn->origin->hostname, NULL,
-                                          remotekey, keylen,
-                                          LIBSSH2_KNOWNHOST_TYPE_PLAIN|
-                                          LIBSSH2_KNOWNHOST_KEYENC_RAW|
-                                          keybit, NULL);
+        int addrc = libssh2_knownhost_addc(sshc->kh,
+                                           conn->origin->hostname, NULL,
+                                           remotekey, keylen,
+                                           NULL, 0,
+                                           LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+                                           LIBSSH2_KNOWNHOST_KEYENC_RAW |
+                                           keybit, NULL);
         if(addrc)
           infof(data, "WARNING: adding the known host %s failed",
                 conn->origin->hostname);


### PR DESCRIPTION
Supported since libssh2 v1.2.5. Replacing `libssh2_knownhost_add()`,
which was deprecated in that same version.

The new API supports a comment field.

Ref: https://github.com/libssh2/libssh2/pull/1977

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
