### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -156,14 +156,14 @@ Maybe use of `realloc()` should rather use the dynbuf functions?
 
 Do not allow new code that grows buffers without using dynbuf.
 
-Use of C functions that rely on a terminating zero must only be used on data
-that really do have a null-terminating zero.
+Use of C functions that rely on a null-terminator must only be used on data
+that really do have a null-terminator (`\0` byte).
 
 ## Dangerous "data styles"
 
-Make extra precautions and verify that memory buffers that need a terminating
-zero always have exactly that. Buffers *without* a null-terminator must not be
-used as input to string functions.
+Make extra precautions and verify that memory buffers that need
+null-terminator always have exactly that. Buffers *without* a null-terminator
+must not be used as input to string functions.
 
 # Commit messages
 

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -173,7 +173,7 @@ static void timer_cb(EV_P_ struct ev_timer *w, int revents)
   CURLMcode mresult;
   struct GlobalInfo *g;
 
-  printf("%s  w %p revents %i\n", __PRETTY_FUNCTION__, (void *)w, revents);
+  printf("%s  w %p revents %d\n", __PRETTY_FUNCTION__, (void *)w, revents);
 
   g = (struct GlobalInfo *)w->data;
 
@@ -207,7 +207,7 @@ static void event_cb(EV_P_ struct ev_io *w, int revents)
   int action = ((revents & EV_READ) ? CURL_POLL_IN : 0) |
                ((revents & EV_WRITE) ? CURL_POLL_OUT : 0);
 
-  printf("%s  w %p revents %i\n", __PRETTY_FUNCTION__, (void *)w, revents);
+  printf("%s  w %p revents %d\n", __PRETTY_FUNCTION__, (void *)w, revents);
   g = (struct GlobalInfo *)w->data;
 
   mresult = curl_multi_socket_action(g->multi, w->fd, action,
@@ -269,7 +269,7 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
   struct SockInfo *fdp = (struct SockInfo *)sockp;
   const char *whatstr[] = { "none", "IN", "OUT", "INOUT", "REMOVE" };
 
-  printf("%s e %p s %i what %i cbp %p sockp %p\n",
+  printf("%s e %p s %d what %d cbp %p sockp %p\n",
          __PRETTY_FUNCTION__, e, s, what, cbp, sockp);
 
   fprintf(MSG_OUT, "socket callback: s=%d e=%p what=%s ", s, e, whatstr[what]);

--- a/docs/internals/DYNBUF.md
+++ b/docs/internals/DYNBUF.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: curl
 This is the internal module for creating and handling "dynamic buffers". This
 means buffers that can be appended to, dynamically and grow to adapt.
 
-There is always a terminating zero put at the end of the dynamic buffer.
+There is always a null-terminator put at the end of the dynamic buffer.
 
 The `struct dynbuf` is used to hold data for each instance of a dynamic
 buffer. The members of that struct **MUST NOT** be accessed or modified
@@ -120,8 +120,8 @@ trusted or used anymore after the next buffer manipulation call.
 size_t curlx_dyn_len(const struct dynbuf *s);
 ```
 
-Returns the length of the buffer in bytes. Does not include the terminating
-zero byte.
+Returns the length of the buffer in bytes. Does not include the
+null-terminator byte.
 
 ## `curlx_dyn_setlen`
 

--- a/docs/libcurl/curl_mprintf.md
+++ b/docs/libcurl/curl_mprintf.md
@@ -54,7 +54,7 @@ write output to stdout, the standard output stream; **curl_mfprintf()** and
 **curl_mvsnprintf()** write to the character string **buffer**.
 
 The functions **curl_msnprintf()** and **curl_mvsnprintf()** write at most
-*maxlength* bytes (including the terminating null byte ('0')) to
+*maxlength* bytes (including the null-terminator byte ('0')) to
 *buffer*.
 
 The functions **curl_mvprintf()**, **curl_mvfprintf()**,
@@ -246,10 +246,10 @@ is written.
 
 The *const char ** argument is expected to be a pointer to an array of
 character type (pointer to a string). Characters from the array are written up
-to (but not including) a terminating null byte. If a precision is specified,
+to (but not including) a null-terminator byte. If a precision is specified,
 no more than the number specified are written. If a precision is given, no
 null byte need be present; if the precision is not specified, or is greater
-than the size of the array, the array must contain a terminating null byte.
+than the size of the array, the array must contain a null-terminator byte.
 
 ## p
 

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.md
@@ -99,6 +99,6 @@ curl_easy_setopt(3) returns a CURLcode indicating success or error.
 CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
 libcurl-errors(3).
 
-Note that curl_easy_setopt(3) does immediately parse the given string so when
-given a bad DoH URL, libcurl might not detect the problem until it later tries
-to resolve a name with it.
+Note that curl_easy_setopt(3) does not immediately parse the given string so
+when given a bad DoH URL, libcurl might not detect the problem until it later
+tries to resolve a name with it.

--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -487,7 +487,7 @@ Features testable here are:
 - `brotli`
 - `c-ares` - c-ares is used for (all) name resolves
 - `CharConv`
-- `codeset-utf8`. If the running codeset is UTF-8 capable.
+- `codeset-utf8` - if the running codeset is UTF-8 capable.
 - `cookies`
 - `crypto`
 - `cygwin`
@@ -509,13 +509,13 @@ Features testable here are:
 - `IPv6`
 - `Kerberos`
 - `Largefile`
-- `large-time` (time_t is larger than 32-bit)
-- `large-size` (size_t is larger than 32-bit)
+- `large-time` - time_t is larger than 32-bit
+- `large-size` - size_t is larger than 32-bit
 - `libssh2`
 - `libssh`
-- `badlibssh` (libssh configuration incompatible with the test suite)
+- `badlibssh` - libssh configuration incompatible with the test suite
 - `libz`
-- `local-http`. The HTTP server runs on 127.0.0.1
+- `local-http` - the HTTP server runs on 127.0.0.1
 - `manual`
 - `mbedtls`
 - `Mime`

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -904,16 +904,16 @@ enum curl_khmatch {
 };
 
 typedef int
-  (*curl_sshkeycallback) (CURL *easy,     /* easy handle */
-                          const struct curl_khkey *knownkey, /* known */
-                          const struct curl_khkey *foundkey, /* found */
-                          enum curl_khmatch, /* libcurl's view on the keys */
-                          void *clientp); /* custom pointer passed with */
-                                          /* CURLOPT_SSH_KEYDATA */
+  (*curl_sshkeycallback)(CURL *easy,     /* easy handle */
+                         const struct curl_khkey *knownkey, /* known */
+                         const struct curl_khkey *foundkey, /* found */
+                         enum curl_khmatch, /* libcurl's view on the keys */
+                         void *clientp); /* custom pointer passed with */
+                                         /* CURLOPT_SSH_KEYDATA */
 
 typedef int
-  (*curl_sshhostkeycallback) (void *clientp,/* custom pointer passed */
-                                            /* with CURLOPT_SSH_HOSTKEYDATA */
+  (*curl_sshhostkeycallback)(void *clientp,/* custom pointer passed */
+                                           /* with CURLOPT_SSH_HOSTKEYDATA */
                           int keytype, /* CURLKHTYPE */
                           const char *key, /* hostkey to check */
                           size_t keylen); /* length of the key */

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -91,7 +91,7 @@ static CURLcode cf_haproxy_date_out_set(struct Curl_cfilter *cf,
     client_dest_ip = ipquad.remote_ip;
   }
 
-  result = curlx_dyn_addf(&ctx->data_out, "PROXY %s %s %s %i %i\r\n",
+  result = curlx_dyn_addf(&ctx->data_out, "PROXY %s %s %s %d %d\r\n",
                           is_ipv6 ? "TCP6" : "TCP4",
                           client_source_ip, client_dest_ip,
                           ipquad.local_port, ipquad.remote_port);

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -667,7 +667,7 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
        * We now have the numerical IP address in the 'myhost' buffer
        */
       host = myhost;
-      infof(data, "Local Interface %s is ip %s using address family %i",
+      infof(data, "Local Interface %s is ip %s using address family %d",
             iface, host, af);
       done = 1;
       break;
@@ -693,7 +693,7 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
         int h_af = h->addr->ai_family;
         /* convert the resolved address, sizeof myhost >= INET_ADDRSTRLEN */
         Curl_printable_address(h->addr, myhost, sizeof(myhost));
-        infof(data, "Name '%s' family %i resolved to '%s' family %i",
+        infof(data, "Name '%s' family %d resolved to '%s' family %d",
               host, af, myhost, h_af);
         Curl_dns_entry_unlink(data, &h); /* this will NULL, potential free h */
         if(af != h_af) {

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -828,7 +828,7 @@ err:
         Curl_hash_delete(&dnscache->entries, entry_id, entry_len + 1);
       }
 
-      /* put this new host in the cache, an overridy for ALL dns queries */
+      /* put this new host in the cache, an override for ALL dns queries */
       dns = dnscache_add_addr(data, dnscache, CURL_DNSQ_ALL,
                               &head, curlx_str(&source),
                               curlx_strlen(&source), port, permanent);

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -351,7 +351,7 @@ UNITTEST CURLcode dns_shuffle_addr(struct Curl_easy *data,
 
   if(num_addrs > 1) {
     struct Curl_addrinfo **nodes;
-    CURL_TRC_DNS(data, "Shuffling %i addresses", num_addrs);
+    CURL_TRC_DNS(data, "Shuffling %d addresses", num_addrs);
 
     nodes = curlx_malloc(num_addrs * sizeof(*nodes));
     if(nodes) {

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -419,7 +419,7 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
 
   (void)curl_easy_setopt(doh, CURLOPT_SSL_OPTIONS,
                          ((long)data->set.ssl.primary.ssl_options &
-                           ~CURLSSLOPT_AUTO_CLIENT_CERT));
+                          ~CURLSSLOPT_AUTO_CLIENT_CERT));
 
   doh->state.internal = TRUE;
   doh->master_mid = data->mid; /* master transfer of this one */

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -262,8 +262,8 @@ static const char *pgrs_timer_name(timerid timer)
     return pgrs_timer_names[(size_t)timer];
   return "?";
 }
-
 #endif /* CURLVERBOSE */
+
 /*
  * Curl_pgrsTimeWas(). Store the timestamp time at the given label.
  */

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -186,7 +186,7 @@ CURLcode Curl_rand_bytes(struct Curl_easy *data,
 
 /*
  * Curl_rand_hex() fills the 'rnd' buffer with a given 'num' size with random
- * hexadecimal digits PLUS a null-terminating byte. It must be an odd number
+ * hexadecimal digits PLUS a null-terminator byte. It must be an odd number
  * size.
  */
 
@@ -214,7 +214,7 @@ CURLcode Curl_rand_hex(struct Curl_easy *data, unsigned char *rnd, size_t num)
 
 /*
  * Curl_rand_alnum() fills the 'rnd' buffer with a given 'num' size with random
- * alphanumerical chars PLUS a null-terminating byte.
+ * alphanumerical chars PLUS a null-terminator byte.
  */
 
 static const char alnum[] =

--- a/lib/rand.h
+++ b/lib/rand.h
@@ -37,14 +37,14 @@ CURLcode Curl_rand_bytes(struct Curl_easy *data,
 
 /*
  * Curl_rand_hex() fills the 'rnd' buffer with a given 'num' size with random
- * hexadecimal digits PLUS a null-terminating byte. It must be an odd number
+ * hexadecimal digits PLUS a null-terminator byte. It must be an odd number
  * size.
  */
 CURLcode Curl_rand_hex(struct Curl_easy *data, unsigned char *rnd, size_t num);
 
 /*
  * Curl_rand_alnum() fills the 'rnd' buffer with a given 'num' size with random
- * alphanumerical chars PLUS a null-terminating byte.
+ * alphanumerical chars PLUS a null-terminator byte.
  */
 CURLcode Curl_rand_alnum(struct Curl_easy *data, unsigned char *rnd,
                          size_t num);

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -491,7 +491,7 @@ static CURLcode tftp_tx(struct tftp_conn *state, tftp_event_t event)
     break;
 
   default:
-    failf(data, "tftp_tx: internal error, event: %i", (int)event);
+    failf(data, "tftp_tx: internal error, event: %d", (int)event);
     break;
   }
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1039,7 +1039,7 @@ static CURLUcode handle_fragment(CURLU *u, const char *fragment,
   CURLUcode ures;
   u->fragment_present = TRUE;
   if(fraglen > 1) {
-    /* skip the leading '#' in the copy but include the terminating null */
+    /* skip the leading '#' in the copy but include the null-terminator */
     if(flags & CURLU_URLENCODE) {
       struct dynbuf enc;
       curlx_dyn_init(&enc, CURL_MAX_INPUT_LENGTH);

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -509,7 +509,6 @@ static CURLUcode hostname_check(struct Curl_URL *u, char *hostname,
  *
  * @unittest 1675
  */
-
 UNITTEST int ipv4_normalize(struct dynbuf *host);
 UNITTEST int ipv4_normalize(struct dynbuf *host)
 {

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -713,7 +713,7 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data,
         failf(data, "Found host key type RSA1 which is not supported");
         return CURLE_SSH;
       default:
-        failf(data, "Unknown host key type: %i",
+        failf(data, "Unknown host key type: %d",
               (store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK));
         return CURLE_SSH;
       }

--- a/lib/vtls/apple.c
+++ b/lib/vtls/apple.c
@@ -208,7 +208,7 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
       status = SecTrustSetOCSPResponse(trust, ocspdata);
       CFRelease(ocspdata);
       if(status != noErr) {
-        failf(data, "Apple SecTrust: failed to set OCSP response: %i",
+        failf(data, "Apple SecTrust: failed to set OCSP response: %d",
               (int)status);
         result = CURLE_PEER_FAILED_VERIFICATION;
         goto out;
@@ -254,7 +254,7 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
     status = SecTrustEvaluate(trust, &sec_result);
 
     if(status != noErr) {
-      failf(data, "Apple SecTrust verification failed: error %i", (int)status);
+      failf(data, "Apple SecTrust verification failed: error %d", (int)status);
       result = CURLE_PEER_FAILED_VERIFICATION;
     }
     else if((sec_result == kSecTrustResultUnspecified) ||

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2192,7 +2192,7 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
         if((cnlen <= 0) || !cn)
           result = CURLE_OUT_OF_MEMORY;
         else if((size_t)cnlen != strlen((char *)cn)) {
-          /* there was a terminating zero before the end of string, this
+          /* there was a null-terminator before the end of string, this
              cannot match and we return failure! */
           failf(data, "SSL: illegal cert name field");
           result = CURLE_PEER_FAILED_VERIFICATION;

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -862,6 +862,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conditional-uninitialized])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
           fi
+
           dnl Only clang 3.1 or later
           if test "$compiler_num" -ge "301"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [format-non-iso])
@@ -883,6 +884,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
                 ;;
             esac
           fi
+
           dnl Only clang 3.3 or later
           if test "$compiler_num" -ge "303"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wno-documentation-unknown-command"
@@ -914,38 +916,46 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
               tmp_CFLAGS="$tmp_CFLAGS -Wno-varargs"
             fi
           fi
+
           dnl clang 7 or later
           if test "$compiler_num" -ge "700"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [assign-enum])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [extra-semi-stmt])
           fi
+
           dnl clang 10 or later
           if test "$compiler_num" -ge "1000"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"  # we have silencing markup for clang 10.0 and above only
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [xor-used-as-pow])
           fi
+
           dnl clang 13 or later
           if test "$compiler_num" -ge "1300"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [reserved-identifier]) # Keep it before -Wno-reserved-macro-identifier
             tmp_CFLAGS="$tmp_CFLAGS -Wno-reserved-macro-identifier"  # Sometimes such external macros need to be set
           fi
+
           dnl clang 16 or later
           if test "$compiler_num" -ge "1600"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wno-unsafe-buffer-usage"
           fi
+
           dnl clang 17 or later
           if test "$compiler_num" -ge "1700"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-function-type-strict])  # with Apple clang it requires 16.0 or above
           fi
+
           dnl clang 19 or later
           if test "$compiler_num" -ge "1901"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wno-format-signedness"
           fi
+
           dnl clang 20 or later
           if test "$compiler_num" -ge "2001"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [array-compare])
           fi
+
           dnl clang 21 or later
           if test "$compiler_num" -ge "2101"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c++-hidden-decl])

--- a/scripts/badwords.txt
+++ b/scripts/badwords.txt
@@ -29,6 +29,7 @@ nul terminated:null-terminated
 null terminated:null-terminated
 NULL-terminated=null-terminated
 zero terminated:null-terminated
+zero-terminated:null-terminated
 nul terminator:null-terminator
 null terminator:null-terminator
 zero terminator:null-terminator

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -197,6 +197,7 @@ class TestErrors:
                     conn.recv(1)  # wait for ClientHello
                     conn.close()
                 except Exception:
+                    # ignore expected socket error
                     pass
 
             t = threading.Thread(target=accept_and_close)

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -89,6 +89,7 @@ class RunProfile:
                 'rss': mem.rss,
             })
         except psutil.NoSuchProcess:
+            # process may exit between sampling ticks: ignore this
             pass
 
     def finish(self):
@@ -238,6 +239,7 @@ class RunTcpDump:
                     try:
                         self._proc.wait(timeout=1)
                     except subprocess.TimeoutExpired:
+                        # timeout means tcpdump is still running
                         pass
         except Exception:
             log.exception('Tcpdump')

--- a/tests/http/testenv/ws_echo_server.py
+++ b/tests/http/testenv/ws_echo_server.py
@@ -37,6 +37,7 @@ async def echo(websocket):
         async for message in websocket:
             await websocket.send(message)
     except ConnectionClosedError:
+        # websocket connection closed by client
         pass
 
 

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -203,7 +203,7 @@ static int t530_checkForCompletion(CURLM *multi, int *success)
         *success = 0;
     }
     else {
-      curl_mfprintf(stderr, "%s got an unexpected message from curl: %i\n",
+      curl_mfprintf(stderr, "%s got an unexpected message from curl: %d\n",
                     t530_tag(), message->msg);
       result = 1;
       *success = 0;
@@ -247,7 +247,7 @@ static CURLMcode socket_action(CURLM *multi, curl_socket_t s, int evBitmask,
   CURLMcode mresult = curl_multi_socket_action(multi, s, evBitmask,
                                               &numhandles);
   if(mresult != CURLM_OK) {
-    curl_mfprintf(stderr, "%s curl error on %s (%i) %s\n",
+    curl_mfprintf(stderr, "%s curl error on %s (%d) %s\n",
                   t530_tag(), info, mresult, curl_multi_strerror(mresult));
   }
   return mresult;

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -150,7 +150,7 @@ static int t582_checkForCompletion(CURLM *multi, int *success)
         *success = 0;
     }
     else {
-      curl_mfprintf(stderr, "Got an unexpected message from curl: %i\n",
+      curl_mfprintf(stderr, "Got an unexpected message from curl: %d\n",
                     message->msg);
       result = 1;
       *success = 0;
@@ -194,7 +194,7 @@ static void notifyCurl(CURLM *multi, curl_socket_t s, int evBitmask,
   CURLMcode mresult = curl_multi_socket_action(multi, s, evBitmask,
                                                &numhandles);
   if(mresult != CURLM_OK) {
-    curl_mfprintf(stderr, "curl error on %s (%i) %s\n",
+    curl_mfprintf(stderr, "curl error on %s (%d) %s\n",
                   info, mresult, curl_multi_strerror(mresult));
   }
 }

--- a/tests/libtest/lib758.c
+++ b/tests/libtest/lib758.c
@@ -249,7 +249,7 @@ static int t758_checkForCompletion(CURLM *multi, int *success)
         *success = 0;
     }
     else {
-      curl_mfprintf(stderr, "%s got an unexpected message from curl: %i\n",
+      curl_mfprintf(stderr, "%s got an unexpected message from curl: %d\n",
                     t758_tag(), message->msg);
       result = 1;
       *success = 0;
@@ -293,7 +293,7 @@ static CURLMcode t758_saction(CURLM *multi, curl_socket_t s,
   CURLMcode mresult = curl_multi_socket_action(multi, s, evBitmask,
                                                &numhandles);
   if(mresult != CURLM_OK) {
-    curl_mfprintf(stderr, "%s curl error on %s (%i) %s\n",
+    curl_mfprintf(stderr, "%s curl error on %s (%d) %s\n",
                   t758_tag(), info, mresult, curl_multi_strerror(mresult));
   }
   return mresult;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -180,7 +180,6 @@ static ssize_t write_wincon(int fd, const void *buf, size_t count)
  * in nbytes or it fails with a condition that cannot be handled with a simple
  * retry of the read call.
  */
-
 static ssize_t fullread(int filedes, void *buffer, size_t nbytes)
 {
   int error;
@@ -234,7 +233,6 @@ static ssize_t fullread(int filedes, void *buffer, size_t nbytes)
  * indicated in nbytes or it fails with a condition that cannot be handled
  * with a simple retry of the write call.
  */
-
 static ssize_t fullwrite(int filedes, const void *buffer, size_t nbytes)
 {
   int error;
@@ -283,7 +281,6 @@ static ssize_t fullwrite(int filedes, const void *buffer, size_t nbytes)
  * read or FALSE when an unrecoverable error has been detected. Failure of this
  * function is an indication that the sockfilt process should terminate.
  */
-
 static bool read_stdin(void *buffer, size_t nbytes)
 {
   ssize_t nread = fullread(fileno(stdin), buffer, nbytes);
@@ -300,7 +297,6 @@ static bool read_stdin(void *buffer, size_t nbytes)
  * written or FALSE when an unrecoverable error has been detected. Failure of
  * this function is an indication that the sockfilt process should terminate.
  */
-
 static bool write_stdout(const void *buffer, size_t nbytes)
 {
   ssize_t nwrite;

--- a/tests/tunit/tool1394.c
+++ b/tests/tunit/tool1394.c
@@ -88,12 +88,10 @@ static CURLcode test_tool1394(const char *arg)
         fail("assertion failure");
       }
     }
-    else {
-      if(certname) {
-        curl_mprintf("expected certname NULL but got '%s' "
-                     "for -E param '%s'\n", certname, p->param);
-        fail("assertion failure");
-      }
+    else if(certname) {
+      curl_mprintf("expected certname NULL but got '%s' "
+                   "for -E param '%s'\n", certname, p->param);
+      fail("assertion failure");
     }
     if(p->passwd) {
       if(passphrase) {
@@ -109,12 +107,10 @@ static CURLcode test_tool1394(const char *arg)
         fail("assertion failure");
       }
     }
-    else {
-      if(passphrase) {
-        curl_mprintf("expected passphrase NULL but got '%s' "
-                     "for -E param '%s'\n", passphrase, p->param);
-        fail("assertion failure");
-      }
+    else if(passphrase) {
+      curl_mprintf("expected passphrase NULL but got '%s' "
+                   "for -E param '%s'\n", passphrase, p->param);
+      fail("assertion failure");
     }
     if(certname)
       curlx_free(certname);

--- a/tests/unit/unit1655.c
+++ b/tests/unit/unit1655.c
@@ -117,12 +117,10 @@ static CURLcode test_unit1655(const char *arg)
         fail_unless(victim.canary3 == 41,
                     "three-byte buffer overwrite has happened");
       }
-      else {
-        if(d == DOH_OK) {
-          fail_unless(olen <= sizeof(victim.dohbuffer),
-                      "wrote outside bounds");
-          fail_unless(olen > strlen(name), "unrealistic low size");
-        }
+      else if(d == DOH_OK) {
+        fail_unless(olen <= sizeof(victim.dohbuffer),
+                    "wrote outside bounds");
+        fail_unless(olen > strlen(name), "unrealistic low size");
       }
     }
   } while(0);

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -29,7 +29,7 @@ static CURLcode test_unit1675(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
 
-    /* Test ipv4_normalize */
+  /* Test ipv4_normalize */
   {
     struct dynbuf host;
     int fails = 0;

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -123,13 +123,11 @@ static CURLcode test_unit1675(const char *arg)
           fails++;
         }
       }
-      else {
-        if(rc == HOST_IPV4) {
-          curl_mfprintf(stderr, "ipv4_normalize('%s') succeeded unexpectedly:"
-                        " got '%s'\n",
-                        tests[i].in, curlx_dyn_ptr(&host));
-          fails++;
-        }
+      else if(rc == HOST_IPV4) {
+        curl_mfprintf(stderr, "ipv4_normalize('%s') succeeded unexpectedly:"
+                      " got '%s'\n",
+                      tests[i].in, curlx_dyn_ptr(&host));
+        fails++;
       }
     }
     curlx_dyn_free(&host);
@@ -238,12 +236,10 @@ static CURLcode test_unit1675(const char *arg)
           }
         }
       }
-      else {
-        if(!uc) {
-          curl_mfprintf(stderr, "ipv6_parse('%s') succeeded unexpectedly\n",
-                        tests[i].in);
-          fails++;
-        }
+      else if(!uc) {
+        curl_mfprintf(stderr, "ipv6_parse('%s') succeeded unexpectedly\n",
+                      tests[i].in);
+        fails++;
       }
       curlx_free(u.host);
       curlx_free(u.zoneid);


### PR DESCRIPTION
- badwords: replace stray synonyms with 'null-terminator'.
- tests/FILEFORMAT.md: tidy up feature descriptions.
- printf: replace stray `%i` masks with `%d` for consistency.
- pytest: add comments for empty excepts to try silencing GitHub CodeQL
  warnings.
- tool1394, unit1675: merge nested `if`s.
- dnscache: fix typo in comment.
- fix whitespace, indent and newlines.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
