### PR TITLE
tidy-up: use uppercase `TRUE`/`FALSE` where missing

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -2176,10 +2176,10 @@ static CURLcode cf_tcp_accept_connect(struct Curl_cfilter *cf,
     int error = 0;
 
     /* activate callback for setting socket options */
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     error = data->set.fsockopt(data->set.sockopt_client,
                                ctx->sock, CURLSOCKTYPE_ACCEPT);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
 
     if(error)
       return CURLE_ABORTED_BY_CALLBACK;

--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -247,7 +247,7 @@ cleanup:
   CURLX_FREE(ibuf);
   CURLX_FREE(obuf);
 #endif
-  return *out ? true : false;
+  return !!*out;
 }
 
 #ifndef CURL_WINDOWS_UWP

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -271,13 +271,12 @@ static bool should_urlencode(struct Curl_str *service_name)
    * should_urlencode == true is equivalent to should_urlencode_uri_path
    * from the AWS SDK. Urls are already normalized by the curl URL parser
    */
-
   if(curlx_str_cmp(service_name, "s3") ||
      curlx_str_cmp(service_name, "s3-express") ||
      curlx_str_cmp(service_name, "s3-outposts")) {
-    return false;
+    return FALSE;
   }
-  return true;
+  return TRUE;
 }
 
 /* maximum length for the aws sivg4 parts */

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1188,9 +1188,9 @@ static bool is_custom_fetch_listing_match(const char *params)
       return FALSE;
   }
   if(*params == ':')
-    return true;
+    return TRUE;
   if(*params == ',')
-    return true;
+    return TRUE;
   return FALSE;
 }
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1452,7 +1452,7 @@ static CURLcode cf_ssl_proxy_create(struct Curl_cfilter **pcf,
   }
 #endif
 
-  ctx = cf_ctx_new(data, alpn_get_spec(wanted, 0, false, use_alpn));
+  ctx = cf_ctx_new(data, alpn_get_spec(wanted, 0, FALSE, use_alpn));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -125,12 +125,12 @@ static size_t win_console(intptr_t fhnd, struct OutStruct *outs,
   /* attempt to complete an incomplete UTF-8 sequence from previous call. the
      sequence does not have to be well-formed. */
   if(outs->utf8seq[0] && rlen) {
-    bool complete = false;
+    bool complete = FALSE;
     /* two byte sequence (lead byte 110yyyyy) */
     if(0xC0 <= outs->utf8seq[0] && outs->utf8seq[0] < 0xE0) {
       outs->utf8seq[1] = *rbuf++;
       --rlen;
-      complete = true;
+      complete = TRUE;
     }
     /* three byte sequence (lead byte 1110zzzz) */
     else if(0xE0 <= outs->utf8seq[0] && outs->utf8seq[0] < 0xF0) {
@@ -141,7 +141,7 @@ static size_t win_console(intptr_t fhnd, struct OutStruct *outs,
       if(rlen && !outs->utf8seq[2]) {
         outs->utf8seq[2] = *rbuf++;
         --rlen;
-        complete = true;
+        complete = TRUE;
       }
     }
     /* four byte sequence (lead byte 11110uuu) */
@@ -157,7 +157,7 @@ static size_t win_console(intptr_t fhnd, struct OutStruct *outs,
       if(rlen && !outs->utf8seq[3]) {
         outs->utf8seq[3] = *rbuf++;
         --rlen;
-        complete = true;
+        complete = TRUE;
       }
     }
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -678,7 +678,7 @@ static void init_terminal(void)
     return;
 
   if((TerminalSettings.dwOutputMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING))
-    tool_term_has_bold = true;
+    tool_term_has_bold = TRUE;
   else {
     /* The signal handler is set before attempting to change the console mode
        because otherwise a signal would not be caught after the change but
@@ -688,7 +688,7 @@ static void init_terminal(void)
       if(SetConsoleMode(TerminalSettings.hStdOut,
                         (TerminalSettings.dwOutputMode |
                          ENABLE_VIRTUAL_TERMINAL_PROCESSING))) {
-        tool_term_has_bold = true;
+        tool_term_has_bold = TRUE;
         atexit(restore_terminal);
       }
       else {

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -45,7 +45,7 @@ static int writeTime(FILE *stream, const struct writeoutvar *wovar,
                      struct per_transfer *per, CURLcode per_result,
                      bool use_json)
 {
-  bool valid = false;
+  bool valid = FALSE;
   curl_off_t us = 0;
 
   (void)per;
@@ -54,7 +54,7 @@ static int writeTime(FILE *stream, const struct writeoutvar *wovar,
 
   if(wovar->ci) {
     if(!curl_easy_getinfo(per->curl, wovar->ci, &us))
-      valid = true;
+      valid = TRUE;
   }
   else {
     DEBUGASSERT(0);
@@ -173,7 +173,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
                        struct per_transfer *per, CURLcode per_result,
                        bool use_json)
 {
-  bool valid = false;
+  bool valid = FALSE;
   const char *strinfo = NULL;
   const char *freestr = NULL;
   struct dynbuf buf;
@@ -189,7 +189,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
         while(m->str) {
           if(m->num == version) {
             strinfo = m->str;
-            valid = true;
+            valid = TRUE;
             break;
           }
           m++;
@@ -198,7 +198,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
     }
     else {
       if(!curl_easy_getinfo(per->curl, wovar->ci, &strinfo) && strinfo)
-        valid = true;
+        valid = TRUE;
     }
   }
   else {
@@ -243,7 +243,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
           if(!strinfo)
             /* maybe not a TLS protocol */
             strinfo = "";
-          valid = true;
+          valid = TRUE;
         }
       }
       else
@@ -253,19 +253,19 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
       if(per_result) {
         strinfo = (per->errorbuffer[0]) ? per->errorbuffer :
           curl_easy_strerror(per_result);
-        valid = true;
+        valid = TRUE;
       }
       break;
     case VAR_EFFECTIVE_FILENAME:
       if(per->outs.filename) {
         strinfo = per->outs.filename;
-        valid = true;
+        valid = TRUE;
       }
       break;
     case VAR_INPUT_URL:
       if(per->url) {
         strinfo = per->url;
-        valid = true;
+        valid = TRUE;
       }
       break;
     case VAR_INPUT_URLSCHEME:
@@ -291,7 +291,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
       if(per->url) {
         if(!urlpart(per, wovar->id, &strinfo)) {
           freestr = strinfo;
-          valid = true;
+          valid = TRUE;
         }
       }
       break;
@@ -324,33 +324,33 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
                      struct per_transfer *per, CURLcode per_result,
                      bool use_json)
 {
-  bool valid = false;
+  bool valid = FALSE;
   long longinfo = 0;
 
   DEBUGASSERT(wovar->writefunc == writeLong);
 
   if(wovar->ci) {
     if(!curl_easy_getinfo(per->curl, wovar->ci, &longinfo))
-      valid = true;
+      valid = TRUE;
   }
   else {
     switch(wovar->id) {
     case VAR_NUM_RETRY:
       longinfo = per->num_retries;
-      valid = true;
+      valid = TRUE;
       break;
     case VAR_NUM_CERTS:
       certinfo(per);
       longinfo = per->certinfo ? per->certinfo->num_of_certs : 0;
-      valid = true;
+      valid = TRUE;
       break;
     case VAR_NUM_HEADERS:
       longinfo = per->num_headers;
-      valid = true;
+      valid = TRUE;
       break;
     case VAR_EXITCODE:
       longinfo = (long)per_result;
-      valid = true;
+      valid = TRUE;
       break;
     default:
       DEBUGASSERT(0);
@@ -380,7 +380,7 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
                        struct per_transfer *per, CURLcode per_result,
                        bool use_json)
 {
-  bool valid = false;
+  bool valid = FALSE;
   curl_off_t offinfo = 0;
 
   (void)per;
@@ -389,14 +389,14 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
 
   if(wovar->ci) {
     if(!curl_easy_getinfo(per->curl, wovar->ci, &offinfo))
-      valid = true;
+      valid = TRUE;
   }
   else {
     switch(wovar->id) {
     case VAR_URLNUM:
       if(per->urlnum <= INT_MAX) {
         offinfo = per->urlnum;
-        valid = true;
+        valid = TRUE;
       }
       break;
     default:
@@ -787,7 +787,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
               headerJSON(stream, per);
               break;
             default:
-              (void)wv->writefunc(stream, wv, per, per_result, false);
+              (void)wv->writefunc(stream, wv, per, per_result, FALSE);
               break;
             }
           }

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -105,7 +105,7 @@ void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
 
   for(i = 0; i < nentries; i++) {
     if(mappings[i].writefunc &&
-       mappings[i].writefunc(stream, &mappings[i], per, per_result, true))
+       mappings[i].writefunc(stream, &mappings[i], per, per_result, TRUE))
       fputs(",", stream);
   }
 

--- a/src/var.c
+++ b/src/var.c
@@ -316,7 +316,7 @@ ParameterError varexpand(const char *line, struct dynbuf *out, bool *replaced)
           if(result)
             return PARAM_NO_MEM;
 
-          added = true;
+          added = TRUE;
         }
       }
       line = &clp[2];

--- a/tests/libtest/lib1565.c
+++ b/tests/libtest/lib1565.c
@@ -93,7 +93,7 @@ static CURLcode test_lib1565(const char *URL)
   int started_num = 0;
   int finished_num = 0;
   pthread_t tid = 0;
-  bool tid_valid = false;
+  bool tid_valid = FALSE;
   struct CURLMsg *message;
 
   start_test_timing();
@@ -106,7 +106,7 @@ static CURLcode test_lib1565(const char *URL)
 
   rc = pthread_create(&tid, NULL, t1565_run_thread, NULL);
   if(!rc)
-    tid_valid = true;
+    tid_valid = TRUE;
   else {
     curl_mfprintf(stderr, "%s:%d Could not create thread, errno %d\n",
                   __FILE__, __LINE__, rc);

--- a/tests/libtest/lib2700.c
+++ b/tests/libtest/lib2700.c
@@ -39,7 +39,7 @@ static const char *descr_flags(int flags)
     return "pong";
   if(flags & CURLWS_CLOSE)
     return "close";
-  assert(false);
+  assert(FALSE);
   return "";
 }
 
@@ -200,7 +200,7 @@ static CURLcode recv_frame(CURL *curl, bool *stop)
   }
 
   if(flags & CURLWS_CLOSE)
-    *stop = true;
+    *stop = TRUE;
 
   curl_mfprintf(stdout, "\n");
 
@@ -212,7 +212,7 @@ static CURLcode test_lib2700(const char *URL)
 {
 #ifndef CURL_DISABLE_WEBSOCKETS
   CURLcode result = CURLE_OK;
-  bool stop = false;
+  bool stop = FALSE;
   CURL *curl;
 
   global_init(CURL_GLOBAL_ALL);

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -34,7 +34,7 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
 
   /* Chains with only a single certificate are always in order */
   if(cert_info->num_of_certs <= 1)
-    return true;
+    return TRUE;
 
   /* Enumerate each certificate in the chain */
   for(cert = 0; cert < cert_info->num_of_certs; cert++) {
@@ -68,7 +68,7 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
                         "cert %d issuer does not match cert %d subject\n",
                         cert - 1, cert);
           curl_mfprintf(stderr, "certificate chain is not in order\n");
-          return false;
+          return FALSE;
         }
       }
     }
@@ -77,7 +77,7 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
   }
 
   curl_mprintf("certificate chain is in order\n");
-  return true;
+  return TRUE;
 }
 
 static size_t wrfu(char *ptr, size_t size, size_t nmemb, void *stream)

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -1047,7 +1047,7 @@ dnsd_cleanup:
   }
 
   clear_resp_queue();
-  restore_signal_handlers(true);
+  restore_signal_handlers(TRUE);
 
   if(got_exit_signal) {
     logmsg("========> %s dnsd (port: %d pid: %ld) exits with signal (%d)",

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1106,7 +1106,7 @@ static int test_rtspd(int argc, const char *argv[])
   snprintf(loglockfile, sizeof(loglockfile), "%s/%s/rtsp-%s.lock",
            logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
-  install_signal_handlers(false);
+  install_signal_handlers(FALSE);
 
 #ifdef USE_IPV6
   if(!use_ipv6)
@@ -1343,7 +1343,7 @@ server_cleanup:
     clear_advisor_read_lock(loglockfile);
   }
 
-  restore_signal_handlers(false);
+  restore_signal_handlers(FALSE);
 
   if(got_exit_signal) {
     logmsg("========> %s rtspd (port: %d pid: %ld) exits with signal (%d)",

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1288,7 +1288,7 @@ static int test_sockfilt(int argc, const char *argv[])
   CURL_BINMODE(stdout);
   CURL_BINMODE(stderr);
 
-  install_signal_handlers(false);
+  install_signal_handlers(FALSE);
 
   sock = socket(socket_domain, SOCK_STREAM, 0);
 
@@ -1389,7 +1389,7 @@ sockfilt_cleanup:
   if(wroteportfile)
     unlink(portname);
 
-  restore_signal_handlers(false);
+  restore_signal_handlers(FALSE);
 
   if(got_exit_signal) {
     logmsg("============> sockfilt exits with signal (%d)", exit_signal);

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -738,7 +738,7 @@ static int test_socksd(int argc, const char *argv[])
 
   const char *unix_socket = NULL;
 #ifdef USE_UNIX_SOCKETS
-  bool unlink_socket = false;
+  bool unlink_socket = FALSE;
 #endif
 
   pidname = ".socksd.pid";
@@ -861,7 +861,7 @@ static int test_socksd(int argc, const char *argv[])
   CURL_BINMODE(stdout);
   CURL_BINMODE(stderr);
 
-  install_signal_handlers(false);
+  install_signal_handlers(FALSE);
 
   sock = socket(socket_domain, SOCK_STREAM, 0);
 
@@ -879,7 +879,7 @@ static int test_socksd(int argc, const char *argv[])
       goto socks5_cleanup;
     }
 #ifdef USE_UNIX_SOCKETS
-    unlink_socket = true;
+    unlink_socket = TRUE;
 #endif
     msgsock = CURL_SOCKET_BAD; /* no stream socket yet */
   }
@@ -930,7 +930,7 @@ socks5_cleanup:
   if(wroteportfile)
     unlink(portname);
 
-  restore_signal_handlers(false);
+  restore_signal_handlers(FALSE);
 
   if(got_exit_signal) {
     logmsg("============> socksd exits with signal (%d)", exit_signal);

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -195,10 +195,10 @@ static bool socket_domain_is_ip(void)
 #ifdef USE_IPV6
   case AF_INET6:
 #endif
-    return true;
+    return TRUE;
   default:
     /* case AF_UNIX: */
-    return false;
+    return FALSE;
   }
 }
 #endif
@@ -1971,7 +1971,7 @@ static int test_sws(int argc, const char *argv[])
   unsigned short port = 8999;
 #ifdef USE_UNIX_SOCKETS
   const char *unix_socket = NULL;
-  bool unlink_socket = false;
+  bool unlink_socket = FALSE;
 #endif
   struct sws_httprequest *req = NULL;
   int rc = 0;
@@ -2135,7 +2135,7 @@ static int test_sws(int argc, const char *argv[])
            logdir, SERVERLOGS_LOCKDIR, protocol_type,
            is_proxy ? "-proxy" : "", socket_type);
 
-  install_signal_handlers(false);
+  install_signal_handlers(FALSE);
 
   req = calloc(1, sizeof(*req));
   if(!req)
@@ -2271,7 +2271,7 @@ static int test_sws(int argc, const char *argv[])
 
 #ifdef USE_UNIX_SOCKETS
   /* listen succeeds, so let's assume a valid listening Unix socket */
-  unlink_socket = true;
+  unlink_socket = TRUE;
 #endif
 
   /*
@@ -2465,7 +2465,7 @@ sws_cleanup:
     clear_advisor_read_lock(loglockfile);
   }
 
-  restore_signal_handlers(false);
+  restore_signal_handlers(FALSE);
 
   if(got_exit_signal) {
     logmsg("========> %s sws (%s pid: %ld) exits with signal (%d)",

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -918,10 +918,10 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
   cp = (char *)&tp->th_stuff;
   filename = cp;
   do {
-    bool endofit = true;
+    bool endofit = TRUE;
     while(cp < &trsbuf.storage[size]) {
       if(*cp == '\0') {
-        endofit = false;
+        endofit = FALSE;
         break;
       }
       cp++;
@@ -1109,7 +1109,7 @@ static int test_tftpd(int argc, const char **argv)
   snprintf(loglockfile, sizeof(loglockfile), "%s/%s/tftp-%s.lock",
            logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
-  install_signal_handlers(true);
+  install_signal_handlers(TRUE);
 
 #ifdef USE_IPV6
   if(!use_ipv6)
@@ -1327,7 +1327,7 @@ tftpd_cleanup:
     clear_advisor_read_lock(loglockfile);
   }
 
-  restore_signal_handlers(true);
+  restore_signal_handlers(TRUE);
 
   if(got_exit_signal) {
     logmsg("========> %s tftpd (port: %d pid: %ld) exits with signal (%d)",

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -110,7 +110,7 @@ static CURLcode test_unit1607(const char *arg)
     struct Curl_addrinfo *addr;
     struct Curl_dns_entry *dns;
     void *entry_id;
-    bool problem = false;
+    bool problem = FALSE;
     easy = curl_easy_init();
     if(!easy)
       goto error;
@@ -151,7 +151,7 @@ static CURLcode test_unit1607(const char *arg)
         curl_mfprintf(stderr, "%s:%d tests[%zu] failed. "
                       "getaddressinfo failed.\n",
                       __FILE__, __LINE__, i);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -159,7 +159,7 @@ static CURLcode test_unit1607(const char *arg)
         curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
                       "is %s but tests[%zu].address[%zu] is NULL.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -167,7 +167,7 @@ static CURLcode test_unit1607(const char *arg)
         curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
                       "is NULL but tests[%zu].address[%zu] is %s.\n",
                       __FILE__, __LINE__, i, i, j, tests[i].address[j]);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -176,7 +176,7 @@ static CURLcode test_unit1607(const char *arg)
                       "%s is not equal to tests[%zu].address[%zu] %s.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j,
                       tests[i].address[j]);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -185,7 +185,7 @@ static CURLcode test_unit1607(const char *arg)
                       "for tests[%zu].address[%zu] is %d "
                       "but tests[%zu].port is %d.\n",
                       __FILE__, __LINE__, i, i, j, port, i, tests[i].port);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -194,7 +194,7 @@ static CURLcode test_unit1607(const char *arg)
                       "%s:%d tests[%zu] failed. the timestamp is not zero "
                       "but tests[%zu].permanent is TRUE\n",
                       __FILE__, __LINE__, i, i);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -202,7 +202,7 @@ static CURLcode test_unit1607(const char *arg)
         curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the timestamp is zero "
                       "but tests[%zu].permanent is FALSE\n",
                       __FILE__, __LINE__, i, i);
-        problem = true;
+        problem = TRUE;
         break;
       }
 

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -106,7 +106,7 @@ static CURLcode test_unit1609(const char *arg)
     struct Curl_addrinfo *addr;
     struct Curl_dns_entry *dns;
     void *entry_id;
-    bool problem = false;
+    bool problem = FALSE;
     easy = curl_easy_init();
     if(!easy) {
       curl_global_cleanup();
@@ -150,7 +150,7 @@ static CURLcode test_unit1609(const char *arg)
         curl_mfprintf(stderr,
                       "%s:%d tests[%zu] failed. Curl_addr2string failed.\n",
                       __FILE__, __LINE__, i);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -158,7 +158,7 @@ static CURLcode test_unit1609(const char *arg)
         curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
                       "is %s but tests[%zu].address[%zu] is NULL.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -166,7 +166,7 @@ static CURLcode test_unit1609(const char *arg)
         curl_mfprintf(stderr, "%s:%d tests[%zu] failed. the retrieved addr "
                       "is NULL but tests[%zu].address[%zu] is %s.\n",
                       __FILE__, __LINE__, i, i, j, tests[i].address[j]);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -175,7 +175,7 @@ static CURLcode test_unit1609(const char *arg)
                       "%s is not equal to tests[%zu].address[%zu] %s.\n",
                       __FILE__, __LINE__, i, ipaddress, i, j,
                       tests[i].address[j]);
-        problem = true;
+        problem = TRUE;
         break;
       }
 
@@ -184,7 +184,7 @@ static CURLcode test_unit1609(const char *arg)
                       "for tests[%zu].address[%zu] is %d "
                       "but tests[%zu].port is %d.\n",
                       __FILE__, __LINE__, i, i, j, port, i, tests[i].port);
-        problem = true;
+        problem = TRUE;
         break;
       }
 

--- a/tests/unit/unit1979.c
+++ b/tests/unit/unit1979.c
@@ -39,19 +39,19 @@ static CURLcode test_unit1979(const char *arg)
   static const struct testcase testcases[] = {
     {
       "test-equals-encode",
-      true,
+      TRUE,
       "/a=b",
       "/a%3Db"
     },
     {
       "test-equals-noencode",
-      false,
+      FALSE,
       "/a=b",
       "/a=b"
     },
     {
       "test-s3-tables",
-      true,
+      TRUE,
       "/tables/arn%3Aaws%3As3tables%3Aus-east-1%3A022954301426%3Abucket%2Fja"
       "soehartablebucket/jasoeharnamespace/jasoehartable/encryption",
       "/tables/arn%253Aaws%253As3tables%253Aus-east-1%253A022954301426%253Ab"
@@ -60,49 +60,49 @@ static CURLcode test_unit1979(const char *arg)
     },
     {
       "get-vanilla",
-      true,
+      TRUE,
       "/",
       "/"
     },
     {
       "get-unreserved",
-      true,
+      TRUE,
       "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
       "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     },
     {
       "get-slashes-unnormalized",
-      false,
+      FALSE,
       "//example//",
       "//example//"
     },
     {
       "get-space-normalized",
-      true,
+      TRUE,
       "/example space/",
       "/example%20space/"
     },
     {
       "get-plus-normalized",
-      true,
+      TRUE,
       "/example+space/",
       "/example%2Bspace/"
     },
     {
       "get-slash-dot-slash-unnormalized",
-      false,
+      FALSE,
       "/./",
       "/./"
     },
     {
       "get-slash-unnormalized",
-      false,
+      FALSE,
       "//",
       "//"
     },
     {
       "get-relative-relative-unnormalized",
-      false,
+      FALSE,
       "/example1/example2/../..",
       "/example1/example2/../.."
     }

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -542,7 +542,7 @@ static CURLcode test_unit3205(const char *arg)
     buf[0] = '\0';
     expect = test->rfc ? test->rfc : test->openssl;
 
-    Curl_cipher_suite_get_str(test->id, buf, sizeof(buf), true);
+    Curl_cipher_suite_get_str(test->id, buf, sizeof(buf), TRUE);
 
     if(expect && strcmp(buf, expect) != 0) {
       curl_mfprintf(stderr, "Curl_cipher_suite_get_str FAILED for 0x%04x, "
@@ -555,7 +555,7 @@ static CURLcode test_unit3205(const char *arg)
     buf[0] = '\0';
     expect = test->openssl ? test->openssl : test->rfc;
 
-    Curl_cipher_suite_get_str(test->id, buf, sizeof(buf), false);
+    Curl_cipher_suite_get_str(test->id, buf, sizeof(buf), FALSE);
 
     /* suites matched by EDH alias will return the DHE name */
     if(test->id >= 0x0011 && test->id < 0x0017) {


### PR DESCRIPTION
Keep it only in external API calls and C++ code.

Also:
- curlx/fopen: replace with `!!`.

Spotted by GitHub Code Quality in cf-socket.c.

---

That said: What is reason for using the uppercase macros throughout the
codebase? Is there a downside in using the lowercase ones everywhere?

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
