### PR TITLE
checksrc-all.pl: do not check files multiple times

### DIFF
--- a/scripts/checksrc-all.pl
+++ b/scripts/checksrc-all.pl
@@ -34,7 +34,7 @@ my $anyfailed = 0;
 for my $dir (@dirs) {
     if($is_git) {
         @files = ();
-        open(O, '-|', 'git', 'ls-files', "$dir/*.[ch]") || die; push @files, <O>; close(O);
+        open(O, '-|', 'git', 'ls-files', ":(glob)$dir/*.[ch]") || die; push @files, <O>; close(O);
         chomp(@files);
     }
     else {


### PR DESCRIPTION
Restrict `git ls-files` to return `*.[ch]` files within `$dir` only.
Before this patch it returned files in subdirectories too, which did
double work and may have made `checksrc.pl` pick `.checksrc` from the
first such subdirectory, masking the one in `$dir`. (current curl tree
is not affected)

Ref: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec

Follow-up to 33f606cd51995b68a0f68ac478f7395d8acda17b #20439

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
