### PR TITLE
http: reject spurious CR bytes in headers

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3818,11 +3818,13 @@ static CURLcode verify_header(struct Curl_easy *data,
     failf(data, "Nul byte in header");
     return CURLE_WEIRD_SERVER_REPLY;
   }
-  ptr = memchr(hd, '\r', hdlen - 2);
-  if(ptr) {
-    /* CR may only precede the LF, nothing else */
-    failf(data, "CR in header");
-    return CURLE_WEIRD_SERVER_REPLY;
+  if(hdlen > 2) {
+    ptr = memchr(hd, '\r', hdlen - 2);
+    if(ptr) {
+      /* CR may only precede the LF, nothing else */
+      failf(data, "CR in header");
+      return CURLE_WEIRD_SERVER_REPLY;
+    }
   }
   if(k->headerline < 2)
     /* the first "header" is the status-line and it has no colon */

--- a/lib/http.c
+++ b/lib/http.c
@@ -3820,7 +3820,7 @@ static CURLcode verify_header(struct Curl_easy *data,
   }
   ptr = memchr(hd, '\r', hdlen - 1);
   if(ptr) {
-    /* CR may only preceed the LF, nothing else */
+    /* CR may only precede the LF, nothing else */
     failf(data, "CR in header");
     return CURLE_WEIRD_SERVER_REPLY;
   }

--- a/lib/http.c
+++ b/lib/http.c
@@ -3818,6 +3818,12 @@ static CURLcode verify_header(struct Curl_easy *data,
     failf(data, "Nul byte in header");
     return CURLE_WEIRD_SERVER_REPLY;
   }
+  ptr = memchr(hd, '\r', hdlen - 1);
+  if(ptr) {
+    /* CR may only preceed the LF, nothing else */
+    failf(data, "CR in header");
+    return CURLE_WEIRD_SERVER_REPLY;
+  }
   if(k->headerline < 2)
     /* the first "header" is the status-line and it has no colon */
     return CURLE_OK;

--- a/lib/http.c
+++ b/lib/http.c
@@ -3818,7 +3818,7 @@ static CURLcode verify_header(struct Curl_easy *data,
     failf(data, "Nul byte in header");
     return CURLE_WEIRD_SERVER_REPLY;
   }
-  ptr = memchr(hd, '\r', hdlen - 1);
+  ptr = memchr(hd, '\r', hdlen - 2);
   if(ptr) {
     /* CR may only precede the LF, nothing else */
     failf(data, "CR in header");

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -253,7 +253,7 @@ test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 \
-test2100 test2101 test2102 test2103 test2104 \
+test2100 test2101 test2102 test2103 test2104 test2105 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 \

--- a/tests/data/test2105
+++ b/tests/data/test2105
@@ -26,7 +26,7 @@ Funny-head: yesyes
 http
 </server>
 <name>
-HTTP with spurious CR in receieved header
+HTTP with spurious CR in received header
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER

--- a/tests/data/test2105
+++ b/tests/data/test2105
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/%CRfake
+Content-Length: 6
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with spurious CR in receieved header
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Verified by test 2105
