### PR TITLE
runtests: allow skipping tests on torture, use for test 357

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -539,6 +539,7 @@ Features testable here are:
 - `SSPI`
 - `threaded-resolver`
 - `TLS-SRP`
+- `torture`
 - `TrackMemory`
 - `typecheck`
 - `threadsafe`

--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -539,7 +539,7 @@ Features testable here are:
 - `SSPI`
 - `threaded-resolver`
 - `TLS-SRP`
-- `torture`
+- `torture` - if runtests is running in memory test mode
 - `TrackMemory`
 - `typecheck`
 - `threadsafe`

--- a/docs/tests/TEST-SUITE.md
+++ b/docs/tests/TEST-SUITE.md
@@ -188,6 +188,9 @@ that memory leaks do not occur even in those situations. It can help to
 compile curl with `CPPFLAGS=-DMEMDEBUG_LOG_SYNC` when using this option, to
 ensure that the memory log file is properly written even if curl crashes.
 
+If a specific test performs slowly in memory test, it is possible to disable
+it individually by adding `!torture` to its `<features>` section.
+
 ### Debug
 
 If a test case fails, you can conveniently get the script to invoke the

--- a/docs/tests/TEST-SUITE.md
+++ b/docs/tests/TEST-SUITE.md
@@ -188,8 +188,8 @@ that memory leaks do not occur even in those situations. It can help to
 compile curl with `CPPFLAGS=-DMEMDEBUG_LOG_SYNC` when using this option, to
 ensure that the memory log file is properly written even if curl crashes.
 
-If a specific test performs slowly in memory test, it is possible to disable
-it individually by adding `!torture` to its `<features>` section.
+If a specific test takes a long time to run in memory test mode, you can
+disable it individually by adding `!torture` to its `<features>` section.
 
 ### Debug
 

--- a/tests/data/test357
+++ b/tests/data/test357
@@ -48,6 +48,9 @@ no-expect
 <server>
 http
 </server>
+<features>
+!torture
+</features>
 <name>
 HTTP PUT with Expect: 100-continue and 417 response
 </name>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -759,6 +759,10 @@ sub checksystemfeatures {
         }
     }
 
+    if($torture) {
+        $feature{"torture"} = 1;
+    }
+
     if(!$curl) {
         logmsg "unable to get curl's version, further details are:\n";
         logmsg "issued command: \n";


### PR DESCRIPTION
Some tests may take a long time in torture mode. Make it possible
to skip individual tests when runtests in running in torture mode.

Also:
- skip test 357 for the reason above.
  Saved 1-3 minutes for the Linux CI torture job, 1-1.5m on Windows.
  No savings on macOS.

Reported-by: Stefan Eissing
Fixes #21873

---

Linux:
After 1: 3m11s https://github.com/curl/curl/actions/runs/27132186593/job/80075629445?pr=21906
After 2: 5m4s https://github.com/curl/curl/actions/runs/27133722273/job/80080806863?pr=21906
Before: 6m11s https://github.com/curl/curl/actions/runs/27122906305/job/80044088080

macOS (no savings):
After 1: 6m36s https://github.com/curl/curl/actions/runs/27132186636/job/80075628667
After 2: 5m59s https://github.com/curl/curl/actions/runs/27133722234/job/80080806436?pr=21906
Before: 6m https://github.com/curl/curl/actions/runs/27122906324/job/80044087567

Windows:
After 1: 5m55s https://github.com/curl/curl/actions/runs/27132186678/job/80078894096
After 2: 6m20s https://github.com/curl/curl/actions/runs/27133722322/job/80080831328?pr=21906
Before: 7m22s https://github.com/curl/curl/actions/runs/27122906306/job/80044111333

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
