### PR TITLE
unit1675: fix potential memory leak on dynbuf fail path

### DIFF
--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -111,6 +111,7 @@ static CURLcode test_unit1675(const char *arg)
       int rc;
       curlx_dyn_reset(&host);
       if(curlx_dyn_add(&host, tests[i].in)) {
+        curlx_dyn_free(&host);
         return CURLE_OUT_OF_MEMORY;
       }
       rc = ipv4_normalize(&host);


### PR DESCRIPTION
Spotted by GitHub Code Quality

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
