### PR TITLE
Revert "url: remove ssh_config_matches"

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -671,6 +671,19 @@ CURLcode Curl_conn_upkeep(struct Curl_easy *data,
   return result;
 }
 
+#ifdef USE_SSH
+static bool ssh_config_matches(struct connectdata *one,
+                               struct connectdata *two)
+{
+  struct ssh_conn *sshc1, *sshc2;
+
+  sshc1 = Curl_conn_meta_get(one, CURL_META_SSH_CONN);
+  sshc2 = Curl_conn_meta_get(two, CURL_META_SSH_CONN);
+  return sshc1 && sshc2 && Curl_safecmp(sshc1->rsa, sshc2->rsa) &&
+         Curl_safecmp(sshc1->rsa_pub, sshc2->rsa_pub);
+}
+#endif
+
 struct url_conn_match {
   struct connectdata *found;
   struct Curl_easy *data;
@@ -927,6 +940,12 @@ static bool url_match_proto_config(struct connectdata *conn,
   if(!url_match_http_version(conn, m))
     return FALSE;
 
+#ifdef USE_SSH
+  if(get_protocol_family(m->needle->scheme) & PROTO_FAMILY_SSH) {
+    if(!ssh_config_matches(m->needle, conn))
+      return FALSE;
+  }
+#endif
 #ifndef CURL_DISABLE_FTP
   else if(get_protocol_family(m->needle->scheme) & PROTO_FAMILY_FTP) {
     if(!ftp_conns_match(m->needle, conn))


### PR DESCRIPTION
This reverts commit 3e9817cd1bb6aa53d3d3bf10572bb245d064870c.

The change was incorrect as the check was not for the options the commit message mentions.

Reported-by: ByteRay on hackerone

