### PR TITLE
tidy-up: drop redundant `== NULL` syntax

### DIFF
--- a/docs/examples/htmltitle.cpp
+++ b/docs/examples/htmltitle.cpp
@@ -73,7 +73,7 @@ static std::string buffer;
 static size_t writer(char *data, size_t size, size_t nmemb,
                      std::string *writerData)
 {
-  if(writerData == NULL)
+  if(!writerData)
     return 0;
 
   writerData->append(data, size * nmemb);

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -657,7 +657,7 @@ struct cf_call_data {
 #define CF_DATA_SAVE(save, cf, data) \
   do { \
     (save) = CF_CTX_CALL_DATA(cf); \
-    DEBUGASSERT((save).data == NULL || (save).depth > 0); \
+    DEBUGASSERT(!(save).data || (save).depth > 0); \
     CF_CTX_CALL_DATA(cf).depth++;  \
     CF_CTX_CALL_DATA(cf).data = (struct Curl_easy *)CURL_UNCONST(data); \
   } while(0)
@@ -665,7 +665,7 @@ struct cf_call_data {
 #define CF_DATA_RESTORE(cf, save) \
   do { \
     DEBUGASSERT(CF_CTX_CALL_DATA(cf).depth == (save).depth + 1); \
-    DEBUGASSERT((save).data == NULL || (save).depth > 0); \
+    DEBUGASSERT(!(save).data || (save).depth > 0); \
     CF_CTX_CALL_DATA(cf) = (save); \
   } while(0)
 

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -942,7 +942,7 @@ static void dupeasy_meta_freeentry(void *p)
   /* Always FALSE. Cannot use a 0 assert here since compilers
    * are not in agreement if they then want a NORETURN attribute or
    * not. *sigh* */
-  DEBUGASSERT(p == NULL);
+  DEBUGASSERT(!p);
 }
 
 /*

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -196,7 +196,7 @@ void Curl_wildcard_dtor(struct WildcardData **wcp)
     wc->dtor = ZERO_NULL;
     wc->ftpwc = NULL;
   }
-  DEBUGASSERT(wc->ftpwc == NULL);
+  DEBUGASSERT(!wc->ftpwc);
 
   Curl_llist_destroy(&wc->filelist, NULL);
   curlx_safefree(wc->path);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -220,7 +220,7 @@ static void ph_freeentry(void *p)
   /* Always FALSE. Cannot use a 0 assert here since compilers
    * are not in agreement if they then want a NORETURN attribute or
    * not. *sigh* */
-  DEBUGASSERT(p == NULL);
+  DEBUGASSERT(!p);
 }
 
 /*

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -152,7 +152,7 @@ CURLcode Curl_pp_vsendf(struct Curl_easy *data,
 
   DEBUGASSERT(pp->sendleft == 0);
   DEBUGASSERT(pp->sendsize == 0);
-  DEBUGASSERT(pp->sendthis == NULL);
+  DEBUGASSERT(!pp->sendthis);
 
   if(!conn)
     /* cannot send without a connection! */

--- a/lib/url.c
+++ b/lib/url.c
@@ -442,7 +442,7 @@ static void easy_meta_freeentry(void *p)
   /* Always FALSE. Cannot use a 0 assert here since compilers
    * are not in agreement if they then want a NORETURN attribute or
    * not. *sigh* */
-  DEBUGASSERT(p == NULL);
+  DEBUGASSERT(!p);
 }
 
 /**
@@ -2591,7 +2591,7 @@ static void conn_meta_freeentry(void *p)
   /* Always FALSE. Cannot use a 0 assert here since compilers
    * are not in agreement if they then want a NORETURN attribute or
    * not. *sigh* */
-  DEBUGASSERT(p == NULL);
+  DEBUGASSERT(!p);
 }
 
 static CURLcode url_create_needle(struct Curl_easy *data,

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1888,8 +1888,8 @@ static void sshc_cleanup(struct ssh_conn *sshc)
     }
 
     /* worst-case scenario cleanup */
-    DEBUGASSERT(sshc->ssh_session == NULL);
-    DEBUGASSERT(sshc->scp_session == NULL);
+    DEBUGASSERT(!sshc->ssh_session);
+    DEBUGASSERT(!sshc->scp_session);
 
     if(sshc->readdir_tmp) {
       ssh_string_free_char(sshc->readdir_tmp);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -152,8 +152,7 @@ static void kbd_callback(const char *name, int name_len,
     /* this function must allocate memory that can be freed by libssh2, which
        uses the LIBSSH2_FREE_FUNC callback */
     responses[0].text = Curl_cstrdup(passwd);
-    responses[0].length =
-      responses[0].text == NULL ? 0 : curlx_uztoui(strlen(passwd));
+    responses[0].length = responses[0].text ? curlx_uztoui(strlen(passwd)) : 0;
   }
   (void)prompts;
 } /* kbd_callback */
@@ -2607,12 +2606,12 @@ static CURLcode sshc_cleanup(struct ssh_conn *sshc, struct Curl_easy *data,
   }
 
   /* worst-case scenario cleanup */
-  DEBUGASSERT(sshc->ssh_session == NULL);
-  DEBUGASSERT(sshc->ssh_channel == NULL);
-  DEBUGASSERT(sshc->sftp_session == NULL);
-  DEBUGASSERT(sshc->sftp_handle == NULL);
-  DEBUGASSERT(sshc->kh == NULL);
-  DEBUGASSERT(sshc->ssh_agent == NULL);
+  DEBUGASSERT(!sshc->ssh_session);
+  DEBUGASSERT(!sshc->ssh_channel);
+  DEBUGASSERT(!sshc->sftp_session);
+  DEBUGASSERT(!sshc->sftp_handle);
+  DEBUGASSERT(!sshc->kh);
+  DEBUGASSERT(!sshc->ssh_agent);
 
   curlx_safefree(sshc->rsa_pub);
   curlx_safefree(sshc->rsa);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1100,7 +1100,7 @@ static CURLcode cr_init_backend(struct Curl_cfilter *cf,
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-  DEBUGASSERT(rconn == NULL);
+  DEBUGASSERT(!rconn);
   rr = rustls_client_connection_new(backend->config,
                                     connssl->peer.dest->hostname,
                                     &rconn);

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -773,7 +773,7 @@ curl_socket_t win32_stdin_read_thread(void)
     assert(stdin_thread != NULL);
     return socket_r;
   }
-  assert(stdin_thread == NULL);
+  assert(!stdin_thread);
 
   do {
     curl_socklen_t socksize = 0;

--- a/tests/libtest/lib1536.c
+++ b/tests/libtest/lib1536.c
@@ -76,8 +76,7 @@ static CURLcode test_lib1536(const char *URL)
   if(!scheme || memcmp(scheme, "http", 5) != 0) {
     curl_mfprintf(stderr, "%s:%d scheme of http resource is incorrect; "
                   "expected 'http' but is %s\n",
-                  __FILE__, __LINE__,
-                  (scheme == NULL ? "NULL" : "invalid"));
+                  __FILE__, __LINE__, scheme ? "invalid" : "NULL");
     result = CURLE_HTTP_RETURNED_ERROR;
     goto test_cleanup;
   }

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -55,8 +55,8 @@ For the actual C file, here's a simple example:
 
       /* here you start doing things and checking that the results are good */
 
-      fail_unless( size == 0 , "initial size should be zero" );
-      fail_if( head == NULL , "head should not be initiated to NULL" );
+      fail_unless(size == 0, "initial size should be zero");
+      fail_if(!head, "head should not be initiated to NULL");
 
       /* you end the test code like this: */
 
@@ -87,8 +87,8 @@ Here's an example using optional initialization and cleanup:
 
       /* here you start doing things and checking that the results are good */
 
-      fail_unless( size == 0 , "initial size should be zero" );
-      fail_if( head == NULL , "head should not be initiated to NULL" );
+      fail_unless(size == 0, "initial size should be zero");
+      fail_if(!head, "head should not be initiated to NULL");
 
       /* you end the test code like this: */
 

--- a/tests/unit/unit1300.c
+++ b/tests/unit/unit1300.c
@@ -67,9 +67,9 @@ static CURLcode test_unit1300(const char *arg)
 
   fail_unless(Curl_llist_count(&llist) == 0,
               "list initial size should be zero");
-  fail_unless(Curl_llist_head(&llist) == NULL,
+  fail_unless(!Curl_llist_head(&llist),
               "list head should initiate to NULL");
-  fail_unless(llist_tail(&llist) == NULL,
+  fail_unless(!llist_tail(&llist),
               "list tail should initiate to NULL");
 
   /**
@@ -152,7 +152,7 @@ static CURLcode test_unit1300(const char *arg)
   fail_unless(Curl_llist_head(&llist) == element_next,
               "llist new head not modified properly");
   abort_unless(Curl_llist_head(&llist), "llist.head is NULL");
-  fail_unless(llist_node_prev(Curl_llist_head(&llist)) == NULL,
+  fail_unless(!llist_node_prev(Curl_llist_head(&llist)),
               "new head previous not set to null");
 
   /**
@@ -208,9 +208,9 @@ static CURLcode test_unit1300(const char *arg)
 
   to_remove = Curl_llist_head(&llist);
   Curl_node_remove(to_remove);
-  fail_unless(Curl_llist_head(&llist) == NULL,
+  fail_unless(!Curl_llist_head(&llist),
               "llist head is not NULL while the llist is empty");
-  fail_unless(llist_tail(&llist) == NULL,
+  fail_unless(!llist_tail(&llist),
               "llist tail is not NULL while the llist is empty");
 
   /**

--- a/tests/unit/unit1304.c
+++ b/tests/unit/unit1304.c
@@ -71,7 +71,7 @@ static CURLcode test_unit1304(const char *arg)
   Curl_netrc_init(&store);
   res = Curl_netrc_scan(data, &store, "test.example.com", NULL, arg, &cr_out);
   fail_unless(res == NETRC_NO_MATCH, "expected no match");
-  fail_unless(cr_out == NULL, "creds did not return NULL!");
+  fail_unless(!cr_out, "creds did not return NULL!");
   Curl_netrc_cleanup(&store);
 
   /*

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -97,7 +97,7 @@ static CURLcode test_unit1309(const char *arg)
     }
   }
 
-  fail_unless(root == NULL, "tree not empty after removing all nodes");
+  fail_unless(!root, "tree not empty after removing all nodes");
 
   /* rebuild tree */
   for(i = 0; i < NUM_NODES; i++) {
@@ -127,7 +127,7 @@ static CURLcode test_unit1309(const char *arg)
     }
   }
 
-  fail_unless(root == NULL, "tree not empty when it should be");
+  fail_unless(!root, "tree not empty when it should be");
 
   UNITTEST_END_SIMPLE
 }

--- a/tests/unit/unit1605.c
+++ b/tests/unit/unit1605.c
@@ -53,10 +53,10 @@ static CURLcode test_unit1605(const char *arg)
   char *esc;
 
   esc = curl_easy_escape(easy, "", -1);
-  fail_unless(esc == NULL, "negative string length cannot work");
+  fail_unless(!esc, "negative string length cannot work");
 
   esc = curl_easy_unescape(easy, "%41%41%41%41", -1, &len);
-  fail_unless(esc == NULL, "negative string length cannot work");
+  fail_unless(!esc, "negative string length cannot work");
 
   UNITTEST_END(t1605_stop(easy))
 }

--- a/tests/unit/unit1620.c
+++ b/tests/unit/unit1620.c
@@ -127,7 +127,7 @@ static CURLcode test_unit1620(const char *arg)
 
   Curl_freeset(empty);
   for(i = (enum dupstring)0; i < STRING_LAST; i++) {
-    fail_unless(empty->set.str[i] == NULL, "Curl_free() did not set to NULL");
+    fail_unless(!empty->set.str[i], "Curl_free() did not set to NULL");
   }
 
   result = Curl_close(&dupe);

--- a/tests/unit/unit2601.c
+++ b/tests/unit/unit2601.c
@@ -99,9 +99,9 @@ static void check_bufq(size_t pool_spares,
 
   fail_unless(q.chunk_size == chunk_size, "chunk_size init wrong");
   fail_unless(q.max_chunks == max_chunks, "max_chunks init wrong");
-  fail_unless(q.head == NULL, "init: head not NULL");
-  fail_unless(q.tail == NULL, "init: tail not NULL");
-  fail_unless(q.spare == NULL, "init: spare not NULL");
+  fail_unless(!q.head, "init: head not NULL");
+  fail_unless(!q.tail, "init: tail not NULL");
+  fail_unless(!q.spare, "init: spare not NULL");
   fail_unless(Curl_bufq_len(&q) == 0, "init: bufq length != 0");
 
   result = Curl_bufq_write(&q, test_data, wsize, &n2);


### PR DESCRIPTION
Where missed by checksrc.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
