### PR TITLE
http-proxy: verify CONNECT response headers

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -476,6 +476,12 @@ static CURLcode single_header(struct Curl_cfilter *cf,
   /* output debug if that is requested */
   Curl_debug(data, CURLINFO_HEADER_IN, linep, line_len);
 
+  /* a CONNECT response line is handed to the client as a header, so it must
+     pass the same checks as a regular response header before delivery */
+  result = Curl_verify_header(data, linep, line_len);
+  if(result)
+    return result;
+
   /* send the header to the callback */
   writetype = CLIENTWRITE_HEADER | CLIENTWRITE_CONNECT |
     (ts->headerlines == 1 ? CLIENTWRITE_STATUS : 0);

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -253,7 +253,7 @@ test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 \
-test2100 test2101 test2102 test2103 test2104 test2105 test2106 \
+test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 \

--- a/tests/data/test2107
+++ b/tests/data/test2107
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP CONNECT
+HTTP proxy
+proxytunnel
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Content-Length: 0
+
+</data>
+<connect nocheck="yes">
+HTTP/1.1 200 OK%CR
+X-Evil: he%hex[%00]hex%llo%CR
+%CR
+</connect>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+http-proxy
+</server>
+<features>
+proxy
+</features>
+<name>
+HTTP CONNECT response with a nul byte in a header
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -p -x http://%HOSTIP:%PROXYPORT
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+8
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
The HTTP/1 proxy `CONNECT` response is read a line at a time in `single_header()` (`lib/cf-h1-proxy.c`) and each line is handed to the application as a header (`CLIENTWRITE_HEADER | CLIENTWRITE_CONNECT`) without passing through `Curl_verify_header()`. Regular response headers and chunked trailers both go through that helper, which rejects an embedded nul byte and a stray carriage return. So a malicious or MITM proxy can place a nul byte in a `CONNECT` response header and have it delivered to `CURLOPT_HEADERFUNCTION` with the nul still in it, the same confusion the helper already guards against for normal headers.

The fix calls `Curl_verify_header()` on each `CONNECT` line before it is delivered, bringing this path in line with the regular header path. The check belongs here because this is the only HTTP/1 reader that emits proxy response headers to the client; it also covers the `CONNECT`-UDP path, as both go through `single_header()`, while the HTTP/2 proxy path is already validated by nghttp2. `test2107` drives a `CONNECT` reply carrying a nul byte in a header and expects `CURLE_WEIRD_SERVER_REPLY` (it returns `0` without the patch).