### PR TITLE
docs: returned header size reflects HTTP/1-style format

### DIFF
--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -202,7 +202,8 @@ The total amount of bytes that were downloaded. This is the size of the
 body/data that was transferred, excluding headers.
 
 ## `size_header`
-The total amount of bytes of the downloaded headers.
+The total amount of bytes of the downloaded headers, as represented in
+HTTP/1-style header format.
 
 ## `size_request`
 The total amount of bytes that were sent in the HTTP request.

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
@@ -35,8 +35,8 @@ bytes.
 The total includes the size of any received headers suppressed by
 CURLOPT_SUPPRESS_CONNECT_HEADERS(3).
 
-The number of bytes sent over the wire (or to the TLS backend) is different
-when using HTTP/2 or greater.
+The number of bytes transferred over the wire (or to the TLS backend) is
+different when using HTTP/2 or greater.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
@@ -29,7 +29,8 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_HEADER_SIZE, long *sizep);
 # DESCRIPTION
 
 Pass a pointer to a long to receive the total size of all the headers
-received, represented in HTTP/1 format. Measured in number of bytes.
+received, represented in HTTP/1-style header format. Measured in number of
+bytes.
 
 The total includes the size of any received headers suppressed by
 CURLOPT_SUPPRESS_CONNECT_HEADERS(3).

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
@@ -29,10 +29,13 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_HEADER_SIZE, long *sizep);
 # DESCRIPTION
 
 Pass a pointer to a long to receive the total size of all the headers
-received. Measured in number of bytes.
+received, represented in HTTP/1 format. Measured in number of bytes.
 
 The total includes the size of any received headers suppressed by
 CURLOPT_SUPPRESS_CONNECT_HEADERS(3).
+
+The number of bytes sent over the wire (or to the TLS backend) is different
+when using HTTP/2 or greater.
 
 # %PROTOCOLS%
 


### PR DESCRIPTION
Ref: #21889

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
