### PR TITLE
psl: require libpsl 0.16.0 (2016-12-10) or greater

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -31,6 +31,7 @@ We aim to support these or later versions.
 - GnuTLS       3.6.5 (2018-12-01)
 - libidn2      2.0.0 (2017-03-29)
 - libgsasl     1.6.0 (2010-12-14)
+- libpsl       0.16.0 (2016-12-10)
 - LibreSSL     2.9.1 (2019-04-22)
 - libssh       0.9.0 (2019-06-28)
 - libssh2      1.9.0 (2019-06-20)

--- a/lib/psl.c
+++ b/lib/psl.c
@@ -29,6 +29,10 @@
 #include "progress.h"
 #include "curl_share.h"
 
+#if !defined(PSL_VERSION_NUMBER) || PSL_VERSION_NUMBER < 0x001000
+#error "libpsl 0.16.0 or greater required"
+#endif
+
 void Curl_psl_destroy(struct PslCache *pslcache)
 {
   if(pslcache->psl) {
@@ -65,7 +69,6 @@ const psl_ctx_t *Curl_psl_use(struct Curl_easy *easy)
       bool dynamic = FALSE;
       time_t expires = TIME_T_MAX;
 
-#if defined(PSL_VERSION_NUMBER) && PSL_VERSION_NUMBER >= 0x001000
       psl = psl_latest(NULL);
       dynamic = psl != NULL;
       /* Take care of possible time computation overflow. */
@@ -74,8 +77,6 @@ const psl_ctx_t *Curl_psl_use(struct Curl_easy *easy)
 
       /* Only get the built-in PSL if we do not already have the "latest". */
       if(!psl && !pslcache->dynamic)
-#endif
-
         psl = psl_builtin();
 
       if(psl) {


### PR DESCRIPTION
Debian Stretch offers 0.17.0.

Ref: https://github.com/rockdaboot/libpsl/releases/tag/libpsl-0.16.0
Ref: https://sources.debian.org/src/libpsl/

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
