### PR TITLE
ssl native_ca_store: always reinit

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -418,7 +418,8 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
   }
 
   (void)curl_easy_setopt(doh, CURLOPT_SSL_OPTIONS,
-                         (long)data->set.ssl.primary.ssl_options);
+                         ((long)data->set.ssl.primary.ssl_options &
+                           ~CURLSSLOPT_AUTO_CLIENT_CERT));
 
   doh->state.internal = TRUE;
   doh->master_mid = data->mid; /* master transfer of this one */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -409,7 +409,7 @@ static void set_ssl_options(struct ssl_config_data *ssl,
   ssl->no_revoke = !!(arg & CURLSSLOPT_NO_REVOKE);
   ssl->no_partialchain = !!(arg & CURLSSLOPT_NO_PARTIALCHAIN);
   ssl->revoke_best_effort = !!(arg & CURLSSLOPT_REVOKE_BEST_EFFORT);
-  ssl->native_ca_store = !!(arg & CURLSSLOPT_NATIVE_CA);
+  ssl->native_ca_store_opt = !!(arg & CURLSSLOPT_NATIVE_CA);
   ssl->auto_client_cert = !!(arg & CURLSSLOPT_AUTO_CLIENT_CERT);
   ssl->earlydata = !!(arg & CURLSSLOPT_EARLYDATA);
 }

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -399,22 +399,6 @@ static CURLcode setopt_RTSP_REQUEST(struct Curl_easy *data, long arg)
 }
 #endif /* !CURL_DISABLE_RTSP */
 
-#ifdef USE_SSL
-static void set_ssl_options(struct ssl_config_data *ssl,
-                            struct ssl_primary_config *config,
-                            long arg)
-{
-  config->ssl_options = (unsigned char)(arg & 0xff);
-  ssl->enable_beast = !!(arg & CURLSSLOPT_ALLOW_BEAST);
-  ssl->no_revoke = !!(arg & CURLSSLOPT_NO_REVOKE);
-  ssl->no_partialchain = !!(arg & CURLSSLOPT_NO_PARTIALCHAIN);
-  ssl->revoke_best_effort = !!(arg & CURLSSLOPT_REVOKE_BEST_EFFORT);
-  ssl->native_ca_store_opt = !!(arg & CURLSSLOPT_NATIVE_CA);
-  ssl->auto_client_cert = !!(arg & CURLSSLOPT_AUTO_CLIENT_CERT);
-  ssl->earlydata = !!(arg & CURLSSLOPT_EARLYDATA);
-}
-#endif
-
 static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
                                  long arg)
 {
@@ -994,11 +978,11 @@ static CURLcode setopt_long_ssl(struct Curl_easy *data, CURLoption option,
       s->use_ssl = (unsigned char)arg;
     break;
   case CURLOPT_SSL_OPTIONS:
-    set_ssl_options(&s->ssl, &s->ssl.primary, arg);
+    s->ssl.primary.ssl_options = (unsigned char)(arg & 0xff);
     break;
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSL_OPTIONS:
-    set_ssl_options(&s->proxy_ssl, &s->proxy_ssl.primary, arg);
+    s->proxy_ssl.primary.ssl_options = (unsigned char)(arg & 0xff);
     break;
 #endif
   case CURLOPT_SSL_ENABLE_NPN:

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -249,9 +249,8 @@ static void ssl_easy_config_compl_options(struct Curl_peer *origin,
   sslc->revoke_best_effort = !!(options & CURLSSLOPT_REVOKE_BEST_EFFORT);
   sslc->earlydata = !!(options & CURLSSLOPT_EARLYDATA);
 
-  if(Curl_peer_equal(origin, initial_origin)) {
-    sslc->auto_client_cert = !!(options & CURLSSLOPT_AUTO_CLIENT_CERT);
-  }
+  sslc->auto_client_cert = Curl_peer_equal(origin, initial_origin) &&
+                           !!(options & CURLSSLOPT_AUTO_CLIENT_CERT);
 }
 
 CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -234,6 +234,26 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
   return TRUE;
 }
 
+static void ssl_easy_config_compl_options(struct Curl_peer *origin,
+                                          struct Curl_peer *initial_origin,
+                                          struct ssl_config_data *sslc)
+{
+  uint8_t options = sslc->primary.ssl_options;
+  /* If set via CURLOPT_(PROXY_)SSL_OPTIONS, we definitely use it.
+   * If not, we switch it on for supported backends if no custom
+   * ca settings exist. */
+  sslc->native_ca_store = !!(options & CURLSSLOPT_NATIVE_CA);
+  sslc->enable_beast = !!(options & CURLSSLOPT_ALLOW_BEAST);
+  sslc->no_partialchain = !!(options & CURLSSLOPT_NO_PARTIALCHAIN);
+  sslc->no_revoke = !!(options & CURLSSLOPT_NO_REVOKE);
+  sslc->revoke_best_effort = !!(options & CURLSSLOPT_REVOKE_BEST_EFFORT);
+  sslc->earlydata = !!(options & CURLSSLOPT_EARLYDATA);
+
+  if(Curl_peer_equal(origin, initial_origin)) {
+    sslc->auto_client_cert = !!(options & CURLSSLOPT_AUTO_CLIENT_CERT);
+  }
+}
+
 CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
                                        struct Curl_peer *origin)
 {
@@ -243,10 +263,7 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
   CURLcode result;
 #endif
 
-  /* If set via CURLOPT_(PROXY_)SSL_OPTIONS, we definitely use it.
-   * If not, we switch it on for supported backends if no custom
-   * ca settings exist. */
-  sslc->native_ca_store = sslc->native_ca_store_opt;
+  ssl_easy_config_compl_options(origin, data->state.initial_origin, sslc);
 
   if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
 #if defined(USE_APPLE_SECTRUST) || defined(CURL_CA_NATIVE)
@@ -313,6 +330,9 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_PROXY
   sslc = &data->set.proxy_ssl;
+  /* no initial origin for proxy, it is not changed for redirects */
+  ssl_easy_config_compl_options(NULL, NULL, sslc);
+
   if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
 #if defined(USE_APPLE_SECTRUST) || defined(CURL_CA_NATIVE)
     if(!sslc->custom_capath && !sslc->custom_cafile && !sslc->custom_cablob)

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -243,6 +243,11 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
   CURLcode result;
 #endif
 
+  /* If set via CURLOPT_(PROXY_)SSL_OPTIONS, we definitely use it.
+   * If not, we switch it on for supported backends if no custom
+   * ca settings exist. */
+  sslc->native_ca_store = sslc->native_ca_store_opt;
+
   if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
 #if defined(USE_APPLE_SECTRUST) || defined(CURL_CA_NATIVE)
     if(!sslc->custom_capath && !sslc->custom_cafile && !sslc->custom_cablob)

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -74,8 +74,6 @@ struct ssl_config_data {
   BIT(no_partialchain); /* do not accept partial certificate chains */
   BIT(revoke_best_effort); /* ignore SSL revocation offline/missing revocation
                               list errors */
-  BIT(native_ca_store_opt); /* use the native CA store, set via
-                               CURLOPT_(PROXY_)SSL_OPTIONS */
   BIT(native_ca_store); /* use the native CA store of operating system */
   BIT(auto_client_cert);   /* automatically locate and use a client
                               certificate for authentication (Schannel) */

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -74,6 +74,8 @@ struct ssl_config_data {
   BIT(no_partialchain); /* do not accept partial certificate chains */
   BIT(revoke_best_effort); /* ignore SSL revocation offline/missing revocation
                               list errors */
+  BIT(native_ca_store_opt); /* use the native CA store, set via
+                               CURLOPT_(PROXY_)SSL_OPTIONS */
   BIT(native_ca_store); /* use the native CA store of operating system */
   BIT(auto_client_cert);   /* automatically locate and use a client
                               certificate for authentication (Schannel) */


### PR DESCRIPTION
Move SSL options evaluation from setopt to ssl_config_complete stage. Common function for main and proxy.

Use CURLSSLOPT_AUTO_CLIENT_CERT only for matching origin, do not set CURLSSLOPT_AUTO_CLIENT_CERT for DoH transfers.

This avoids `native_ca_store` getting stuck on TRUE after being set once.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
