### PR TITLE
lib: Implement CURLOPT_LOCALPORTRANGE with kernel support if available.

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -783,6 +783,23 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
   (void)setsockopt(sockfd, SOL_IP, IP_BIND_ADDRESS_NO_PORT, &on, sizeof(on));
 #endif
   for(;;) {
+#ifdef IP_LOCAL_PORT_RANGE
+    if(portnum >= 1 && port != 0) {
+      uint32_t lo = (uint32_t)port;
+      uint32_t hi = (uint32_t)(port + portnum - 1);
+      uint32_t range = (hi << 16) | lo;
+      if(setsockopt(sockfd, IPPROTO_IP, IP_LOCAL_PORT_RANGE, &range, sizeof(range)) != -1) {
+        /* We can let the kernel choose.
+         * This is an advice, the kernel will ignore it if the port range
+         * does not overlap ip_local_port_range.
+         * Port is not bound right now, but pretend it is.
+         * It will be choosen at connect() time using a much smarter
+         * algorithm. */
+        conn->bits.bound = TRUE;
+        return CURLE_OK;
+      }
+    }
+#endif
     if(bind(sockfd, sock, sizeof_sa) >= 0) {
       /* we succeeded to bind */
       infof(data, "Local port: %hu", port);


### PR DESCRIPTION
The Linux kernel version 6.3 or later allows implementing CURLOPT_LOCALPORTRANGE as smart and safely as it is possible.

Behaviour is different but compatible.

if a single port is given and the kernel can honour that request you save one bind() syscall and the given port is choosen at connect time. if port is not available, connect fails with EADDRNOTAVAIL.

If a port range is given the kernel selects a port within it at connect time when it has all the relevant information to make the best decision if not possible connect fails with EADDRNOTAVAIL.

If the port range supplied does not overlap the current namespace local port range, the kernel ignores it and chooses a free port anyways.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
