### PR TITLE
build: enable `-Wlogical-op` picky warning for GCC 4.4+

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -300,6 +300,7 @@ if(PICKY_COMPILER)
         list(APPEND _picky_enable
           -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.1
           -Wformat=2                       # clang  2.7  gcc  4.8
+          -Wlogical-op                     #             gcc  4.4
           -Wtrampolines                    #             gcc  4.6
         )
       endif()

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1115,6 +1115,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             tmp_CFLAGS="$tmp_CFLAGS -ftree-vrp"
           fi
 
+          dnl Only gcc 4.4 or later
+          if test "$compiler_num" -ge "404"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [logical-op])
+          fi
+
           dnl Only gcc 4.5 or later
           if test "$compiler_num" -ge "405"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [jump-misses-init])


### PR DESCRIPTION
Follow-up to 879a1514c3cf41926fd565db9e9ae62ab9733554 #21992

---

- [x] move the EAGAIN/EWOULDBLOCK macro/tidy-up parts to separate PR. → #21992
- [x] rebase on #21992
