### PR TITLE
resolve: Mention in error that IP address is expected

### DIFF
--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -775,7 +775,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
 
         result = Curl_str2addr(address, port, &ai);
         if(result) {
-          infof(data, "Resolve address '%s' found illegal", address);
+          infof(data, "Resolve IP address '%s' found is illegal", address);
           goto err;
         }
 


### PR DESCRIPTION
If you try using a DNS name like connect-to supports it can be confusing that it is illegal. Also make it a bit more readable
