### PR TITLE
tool: warn when --ssl and --ftp-ssl-control override each other

### DIFF
--- a/docs/cmdline-opts/ftp-ssl-control.md
+++ b/docs/cmdline-opts/ftp-ssl-control.md
@@ -18,3 +18,5 @@ Example:
 Require SSL/TLS for the FTP login, clear for transfer. Allows secure
 authentication, but non-encrypted data transfers for efficiency. Fails the
 transfer if the server does not support SSL/TLS.
+
+If set, this option overrides --ssl.

--- a/docs/cmdline-opts/ssl.md
+++ b/docs/cmdline-opts/ssl.md
@@ -30,5 +30,7 @@ OpenLDAP backend and ignored by the generic ldap backend.
 
 Please note that a server may close the connection if the negotiation fails.
 
+If set, this option overrides --ftp-ssl-control.
+
 This option was formerly known as --ftp-ssl (added in 7.11.0). That option
 name can still be used but might be removed in a future version.

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1908,6 +1908,10 @@ static ParameterError opt_bool(struct OperationConfig *config,
     if(config->ftp_ssl)
       warnf("--%s is an insecure option, consider --ssl-reqd instead",
             a->lname);
+    if(toggle && config->ftp_ssl_control) {
+      config->ftp_ssl_control = FALSE;
+      warnf("--%s overrides --ftp-ssl-control", a->lname);
+    }
     break;
   case C_FTP_SSL_CCC: /* --ftp-ssl-ccc */
     config->ftp_ssl_ccc = toggle;
@@ -1959,6 +1963,10 @@ static ParameterError opt_bool(struct OperationConfig *config,
     break;
   case C_FTP_SSL_CONTROL: /* --ftp-ssl-control */
     config->ftp_ssl_control = toggle;
+    if(toggle && config->ftp_ssl) {
+      config->ftp_ssl = FALSE;
+      warnf("--%s overrides --ssl", a->lname);
+    }
     break;
   case C_RAW: /* --raw */
     config->raw = toggle;


### PR DESCRIPTION
and mention this properly in the docs.
