### PR TITLE
var: use a dedicated pointer for the alloc

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -78,7 +78,7 @@ static ParameterError varfunc(char *c, /* content */
                               size_t flen, /* function string length */
                               struct dynbuf *out)
 {
-  bool alloc = FALSE;
+  char *allocptr = NULL;
   ParameterError err = PARAM_OK;
   const char *finput = f;
 
@@ -185,19 +185,18 @@ static ParameterError varfunc(char *c, /* content */
       err = PARAM_EXPAND_ERROR;
       break;
     }
-    if(alloc)
-      curlx_free(c);
+    if(allocptr)
+      curlx_free(allocptr);
 
     clen = curlx_dyn_len(out);
-    c = curlx_memdup0(curlx_dyn_ptr(out), clen);
+    allocptr = c = curlx_memdup0(curlx_dyn_ptr(out), clen);
     if(!c) {
       err = PARAM_NO_MEM;
       break;
     }
-    alloc = TRUE;
   }
-  if(alloc)
-    curlx_free(c);
+  if(allocptr)
+    curlx_free(allocptr);
   if(err)
     curlx_dyn_free(out);
   return err;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -258,7 +258,7 @@ test2100 test2101 test2102 test2103 test2104 test2105 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 \
 test2300 test2301 test2302 test2303 test2304 test2306 test2307 test2308 \
-test2309 \
+test2309 test2310 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 test2407 \
 test2408 test2409 test2410 test2411 \

--- a/tests/data/test2310
+++ b/tests/data/test2310
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+variables
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: something-close, close-something, close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+variable decode and trim
+</name>
+<command>
+--variable 'VAR=IA==' --expand-url 'http://%HOSTIP:%HTTPPORT/{{VAR:64dec:trim}}'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/data/test2310
+++ b/tests/data/test2310
@@ -39,5 +39,12 @@ variable decode and trim
 
 # Verify data after the test has been "shot"
 <verify>
+<protocol crlf="headers">
+GET / HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
 </verify>
 </testcase>


### PR DESCRIPTION
As the 'c' pointer might actually get modified before it is time to free the memory.

Verify in test 2310

Reported-by: Eunsoo Kim
Fixes #21898