### PR TITLE
libssh2: save non-standard port to `known_hosts`

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -441,9 +441,8 @@ static CURLcode ssh_knownhost(struct Curl_easy *data,
           hostbuf = conn->origin->hostname;
         /* the found host+key did not match but has been told to be fine
            anyway so we add it in memory */
-        addrc = libssh2_knownhost_addc(sshc->kh,
-                                       hostbuf, NULL, remotekey, keylen,
-                                       NULL, 0,
+        addrc = libssh2_knownhost_addc(sshc->kh, hostbuf, NULL,
+                                       remotekey, keylen, NULL, 0,
                                        LIBSSH2_KNOWNHOST_TYPE_PLAIN |
                                        LIBSSH2_KNOWNHOST_KEYENC_RAW |
                                        keybit, NULL);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -436,7 +436,7 @@ static CURLcode ssh_knownhost(struct Curl_easy *data,
           hostbuf = hostport = curl_maprintf("[%s]:%u", conn->origin->hostname,
                                              conn->origin->port);
           if(!hostbuf)
-            infof(data, "WARNING: failed allocating [host]:port string buffer");
+            infof(data, "WARNING: failed allocating buffer for [host]:port");
         }
         else
           hostbuf = conn->origin->hostname;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -429,15 +429,24 @@ static CURLcode ssh_knownhost(struct Curl_easy *data,
     case CURLKHSTAT_FINE_ADD_TO_FILE:
       /* proceed */
       if(keycheck != LIBSSH2_KNOWNHOST_CHECK_MATCH) {
+        int addrc;
+        const char *hostbuf;
+        char hostport[270]; /* match length used within libssh2 */
+        if(conn->origin->port != PORT_SSH) {
+          curl_msnprintf(hostport, sizeof(hostport), "[%s]:%u",
+                         conn->origin->hostname, conn->origin->port);
+          hostbuf = hostport;
+        }
+        else
+          hostbuf = conn->origin->hostname;
         /* the found host+key did not match but has been told to be fine
            anyway so we add it in memory */
-        int addrc = libssh2_knownhost_addc(sshc->kh,
-                                           conn->origin->hostname, NULL,
-                                           remotekey, keylen,
-                                           NULL, 0,
-                                           LIBSSH2_KNOWNHOST_TYPE_PLAIN |
-                                           LIBSSH2_KNOWNHOST_KEYENC_RAW |
-                                           keybit, NULL);
+        addrc = libssh2_knownhost_addc(sshc->kh,
+                                       hostbuf, NULL, remotekey, keylen,
+                                       NULL, 0,
+                                       LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+                                       LIBSSH2_KNOWNHOST_KEYENC_RAW |
+                                       keybit, NULL);
         if(addrc)
           infof(data, "WARNING: adding the known host %s failed",
                 conn->origin->hostname);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -449,8 +449,7 @@ static CURLcode ssh_knownhost(struct Curl_easy *data,
                                          LIBSSH2_KNOWNHOST_KEYENC_RAW |
                                          keybit, NULL);
           if(addrc)
-            infof(data, "WARNING: adding the known host %s failed",
-                  conn->origin->hostname);
+            infof(data, "WARNING: adding the known host %s failed", hostbuf);
           else if(rc == CURLKHSTAT_FINE_ADD_TO_FILE ||
                   rc == CURLKHSTAT_FINE_REPLACE) {
             /* now we write the entire in-memory list of known hosts to the

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -431,37 +431,41 @@ static CURLcode ssh_knownhost(struct Curl_easy *data,
       if(keycheck != LIBSSH2_KNOWNHOST_CHECK_MATCH) {
         int addrc;
         const char *hostbuf;
-        char hostport[270]; /* match length used within libssh2 */
+        char *hostport = NULL;
         if(conn->origin->port != PORT_SSH) {
-          curl_msnprintf(hostport, sizeof(hostport), "[%s]:%u",
-                         conn->origin->hostname, conn->origin->port);
-          hostbuf = hostport;
+          hostbuf = hostport = curl_maprintf("[%s]:%u", conn->origin->hostname,
+                                             conn->origin->port);
+          if(!hostbuf)
+            infof(data, "WARNING: failed allocating [host]:port string buffer");
         }
         else
           hostbuf = conn->origin->hostname;
-        /* the found host+key did not match but has been told to be fine
-           anyway so we add it in memory */
-        addrc = libssh2_knownhost_addc(sshc->kh, hostbuf, NULL,
-                                       remotekey, keylen, NULL, 0,
-                                       LIBSSH2_KNOWNHOST_TYPE_PLAIN |
-                                       LIBSSH2_KNOWNHOST_KEYENC_RAW |
-                                       keybit, NULL);
-        if(addrc)
-          infof(data, "WARNING: adding the known host %s failed",
-                conn->origin->hostname);
-        else if(rc == CURLKHSTAT_FINE_ADD_TO_FILE ||
-                rc == CURLKHSTAT_FINE_REPLACE) {
-          /* now we write the entire in-memory list of known hosts to the
-             known_hosts file */
-          int wrc =
-            libssh2_knownhost_writefile(sshc->kh,
-                                        data->set.str[STRING_SSH_KNOWNHOSTS],
-                                        LIBSSH2_KNOWNHOST_FILE_OPENSSH);
-          if(wrc) {
-            infof(data, "WARNING: writing %s failed",
-                  data->set.str[STRING_SSH_KNOWNHOSTS]);
+        if(hostbuf) {
+          /* the found host+key did not match but has been told to be fine
+             anyway so we add it in memory */
+          addrc = libssh2_knownhost_addc(sshc->kh, hostbuf, NULL,
+                                         remotekey, keylen, NULL, 0,
+                                         LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+                                         LIBSSH2_KNOWNHOST_KEYENC_RAW |
+                                         keybit, NULL);
+          if(addrc)
+            infof(data, "WARNING: adding the known host %s failed",
+                  conn->origin->hostname);
+          else if(rc == CURLKHSTAT_FINE_ADD_TO_FILE ||
+                  rc == CURLKHSTAT_FINE_REPLACE) {
+            /* now we write the entire in-memory list of known hosts to the
+               known_hosts file */
+            int wrc =
+              libssh2_knownhost_writefile(sshc->kh,
+                                          data->set.str[STRING_SSH_KNOWNHOSTS],
+                                          LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+            if(wrc) {
+              infof(data, "WARNING: writing %s failed",
+                    data->set.str[STRING_SSH_KNOWNHOSTS]);
+            }
           }
         }
+        curlx_free(hostport);
       }
       break;
     }


### PR DESCRIPTION
Reported-by: dyingc on github
Fixes #21863

---

https://github.com/curl/curl/pull/21874/files?w=1

- [x] add hostname length check? → allow any length instead

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
