### PR TITLE
cookie: tailmatch the domains for secure override

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -863,8 +863,8 @@ static bool replace_existing(struct Curl_easy *data,
       bool matching_domains = FALSE;
 
       if(clist->domain && co->domain) {
-        if(curl_strequal(clist->domain, co->domain))
-          /* The domains are identical */
+        if(cookie_tailmatch(clist->domain, strlen(clist->domain), co->domain))
+          /* The existing one is a tail of the new */
           matching_domains = TRUE;
       }
       else if(!clist->domain && !co->domain)

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -863,8 +863,10 @@ static bool replace_existing(struct Curl_easy *data,
       bool matching_domains = FALSE;
 
       if(clist->domain && co->domain) {
-        if(cookie_tailmatch(clist->domain, strlen(clist->domain), co->domain))
-          /* The existing one is a tail of the new */
+        if(cookie_tailmatch(clist->domain, strlen(clist->domain),
+                            co->domain) ||
+           cookie_tailmatch(co->domain, strlen(co->domain), clist->domain))
+          /* The existing one is a tail of the new or vice versa */
           matching_domains = TRUE;
       }
       else if(!clist->domain && !co->domain)

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -283,7 +283,7 @@ test3200 test3201 test3202 test3203 test3204 test3205 test3206 test3207 \
 test3208 test3209 test3210 test3211 test3212 test3213 test3214 test3215 \
 test3216 test3217 test3218 test3219 test3220 \
 \
-test3300 test3301 test3302 test3303 test3304 \
+test3300 test3301 test3302 test3303 test3304 test3305 \
 \
 test3400 \
 \

--- a/tests/data/test3305
+++ b/tests/data/test3305
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+cookies
+--resolve
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 301 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Set-Cookie: this=secret; domain=example.com; secure; path=/
+Set-Cookie: second=fine;
+
+-foo-
+</data>
+
+# The cookie 'this' should not be accepted since it would be the same as already
+# set with a 'secure' flag.
+# The cookie 'second' is however not secure so it is fair game to override
+<data2>
+HTTP/1.1 301 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Set-Cookie: this=open; path=/
+Set-Cookie: second=override
+
+-foo-
+</data2>
+
+<data3>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 6
+
+-foo-
+</data3>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+https
+</server>
+<name>
+HTTPS cookie, HTTP same cookie, HTTPS verify cookies
+</name>
+<command>
+https://www.example.com:%HTTPSPORT/ http://www.example.com:%HTTPPORT/%TESTNUMBER0002 https://www.example.com:%HTTPSPORT/%TESTNUMBER0003 --insecure -c %LOGDIR/cookie%TESTNUMBER --resolve www.example.com:%HTTPSPORT:%HOSTIP --resolve www.example.com:%HTTPPORT:%HOSTIP
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET / HTTP/1.1
+Host: www.example.com:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: www.example.com:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Cookie: second=fine
+
+GET /%TESTNUMBER0003 HTTP/1.1
+Host: www.example.com:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Cookie: second=override; this=secret
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test3305
+++ b/tests/data/test3305
@@ -15,6 +15,7 @@ HTTP/1.1 301 OK
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Content-Length: 6
 Set-Cookie: this=secret; domain=example.com; secure; path=/
+Set-Cookie: that=secret; domain=www.example.com; secure; path=/
 Set-Cookie: second=fine;
 
 -foo-
@@ -28,6 +29,7 @@ HTTP/1.1 301 OK
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Content-Length: 6
 Set-Cookie: this=open; path=/
+Set-Cookie: that=open; path=/; domain=example.com
 Set-Cookie: second=override
 
 -foo-
@@ -50,7 +52,7 @@ http
 https
 </server>
 <name>
-HTTPS cookie, HTTP same cookie, HTTPS verify cookies
+same-name cookie over HTTPS and HTTP with different domains
 </name>
 <command>
 https://www.example.com:%HTTPSPORT/ http://www.example.com:%HTTPPORT/%TESTNUMBER0002 https://www.example.com:%HTTPSPORT/%TESTNUMBER0003 --insecure -c %LOGDIR/cookie%TESTNUMBER --resolve www.example.com:%HTTPSPORT:%HOSTIP --resolve www.example.com:%HTTPPORT:%HOSTIP
@@ -75,7 +77,7 @@ GET /%TESTNUMBER0003 HTTP/1.1
 Host: www.example.com:%HTTPSPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Cookie: second=override; this=secret
+Cookie: second=override; that=secret; this=secret
 
 </protocol>
 </verify>


### PR DESCRIPTION
If a SECURE cookie is set for a sub-domain (`example.com`) and is then attempted to get set again for more specific part of that domain (`www.example.com`) without the SECURE property, the second occurance should not be allowed.

Reported-by: Trail of Bits

Verified by test 3305
