### PR TITLE
pytest: close file handles after use, and two minor tidy-ups

### DIFF
--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -473,8 +473,10 @@ class TestDownload:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -473,9 +473,9 @@ class TestDownload:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -473,8 +473,9 @@ class TestDownload:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
+                with open(srcfile) as sf:
                     a = sf.readlines()
+                with open(dfile) as df:
                     b = df.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -473,9 +473,8 @@ class TestDownload:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf:
+                with open(srcfile) as sf, open(dfile) as df:
                     a = sf.readlines()
-                with open(dfile) as df:
                     b = df.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -57,8 +57,8 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=data, alpn_proto=proto)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(curl.response_file(0)) as fr:
+            respdata = fr.readlines()
         assert respdata == [data]
 
     # upload large data, check that this is what was echoed
@@ -69,10 +69,9 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as fd:
-            indata = fd.readlines()
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(fdata) as fi, open(curl.response_file(0)) as fr:
+            indata = fi.readlines()
+            respdata = fr.readlines()
         assert respdata == indata
 
     # upload data sequentially, check that they were echoed
@@ -85,8 +84,8 @@ class TestUpload:
         r = curl.http_upload(urls=[url], data=data, alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == [data]
 
     # upload data parallel, check that they were echoed
@@ -101,8 +100,8 @@ class TestUpload:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == [data]
 
     # upload large data sequentially, check that this is what was echoed
@@ -114,12 +113,12 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_response(count=count, http_status=200)
-        with open(fdata) as fd:
-            indata = fd.readlines()
+        with open(fdata) as fi:
+            indata = fi.readlines()
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == indata
 
     # upload very large data sequentially, check that this is what was echoed
@@ -131,11 +130,11 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        with open(fdata) as fd:
-            indata = fd.readlines()
+        with open(fdata) as fi:
+            indata = fi.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == indata
 
     # upload from stdin, issue #14870
@@ -150,8 +149,8 @@ class TestUpload:
         r = curl.http_put(urls=[url], data=indata, alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == [f'{len(indata)}']
 
     @pytest.mark.parametrize("proto", Env.http_protos())
@@ -208,8 +207,8 @@ class TestUpload:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == [data]
 
     # upload large data parallel, check that this is what was echoed
@@ -254,8 +253,8 @@ class TestUpload:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == exp_data
 
     # PUT 10m
@@ -271,8 +270,8 @@ class TestUpload:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == exp_data
 
     # issue #10591
@@ -364,10 +363,10 @@ class TestUpload:
         r.check_response(count=1, http_status=200)
         # apache does not Upgrade on request with a body
         assert r.stats[0]['http_version'] == '1.1', f'{r}'
-        with open(fdata) as fd:
-            indata = fd.readlines()
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(fdata) as fi:
+            indata = fi.readlines()
+        with open(curl.response_file(0)) as fr:
+            respdata = fr.readlines()
         assert respdata == indata
 
     # upload to a 301,302,303 response
@@ -383,8 +382,8 @@ class TestUpload:
             '-L', '--trace-config', 'http/2,http/3'
         ])
         r.check_response(count=1, http_status=200)
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(curl.response_file(0)) as fr:
+            respdata = fr.readlines()
         assert respdata == []  # was transformed to a GET
 
     # upload to a 307 response
@@ -399,8 +398,8 @@ class TestUpload:
             '-L', '--trace-config', 'http/2,http/3'
         ])
         r.check_response(count=1, http_status=200)
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(curl.response_file(0)) as fr:
+            respdata = fr.readlines()
         assert respdata == [data]  # was POST again
 
     # POST form data, yet another code path in transfer
@@ -423,10 +422,10 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as fd:
-            indata = fd.readlines()
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(fdata) as fi:
+            indata = fi.readlines()
+        with open(curl.response_file(0)) as fr:
+            respdata = fr.readlines()
         assert respdata == indata
 
     # POST data urlencoded, large enough to be sent separate from request headers
@@ -439,10 +438,10 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as fd:
-            indata = fd.readlines()
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(fdata) as fi:
+            indata = fi.readlines()
+        with open(curl.response_file(0)) as fr:
+            respdata = fr.readlines()
         assert respdata == indata
 
     # POST data urlencoded, small enough to be sent with request headers
@@ -463,10 +462,10 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto, extra_args=extra_args)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as fd:
-            indata = fd.readlines()
-        with open(curl.response_file(0)) as fd:
-            respdata = fd.readlines()
+        with open(fdata) as fi:
+            indata = fi.readlines()
+        with open(curl.response_file(0)) as fr:
+            respdata = fr.readlines()
         assert respdata == indata
 
     def check_download(self, r: ExecResult, count: int, srcfile: Union[str, os.PathLike], curl: CurlClient):

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -474,9 +474,9 @@ class TestUpload:
             dfile = curl.download_file(i)
             assert os.path.exists(dfile), f'download {dfile} missing\n{r.dump_logs()}'
             if not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
@@ -724,8 +724,8 @@ class TestUpload:
             dfile = client.download_file(i)
             assert os.path.exists(dfile), f'download {dfile} missing\n{r.dump_logs()}'
             if complete:
-                with open(dfile) as df:
-                    b = df.readlines()
+                with open(dfile) as fb:
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=source, b=b,
                                                     fromfile='-',
                                                     tofile=dfile,

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -57,8 +57,8 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=data, alpn_proto=proto)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == [data]
 
     # upload large data, check that this is what was echoed
@@ -69,10 +69,10 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as f:
-            indata = f.readlines()
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == indata
 
     # upload data sequentially, check that they were echoed
@@ -85,8 +85,8 @@ class TestUpload:
         r = curl.http_upload(urls=[url], data=data, alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == [data]
 
     # upload data parallel, check that they were echoed
@@ -101,8 +101,8 @@ class TestUpload:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == [data]
 
     # upload large data sequentially, check that this is what was echoed
@@ -114,12 +114,12 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_response(count=count, http_status=200)
-        with open(fdata) as f:
-            indata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == indata
 
     # upload very large data sequentially, check that this is what was echoed
@@ -131,11 +131,11 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        with open(fdata) as f:
-            indata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == indata
 
     # upload from stdin, issue #14870
@@ -150,8 +150,8 @@ class TestUpload:
         r = curl.http_put(urls=[url], data=indata, alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == [f'{len(indata)}']
 
     @pytest.mark.parametrize("proto", Env.http_protos())
@@ -208,8 +208,8 @@ class TestUpload:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == [data]
 
     # upload large data parallel, check that this is what was echoed
@@ -254,8 +254,8 @@ class TestUpload:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == exp_data
 
     # PUT 10m
@@ -271,8 +271,8 @@ class TestUpload:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == exp_data
 
     # issue #10591
@@ -364,10 +364,10 @@ class TestUpload:
         r.check_response(count=1, http_status=200)
         # apache does not Upgrade on request with a body
         assert r.stats[0]['http_version'] == '1.1', f'{r}'
-        with open(fdata) as f:
-            indata = f.readlines()
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == indata
 
     # upload to a 301,302,303 response
@@ -383,8 +383,8 @@ class TestUpload:
             '-L', '--trace-config', 'http/2,http/3'
         ])
         r.check_response(count=1, http_status=200)
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == []  # was transformed to a GET
 
     # upload to a 307 response
@@ -399,8 +399,8 @@ class TestUpload:
             '-L', '--trace-config', 'http/2,http/3'
         ])
         r.check_response(count=1, http_status=200)
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == [data]  # was POST again
 
     # POST form data, yet another code path in transfer
@@ -423,10 +423,10 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as f:
-            indata = f.readlines()
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == indata
 
     # POST data urlencoded, large enough to be sent separate from request headers
@@ -439,10 +439,10 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as f:
-            indata = f.readlines()
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == indata
 
     # POST data urlencoded, small enough to be sent with request headers
@@ -463,10 +463,10 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto, extra_args=extra_args)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as f:
-            indata = f.readlines()
-        with open(curl.response_file(0)) as f:
-            respdata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
+        with open(curl.response_file(0)) as fd:
+            respdata = fd.readlines()
         assert respdata == indata
 
     def check_download(self, r: ExecResult, count: int, srcfile: Union[str, os.PathLike], curl: CurlClient):

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -363,9 +363,8 @@ class TestUpload:
         r.check_response(count=1, http_status=200)
         # apache does not Upgrade on request with a body
         assert r.stats[0]['http_version'] == '1.1', f'{r}'
-        with open(fdata) as fi:
+        with open(fdata) as fi, open(curl.response_file(0)) as fr:
             indata = fi.readlines()
-        with open(curl.response_file(0)) as fr:
             respdata = fr.readlines()
         assert respdata == indata
 
@@ -422,9 +421,8 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as fi:
+        with open(fdata) as fi, open(curl.response_file(0)) as fr:
             indata = fi.readlines()
-        with open(curl.response_file(0)) as fr:
             respdata = fr.readlines()
         assert respdata == indata
 
@@ -438,9 +436,8 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as fi:
+        with open(fdata) as fi, open(curl.response_file(0)) as fr:
             indata = fi.readlines()
-        with open(curl.response_file(0)) as fr:
             respdata = fr.readlines()
         assert respdata == indata
 
@@ -462,9 +459,8 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto, extra_args=extra_args)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        with open(fdata) as fi:
+        with open(fdata) as fi, open(curl.response_file(0)) as fr:
             indata = fi.readlines()
-        with open(curl.response_file(0)) as fr:
             respdata = fr.readlines()
         assert respdata == indata
 

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -57,7 +57,8 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=data, alpn_proto=proto)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        respdata = open(curl.response_file(0)).readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == [data]
 
     # upload large data, check that this is what was echoed
@@ -68,8 +69,10 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        indata = open(fdata).readlines()
-        respdata = open(curl.response_file(0)).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == indata
 
     # upload data sequentially, check that they were echoed
@@ -82,7 +85,8 @@ class TestUpload:
         r = curl.http_upload(urls=[url], data=data, alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == [data]
 
     # upload data parallel, check that they were echoed
@@ -97,7 +101,8 @@ class TestUpload:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == [data]
 
     # upload large data sequentially, check that this is what was echoed
@@ -109,10 +114,12 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_response(count=count, http_status=200)
-        indata = open(fdata).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == indata
 
     # upload very large data sequentially, check that this is what was echoed
@@ -124,9 +131,11 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        indata = open(fdata).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == indata
 
     # upload from stdin, issue #14870
@@ -141,7 +150,8 @@ class TestUpload:
         r = curl.http_put(urls=[url], data=indata, alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == [f'{len(indata)}']
 
     @pytest.mark.parametrize("proto", Env.http_protos())
@@ -198,7 +208,8 @@ class TestUpload:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == [data]
 
     # upload large data parallel, check that this is what was echoed
@@ -243,7 +254,8 @@ class TestUpload:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == exp_data
 
     # PUT 10m
@@ -259,7 +271,8 @@ class TestUpload:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == exp_data
 
     # issue #10591
@@ -351,8 +364,10 @@ class TestUpload:
         r.check_response(count=1, http_status=200)
         # apache does not Upgrade on request with a body
         assert r.stats[0]['http_version'] == '1.1', f'{r}'
-        indata = open(fdata).readlines()
-        respdata = open(curl.response_file(0)).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == indata
 
     # upload to a 301,302,303 response
@@ -368,7 +383,8 @@ class TestUpload:
             '-L', '--trace-config', 'http/2,http/3'
         ])
         r.check_response(count=1, http_status=200)
-        respdata = open(curl.response_file(0)).readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == []  # was transformed to a GET
 
     # upload to a 307 response
@@ -383,7 +399,8 @@ class TestUpload:
             '-L', '--trace-config', 'http/2,http/3'
         ])
         r.check_response(count=1, http_status=200)
-        respdata = open(curl.response_file(0)).readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == [data]  # was POST again
 
     # POST form data, yet another code path in transfer
@@ -406,8 +423,10 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        indata = open(fdata).readlines()
-        respdata = open(curl.response_file(0)).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == indata
 
     # POST data urlencoded, large enough to be sent separate from request headers
@@ -420,8 +439,10 @@ class TestUpload:
             '--trace-config', 'http/2,http/3'
         ])
         r.check_stats(count=1, http_status=200, exitcode=0)
-        indata = open(fdata).readlines()
-        respdata = open(curl.response_file(0)).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == indata
 
     # POST data urlencoded, small enough to be sent with request headers
@@ -442,8 +463,10 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto, extra_args=extra_args)
         r.check_stats(count=1, http_status=200, exitcode=0)
-        indata = open(fdata).readlines()
-        respdata = open(curl.response_file(0)).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
+        with open(curl.response_file(0)) as f:
+            respdata = f.readlines()
         assert respdata == indata
 
     def check_download(self, r: ExecResult, count: int, srcfile: Union[str, os.PathLike], curl: CurlClient):

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -474,8 +474,10 @@ class TestUpload:
             dfile = curl.download_file(i)
             assert os.path.exists(dfile), f'download {dfile} missing\n{r.dump_logs()}'
             if not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))
@@ -722,8 +724,9 @@ class TestUpload:
             dfile = client.download_file(i)
             assert os.path.exists(dfile), f'download {dfile} missing\n{r.dump_logs()}'
             if complete:
-                diff = "".join(difflib.unified_diff(a=source,
-                                                    b=open(dfile).readlines(),
+                with open(dfile) as df:
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=source, b=b
                                                     fromfile='-',
                                                     tofile=dfile,
                                                     n=1))

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -726,7 +726,7 @@ class TestUpload:
             if complete:
                 with open(dfile) as df:
                     b = df.readlines()
-                diff = "".join(difflib.unified_diff(a=source, b=b
+                diff = "".join(difflib.unified_diff(a=source, b=b,
                                                     fromfile='-',
                                                     tofile=dfile,
                                                     n=1))

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -212,9 +212,9 @@ class TestCaddy:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -212,8 +212,10 @@ class TestCaddy:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -151,8 +151,8 @@ class TestCaddy:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == [data]
 
     # put large file, check that they length were echoed
@@ -167,8 +167,8 @@ class TestCaddy:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == exp_data
 
     @pytest.mark.parametrize("proto", Env.http_protos())

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -151,7 +151,8 @@ class TestCaddy:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == [data]
 
     # put large file, check that they length were echoed
@@ -166,7 +167,8 @@ class TestCaddy:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == exp_data
 
     @pytest.mark.parametrize("proto", Env.http_protos())

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -151,8 +151,8 @@ class TestCaddy:
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == [data]
 
     # put large file, check that they length were echoed
@@ -167,8 +167,8 @@ class TestCaddy:
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == exp_data
 
     @pytest.mark.parametrize("proto", Env.http_protos())

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -104,11 +104,11 @@ class TestProxy:
                              extra_args=xargs)
         r.check_response(count=count, http_status=200,
                          protocol='HTTP/2' if proto == 'h2' else 'HTTP/1.1')
-        with open(srcfile) as f:
-            indata = f.readlines()
+        with open(srcfile) as fd:
+            indata = fd.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == indata
 
     # download http: via http: proxytunnel
@@ -230,11 +230,11 @@ class TestProxy:
         assert self.get_tunnel_proto_used(r) == tunnel
         r.check_response(count=count, http_status=200)
         assert r.total_connects == 1, r.dump_logs()
-        with open(srcfile) as f:
-            indata = f.readlines()
+        with open(srcfile) as fd:
+            indata = fd.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == indata, f'response {i} differs'
 
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -57,7 +57,6 @@ class TestProxy:
             if m:
                 return m.group(1)
         assert False, f'tunnel protocol not found in:\n{"".join(r.trace_lines)}'
-        return None
 
     # download via http: proxy (no tunnel)
     def test_10_01_proxy_http(self, env: Env, httpd):

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -104,11 +104,11 @@ class TestProxy:
                              extra_args=xargs)
         r.check_response(count=count, http_status=200,
                          protocol='HTTP/2' if proto == 'h2' else 'HTTP/1.1')
-        with open(srcfile) as fd:
-            indata = fd.readlines()
+        with open(srcfile) as fi:
+            indata = fi.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == indata
 
     # download http: via http: proxytunnel
@@ -230,11 +230,11 @@ class TestProxy:
         assert self.get_tunnel_proto_used(r) == tunnel
         r.check_response(count=count, http_status=200)
         assert r.total_connects == 1, r.dump_logs()
-        with open(srcfile) as fd:
-            indata = fd.readlines()
+        with open(srcfile) as fi:
+            indata = fi.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == indata, f'response {i} differs'
 
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -105,9 +105,11 @@ class TestProxy:
                              extra_args=xargs)
         r.check_response(count=count, http_status=200,
                          protocol='HTTP/2' if proto == 'h2' else 'HTTP/1.1')
-        indata = open(srcfile).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == indata
 
     # download http: via http: proxytunnel
@@ -229,9 +231,11 @@ class TestProxy:
         assert self.get_tunnel_proto_used(r) == tunnel
         r.check_response(count=count, http_status=200)
         assert r.total_connects == 1, r.dump_logs()
-        indata = open(srcfile).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == indata, f'response {i} differs'
 
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -105,7 +105,7 @@ class TestProxy:
                              extra_args=xargs)
         r.check_response(count=count, http_status=200,
                          protocol='HTTP/2' if proto == 'h2' else 'HTTP/1.1')
-        with open(fdata) as f:
+        with open(srcfile) as f:
             indata = f.readlines()
         for i in range(count):
             with open(curl.response_file(i)) as f:
@@ -231,7 +231,7 @@ class TestProxy:
         assert self.get_tunnel_proto_used(r) == tunnel
         r.check_response(count=count, http_status=200)
         assert r.total_connects == 1, r.dump_logs()
-        with open(fdata) as f:
+        with open(srcfile) as f:
             indata = f.readlines()
         for i in range(count):
             with open(curl.response_file(i)) as f:

--- a/tests/http/test_13_proxy_auth.py
+++ b/tests/http/test_13_proxy_auth.py
@@ -48,7 +48,6 @@ class TestProxyAuth:
             if m:
                 return m.group(1)
         assert False, f'tunnel protocol not found in:\n{"".join(r.trace_lines)}'
-        return None
 
     # download via http: proxy (no tunnel), no auth
     def test_13_01_proxy_no_auth(self, env: Env, httpd, configures_httpd):

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -243,10 +243,10 @@ class TestSSLUse:
                                succeed13, succeed12):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
-            'SSLCipherSuite SSL'
-            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
+            'SSLCipherSuite SSL' +
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' +
             ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
-            'SSLCipherSuite TLSv1.3'
+            'SSLCipherSuite TLSv1.3' +
             ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
             f'SSLProtocol {tls_proto}'
         ])
@@ -525,10 +525,10 @@ class TestSSLUse:
     def test_17_18_gnutls_priority(self, env: Env, httpd, configures_httpd, priority, tls_proto, ciphers, success):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
-            'SSLCipherSuite SSL'
-            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
+            'SSLCipherSuite SSL' +
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' +
             ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
-            'SSLCipherSuite TLSv1.3'
+            'SSLCipherSuite TLSv1.3' +
             ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
         ])
         httpd.reload_if_config_changed()

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -243,10 +243,10 @@ class TestSSLUse:
                                succeed13, succeed12):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
-            'SSLCipherSuite SSL' +
-            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' +
+            'SSLCipherSuite SSL' \
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' \
             ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
-            'SSLCipherSuite TLSv1.3' +
+            'SSLCipherSuite TLSv1.3' \
             ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
             f'SSLProtocol {tls_proto}'
         ])
@@ -525,10 +525,10 @@ class TestSSLUse:
     def test_17_18_gnutls_priority(self, env: Env, httpd, configures_httpd, priority, tls_proto, ciphers, success):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
-            'SSLCipherSuite SSL' +
-            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' +
+            'SSLCipherSuite SSL' \
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' \
             ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
-            'SSLCipherSuite TLSv1.3' +
+            'SSLCipherSuite TLSv1.3' \
             ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
         ])
         httpd.reload_if_config_changed()

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -243,10 +243,10 @@ class TestSSLUse:
                                succeed13, succeed12):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
-            'SSLCipherSuite SSL' \
-            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' \
+            'SSLCipherSuite SSL' +
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' +
             ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
-            'SSLCipherSuite TLSv1.3' \
+            'SSLCipherSuite TLSv1.3' +
             ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
             f'SSLProtocol {tls_proto}'
         ])
@@ -525,10 +525,10 @@ class TestSSLUse:
     def test_17_18_gnutls_priority(self, env: Env, httpd, configures_httpd, priority, tls_proto, ciphers, success):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
-            'SSLCipherSuite SSL' \
-            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' \
+            'SSLCipherSuite SSL' +
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' +
             ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
-            'SSLCipherSuite TLSv1.3' \
+            'SSLCipherSuite TLSv1.3' +
             ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
         ])
         httpd.reload_if_config_changed()

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -252,8 +252,10 @@ class TestVsFTPD:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))
@@ -265,8 +267,10 @@ class TestVsFTPD:
         assert os.path.exists(srcfile)
         assert os.path.exists(dstfile)
         if not filecmp.cmp(srcfile, dstfile, shallow=False):
-            diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                b=open(dstfile).readlines(),
+            with open(srcfile) as sf, open(dstfile) as df:
+                a = sf.readlines()
+                b = df.readlines()
+            diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=dstfile,
                                                 n=1))

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -77,7 +77,8 @@ class TestVsFTPD:
         url = f'ftp://{env.ftp_domain}:{vsftpd.port}/'
         r = curl.ftp_get(urls=[url], with_stats=True)
         r.check_stats(count=1, http_status=226)
-        lines = open(os.path.join(curl.run_dir, 'download_#1.data')).readlines()
+        with open(os.path.join(curl.run_dir, 'download_#1.data')) as f:
+            lines = f.readlines()
         assert len(lines) == 5, f'list: {lines}'
         r.check_stats_timelines()
 

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -252,9 +252,9 @@ class TestVsFTPD:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
@@ -267,9 +267,9 @@ class TestVsFTPD:
         assert os.path.exists(srcfile)
         assert os.path.exists(dstfile)
         if not filecmp.cmp(srcfile, dstfile, shallow=False):
-            with open(srcfile) as sf, open(dstfile) as df:
-                a = sf.readlines()
-                b = df.readlines()
+            with open(srcfile) as fa, open(dstfile) as fb:
+                a = fa.readlines()
+                b = fb.readlines()
             diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=dstfile,

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -77,8 +77,8 @@ class TestVsFTPD:
         url = f'ftp://{env.ftp_domain}:{vsftpd.port}/'
         r = curl.ftp_get(urls=[url], with_stats=True)
         r.check_stats(count=1, http_status=226)
-        with open(os.path.join(curl.run_dir, 'download_#1.data')) as f:
-            lines = f.readlines()
+        with open(os.path.join(curl.run_dir, 'download_#1.data')) as fd:
+            lines = fd.readlines()
         assert len(lines) == 5, f'list: {lines}'
         r.check_stats_timelines()
 

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -82,8 +82,8 @@ class TestVsFTPD:
         url = f'ftp://{env.ftp_domain}:{vsftpds.port}/'
         r = curl.ftp_ssl_get(urls=[url], with_stats=True)
         r.check_stats(count=1, http_status=226)
-        with open(os.path.join(curl.run_dir, 'download_#1.data')) as f:
-            lines = f.readlines()
+        with open(os.path.join(curl.run_dir, 'download_#1.data')) as fd:
+            lines = fd.readlines()
         assert len(lines) == 4, f'list: {lines}'
         r.check_stats_timelines()
 
@@ -250,8 +250,8 @@ class TestVsFTPD:
         r = curl.ftp_ssl_upload(urls=[url], updata=indata, with_stats=True)
         r.check_stats(count=count, http_status=226)
         assert os.path.exists(dstfile)
-        with open(dstfile) as f:
-            destdata = f.readlines()
+        with open(dstfile) as fd:
+            destdata = fd.readlines()
         expdata = [indata] if len(indata) else []
         assert expdata == destdata, f'expected: {expdata}, got: {destdata}'
 

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -302,8 +302,10 @@ class TestVsFTPD:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))
@@ -315,8 +317,10 @@ class TestVsFTPD:
         assert os.path.exists(srcfile)
         assert os.path.exists(dstfile)
         if not filecmp.cmp(srcfile, dstfile, shallow=False):
-            diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                b=open(dstfile).readlines(),
+            with open(srcfile) as sf, open(dstfile) as df:
+                a = sf.readlines()
+                b = df.readlines()
+            diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=dstfile,
                                                 n=1))

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -82,7 +82,8 @@ class TestVsFTPD:
         url = f'ftp://{env.ftp_domain}:{vsftpds.port}/'
         r = curl.ftp_ssl_get(urls=[url], with_stats=True)
         r.check_stats(count=1, http_status=226)
-        lines = open(os.path.join(curl.run_dir, 'download_#1.data')).readlines()
+        with open(os.path.join(curl.run_dir, 'download_#1.data')) as f:
+            lines = f.readlines()
         assert len(lines) == 4, f'list: {lines}'
         r.check_stats_timelines()
 
@@ -248,7 +249,8 @@ class TestVsFTPD:
         r = curl.ftp_ssl_upload(urls=[url], updata=indata, with_stats=True)
         r.check_stats(count=count, http_status=226)
         assert os.path.exists(dstfile)
-        destdata = open(dstfile).readlines()
+        with open(dstfile) as f:
+            destdata = f.readlines()
         expdata = [indata] if len(indata) else []
         assert expdata == destdata, f'expected: {expdata}, got: {destdata}'
 

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -204,8 +204,8 @@ class TestVsFTPD:
         r.check_stats(count=count, http_status=226)
         # expect the uploaded file to be number of converted newlines larger
         dstsize = os.path.getsize(dstfile)
-        with open(srcfile) as f:
-            newlines = len(f.readlines())
+        with open(srcfile) as fd:
+            newlines = len(fd.readlines())
         assert (srcsize + newlines) == dstsize, \
             f'expected source with {newlines} lines to be that much larger,'\
             f'instead srcsize={srcsize}, upload size={dstsize}, diff={dstsize-srcsize}'
@@ -303,9 +303,9 @@ class TestVsFTPD:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
@@ -318,9 +318,9 @@ class TestVsFTPD:
         assert os.path.exists(srcfile)
         assert os.path.exists(dstfile)
         if not filecmp.cmp(srcfile, dstfile, shallow=False):
-            with open(srcfile) as sf, open(dstfile) as df:
-                a = sf.readlines()
-                b = df.readlines()
+            with open(srcfile) as fa, open(dstfile) as fb:
+                a = fa.readlines()
+                b = fb.readlines()
             diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=dstfile,

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -204,7 +204,8 @@ class TestVsFTPD:
         r.check_stats(count=count, http_status=226)
         # expect the uploaded file to be number of converted newlines larger
         dstsize = os.path.getsize(dstfile)
-        newlines = len(open(srcfile).readlines())
+        with open(srcfile) as f:
+            newlines = len(f.readlines())
         assert (srcsize + newlines) == dstsize, \
             f'expected source with {newlines} lines to be that much larger,'\
             f'instead srcsize={srcsize}, upload size={dstsize}, diff={dstsize-srcsize}'

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -82,7 +82,8 @@ class TestFtpsVsFTPD:
         url = f'ftps://{env.ftp_domain}:{vsftpds.port}/'
         r = curl.ftp_get(urls=[url], with_stats=True)
         r.check_stats(count=1, http_status=226)
-        lines = open(os.path.join(curl.run_dir, 'download_#1.data')).readlines()
+        with open(os.path.join(curl.run_dir, 'download_#1.data')) as f:
+            lines = f.readlines()
         assert len(lines) == 4, f'list: {lines}'
         r.check_stats_timelines()
 
@@ -261,7 +262,8 @@ class TestFtpsVsFTPD:
         r = curl.ftp_upload(urls=[url], updata=indata, with_stats=True)
         r.check_stats(count=count, http_status=226)
         assert os.path.exists(dstfile)
-        destdata = open(dstfile).readlines()
+        with open(dstfile) as f:
+            destdata = f.readlines()
         expdata = [indata] if len(indata) else []
         assert expdata == destdata, f'expected: {expdata}, got: {destdata}'
 

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -217,7 +217,8 @@ class TestFtpsVsFTPD:
         r.check_stats(count=count, http_status=226)
         # expect the uploaded file to be number of converted newlines larger
         dstsize = os.path.getsize(dstfile)
-        newlines = len(open(srcfile).readlines())
+        with open(srcfile) as f:
+            newlines = len(f.readlines())
         assert (srcsize + newlines) == dstsize, \
             f'expected source with {newlines} lines to be that much larger,'\
             f'instead srcsize={srcsize}, upload size={dstsize}, diff={dstsize-srcsize}'

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -82,8 +82,8 @@ class TestFtpsVsFTPD:
         url = f'ftps://{env.ftp_domain}:{vsftpds.port}/'
         r = curl.ftp_get(urls=[url], with_stats=True)
         r.check_stats(count=1, http_status=226)
-        with open(os.path.join(curl.run_dir, 'download_#1.data')) as f:
-            lines = f.readlines()
+        with open(os.path.join(curl.run_dir, 'download_#1.data')) as fd:
+            lines = fd.readlines()
         assert len(lines) == 4, f'list: {lines}'
         r.check_stats_timelines()
 
@@ -217,8 +217,8 @@ class TestFtpsVsFTPD:
         r.check_stats(count=count, http_status=226)
         # expect the uploaded file to be number of converted newlines larger
         dstsize = os.path.getsize(dstfile)
-        with open(srcfile) as f:
-            newlines = len(f.readlines())
+        with open(srcfile) as fd:
+            newlines = len(fd.readlines())
         assert (srcsize + newlines) == dstsize, \
             f'expected source with {newlines} lines to be that much larger,'\
             f'instead srcsize={srcsize}, upload size={dstsize}, diff={dstsize-srcsize}'
@@ -263,8 +263,8 @@ class TestFtpsVsFTPD:
         r = curl.ftp_upload(urls=[url], updata=indata, with_stats=True)
         r.check_stats(count=count, http_status=226)
         assert os.path.exists(dstfile)
-        with open(dstfile) as f:
-            destdata = f.readlines()
+        with open(dstfile) as fd:
+            destdata = fd.readlines()
         expdata = [indata] if len(indata) else []
         assert expdata == destdata, f'expected: {expdata}, got: {destdata}'
 
@@ -292,9 +292,9 @@ class TestFtpsVsFTPD:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
@@ -307,9 +307,9 @@ class TestFtpsVsFTPD:
         assert os.path.exists(srcfile)
         assert os.path.exists(dstfile)
         if not filecmp.cmp(srcfile, dstfile, shallow=False):
-            with open(srcfile) as sf, open(dstfile) as df:
-                a = sf.readlines()
-                b = df.readlines()
+            with open(srcfile) as fa, open(dstfile) as fb:
+                a = fa.readlines()
+                b = fb.readlines()
             diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=dstfile,

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -291,8 +291,10 @@ class TestFtpsVsFTPD:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))
@@ -304,8 +306,10 @@ class TestFtpsVsFTPD:
         assert os.path.exists(srcfile)
         assert os.path.exists(dstfile)
         if not filecmp.cmp(srcfile, dstfile, shallow=False):
-            diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                b=open(dstfile).readlines(),
+            with open(srcfile) as sf, open(dstfile) as df:
+                a = sf.readlines()
+                b = df.readlines()
+            diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=dstfile,
                                                 n=1))

--- a/tests/http/test_40_socks.py
+++ b/tests/http/test_40_socks.py
@@ -96,7 +96,9 @@ class TestSocks:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        indata = open(fdata).readlines()
+        with open(fdata) as f:
+            indata = f.readlines()
         for i in range(count):
-            respdata = open(curl.response_file(i)).readlines()
+            with open(curl.response_file(i)) as f:
+                respdata = f.readlines()
             assert respdata == indata

--- a/tests/http/test_40_socks.py
+++ b/tests/http/test_40_socks.py
@@ -96,9 +96,9 @@ class TestSocks:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        with open(fdata) as f:
-            indata = f.readlines()
+        with open(fdata) as fd:
+            indata = fd.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as f:
-                respdata = f.readlines()
+            with open(curl.response_file(i)) as fd:
+                respdata = fd.readlines()
             assert respdata == indata

--- a/tests/http/test_40_socks.py
+++ b/tests/http/test_40_socks.py
@@ -96,9 +96,9 @@ class TestSocks:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        with open(fdata) as fd:
-            indata = fd.readlines()
+        with open(fdata) as fi:
+            indata = fi.readlines()
         for i in range(count):
-            with open(curl.response_file(i)) as fd:
-                respdata = fd.readlines()
+            with open(curl.response_file(i)) as fr:
+                respdata = fr.readlines()
             assert respdata == indata

--- a/tests/http/test_50_scp.py
+++ b/tests/http/test_50_scp.py
@@ -204,7 +204,7 @@ class TestScp:
         assert os.path.exists(srcfile)
         assert os.path.exists(destfile)
         if not filecmp.cmp(srcfile, destfile, shallow=False):
-            with open(srcfile) as sf, open(dfile) as df:
+            with open(srcfile) as sf, open(destfile) as df:
                 a = sf.readlines()
                 b = df.readlines()
             diff = "".join(difflib.unified_diff(a=a, b=b,

--- a/tests/http/test_50_scp.py
+++ b/tests/http/test_50_scp.py
@@ -191,7 +191,7 @@ class TestScp:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(destfile) as df:
+                with open(srcfile) as sf, open(dfile) as df:
                     a = sf.readlines()
                     b = df.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,

--- a/tests/http/test_50_scp.py
+++ b/tests/http/test_50_scp.py
@@ -191,9 +191,9 @@ class TestScp:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
@@ -204,9 +204,9 @@ class TestScp:
         assert os.path.exists(srcfile)
         assert os.path.exists(destfile)
         if not filecmp.cmp(srcfile, destfile, shallow=False):
-            with open(srcfile) as sf, open(destfile) as df:
-                a = sf.readlines()
-                b = df.readlines()
+            with open(srcfile) as fa, open(destfile) as fb:
+                a = fa.readlines()
+                b = fb.readlines()
             diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=destfile,

--- a/tests/http/test_50_scp.py
+++ b/tests/http/test_50_scp.py
@@ -191,7 +191,7 @@ class TestScp:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
+                with open(srcfile) as sf, open(destfile) as df:
                     a = sf.readlines()
                     b = df.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,

--- a/tests/http/test_50_scp.py
+++ b/tests/http/test_50_scp.py
@@ -191,8 +191,10 @@ class TestScp:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))
@@ -202,8 +204,10 @@ class TestScp:
         assert os.path.exists(srcfile)
         assert os.path.exists(destfile)
         if not filecmp.cmp(srcfile, destfile, shallow=False):
-            diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                b=open(destfile).readlines(),
+            with open(srcfile) as sf, open(dfile) as df:
+                a = sf.readlines()
+                b = df.readlines()
+            diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=destfile,
                                                 n=1))

--- a/tests/http/test_51_sftp.py
+++ b/tests/http/test_51_sftp.py
@@ -191,8 +191,10 @@ class TestSftp:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                    b=open(dfile).readlines(),
+                with open(srcfile) as sf, open(dfile) as df:
+                    a = sf.readlines()
+                    b = df.readlines()
+                diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
                                                     n=1))
@@ -202,8 +204,10 @@ class TestSftp:
         assert os.path.exists(srcfile)
         assert os.path.exists(destfile)
         if not filecmp.cmp(srcfile, destfile, shallow=False):
-            diff = "".join(difflib.unified_diff(a=open(srcfile).readlines(),
-                                                b=open(destfile).readlines(),
+            with open(srcfile) as sf, open(destfile) as df:
+                a = sf.readlines()
+                b = df.readlines()
+            diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=destfile,
                                                 n=1))

--- a/tests/http/test_51_sftp.py
+++ b/tests/http/test_51_sftp.py
@@ -191,9 +191,9 @@ class TestSftp:
             dfile = client.download_file(i)
             assert os.path.exists(dfile)
             if complete and not filecmp.cmp(srcfile, dfile, shallow=False):
-                with open(srcfile) as sf, open(dfile) as df:
-                    a = sf.readlines()
-                    b = df.readlines()
+                with open(srcfile) as fa, open(dfile) as fb:
+                    a = fa.readlines()
+                    b = fb.readlines()
                 diff = "".join(difflib.unified_diff(a=a, b=b,
                                                     fromfile=srcfile,
                                                     tofile=dfile,
@@ -204,9 +204,9 @@ class TestSftp:
         assert os.path.exists(srcfile)
         assert os.path.exists(destfile)
         if not filecmp.cmp(srcfile, destfile, shallow=False):
-            with open(srcfile) as sf, open(destfile) as df:
-                a = sf.readlines()
-                b = df.readlines()
+            with open(srcfile) as fa, open(destfile) as fb:
+                a = fa.readlines()
+                b = fb.readlines()
             diff = "".join(difflib.unified_diff(a=a, b=b,
                                                 fromfile=srcfile,
                                                 tofile=destfile,

--- a/tests/http/testenv/client.py
+++ b/tests/http/testenv/client.py
@@ -104,9 +104,9 @@ class LocalClient:
             log.warning(f'Timeout after {self._timeout}s: {args}')
             exitcode = -1
             exception = 'TimeoutExpired'
-        with open(self._stdoutfile) as fo, open(self._stderrfile) as fe:
-            coutput = fo.readlines()
-            cerrput = fe.readlines()
+        with open(self._stdoutfile) as fout, open(self._stderrfile) as ferr:
+            coutput = fout.readlines()
+            cerrput = ferr.readlines()
         return ExecResult(args=myargs, exit_code=exitcode, exception=exception,
                           stdout=coutput, stderr=cerrput,
                           duration=datetime.now() - start)

--- a/tests/http/testenv/client.py
+++ b/tests/http/testenv/client.py
@@ -104,10 +104,9 @@ class LocalClient:
             log.warning(f'Timeout after {self._timeout}s: {args}')
             exitcode = -1
             exception = 'TimeoutExpired'
-        with open(self._stdoutfile) as f:
-            coutput = f.readlines()
-        with open(self._stderrfile) as f:
-            cerrput = f.readlines()
+        with open(self._stdoutfile) as fo, open(self._stderrfile) as fe:
+            coutput = fo.readlines()
+            cerrput = fe.readlines()
         return ExecResult(args=myargs, exit_code=exitcode, exception=exception,
                           stdout=coutput, stderr=cerrput,
                           duration=datetime.now() - start)

--- a/tests/http/testenv/client.py
+++ b/tests/http/testenv/client.py
@@ -115,8 +115,10 @@ class LocalClient:
     def dump_logs(self):
         lines = []
         lines.append('>>--stdout ----------------------------------------------\n')
-        lines.extend(open(self._stdoutfile).readlines())
+        with open(self._stdoutfile) as cstdout:
+            lines.extend(cstdout.readlines())
         lines.append('>>--stderr ----------------------------------------------\n')
-        lines.extend(open(self._stderrfile).readlines())
+        with open(self._stderrfile) as cstderr:
+            lines.extend(cstderr.readlines())
         lines.append('<<-------------------------------------------------------\n')
         return ''.join(lines)

--- a/tests/http/testenv/client.py
+++ b/tests/http/testenv/client.py
@@ -104,8 +104,10 @@ class LocalClient:
             log.warning(f'Timeout after {self._timeout}s: {args}')
             exitcode = -1
             exception = 'TimeoutExpired'
-        coutput = open(self._stdoutfile).readlines()
-        cerrput = open(self._stderrfile).readlines()
+        with open(self._stdoutfile) as f:
+            coutput = f.readlines()
+        with open(self._stderrfile) as f:
+            cerrput = f.readlines()
         return ExecResult(args=myargs, exit_code=exitcode, exception=exception,
                           stdout=coutput, stderr=cerrput,
                           duration=datetime.now() - start)

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -393,7 +393,7 @@ class ExecResult:
                                         f'got {self.exit_code}\n{self.dump_logs()}'
         elif code is False:
             assert self.exit_code != 0, f'expected exit code {code}, '\
-                                                f'got {self.exit_code}\n{self.dump_logs()}'
+                                        f'got {self.exit_code}\n{self.dump_logs()}'
         else:
             assert self.exit_code == code, f'expected exit code {code}, '\
                                            f'got {self.exit_code}\n{self.dump_logs()}'
@@ -1168,8 +1168,8 @@ class CurlClient:
         return args
 
     def _parse_headerfile(self, headerfile: str, r: Optional[ExecResult] = None) -> ExecResult:
-        with open(headerfile) as f:
-            lines = f.readlines()
+        with open(headerfile) as fd:
+            lines = fd.readlines()
         if r is None:
             r = ExecResult(args=[], exit_code=0, stdout=[], stderr=[])
 

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -1072,9 +1072,9 @@ class CurlClient:
             dtrace.finish()
         if self._with_flame:
             self._generate_flame(args, dtrace=dtrace, perf=perf)
-        with open(self._stdoutfile) as fo, open(self._stderrfile) as fe:
-            coutput = fo.readlines()
-            cerrput = fe.readlines()
+        with open(self._stdoutfile) as fout, open(self._stderrfile) as ferr:
+            coutput = fout.readlines()
+            cerrput = ferr.readlines()
         return ExecResult(args=args, exit_code=exitcode, exception=exception,
                           stdout=coutput, stderr=cerrput,
                           duration=ended_at - started_at,

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -1072,10 +1072,9 @@ class CurlClient:
             dtrace.finish()
         if self._with_flame:
             self._generate_flame(args, dtrace=dtrace, perf=perf)
-        with open(self._stdoutfile) as f:
-            coutput = f.readlines()
-        with open(self._stderrfile) as f:
-            cerrput = f.readlines()
+        with open(self._stdoutfile) as fo, open(self._stderrfile) as fe:
+            coutput = fo.readlines()
+            cerrput = fe.readlines()
         return ExecResult(args=args, exit_code=exitcode, exception=exception,
                           stdout=coutput, stderr=cerrput,
                           duration=ended_at - started_at,

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -1072,8 +1072,10 @@ class CurlClient:
             dtrace.finish()
         if self._with_flame:
             self._generate_flame(args, dtrace=dtrace, perf=perf)
-        coutput = open(self._stdoutfile).readlines()
-        cerrput = open(self._stderrfile).readlines()
+        with open(self._stdoutfile) as f:
+            coutput = f.readlines()
+        with open(self._stderrfile) as f:
+            cerrput = f.readlines()
         return ExecResult(args=args, exit_code=exitcode, exception=exception,
                           stdout=coutput, stderr=cerrput,
                           duration=ended_at - started_at,

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -1167,7 +1167,8 @@ class CurlClient:
         return args
 
     def _parse_headerfile(self, headerfile: str, r: Optional[ExecResult] = None) -> ExecResult:
-        lines = open(headerfile).readlines()
+        with open(headerfile) as f:
+            lines = f.readlines()
         if r is None:
             r = ExecResult(args=[], exit_code=0, stdout=[], stderr=[])
 

--- a/tests/http/testenv/sshd.py
+++ b/tests/http/testenv/sshd.py
@@ -132,8 +132,8 @@ class Sshd:
                 self._host_key_files.append(key_file)
                 pub_file = f'{key_file}.pub'
                 self._host_pub_files.append(pub_file)
-                with open(pub_file) as f:
-                    pubkey = f.read()
+                with open(pub_file) as fp:
+                    pubkey = fp.read()
                 # fd_known.write(f'[127.0.0.1]:{self.port} {pubkey}')
                 fd_known.write(f'[{self.env.domain1.lower()}]:{self.port} {pubkey}')
                 fd_unknown.write(f'dummy.invalid {pubkey}')
@@ -160,8 +160,8 @@ class Sshd:
             self._user_pub_files.append(f'{key_file}.pub')
         with open(self._auth_keys, 'w') as fd:
             os.chmod(self._auth_keys, stat.S_IRUSR | stat.S_IWUSR)
-            with open(self._user_pub_files[0]) as f:
-                pubkey = f.read()
+            with open(self._user_pub_files[0]) as fp:
+                pubkey = fp.read()
             fd.write(pubkey)
 
     def clear_logs(self):

--- a/tests/http/testenv/sshd.py
+++ b/tests/http/testenv/sshd.py
@@ -132,7 +132,8 @@ class Sshd:
                 self._host_key_files.append(key_file)
                 pub_file = f'{key_file}.pub'
                 self._host_pub_files.append(pub_file)
-                pubkey = open(pub_file).read()
+                with open(pub_file) as f:
+                    pubkey = f.read()
                 # fd_known.write(f'[127.0.0.1]:{self.port} {pubkey}')
                 fd_known.write(f'[{self.env.domain1.lower()}]:{self.port} {pubkey}')
                 fd_unknown.write(f'dummy.invalid {pubkey}')
@@ -159,7 +160,8 @@ class Sshd:
             self._user_pub_files.append(f'{key_file}.pub')
         with open(self._auth_keys, 'w') as fd:
             os.chmod(self._auth_keys, stat.S_IRUSR | stat.S_IWUSR)
-            pubkey = open(self._user_pub_files[0]).read()
+            with open(self._user_pub_files[0]) as f:
+                pubkey = f.read()
             fd.write(pubkey)
 
     def clear_logs(self):


### PR DESCRIPTION
Also:
- drop two unreachable return statements.
- test_17_ssl_use: avoid implicit string concatenations in lists.

Reported by GitHub CodeQL

---

- maybe tackling the remaining 8, slightly different, cases in a separate PR

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
