### PR TITLE
tidy-up: drop redundant `!= NULL` syntax

### DIFF
--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -173,7 +173,7 @@ static size_t follow_links(CURLM *multi, struct memory *mem, const char *url)
 
 static int is_html(const char *ctype)
 {
-  return ctype != NULL && strlen(ctype) > 10 && strstr(ctype, "text/html");
+  return ctype && strlen(ctype) > 10 && strstr(ctype, "text/html");
 }
 
 int main(void)

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -489,7 +489,7 @@ static struct Curl_addrinfo *async_ares_node2addr(
   struct Curl_addrinfo *calast = NULL;
   int error = 0;
 
-  for(ai = node; ai != NULL; ai = ai->ai_next) {
+  for(ai = node; ai; ai = ai->ai_next) {
     size_t ss_size;
     struct Curl_addrinfo *ca;
     /* ignore elements with unsupported address family,

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -625,7 +625,7 @@ bool Curl_conn_is_setup(struct connectdata *conn, int sockindex)
 {
   if(!CONN_SOCK_IDX_VALID(sockindex))
     return FALSE;
-  return (conn->cfilter[sockindex] != NULL);
+  return !!conn->cfilter[sockindex];
 }
 
 bool Curl_conn_is_connected(struct connectdata *conn, int sockindex)

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -114,7 +114,7 @@ int Curl_getaddrinfo_ex(const char *nodename,
 
   /* traverse the addrinfo list */
 
-  for(ai = aihead; ai != NULL; ai = ai->ai_next) {
+  for(ai = aihead; ai; ai = ai->ai_next) {
     size_t namelen = ai->ai_canonname ? strlen(ai->ai_canonname) + 1 : 0;
     /* ignore elements with unsupported address family,
        settle family-specific sockaddr structure size. */
@@ -257,7 +257,7 @@ struct Curl_addrinfo *Curl_he2ai(const struct hostent *he, int port)
     /* no input == no output! */
     return NULL;
 
-  DEBUGASSERT((he->h_name != NULL) && (he->h_addr_list != NULL));
+  DEBUGASSERT(he->h_name && he->h_addr_list);
 
   for(i = 0; (curr = he->h_addr_list[i]) != NULL; i++) {
     size_t ss_size;
@@ -613,7 +613,7 @@ void Curl_addrinfo_set_port(struct Curl_addrinfo *addrinfo, int port)
 #ifdef USE_IPV6
   struct sockaddr_in6 *addr6;
 #endif
-  for(ca = addrinfo; ca != NULL; ca = ca->ai_next) {
+  for(ca = addrinfo; ca; ca = ca->ai_next) {
     switch(ca->ai_family) {
     case AF_INET:
       addr = (void *)ca->ai_addr; /* storage area for this info */

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -262,7 +262,7 @@ static CURLcode Curl_sha512_256_update(void *context,
 {
   Curl_sha512_256_ctx * const ctx = (Curl_sha512_256_ctx *)context;
 
-  DEBUGASSERT((data != NULL) || (length == 0));
+  DEBUGASSERT(data || (length == 0));
 
   sha512_256_update(ctx, length, (const uint8_t *)data);
 
@@ -645,7 +645,7 @@ static CURLcode Curl_sha512_256_update(void *context,
   /* the void pointer here is required to mute Intel compiler warning */
   void * const ctx_buf = ctx->buffer;
 
-  DEBUGASSERT((data != NULL) || (length == 0));
+  DEBUGASSERT(data || (length == 0));
 
   if(length == 0)
     return CURLE_OK; /* Shortcut, do nothing */

--- a/lib/fake_addrinfo.c
+++ b/lib/fake_addrinfo.c
@@ -64,7 +64,7 @@ static struct addrinfo *mk_getaddrinfo(const struct ares_addrinfo *aihead)
   const char *name = aihead->name;
 
   /* traverse the addrinfo list */
-  for(ai = aihead->nodes; ai != NULL; ai = ai->ai_next) {
+  for(ai = aihead->nodes; ai; ai = ai->ai_next) {
     size_t ss_size;
     size_t namelen = name ? strlen(name) + 1 : 0;
     /* ignore elements with unsupported address family,

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -154,7 +154,7 @@ static void AddFormInfo(struct FormInfo *form_info, struct FormInfo *parent)
 
 static void free_formlist(struct FormInfo *ptr)
 {
-  for(; ptr != NULL; ptr = ptr->more) {
+  for(; ptr; ptr = ptr->more) {
     Curl_bufref_free(&ptr->name);
     Curl_bufref_free(&ptr->value);
     Curl_bufref_free(&ptr->contenttype);
@@ -223,7 +223,7 @@ static CURLFORMcode FormAddCheck(struct FormInfo *first_form,
   /* go through the list, check for completeness and if everything is
    * alright add the HttpPost item otherwise set retval accordingly */
 
-  for(form = first_form; form != NULL; form = form->more) {
+  for(form = first_form; form; form = form->more) {
     const char *name = Curl_bufref_ptr(&form->name);
 
     if(((!name || !Curl_bufref_ptr(&form->value)) && !post) ||

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -215,8 +215,8 @@ static uint32_t cf_h2_initial_win_size(struct Curl_easy *data)
 }
 
 static size_t populate_settings(nghttp2_settings_entry *iv,
-                                  struct Curl_easy *data,
-                                  struct cf_h2_ctx *ctx)
+                                struct Curl_easy *data,
+                                struct cf_h2_ctx *ctx)
 {
   iv[0].settings_id = NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
   iv[0].value = Curl_multi_max_concurrent_streams(data->multi);
@@ -226,7 +226,7 @@ static size_t populate_settings(nghttp2_settings_entry *iv,
   if(ctx)
     ctx->initial_win_size = iv[1].value;
   iv[2].settings_id = NGHTTP2_SETTINGS_ENABLE_PUSH;
-  iv[2].value = data->multi->push_cb != NULL;
+  iv[2].value = !!data->multi->push_cb;
 
   return 3;
 }

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -107,7 +107,7 @@ if2ip_result_t Curl_if2ip(int af,
 #endif
 
   if(getifaddrs(&head) >= 0) {
-    for(iface = head; iface != NULL; iface = iface->ifa_next) {
+    for(iface = head; iface; iface = iface->ifa_next) {
       if(iface->ifa_addr) {
         if(iface->ifa_addr->sa_family == af) {
           if(curl_strequal(iface->ifa_name, interf)) {

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -488,7 +488,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 
       vals = ldap_get_values_len(server, entryIterator, attribute);
       if(vals) {
-        for(i = 0; (vals[i] != NULL); i++) {
+        for(i = 0; vals[i]; i++) {
           result = Curl_client_write(data, CLIENTWRITE_BODY, "\t", 1);
           if(result) {
             ldap_value_free_len(vals);

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -269,7 +269,7 @@ char *curl_dbg_strdup(const char *str, int line, const char *source)
   char *mem;
   size_t len;
 
-  DEBUGASSERT(str != NULL);
+  DEBUGASSERT(str);
 
   if(countcheck("strdup", line, source))
     return NULL;
@@ -294,7 +294,7 @@ wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source)
   wchar_t *mem;
   size_t wsiz, bsiz;
 
-  DEBUGASSERT(str != NULL);
+  DEBUGASSERT(str);
 
   if(countcheck("wcsdup", line, source))
     return NULL;
@@ -510,7 +510,7 @@ int curl_dbg_fclose(FILE *file, int line, const char *source)
 {
   int res;
 
-  DEBUGASSERT(file != NULL);
+  DEBUGASSERT(file);
 
   if(source)
     curl_dbg_log("FILE %s:%d fclose(%p)\n", source, line, (void *)file);

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -499,7 +499,7 @@ static Sockbuf_IO ldapsb_tls = {
 static bool ssl_installed(struct connectdata *conn)
 {
   struct ldapconninfo *li = Curl_conn_meta_get(conn, CURL_META_LDAP_CONN);
-  return li && li->recv != NULL;
+  return li && li->recv;
 }
 
 static CURLcode oldap_ssl_connect(struct Curl_easy *data, ldapstate newstate)
@@ -1177,7 +1177,7 @@ static CURLcode oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
       binary = bv.bv_len > 7 &&
         curl_strnequal(bv.bv_val + bv.bv_len - 7, ";binary", 7);
 
-      for(i = 0; bvals[i].bv_val != NULL; i++) {
+      for(i = 0; bvals[i].bv_val; i++) {
         bool binval = FALSE;
 
         result = client_write(data, STRCONST("\t"), bv.bv_val, bv.bv_len,

--- a/lib/psl.c
+++ b/lib/psl.c
@@ -70,7 +70,7 @@ const psl_ctx_t *Curl_psl_use(struct Curl_easy *easy)
       time_t expires = TIME_T_MAX;
 
       psl = psl_latest(NULL);
-      dynamic = psl != NULL;
+      dynamic = !!psl;
       /* Take care of possible time computation overflow. */
       expires = (now_sec < TIME_T_MAX - PSL_TTL) ?
                 (now_sec + PSL_TTL) : TIME_T_MAX;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -678,7 +678,7 @@ static void xfer_setup(
   struct SingleRequest *k = &data->req;
   struct connectdata *conn = data->conn;
 
-  DEBUGASSERT(conn != NULL);
+  DEBUGASSERT(conn);
   /* indexes are in range */
   DEBUGASSERT((send_idx <= 1) && (send_idx >= -1));
   DEBUGASSERT((recv_idx <= 1) && (recv_idx >= -1));

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1171,8 +1171,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     /* this pathlen also contains the query and the fragment */
     pathlen = urllen - (path - url);
     if(hostlen) {
-      ures = parse_authority(u, hostp, hostlen, flags, &host,
-                             u->scheme != NULL);
+      ures = parse_authority(u, hostp, hostlen, flags, &host, !!u->scheme);
       if(!ures && (flags & CURLU_GUESS_SCHEME) && !u->scheme)
         ures = guess_scheme(u, &host);
     }

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -120,7 +120,7 @@ bool Curl_auth_user_contains_domain(struct Curl_creds *creds)
     /* Check we have a domain name or UPN present */
     const char *p = strpbrk(creds->user, "\\/@");
 
-    valid = (p != NULL) && (p > creds->user) &&
+    valid = p && (p > creds->user) &&
             (p < (creds->user + strlen(creds->user) - 1));
   }
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)

--- a/lib/version.c
+++ b/lib/version.c
@@ -388,7 +388,7 @@ static int idn_present(curl_version_info_data *info)
   (void)info;
   return TRUE;
 #else
-  return info->libidn != NULL;
+  return !!info->libidn;
 #endif
 }
 #endif

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -2528,7 +2528,7 @@ static int wssl_quic_new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
   ngtcp2_crypto_conn_ref *conn_ref = wolfSSL_get_app_data(ssl);
   struct Curl_cfilter *cf = conn_ref ? conn_ref->user_data : NULL;
 
-  DEBUGASSERT(cf != NULL);
+  DEBUGASSERT(cf);
   if(cf && session) {
     struct cf_ngtcp2_ctx *ctx = cf->ctx;
     struct Curl_easy *data = CF_DATA_CURRENT(cf);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -479,9 +479,9 @@ static CURLcode ssh_check_fingerprint(struct Curl_easy *data,
   const char *pubkey_sha256 = data->set.str[STRING_SSH_HOST_PUBLIC_KEY_SHA256];
 
   infof(data, "SSH MD5 public key: %s",
-        pubkey_md5 != NULL ? pubkey_md5 : "NULL");
+        pubkey_md5 ? pubkey_md5 : "NULL");
   infof(data, "SSH SHA256 public key: %s",
-        pubkey_sha256 != NULL ? pubkey_sha256 : "NULL");
+        pubkey_sha256 ? pubkey_sha256 : "NULL");
 
   if(pubkey_sha256) {
     const char *fingerprint = NULL;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1098,7 +1098,7 @@ static CURLcode ssh_state_pkey_init(struct Curl_easy *data,
   sshc->authed = FALSE;
 
   if((data->set.ssh_auth_types & CURLSSH_AUTH_PUBLICKEY) &&
-     (strstr(sshc->authlist, "publickey") != NULL)) {
+     strstr(sshc->authlist, "publickey")) {
     bool out_of_memory = FALSE;
 
     sshc->rsa_pub = sshc->rsa = NULL;
@@ -1587,7 +1587,7 @@ static CURLcode ssh_state_auth_pass_init(struct Curl_easy *data,
                                          struct ssh_conn *sshc)
 {
   if((data->set.ssh_auth_types & CURLSSH_AUTH_PASSWORD) &&
-     (strstr(sshc->authlist, "password") != NULL)) {
+     strstr(sshc->authlist, "password")) {
     myssh_to(data, sshc, SSH_AUTH_PASS);
   }
   else {
@@ -1626,7 +1626,7 @@ static CURLcode ssh_state_auth_host_init(struct Curl_easy *data,
                                          struct ssh_conn *sshc)
 {
   if((data->set.ssh_auth_types & CURLSSH_AUTH_HOST) &&
-     (strstr(sshc->authlist, "hostbased") != NULL)) {
+     strstr(sshc->authlist, "hostbased")) {
     myssh_to(data, sshc, SSH_AUTH_HOST);
   }
   else {
@@ -1640,7 +1640,7 @@ static CURLcode ssh_state_auth_agent_init(struct Curl_easy *data,
 {
   int rc = 0;
   if((data->set.ssh_auth_types & CURLSSH_AUTH_AGENT) &&
-     (strstr(sshc->authlist, "publickey") != NULL)) {
+     strstr(sshc->authlist, "publickey")) {
 
     /* Connect to the ssh-agent */
     /* The agent could be shared by a curl thread i believe
@@ -1736,7 +1736,7 @@ static CURLcode ssh_state_auth_key_init(struct Curl_easy *data,
                                         struct ssh_conn *sshc)
 {
   if((data->set.ssh_auth_types & CURLSSH_AUTH_KEYBOARD) &&
-     (strstr(sshc->authlist, "keyboard-interactive") != NULL)) {
+     strstr(sshc->authlist, "keyboard-interactive")) {
     myssh_to(data, sshc, SSH_AUTH_KEY);
   }
   else {

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -66,7 +66,7 @@ void Curl_tls_keylog_close(void)
 
 bool Curl_tls_keylog_enabled(void)
 {
-  return keylog_file_fp != NULL;
+  return !!keylog_file_fp;
 }
 
 const char *Curl_tls_keylog_file_name(void)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -379,7 +379,7 @@ static CURLcode get_client_cert(struct Curl_easy *data,
     FILE *fInCert = NULL;
     void *certdata = NULL;
     size_t certsize = 0;
-    bool blob = data->set.ssl.primary.cert_blob != NULL;
+    bool blob = !!data->set.ssl.primary.cert_blob;
 
     if(blob) {
       certdata = data->set.ssl.primary.cert_blob->data;
@@ -1491,9 +1491,9 @@ static CURLcode schannel_connect_step2(struct Curl_cfilter *cf,
 
 static bool valid_cert_encoding(const CERT_CONTEXT *cert_context)
 {
-  return (cert_context != NULL) &&
+  return cert_context &&
     ((cert_context->dwCertEncodingType & X509_ASN_ENCODING) != 0) &&
-    (cert_context->pbCertEncoded != NULL) &&
+    cert_context->pbCertEncoded &&
     (cert_context->cbCertEncoded > 0);
 }
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -353,7 +353,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
   if(!alt_name_info)
     return 0;
 
-  compute_content = host_names != NULL && length != 0;
+  compute_content = host_names && length != 0;
 
   /* Initialize default return values. */
   actual_length = 1;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -480,7 +480,7 @@ static int wssl_vtls_new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
   struct Curl_cfilter *cf;
 
   cf = (struct Curl_cfilter *)wolfSSL_get_app_data(ssl);
-  DEBUGASSERT(cf != NULL);
+  DEBUGASSERT(cf);
   if(cf && session) {
     struct ssl_connect_data *connssl = cf->ctx;
     struct Curl_easy *data = CF_DATA_CURRENT(cf);
@@ -1153,7 +1153,7 @@ static CURLcode wssl_init_curves(struct Curl_easy *data,
   if(curves) {
 #ifdef WOLFSSL_HAVE_KYBER
     size_t idx;
-    for(idx = 0; gnm[idx].name != NULL; idx++) {
+    for(idx = 0; gnm[idx].name; idx++) {
       if(!strncmp(curves, gnm[idx].name, strlen(gnm[idx].name))) {
         *out_pqkem = gnm[idx].group;
         break;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -770,7 +770,7 @@ curl_socket_t win32_stdin_read_thread(void)
   static curl_socket_t socket_r = CURL_SOCKET_BAD;
 
   if(socket_r != CURL_SOCKET_BAD) {
-    assert(stdin_thread != NULL);
+    assert(stdin_thread);
     return socket_r;
   }
   assert(stdin_thread == NULL);

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -154,7 +154,7 @@ static void decc_init(void)
   decc_init_done = 1;
 
   /* Loop through all items in the decc_feat_array[]. */
-  for(i = 0; decc_feat_array[i].name != NULL; i++) {
+  for(i = 0; decc_feat_array[i].name; i++) {
 
     /* Get the feature index. */
     feat_index = decc$feature_get_index(decc_feat_array[i].name);

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -63,7 +63,7 @@ static size_t add_data(struct ws_data *wd, const char *buf, size_t blen,
      (meta && meta->flags != wd->meta_flags)) {
     if(wd->nwrites > 0)
       flush_data(wd);
-    wd->has_meta = (meta != NULL);
+    wd->has_meta = !!meta;
     wd->meta_flags = meta ? meta->flags : 0;
   }
 

--- a/tests/libtest/lib2700.c
+++ b/tests/libtest/lib2700.c
@@ -92,7 +92,7 @@ retry:
   }
 
   assert(nread == 0);
-  assert(meta != NULL);
+  assert(meta);
   assert(meta->flags);
   assert(meta->offset == 0);
 
@@ -163,7 +163,7 @@ retry:
   }
 
   assert(nread <= sizeof(buffer));
-  assert(meta != NULL);
+  assert(meta);
   assert(meta->flags == flags);
   assert(meta->offset == *offset);
   assert(meta->bytesleft == (*bytesleft - (curl_off_t)nread));

--- a/tests/unit/unit1396.c
+++ b/tests/unit/unit1396.c
@@ -83,12 +83,12 @@ static CURLcode test_unit1396(const char *arg)
   int i;
 
   easy = curl_easy_init();
-  abort_unless(easy != NULL, "returned NULL!");
+  abort_unless(easy, "returned NULL!");
   for(i = 0; list1[i].in; i++) {
     int outlen;
     char *out = curl_easy_unescape(easy, list1[i].in, list1[i].inlen, &outlen);
 
-    abort_unless(out != NULL, "returned NULL!");
+    abort_unless(out, "returned NULL!");
     fail_unless(outlen == list1[i].outlen, "wrong output length returned");
     fail_unless(!memcmp(out, list1[i].out, list1[i].outlen),
                 "bad output data returned");
@@ -101,7 +101,7 @@ static CURLcode test_unit1396(const char *arg)
   for(i = 0; list2[i].in; i++) {
     int outlen;
     char *out = curl_easy_escape(easy, list2[i].in, list2[i].inlen);
-    abort_unless(out != NULL, "returned NULL!");
+    abort_unless(out, "returned NULL!");
 
     outlen = (int)strlen(out);
     fail_unless(outlen == list2[i].outlen, "wrong output length returned");

--- a/tests/unit/unit1602.c
+++ b/tests/unit/unit1602.c
@@ -57,7 +57,7 @@ static CURLcode test_unit1602(const char *arg)
   int key2 = 25;
 
   value = curlx_malloc(sizeof(int));
-  abort_unless(value != NULL, "Out of memory");
+  abort_unless(value, "Out of memory");
   *value = 199;
   nodep = Curl_hash_add(&hash, &key, klen, value);
   if(!nodep)
@@ -67,7 +67,7 @@ static CURLcode test_unit1602(const char *arg)
 
   /* Attempt to add another key/value pair */
   value2 = curlx_malloc(sizeof(int));
-  abort_unless(value2 != NULL, "Out of memory");
+  abort_unless(value2, "Out of memory");
   *value2 = 204;
   nodep = Curl_hash_add(&hash, &key2, klen, value2);
   if(!nodep)

--- a/tests/unit/unit1616.c
+++ b/tests/unit/unit1616.c
@@ -56,7 +56,7 @@ static CURLcode test_unit1616(const char *arg)
   uint32_t key2 = 25;
 
   value = curlx_malloc(sizeof(int));
-  abort_unless(value != NULL, "Out of memory");
+  abort_unless(value, "Out of memory");
   *value = 199;
   ok = Curl_uint32_hash_set(&hash, key, value);
   if(!ok)
@@ -70,7 +70,7 @@ static CURLcode test_unit1616(const char *arg)
 
   /* Attempt to add another key/value pair */
   value2 = curlx_malloc(sizeof(int));
-  abort_unless(value2 != NULL, "Out of memory");
+  abort_unless(value2, "Out of memory");
   *value2 = 204;
   ok = Curl_uint32_hash_set(&hash, key2, value2);
   if(!ok)

--- a/tests/unit/unit1676.c
+++ b/tests/unit/unit1676.c
@@ -100,9 +100,9 @@ static CURLcode test_unit1676(const char *arg)
         dhpk_value = slist->data + 12;
     }
 
-    abort_unless(dhp_value != NULL, "dh(p) not found in certinfo");
-    abort_unless(dhg_value != NULL, "dh(g) not found in certinfo");
-    abort_unless(dhpk_value != NULL, "dh(pub_key) not found in certinfo");
+    abort_unless(dhp_value, "dh(p) not found in certinfo");
+    abort_unless(dhg_value, "dh(g) not found in certinfo");
+    abort_unless(dhpk_value, "dh(pub_key) not found in certinfo");
     fail_if(strcmp(dhp_value, dhg_value) == 0,
             "dh(p) and dh(g) have the same value (bug: g re-reads p)");
     fail_unless(strcmp(dhp_value, "17") == 0, "dh(p) expected 17 (0x11)");

--- a/tests/unit/unit3200.c
+++ b/tests/unit/unit3200.c
@@ -85,12 +85,12 @@ static CURLcode test_unit3200(const char *arg)
     curlx_dyn_init(&buf, len);
 
     fp = curlx_fopen(arg, "wb");
-    abort_unless(fp != NULL, "Cannot open testfile");
+    abort_unless(fp, "Cannot open testfile");
     fwrite(filecontents[i], 1, strlen(filecontents[i]), fp);
     curlx_fclose(fp);
 
     fp = curlx_fopen(arg, "rb");
-    abort_unless(fp != NULL, "Cannot open testfile");
+    abort_unless(fp, "Cannot open testfile");
 
     curl_mfprintf(stderr, "Test %zu...", i);
     switch(i) {


### PR DESCRIPTION
Where missed by checksrc.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
