### PR TITLE
CURLOPT_PORT.md: use stronger language

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PORT.md
+++ b/docs/libcurl/opts/CURLOPT_PORT.md
@@ -27,8 +27,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PORT, long number);
 
 # DESCRIPTION
 
-We discourage using this option since its scope is not obvious and hard to
-predict. Set the preferred port number in the URL instead.
+We strongly discourage using this unreliable option since its scope is not
+obvious and hard to predict. Consider it deprecated. Set the preferred port
+number in the URL instead.
 
 This option sets *number* to be the remote port number to connect to,
 instead of the one specified in the URL or the default port for the used

--- a/docs/libcurl/opts/CURLOPT_PORT.md
+++ b/docs/libcurl/opts/CURLOPT_PORT.md
@@ -28,8 +28,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PORT, long number);
 # DESCRIPTION
 
 We strongly discourage using this unreliable option since its scope is not
-obvious and hard to predict. Consider it deprecated. Set the preferred port
-number in the URL instead.
+obvious and hard to predict. Set the preferred port number in the URL instead.
 
 This option sets *number* to be the remote port number to connect to,
 instead of the one specified in the URL or the default port for the used


### PR DESCRIPTION
This option should not be used.
