### PR TITLE
appveyor: bump 3 VS2022 jobs to VS2026

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -46,7 +46,7 @@ if [ -n "${CMAKE_GENERATOR:-}" ]; then
   elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
     openssl_root_win="C:/OpenSSL-v30${openssl_suffix}"
   fi
-  [ -n "${openssl_root_win}" ] && openssl_root="$(cygpath "${openssl_root_win}")"
+  [ -n "${openssl_root_win:-}" ] && openssl_root="$(cygpath "${openssl_root_win}")"
 
   # Install custom cmake version
   if [ -n "${CMAKE_VERSION:-}" ]; then

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -39,13 +39,14 @@ if [ -n "${CMAKE_GENERATOR:-}" ]; then
     *)       openssl_suffix='-Win64';;
   esac
 
-  if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
+  if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2026' ]; then
     openssl_root_win="C:/OpenSSL-v36${openssl_suffix}"
-    openssl_root="$(cygpath "${openssl_root_win}")"
+  elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
+    openssl_root_win="C:/OpenSSL-v35${openssl_suffix}"
   elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
     openssl_root_win="C:/OpenSSL-v30${openssl_suffix}"
-    openssl_root="$(cygpath "${openssl_root_win}")"
   fi
+  openssl_root="$(cygpath "${openssl_root_win}")"
 
   # Install custom cmake version
   if [ -n "${CMAKE_VERSION:-}" ]; then

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -46,7 +46,7 @@ if [ -n "${CMAKE_GENERATOR:-}" ]; then
   elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
     openssl_root_win="C:/OpenSSL-v30${openssl_suffix}"
   fi
-  openssl_root="$(cygpath "${openssl_root_win}")"
+  [ -n "${openssl_root_win}" ] && openssl_root="$(cygpath "${openssl_root_win}")"
 
   # Install custom cmake version
   if [ -n "${CMAKE_VERSION:-}" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -110,7 +110,7 @@ environment:
     # VisualStudioSolution builds
 
     - job_name: 'VisualStudioSolution VS2010, Release, x86, Schannel'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2013'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       PRJ_CFG: 'DLL Release - DLL Windows SSPI - DLL WinIDN'
       PLAT: 'Win32'
       VC_VERSION: VC10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,14 +36,14 @@ environment:
   matrix:
     # CMake Visual Studio builds
 
-    - job_name: 'CM VS2022, Release, x64, OpenSSL 3.6, Shared, Build-tests'
+    - job_name: 'CM VS2022, Release, x64, OpenSSL 3.5, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       CMAKE_GENERATOR: 'Visual Studio 17 2022'
       CMAKE_GENERATE: '-A x64 -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON'
 
-    - job_name: 'CM VS2022, Release, arm64, Schannel, Static, !DEBUGBUILD, Build-tests'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
-      CMAKE_GENERATOR: 'Visual Studio 17 2022'
+    - job_name: 'CM VS2026, Release, arm64, Schannel, Static, !DEBUGBUILD, Build-tests'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2026'
+      CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A ARM64 -DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=OFF'
 
     - job_name: 'CM VS2010, Debug, x64, Schannel, Shared, Build-tests & examples'
@@ -86,9 +86,9 @@ environment:
       CMAKE_GENERATOR: 'Visual Studio 16 2019'
       CMAKE_GENERATE: '-A x64 -DCURL_USE_OPENSSL=ON -DCURL_DISABLE_VERBOSE_STRINGS=ON'
 
-    - job_name: 'CM VS2022, Debug, x64, OpenSSL 3.6 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
-      CMAKE_GENERATOR: 'Visual Studio 17 2022'
+    - job_name: 'CM VS2026, Debug, x64, OpenSSL 3.5 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2026'
+      CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A x64 -T ClangCl -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=ON'
 
     - job_name: 'CM VS2022, Release, x64, Schannel, Shared, Unicode, !DEBUGBUILD, Build-tests'
@@ -97,9 +97,9 @@ environment:
       ENABLE_UNICODE: 'ON'
       CMAKE_GENERATE: '-A x64 -DENABLE_UNICODE=ON -DENABLE_DEBUG=OFF'
 
-    - job_name: 'CM VS2022, Debug, x64, !ssl, Static, Build-tests'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
-      CMAKE_GENERATOR: 'Visual Studio 17 2022'
+    - job_name: 'CM VS2026, Debug, x64, !ssl, Static, Build-tests'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2026'
+      CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A x64 -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=OFF'
 
     - job_name: 'CM VS2022, Debug, x64, !ssl, Static, HTTP-only, Build-tests'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,8 @@ environment:
 
     - job_name: 'CM VS2026, Release, arm64, Schannel, Static, !DEBUGBUILD, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2026'
+      CMAKE_VERSION: 4.2.1
+      CMAKE_SHA256: dfc2b2afac257555e3b9ce375b12b2883964283a366c17fec96cf4d17e4f1677
       CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A ARM64 -DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=OFF'
 
@@ -88,6 +90,8 @@ environment:
 
     - job_name: 'CM VS2026, Debug, x64, OpenSSL 3.5 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2026'
+      CMAKE_VERSION: 4.2.1
+      CMAKE_SHA256: dfc2b2afac257555e3b9ce375b12b2883964283a366c17fec96cf4d17e4f1677
       CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A x64 -T ClangCl -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=ON'
 
@@ -99,6 +103,8 @@ environment:
 
     - job_name: 'CM VS2026, Debug, x64, !ssl, Static, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2026'
+      CMAKE_VERSION: 4.2.1
+      CMAKE_SHA256: dfc2b2afac257555e3b9ce375b12b2883964283a366c17fec96cf4d17e4f1677
       CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A x64 -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=OFF'
 


### PR DESCRIPTION
Also:
- install CMake 4.2.1 manually for VS2026 jobs, because the preinstalled
  version (4.1.2) does not yet support the compatible generator.
- VisualStudioSolution VS2010 job to VS2015 worker image (from VS2013).
  VS2013 is no longer listed on the AppVeyor support page.
- downgrade OpenSSL to 3.5 (from 3.6) for the VS2022 job, to add
  variation.

Note: the jobs run much slower after bumping to VS2026. This seems to be
due slower configure and build steps.

Refs:
https://github.com/appveyor/website/commit/9ef4152eda92d0f8a486ab67824a6d420e1151e4
https://github.com/appveyor/website/pull/912
https://github.com/appveyor/build-images/commit/fa7f7b928ebee4e2cfc6eccc953d2dec95374114
https://github.com/appveyor/build-images/pull/175
https://www.appveyor.com/docs/windows-images-software/
https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2018%202026.html

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
