### PR TITLE
setopt: clear the "custom" CA booleans when set to NULL

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1782,8 +1782,9 @@ static CURLcode setopt_cptr_proxy(struct Curl_easy *data, CURLoption option,
      * Set CA info SSL connection for proxy. Specify filename of the
      * CA certificate
      */
-    s->proxy_ssl.custom_cafile = !!ptr;
-    return Curl_setstropt(&s->str[STRING_SSL_CAFILE_PROXY], ptr);
+    result = Curl_setstropt(&s->str[STRING_SSL_CAFILE_PROXY], ptr);
+    s->proxy_ssl.custom_cafile = !!s->str[STRING_SSL_CAFILE_PROXY];
+    return result;
   case CURLOPT_PROXY_CRLFILE:
     /*
      * Set CRL file info for SSL connection for proxy. Specify filename of the
@@ -1807,8 +1808,9 @@ static CURLcode setopt_cptr_proxy(struct Curl_easy *data, CURLoption option,
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CA_PATH)) {
       /* This does not work on Windows. */
-      s->proxy_ssl.custom_capath = !!ptr;
-      return Curl_setstropt(&s->str[STRING_SSL_CAPATH_PROXY], ptr);
+      result = Curl_setstropt(&s->str[STRING_SSL_CAPATH_PROXY], ptr);
+      s->proxy_ssl.custom_capath = !!s->str[STRING_SSL_CAPATH_PROXY];
+      return result;
     }
 #endif
     return CURLE_NOT_BUILT_IN;
@@ -1915,8 +1917,9 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Set CA info for SSL connection. Specify filename of the CA certificate
      */
-    s->ssl.custom_cafile = !!ptr;
-    return Curl_setstropt(&s->str[STRING_SSL_CAFILE], ptr);
+    result = Curl_setstropt(&s->str[STRING_SSL_CAFILE], ptr);
+    s->ssl.custom_cafile = !!s->str[STRING_SSL_CAFILE];
+    return result;
   case CURLOPT_CAPATH:
     /*
      * Set CA path info for SSL connection. Specify directory name of the CA
@@ -1925,8 +1928,9 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CA_PATH)) {
       /* This does not work on Windows. */
-      s->ssl.custom_capath = !!ptr;
-      return Curl_setstropt(&s->str[STRING_SSL_CAPATH], ptr);
+      result = Curl_setstropt(&s->str[STRING_SSL_CAPATH], ptr);
+      s->ssl.custom_capath = !!s->str[STRING_SSL_CAPATH];
+      return result;
     }
 #endif
     return CURLE_NOT_BUILT_IN;
@@ -2845,8 +2849,9 @@ static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB)) {
-      s->proxy_ssl.custom_cablob = !!blob;
-      return Curl_setblobopt(&s->blobs[BLOB_CAINFO_PROXY], blob);
+      CURLcode result = Curl_setblobopt(&s->blobs[BLOB_CAINFO_PROXY], blob);
+      s->proxy_ssl.custom_cablob = !!s->blobs[BLOB_CAINFO_PROXY];
+      return result;
     }
 #endif
     return CURLE_NOT_BUILT_IN;
@@ -2870,8 +2875,9 @@ static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB)) {
-      s->ssl.custom_cablob = !!blob;
-      return Curl_setblobopt(&s->blobs[BLOB_CAINFO], blob);
+      CURLcode result = Curl_setblobopt(&s->blobs[BLOB_CAINFO], blob);
+      s->ssl.custom_cablob = !!s->blobs[BLOB_CAINFO];
+      return result;
     }
 #endif
     return CURLE_NOT_BUILT_IN;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1782,7 +1782,7 @@ static CURLcode setopt_cptr_proxy(struct Curl_easy *data, CURLoption option,
      * Set CA info SSL connection for proxy. Specify filename of the
      * CA certificate
      */
-    s->proxy_ssl.custom_cafile = TRUE;
+    s->proxy_ssl.custom_cafile = !!ptr;
     return Curl_setstropt(&s->str[STRING_SSL_CAFILE_PROXY], ptr);
   case CURLOPT_PROXY_CRLFILE:
     /*
@@ -1807,7 +1807,7 @@ static CURLcode setopt_cptr_proxy(struct Curl_easy *data, CURLoption option,
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CA_PATH)) {
       /* This does not work on Windows. */
-      s->proxy_ssl.custom_capath = TRUE;
+      s->proxy_ssl.custom_capath = !!ptr;
       return Curl_setstropt(&s->str[STRING_SSL_CAPATH_PROXY], ptr);
     }
 #endif
@@ -1915,7 +1915,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Set CA info for SSL connection. Specify filename of the CA certificate
      */
-    s->ssl.custom_cafile = TRUE;
+    s->ssl.custom_cafile = !!ptr;
     return Curl_setstropt(&s->str[STRING_SSL_CAFILE], ptr);
   case CURLOPT_CAPATH:
     /*
@@ -1925,7 +1925,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CA_PATH)) {
       /* This does not work on Windows. */
-      s->ssl.custom_capath = TRUE;
+      s->ssl.custom_capath = !!ptr;
       return Curl_setstropt(&s->str[STRING_SSL_CAPATH], ptr);
     }
 #endif
@@ -2845,7 +2845,7 @@ static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB)) {
-      s->proxy_ssl.custom_cablob = TRUE;
+      s->proxy_ssl.custom_cablob = !!blob;
       return Curl_setblobopt(&s->blobs[BLOB_CAINFO_PROXY], blob);
     }
 #endif
@@ -2870,7 +2870,7 @@ static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB)) {
-      s->ssl.custom_cablob = TRUE;
+      s->ssl.custom_cablob = !!blob;
       return Curl_setblobopt(&s->blobs[BLOB_CAINFO], blob);
     }
 #endif


### PR DESCRIPTION
Mark them as custom choices only when pointer is passed, and clear them again when set to NULL.
