### PR TITLE
cf-socket: Store errno from do_connect in ctx->error

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1319,6 +1319,7 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
     CURL_TRC_CF(data, cf, "local address %s port %d...",
                 ctx->ip.local_ip, ctx->ip.local_port);
     if(rc == -1) {
+      ctx->error = error;
       result = socket_connect_result(data, ctx->ip.remote_ip, error);
       goto out;
     }


### PR DESCRIPTION
This fixes a misleading log in verbose mode when ipv6 connectivity isn't available, presumably also in other cases:
```
* Immediate connect fail for 2a00:1450:4028:806::200e: Network is unreachable
* connect to 2a00:1450:4028:806::200e port 443 from :: port 0 failed: Success
```