### PR TITLE
asyn-thrdd: add IPv6 guards

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -481,12 +481,13 @@ static void async_thrdd_report_item(struct Curl_easy *data,
   struct dynbuf tmp;
   const char *sep = "";
   const struct Curl_addrinfo *ai = item->res;
-#ifdef USE_IPV6
-  int ai_family = (item->dns_queries & CURL_DNSQ_AAAA) ? AF_INET6 : AF_INET;
-#else
-  int ai_family = AF_INET;
-#endif
   CURLcode result;
+  int ai_family;
+#ifdef USE_IPV6
+  ai_family = (item->dns_queries & CURL_DNSQ_AAAA) ? AF_INET6 : AF_INET;
+#else
+  ai_family = AF_INET;
+#endif
 
   if(!CURL_TRC_DNS_is_verbose(data))
     return;

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -481,7 +481,11 @@ static void async_thrdd_report_item(struct Curl_easy *data,
   struct dynbuf tmp;
   const char *sep = "";
   const struct Curl_addrinfo *ai = item->res;
+#ifdef USE_IPV6
   int ai_family = (item->dns_queries & CURL_DNSQ_AAAA) ? AF_INET6 : AF_INET;
+#else
+  int ai_family = AF_INET;
+#endif
   CURLcode result;
 
   if(!CURL_TRC_DNS_is_verbose(data))
@@ -792,10 +796,12 @@ const struct Curl_addrinfo *Curl_async_get_ai(struct Curl_easy *data,
     if(thrdd->res_A)
       return async_thrdd_get_ai(thrdd->res_A->res, ai_family, index);
     break;
+#ifdef USE_IPV6
   case AF_INET6:
     if(thrdd->res_AAAA)
       return async_thrdd_get_ai(thrdd->res_AAAA->res, ai_family, index);
     break;
+#endif
   default:
     break;
   }


### PR DESCRIPTION
it seems that the usual '#ifdef USE_IPV6' guards have been overlooked in lib/asyn-thrdd.c

this commit makes sure that the code compiles if IPv6 is not available
