### PR TITLE
tests/data/test16{29,45}: Add the keyword "--resolve"

### DIFF
--- a/tests/data/test1629
+++ b/tests/data/test1629
@@ -4,6 +4,7 @@
 <keywords>
 HTTP
 HTTP GET
+--resolve
 </keywords>
 </info>
 

--- a/tests/data/test1645
+++ b/tests/data/test1645
@@ -6,6 +6,7 @@ HTTP
 HTTP GET
 cookies
 cookiejar
+--resolve
 </keywords>
 </info>
 # Server-side

--- a/tests/data/test1646
+++ b/tests/data/test1646
@@ -3,6 +3,7 @@
 <info>
 <keywords>
 netrc
+--resolve
 </keywords>
 </info>
 

--- a/tests/data/test1966
+++ b/tests/data/test1966
@@ -5,6 +5,7 @@
 HTTP
 HTTP GET
 HTTP Digest auth
+--resolve
 </keywords>
 </info>
 # Server-side

--- a/tests/data/test2008
+++ b/tests/data/test2008
@@ -5,6 +5,7 @@
 HTTP
 -G
 --proto-default
+--resolve
 </keywords>
 </info>
 

--- a/tests/data/test2500
+++ b/tests/data/test2500
@@ -5,6 +5,7 @@
 HTTP
 HTTP GET
 HTTP/3
+--resolve
 </keywords>
 </info>
 

--- a/tests/data/test2503
+++ b/tests/data/test2503
@@ -5,6 +5,7 @@
 HTTP
 HTTP/3
 HTTPS
+--resolve
 -w
 %header
 </keywords>

--- a/tests/data/test31
+++ b/tests/data/test31
@@ -6,6 +6,7 @@ HTTP
 HTTP GET
 cookies
 cookiejar
+--resolve
 </keywords>
 </info>
 # Server-side

--- a/tests/data/test779
+++ b/tests/data/test779
@@ -6,6 +6,7 @@ HTTP
 IMAP
 oauth2-bearer
 followlocation
+--resolve
 </keywords>
 </info>
 # Server-side

--- a/tests/data/test795
+++ b/tests/data/test795
@@ -5,6 +5,7 @@
 HTTP
 IMAP
 followlocation
+--resolve
 </keywords>
 </info>
 # Server-side


### PR DESCRIPTION
So the tests can be skipped automatically based on the keyword when executing Privoxy's cts tests.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
