### PR TITLE
quic: count zero length packets against max

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -508,8 +508,10 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
     VERBOSE(++calls);
     for(i = 0; i < mcount; ++i) {
       /* A zero-length UDP packet is no QUIC packet. Ignore. */
-      if(!mmsg[i].msg_len)
+      if(!mmsg[i].msg_len) {
+        ++pkts;
         continue;
+      }
       total_nread += mmsg[i].msg_len;
 
       gso_size = vquic_msghdr_get_udp_gro(&mmsg[i].msg_hdr);
@@ -593,8 +595,10 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
     ++calls;
 
     /* A 0-length UDP packet is no QUIC packet */
-    if(!nread)
+    if(!nread) {
+      ++pkts;
       continue;
+    }
 
     gso_size = vquic_msghdr_get_udp_gro(&msg);
     if(gso_size == 0)


### PR DESCRIPTION
With a flood of zero lenght UDP packets to curl, the receive loop might run longer than intended to. Count such packets against the max to terminate the loop as intended.
