### PR TITLE
digest: escape control codes too

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -36,6 +36,7 @@
 #include "curl_sha512_256.h"
 #include "curlx/strparse.h"
 #include "rand.h"
+#include "escape.h"
 
 #ifndef USE_WINDOWS_SSPI
 #define SESSION_ALGO 1 /* for algos with this bit set */
@@ -162,6 +163,11 @@ static char *auth_digest_string_quoted(const char *s)
       result = curlx_dyn_addn(&out, "\\", 1);
       if(!result)
         result = curlx_dyn_addn(&out, s, 1);
+    }
+    else if((*s < ' ') || (*s > 0x7e)) {
+      unsigned char buf[3] = { '%' };
+      Curl_hexbyte(&buf[1], *s);
+      result = curlx_dyn_addn(&out, buf, 3);
     }
     else
       result = curlx_dyn_addn(&out, s, 1);

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -166,7 +166,7 @@ static char *auth_digest_string_quoted(const char *s)
     }
     else if((*s < ' ') || (*s > 0x7e)) {
       unsigned char buf[3] = { '%' };
-      Curl_hexbyte(&buf[1], *s);
+      Curl_hexbyte(&buf[1], (unsigned char)*s);
       result = curlx_dyn_addn(&out, buf, 3);
     }
     else

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -281,7 +281,7 @@ test3100 test3101 test3102 test3103 test3104 test3105 test3106 \
 \
 test3200 test3201 test3202 test3203 test3204 test3205 test3206 test3207 \
 test3208 test3209 test3210 test3211 test3212 test3213 test3214 test3215 \
-test3216 test3217 test3218 test3219 test3220 \
+test3216 test3217 test3218 test3219 test3220 test3221 \
 \
 test3300 test3301 test3302 test3303 test3304 \
 \

--- a/tests/data/test3221
+++ b/tests/data/test3221
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+digest
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 401 Authorization Required
+WWW-Authenticate: Digest realm="testrealm%0a%0d", nonce="1053604145"
+Content-Length: 4
+
+hej
+</data>
+
+<data1000 crlf="headers">
+HTTP/1.1 200 OK
+Content-Length: 23
+
+This IS the real page!
+</data1000>
+
+<datacheck crlf="headers">
+HTTP/1.1 401 Authorization Required
+WWW-Authenticate: Digest realm="testrealm%0a%0d", nonce="1053604145"
+Content-Length: 4
+
+HTTP/1.1 200 OK
+Content-Length: 23
+
+This IS the real page!
+</datacheck>
+
+
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP Digest with CRLF in username
+</name>
+<command>
+http://hello%0a%0d:there@%HOSTIP:%HTTPPORT/ --digest
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET / HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET / HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Digest username="hello%0A%0D", realm="testrealm%0a%0d", nonce="1053604145", uri="/", response="64e5ae1b90f05309847ac483c1094284"
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test3221
+++ b/tests/data/test3221
@@ -35,8 +35,6 @@ Content-Length: 23
 
 This IS the real page!
 </datacheck>
-
-
 </reply>
 
 # Client-side

--- a/tests/data/test3221
+++ b/tests/data/test3221
@@ -42,6 +42,11 @@ This IS the real page!
 <server>
 http
 </server>
+<features>
+!SSPI
+crypto
+digest
+</features>
 <name>
 HTTP Digest with CRLF in username
 </name>


### PR DESCRIPTION
Since the username is decoded when used and control codes are accepted in HTTP usernames in general, the username encoding for the Digest auth needs to percent encode such bytes.

Verified by test 3221

Reported-by: Trail of Bits
