### PR TITLE
pytest: fix remaining code checker warnings

### DIFF
--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -264,6 +264,8 @@ class TestWebsockets:
                         f = b"\x88\x00"  # CLOSE frame
                         c.sendall(f)
                     except OSError:
+                        # Client may close/reset while we intentionally flood frames.
+                        # Send errors are expected here, ignore them.
                         pass
                     time.sleep(1)
                     c.close()

--- a/tests/http/testenv/certs.py
+++ b/tests/http/testenv/certs.py
@@ -484,8 +484,7 @@ class TestCA:
             else:
                 try:
                     names.append(x509.IPAddress(ipaddress.ip_address(name)))
-                # TODO: specify specific exceptions here
-                except:  # noqa: E722
+                except ValueError:
                     names.append(x509.DNSName(name))
 
         return csr.add_extension(

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -284,11 +284,10 @@ class ExecResult:
         if with_stats:
             self._parse_stats()
         else:
-            # noinspection PyBroadException
             try:
                 out = ''.join(self._stdout)
                 self._json_out = json.loads(out)
-            except:  # noqa: E722
+            except (json.JSONDecodeError, TypeError, ValueError):
                 pass
 
     def __repr__(self):
@@ -300,8 +299,7 @@ class ExecResult:
         for line in self._stdout:
             try:
                 self._stats.append(json.loads(line))
-            # TODO: specify specific exceptions here
-            except:  # noqa: E722
+            except (json.JSONDecodeError, TypeError, ValueError):
                 log.exception(f'not a JSON stat: {line}')
                 break
 

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -1029,8 +1029,6 @@ class CurlClient:
                                          cwd=self._run_dir, shell=False,
                                          env=self._run_env)
                     profile = RunProfile(p.pid, started_at, self._run_dir)
-                    #if intext is not None and False:
-                    #    p.communicate(input=intext.encode(), timeout=1)
                     if self._with_perf:
                         perf = PerfProfile(p.pid, self._run_dir)
                         perf.start()


### PR DESCRIPTION
- curl.py: delete commented no-op code.
- certs.py, curl.py: narrow down exceptions to fix:
  Except block handles 'BaseException'
- test_20_websockets: add comment to empty except branch.

Reported by GitHub CodeQL

---

There remains one false positive: Unused import impacket in smbserver.py.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
