### PR TITLE
make Curl_addr2string static

### DIFF
--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -56,6 +56,7 @@
 #include "multiif.h"
 #include "progress.h"
 #include "select.h"
+#include "sockaddr.h"
 #include "vquic/vquic.h" /* for quic cfilters */
 
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -26,6 +26,9 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h> /* <netinet/tcp.h> may need it */
 #endif
+#ifdef HAVE_SYS_UN_H
+#include <sys/un.h> /* for sockaddr_un */
+#endif
 #ifdef HAVE_LINUX_TCP_H
 #include <linux/tcp.h>
 #elif defined(HAVE_NETINET_TCP_H)
@@ -64,11 +67,13 @@
 #include "curl_addrinfo.h"
 #include "select.h"
 #include "multiif.h"
+#include "curlx/inet_ntop.h"
 #include "curlx/inet_pton.h"
 #include "progress.h"
 #include "conncache.h"
 #include "multihandle.h"
 #include "rand.h"
+#include "sockaddr.h"
 #include "curlx/strdup.h"
 #include "system_win32.h"
 #include "curlx/nonblock.h"
@@ -77,6 +82,63 @@
 #include "curlx/strerr.h"
 #include "curlx/strparse.h"
 
+
+/* retrieves ip address and port from a sockaddr structure. note it calls
+ * curlx_inet_ntop which sets errno on fail, not SOCKERRNO.
+ * @unittest 1607
+ */
+UNITTEST bool sockaddr2string(struct sockaddr *sa, curl_socklen_t salen,
+                              char *addr, uint16_t *port);
+UNITTEST bool sockaddr2string(struct sockaddr *sa, curl_socklen_t salen,
+                              char *addr, uint16_t *port)
+{
+  struct sockaddr_in *si = NULL;
+#ifdef USE_IPV6
+  struct sockaddr_in6 *si6 = NULL;
+#endif
+#ifdef USE_UNIX_SOCKETS
+  struct sockaddr_un *su = NULL;
+#else
+  (void)salen;
+#endif
+
+  switch(sa->sa_family) {
+  case AF_INET:
+    si = (struct sockaddr_in *)(void *)sa;
+    if(curlx_inet_ntop(sa->sa_family, &si->sin_addr, addr, MAX_IPADR_LEN)) {
+      *port = ntohs(si->sin_port);
+      return TRUE;
+    }
+    break;
+#ifdef USE_IPV6
+  case AF_INET6:
+    si6 = (struct sockaddr_in6 *)(void *)sa;
+    if(curlx_inet_ntop(sa->sa_family, &si6->sin6_addr, addr, MAX_IPADR_LEN)) {
+      *port = ntohs(si6->sin6_port);
+      return TRUE;
+    }
+    break;
+#endif
+#ifdef USE_UNIX_SOCKETS
+  case AF_UNIX:
+    if(salen > (curl_socklen_t)sizeof(CURL_SA_FAMILY_T)) {
+      su = (struct sockaddr_un *)sa;
+      curl_msnprintf(addr, MAX_IPADR_LEN, "%s", su->sun_path);
+    }
+    else
+      addr[0] = 0; /* socket with no name */
+    *port = 0;
+    return TRUE;
+#endif
+  default:
+    break;
+  }
+
+  addr[0] = '\0';
+  *port = 0;
+  errno = SOCKEAFNOSUPPORT;
+  return FALSE;
+}
 
 static void tcpnodelay(struct Curl_cfilter *cf,
                        struct Curl_easy *data,
@@ -1042,8 +1104,8 @@ static void set_local_ip(struct Curl_cfilter *cf,
       infof(data, "getsockname() failed with errno %d: %s",
             error, curlx_strerror(error, buffer, sizeof(buffer)));
     }
-    else if(!Curl_addr2string((struct sockaddr *)&ssloc, slen,
-                              ctx->ip.local_ip, &ctx->ip.local_port)) {
+    else if(!sockaddr2string((struct sockaddr *)&ssloc, slen,
+                             ctx->ip.local_ip, &ctx->ip.local_port)) {
       infof(data, "ssloc inet_ntop() failed with errno %d: %s",
             errno, curlx_strerror(errno, buffer, sizeof(buffer)));
     }
@@ -1060,9 +1122,9 @@ static CURLcode set_remote_ip(struct Curl_cfilter *cf,
 
   /* store remote address and port used in this connection attempt */
   ctx->ip.transport = ctx->transport;
-  if(!Curl_addr2string(&ctx->addr.curl_sa_addr,
-                       (curl_socklen_t)ctx->addr.addrlen,
-                       ctx->ip.remote_ip, &ctx->ip.remote_port)) {
+  if(!sockaddr2string(&ctx->addr.curl_sa_addr,
+                      (curl_socklen_t)ctx->addr.addrlen,
+                      ctx->ip.remote_ip, &ctx->ip.remote_port)) {
     char buffer[STRERROR_LEN];
 
     ctx->error = errno;
@@ -2084,8 +2146,8 @@ static void cf_tcp_set_accepted_remote_ip(struct Curl_cfilter *cf,
           error, curlx_strerror(error, buffer, sizeof(buffer)));
     return;
   }
-  if(!Curl_addr2string((struct sockaddr *)&ssrem, plen,
-                       ctx->ip.remote_ip, &ctx->ip.remote_port)) {
+  if(!sockaddr2string((struct sockaddr *)&ssrem, plen,
+                      ctx->ip.remote_ip, &ctx->ip.remote_port)) {
     failf(data, "ssrem inet_ntop() failed with errno %d: %s",
           errno, curlx_strerror(errno, buffer, sizeof(buffer)));
     return;

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -25,8 +25,6 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#include "sockaddr.h" /* required for Curl_sockaddr_storage */
-
 struct Curl_addrinfo;
 struct Curl_cfilter;
 struct Curl_easy;
@@ -34,23 +32,6 @@ struct connectdata;
 struct Curl_sockaddr_ex;
 struct ip_quadruple;
 
-/*
- * The Curl_sockaddr_ex structure is libcurl's external API curl_sockaddr
- * structure with enough space available to directly hold any
- * protocol-specific address structures. The variable declared here will be
- * used to pass / receive data to/from the fopensocket callback if this has
- * been set, before that, it is initialized from parameters.
- */
-struct Curl_sockaddr_ex {
-  int family;
-  int socktype;
-  int protocol;
-  unsigned int addrlen;
-  union {
-    struct sockaddr sa;
-    struct Curl_sockaddr_storage buf;
-  } addr;
-};
 #define curl_sa_addr    addr.sa
 #define curl_sa_addrbuf addr.buf
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -26,9 +26,6 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h> /* <netinet/tcp.h> may need it */
 #endif
-#ifdef HAVE_SYS_UN_H
-#include <sys/un.h> /* for sockaddr_un */
-#endif
 #ifdef HAVE_LINUX_TCP_H
 #include <linux/tcp.h>
 #elif defined(HAVE_NETINET_TCP_H)
@@ -60,7 +57,6 @@
 #include "cf-ip-happy.h"
 #include "cf-socket.h"
 #include "multiif.h"
-#include "curlx/inet_ntop.h"
 #include "curlx/strparse.h"
 #include "vtls/vtls.h" /* for vtls cfilters */
 #include "vquic/vquic.h" /* for QUIC cfilters */
@@ -209,59 +205,6 @@ bool Curl_shutdown_started(struct Curl_easy *data, int sockindex)
     struct curltime *pt = &data->conn->shutdown.start[sockindex];
     return (pt->tv_sec > 0) || (pt->tv_usec > 0);
   }
-  return FALSE;
-}
-
-/* retrieves ip address and port from a sockaddr structure. note it calls
-   curlx_inet_ntop which sets errno on fail, not SOCKERRNO. */
-bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
-                      char *addr, uint16_t *port)
-{
-  struct sockaddr_in *si = NULL;
-#ifdef USE_IPV6
-  struct sockaddr_in6 *si6 = NULL;
-#endif
-#ifdef USE_UNIX_SOCKETS
-  struct sockaddr_un *su = NULL;
-#else
-  (void)salen;
-#endif
-
-  switch(sa->sa_family) {
-  case AF_INET:
-    si = (struct sockaddr_in *)(void *)sa;
-    if(curlx_inet_ntop(sa->sa_family, &si->sin_addr, addr, MAX_IPADR_LEN)) {
-      *port = ntohs(si->sin_port);
-      return TRUE;
-    }
-    break;
-#ifdef USE_IPV6
-  case AF_INET6:
-    si6 = (struct sockaddr_in6 *)(void *)sa;
-    if(curlx_inet_ntop(sa->sa_family, &si6->sin6_addr, addr, MAX_IPADR_LEN)) {
-      *port = ntohs(si6->sin6_port);
-      return TRUE;
-    }
-    break;
-#endif
-#ifdef USE_UNIX_SOCKETS
-  case AF_UNIX:
-    if(salen > (curl_socklen_t)sizeof(CURL_SA_FAMILY_T)) {
-      su = (struct sockaddr_un *)sa;
-      curl_msnprintf(addr, MAX_IPADR_LEN, "%s", su->sun_path);
-    }
-    else
-      addr[0] = 0; /* socket with no name */
-    *port = 0;
-    return TRUE;
-#endif
-  default:
-    break;
-  }
-
-  addr[0] = '\0';
-  *port = 0;
-  errno = SOCKEAFNOSUPPORT;
   return FALSE;
 }
 

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -72,9 +72,6 @@ bool Curl_shutdown_started(struct Curl_easy *data, int sockindex);
 curl_socket_t Curl_getconnectinfo(struct Curl_easy *data,
                                   struct connectdata **connp);
 
-bool Curl_addr2string(struct sockaddr *sa, curl_socklen_t salen,
-                      char *addr, uint16_t *port);
-
 /*
  * Curl_conncontrol() marks the end of a connection/stream. The 'ctrl'
  * argument specifies if it is the end of a connection or a stream.

--- a/lib/sockaddr.h
+++ b/lib/sockaddr.h
@@ -40,4 +40,22 @@ struct Curl_sockaddr_storage {
   } buffer;
 };
 
+/*
+ * The Curl_sockaddr_ex structure is libcurl's external API curl_sockaddr
+ * structure with enough space available to directly hold any
+ * protocol-specific address structures. The variable declared here will be
+ * used to pass / receive data to/from the fopensocket callback if this has
+ * been set, before that, it is initialized from parameters.
+ */
+struct Curl_sockaddr_ex {
+  int family;
+  int socktype;
+  int protocol;
+  unsigned int addrlen;
+  union {
+    struct sockaddr sa;
+    struct Curl_sockaddr_storage buf;
+  } addr;
+};
+
 #endif /* HEADER_CURL_SOCKADDR_H */

--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -62,6 +62,7 @@
 #include "curlx/dynbuf.h"
 #include "http1.h"
 #include "select.h"
+#include "sockaddr.h"
 #include "transfer.h"
 #include "bufref.h"
 #include "vquic/vquic.h"

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -41,6 +41,7 @@
 #include "http1.h"
 #include "select.h"
 #include "transfer.h"
+#include "sockaddr.h"
 #include "bufref.h"
 #include "vquic/vquic.h"
 #include "vquic/vquic_int.h"

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -41,7 +41,6 @@
 #include "http1.h"
 #include "select.h"
 #include "transfer.h"
-#include "sockaddr.h"
 #include "bufref.h"
 #include "vquic/vquic.h"
 #include "vquic/vquic_int.h"

--- a/lib/vquic/cf-quiche.c
+++ b/lib/vquic/cf-quiche.c
@@ -41,6 +41,7 @@
 #include "progress.h"
 #include "select.h"
 #include "http1.h"
+#include "sockaddr.h"
 #include "vquic/vquic.h"
 #include "vquic/vquic_int.h"
 #include "vquic/vquic-tls.h"

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -23,7 +23,6 @@
  ***************************************************************************/
 #include "unitcheck.h"
 #include "urldata.h"
-#include "connect.h"
 #include "curl_addrinfo.h"
 
 static CURLcode t1607_setup(void)
@@ -146,8 +145,8 @@ static CURLcode test_unit1607(const char *arg)
       if(tests[i].address[j] == &skip)
         continue;
 
-      if(addr && !Curl_addr2string(addr->ai_addr, addr->ai_addrlen,
-                                   ipaddress, &port)) {
+      if(addr && !sockaddr2string(addr->ai_addr, addr->ai_addrlen,
+                                  ipaddress, &port)) {
         curl_mfprintf(stderr, "%s:%d tests[%zu] failed. "
                       "getaddressinfo failed.\n",
                       __FILE__, __LINE__, i);

--- a/tests/unit/unit1609.c
+++ b/tests/unit/unit1609.c
@@ -145,8 +145,8 @@ static CURLcode test_unit1609(const char *arg)
       if(!addr && !tests[i].address[j])
         break;
 
-      if(addr && !Curl_addr2string(addr->ai_addr, addr->ai_addrlen,
-                                   ipaddress, &port)) {
+      if(addr && !sockaddr2string(addr->ai_addr, addr->ai_addrlen,
+                                  ipaddress, &port)) {
         curl_mfprintf(stderr,
                       "%s:%d tests[%zu] failed. Curl_addr2string failed.\n",
                       __FILE__, __LINE__, i);

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -46,6 +46,7 @@
 #include "cf-ip-happy.h"
 #include "multiif.h"
 #include "select.h"
+#include "sockaddr.h"
 #include "curl_addrinfo.h"
 #include "curl_trc.h"
 


### PR DESCRIPTION
Move as sockaddr2string() into cf-socket.c where its only callers are.

Mark as UNITTEST for unit1609.

Move "struct Curl_sockaddr_ex" into sockaddr.h, so connect.h and cf-socket.h can be included without all the system headers needed.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
