### PR TITLE
Implement a test server that drops connections right away

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -430,6 +430,7 @@ Commands for the test DNS server.
 ### `<server>`
 What server(s) this test case requires/uses. Available servers:
 
+- `conndrop`
 - `dict`
 - `file`
 - `ftp`

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -221,7 +221,7 @@ test1653 test1654 test1655 test1656 test1657 test1658 test1659 test1660 \
 test1661 test1662 test1663 test1664 test1665 test1666 test1667 test1668 \
 test1669 test1670 test1671 test1672 test1673 test1674 test1675 test1676 \
 test1677                   test1680 test1681 test1682 test1683 test1684 \
-test1685 test1686 \
+test1685 test1686 test1687 \
 \
 test1700 test1701 test1702 test1703 test1704 test1705 test1706 test1707 \
 test1708 test1709 test1710 test1711 test1712 test1713 test1714 test1715 \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -221,7 +221,7 @@ test1653 test1654 test1655 test1656 test1657 test1658 test1659 test1660 \
 test1661 test1662 test1663 test1664 test1665 test1666 test1667 test1668 \
 test1669 test1670 test1671 test1672 test1673 test1674 test1675 test1676 \
 test1677                   test1680 test1681 test1682 test1683 test1684 \
-test1685 \
+test1685 test1686 \
 \
 test1700 test1701 test1702 test1703 test1704 test1705 test1706 test1707 \
 test1708 test1709 test1710 test1711 test1712 test1713 test1714 test1715 \

--- a/tests/data/test1686
+++ b/tests/data/test1686
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP proxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+conndrop
+http
+</server>
+<features>
+proxy
+</features>
+<name>
+HTTP GET to a proxy that closes the connection right away
+</name>
+<command>
+--proxy http://%HOSTIP:%CONNDROPPORT http://example.org/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+52
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test1687
+++ b/tests/data/test1687
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+conndrop
+http
+</server>
+<name>
+HTTP GET to a server that closes the connection right away
+</name>
+<command>
+http://%HOSTIP:%CONNDROPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+52
+</errorcode>
+</verify>
+</testcase>

--- a/tests/http-server.pl
+++ b/tests/http-server.pl
@@ -53,6 +53,7 @@ my $connect;         # IP to connect to on CONNECT
 my $keepalive_secs;  # number of seconds to keep idle connections
 my $srcdir;
 my $gopher = 0;
+my $drop_connection = 0;
 
 my $flags  = "";
 my $path   = '.';
@@ -111,6 +112,9 @@ while(@ARGV) {
     }
     elsif($ARGV[0] eq '--gopher') {
         $gopher = 1;
+    }
+    elsif($ARGV[0] eq '--conndrop') {
+        $drop_connection = 1;
     }
     elsif($ARGV[0] eq '--port') {
         if($ARGV[1] =~ /^(\d+)$/) {
@@ -174,6 +178,7 @@ $flags .= "--pidfile \"$pidfile\" ".
     "--logdir \"$logdir\" ".
     "--portfile \"$portfile\" ";
 $flags .= "--gopher " if($gopher);
+$flags .= "--conndrop " if($drop_connection);
 $flags .= "--connect $connect " if($connect);
 $flags .= "--keepalive $keepalive_secs " if($keepalive_secs);
 if($ipvnum eq 'unix') {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -36,6 +36,7 @@
 
 static bool use_gopher = FALSE;
 static bool is_proxy = FALSE;
+static bool drop_connection = FALSE;
 
 #define MAX_SLEEP_TIME_MS 250
 
@@ -2037,6 +2038,11 @@ static int test_sws(int argc, const char *argv[])
       protocol_type = "GOPHER";
       end_of_headers = "\r\n"; /* gopher style is much simpler */
     }
+    else if(!strcmp("--conndrop", argv[arg])) {
+      arg++;
+      protocol_type = "conndrop";
+      drop_connection = TRUE;
+    }
     else if(!strcmp("--ipv4", argv[arg])) {
       socket_type = "IPv4";
       socket_domain = AF_INET;
@@ -2125,6 +2131,7 @@ static int test_sws(int argc, const char *argv[])
            " --unix-socket [file]\n"
            " --port [port]\n"
            " --srcdir [path]\n"
+           " --conndrop\n"
            " --connect [ip4-addr]\n"
            " --gopher");
       return 0;
@@ -2359,6 +2366,17 @@ static int test_sws(int argc, const char *argv[])
                (long)sock, (long)msgsock);
         if(msgsock == CURL_SOCKET_BAD)
           goto sws_cleanup;
+        if(drop_connection) {
+          num_sockets--;
+          logmsg("closing connection on socket %ld right away.",
+             (long)all_sockets[num_sockets]);
+          sclose(all_sockets[num_sockets]);
+          all_sockets[num_sockets] = CURL_SOCKET_BAD;
+          serverlogslocked -= 1;
+          if(!serverlogslocked)
+            clear_advisor_read_lock(loglockfile);
+          break;
+        }
         if(req->delay)
           curlx_wait_ms(req->delay);
       } while(msgsock > 0);

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -125,7 +125,7 @@ sub servername_str {
 
     $proto = uc($proto) if($proto);
     die "unsupported protocol: '$proto'" unless($proto &&
-        ($proto =~ /^(((DNS|FTP|HTTP|HTTP\/2|HTTP\/3|IMAP|POP3|GOPHER|SMTP|HTTPS-MTLS)S?)|(TFTP|SFTP|SOCKS|SSH|RTSP|HTTPTLS|DICT|SMB|SMBS|TELNET|MQTT|MQTTS))$/));
+        ($proto =~ /^(((DNS|FTP|HTTP|HTTP\/2|HTTP\/3|IMAP|POP3|GOPHER|SMTP|HTTPS-MTLS)S?)|(TFTP|SFTP|SOCKS|SSH|RTSP|HTTPTLS|DICT|SMB|SMBS|TELNET|MQTT|MQTTS|CONNDROP))$/));
 
     $ipver = (not $ipver) ? 'ipv4' : lc($ipver);
     die "unsupported IP version: '$ipver'" unless($ipver &&

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -238,7 +238,7 @@ sub init_serverpidfile_hash {
     }
     for my $proto (('tftp', 'sftp', 'socks', 'ssh', 'rtsp', 'httptls',
                     'dict', 'smb', 'smbs', 'telnet', 'mqtt', 'mqtts',
-                    'https-mtls', 'dns')) {
+                    'https-mtls', 'conndrop', 'dns')) {
         for my $ipvnum ((4, 6)) {
             for my $idnum ((1, 2)) {
                 my $serv = servername_id($proto, $ipvnum, $idnum);
@@ -308,6 +308,7 @@ sub serverfortest {
 
             my @lprotocols = @protocols;
 
+            push @lprotocols, "conndrop";
             push @lprotocols, "dns";
 
             if(! grep /^\Q$server\E$/, @lprotocols) {
@@ -1037,6 +1038,7 @@ my %protofunc = ('http' => \&verifyhttp,
                  'dns' => \&verifypid,
                  'socks' => \&verifypid,
                  'socks5unix' => \&verifypid,
+                 'conndrop' => \&verifypid,
                  'gopher' => \&verifyhttp,
                  'httptls' => \&verifyhttptls,
                  'dict' => \&verifyftp,
@@ -1113,6 +1115,7 @@ sub runhttpserver {
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
 
     my $flags = "";
+    $flags .= "--conndrop " if($proto eq "conndrop");
     $flags .= "--gopher " if($proto eq "gopher");
     $flags .= "--connect $HOSTIP " if($alt eq "proxy");
     $flags .= "--keepalive $keepalive_secs ";
@@ -2453,6 +2456,25 @@ sub startservers {
                 $run{'ftp-ipv6'}="$pid $pid2";
             }
         }
+        elsif($what eq "conndrop") {
+            if($run{'conndrop'} &&
+               !responsive_http_server("conndrop", $verbose, 0,
+                                       protoport("conndrop"))) {
+                if(stopserver('conndrop')) {
+                    return ("failed stopping unresponsive conndrop server", 3);
+                }
+            }
+            if(!$run{'conndrop'}) {
+                ($serr, $pid, $pid2, $PORT{'conndrop'}) =
+                    runhttpserver("conndrop", $verbose, 0);
+                if($pid <= 0) {
+                    return ("failed starting conndrop server", $serr);
+                }
+                logmsg sprintf ("* pid conndrop => %d %d\n", $pid, $pid2)
+                    if($verbose);
+                $run{'conndrop'}="$pid $pid2";
+            }
+        }
         elsif($what eq "gopher") {
             if($run{'gopher'} &&
                !responsive_http_server("gopher", $verbose, 0,
@@ -3134,7 +3156,8 @@ sub subvariables {
 
     # test server ports
     # Substitutes variables like %HTTPPORT and %SMTP6PORT with the server ports
-    foreach my $proto ('DICT', 'DNS',
+    foreach my $proto ('CONNDROP',
+                       'DICT', 'DNS',
                        'FTP', 'FTP6', 'FTPS',
                        'GOPHER', 'GOPHER6', 'GOPHERS',
                        'HTTP', 'HTTP6', 'HTTPS', 'HTTPS-MTLS',


### PR DESCRIPTION
... without sending a response.
   
It behaves like Privoxy when the connection is dropped due to
an ACL rule with wildcard destination and can be used to show
different curl(1) behaviour before and after 335dc0e3c59 on
(at least) ElectroBSD and OpenBSD.

The changed behaviour was previously reported in [0] and not considered a bug
according to [1] but at the time it wasn't known (to me) that curl's behaviour did not
actually change on Debian GNU/Linux [2].
    
[0]: <https://curl.se/mail/lib-2026-04/0015.html>
[1]: <https://curl.se/mail/lib-2026-04/0018.html>
[2]: <https://curl.se/mail/lib-2026-05/0013.html>

Add two tests that currently work on Debian GNU/Linux but fail on ElectroBSD and OpenBSD.

curl's inconsistent behaviour is inconvenient (for me) as two of Privoxy's ACL-related tests
no longer work reliably cross-platform when using a recent curl version and had to be disabled [4].

[4]: <https://www.privoxy.org/gitweb/?p=privoxy.git;a=commitdiff;h=cfe58bbd25320c6>