### PR TITLE
tidy-up: drop stray comparisons with literal zero

### DIFF
--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -109,7 +109,7 @@ int main(int argc, const char **argv)
   if(!fp)
     return 2;
 
-  if(fstat(fileno(fp), &file_info) != 0) {
+  if(fstat(fileno(fp), &file_info)) {
     fclose(fp);
     return 1; /* cannot continue */
   }

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -412,7 +412,7 @@ static int init_fifo(struct GlobalInfo *g)
   struct epoll_event epev;
 
   fprintf(MSG_OUT, "Creating named pipe \"%s\"\n", fifo);
-  if(lstat(fifo, &st) == 0) {
+  if(!lstat(fifo, &st)) {
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -382,7 +382,7 @@ static int init_fifo(struct GlobalInfo *g)
   curl_socket_t sockfd;
 
   fprintf(MSG_OUT, "Creating named pipe \"%s\"\n", fifo);
-  if(lstat(fifo, &st) == 0) {
+  if(!lstat(fifo, &st)) {
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");

--- a/docs/examples/fileupload.c
+++ b/docs/examples/fileupload.c
@@ -64,7 +64,7 @@ int main(void)
   }
 
   /* to get the file size */
-  if(fstat(fileno(fd), &file_info) != 0) {
+  if(fstat(fileno(fd), &file_info)) {
     fclose(fd);
     curl_global_cleanup();
     return 1; /* cannot continue */

--- a/docs/examples/ftpupload.c
+++ b/docs/examples/ftpupload.c
@@ -96,7 +96,7 @@ int main(void)
   }
 
   /* to get the file size */
-  if(fstat(fileno(hd_src), &file_info) != 0) {
+  if(fstat(fileno(hd_src), &file_info)) {
     fclose(hd_src);
     return 1; /* cannot continue */
   }

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -399,7 +399,7 @@ int init_fifo(void)
   const char *fifo = "hiper.fifo";
   int socket;
 
-  if(lstat(fifo, &st) == 0) {
+  if(!lstat(fifo, &st)) {
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -383,7 +383,7 @@ static int init_fifo(struct GlobalInfo *g)
   curl_socket_t sockfd;
 
   fprintf(MSG_OUT, "Creating named pipe \"%s\"\n", fifo);
-  if(lstat(fifo, &st) == 0) {
+  if(!lstat(fifo, &st)) {
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -234,7 +234,7 @@ static int setup(struct input *t, int num, const char *upload)
     return 1;
   }
 
-  if(fstat(fileno(t->in), &file_info) != 0) {
+  if(fstat(fileno(t->in), &file_info)) {
     fprintf(stderr, "error: could not stat file %s: %s\n", upload,
             strerror(errno));
     fclose(t->out);

--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -96,7 +96,7 @@ int main(int argc, const char **argv)
     return 2;
 
   /* get the file size of the local file */
-  if(fstat(fileno(hd_src), &file_info) != 0) {
+  if(fstat(fileno(hd_src), &file_info)) {
     fclose(hd_src);
     return 1; /* cannot continue */
   }

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -210,7 +210,7 @@ int main(int argc, const char **argv)
   g_signal_connect(G_OBJECT(top_window), "delete-event",
                    G_CALLBACK(cb_delete), NULL);
 
-  if(!g_thread_create(&create_thread, progress_bar, FALSE, NULL) != 0)
+  if(!g_thread_create(&create_thread, progress_bar, FALSE, NULL))
     g_warning("cannot create the thread");
 
   gtk_main();

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -149,7 +149,7 @@ static size_t SyncTime_CURL_WriteHeader(void *ptr, size_t size, size_t nmemb,
         int i;
         SYSTime.wMilliseconds = 500;  /* adjust to midpoint, 0.5 sec */
         for(i = 0; i < 12; i++) {
-          if(strcmp(MthStr[i], TmpStr2) == 0) {
+          if(!strcmp(MthStr[i], TmpStr2)) {
             SYSTime.wMonth = (WORD)(i + 1);
             break;
           }
@@ -232,26 +232,26 @@ int main(int argc, const char *argv[])
   if(argc > 1) {
     int OptionIndex = 1;
     while(OptionIndex < argc) {
-      if(strncmp(argv[OptionIndex], "--server=", 9) == 0)
+      if(!strncmp(argv[OptionIndex], "--server=", 9))
         snprintf(conf.timeserver, sizeof(conf.timeserver) - 1, "%s",
                  &argv[OptionIndex][9]);
 
-      if(strcmp(argv[OptionIndex], "--showall") == 0)
+      if(!strcmp(argv[OptionIndex], "--showall"))
         ShowAllHeader = 1;
 
-      if(strcmp(argv[OptionIndex], "--synctime") == 0)
+      if(!strcmp(argv[OptionIndex], "--synctime"))
         AutoSyncTime = 1;
 
-      if(strncmp(argv[OptionIndex], "--proxy-user=", 13) == 0)
+      if(!strncmp(argv[OptionIndex], "--proxy-user=", 13))
         snprintf(conf.proxy_user, sizeof(conf.proxy_user) - 1, "%s",
                  &argv[OptionIndex][13]);
 
-      if(strncmp(argv[OptionIndex], "--proxy=", 8) == 0)
+      if(!strncmp(argv[OptionIndex], "--proxy=", 8))
         snprintf(conf.http_proxy, sizeof(conf.http_proxy) - 1, "%s",
                  &argv[OptionIndex][8]);
 
-      if((strcmp(argv[OptionIndex], "--help") == 0) ||
-         (strcmp(argv[OptionIndex], "/?") == 0)) {
+      if(!strcmp(argv[OptionIndex], "--help") ||
+         !strcmp(argv[OptionIndex], "/?")) {
         showUsage();
         return 0;
       }

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -576,7 +576,7 @@ static int proxy_h2_on_header(nghttp2_session *session,
   }
 
   if(namelen == sizeof(HTTP_PSEUDO_STATUS) - 1 &&
-     memcmp(HTTP_PSEUDO_STATUS, name, namelen) == 0) {
+     !memcmp(HTTP_PSEUDO_STATUS, name, namelen)) {
     int http_status;
     struct http_resp *resp;
 

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -687,7 +687,7 @@ static CURLcode parse_netscape(struct Cookie *co,
    * Firefox's cookie files, they are prefixed #HttpOnly_ and the rest
    * remains as usual, so we skip 10 characters of the line.
    */
-  if(strncmp(lineptr, "#HttpOnly_", 10) == 0) {
+  if(!strncmp(lineptr, "#HttpOnly_", 10)) {
     lineptr += 10;
     co->httponly = TRUE;
   }

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -96,25 +96,25 @@ static int parsekeyword(const unsigned char **pattern, unsigned char *charset)
 #undef KEYLEN
 
   *pattern = p; /* move caller's pattern pointer */
-  if(strcmp(keyword, "digit") == 0)
+  if(!strcmp(keyword, "digit"))
     charset[CURLFNM_DIGIT] = 1;
-  else if(strcmp(keyword, "alnum") == 0)
+  else if(!strcmp(keyword, "alnum"))
     charset[CURLFNM_ALNUM] = 1;
-  else if(strcmp(keyword, "alpha") == 0)
+  else if(!strcmp(keyword, "alpha"))
     charset[CURLFNM_ALPHA] = 1;
-  else if(strcmp(keyword, "xdigit") == 0)
+  else if(!strcmp(keyword, "xdigit"))
     charset[CURLFNM_XDIGIT] = 1;
-  else if(strcmp(keyword, "print") == 0)
+  else if(!strcmp(keyword, "print"))
     charset[CURLFNM_PRINT] = 1;
-  else if(strcmp(keyword, "graph") == 0)
+  else if(!strcmp(keyword, "graph"))
     charset[CURLFNM_GRAPH] = 1;
-  else if(strcmp(keyword, "space") == 0)
+  else if(!strcmp(keyword, "space"))
     charset[CURLFNM_SPACE] = 1;
-  else if(strcmp(keyword, "blank") == 0)
+  else if(!strcmp(keyword, "blank"))
     charset[CURLFNM_BLANK] = 1;
-  else if(strcmp(keyword, "upper") == 0)
+  else if(!strcmp(keyword, "upper"))
     charset[CURLFNM_UPPER] = 1;
-  else if(strcmp(keyword, "lower") == 0)
+  else if(!strcmp(keyword, "lower"))
     charset[CURLFNM_LOWER] = 1;
   else
     return SETCHARSET_FAIL;

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -939,7 +939,7 @@ static CURLcode parse_winnt(struct Curl_easy *data,
       parser->item_length++;
       if(c == ' ') {
         mem[parser->item_offset + parser->item_length - 1] = 0;
-        if(strcmp("<DIR>", mem + parser->item_offset) == 0) {
+        if(!strcmp("<DIR>", mem + parser->item_offset)) {
           finfo->filetype = CURLFILETYPE_DIRECTORY;
           finfo->size = 0;
         }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1505,7 +1505,7 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
   }
 
   if(namelen == sizeof(HTTP_PSEUDO_STATUS) - 1 &&
-     memcmp(HTTP_PSEUDO_STATUS, name, namelen) == 0) {
+     !memcmp(HTTP_PSEUDO_STATUS, name, namelen)) {
     /* nghttp2 guarantees :status is received first and only once. */
     char buffer[32];
     size_t hlen;

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -512,7 +512,7 @@ CURLcode Curl_http_proxy_inspect_tunnel_response(
       capsule_protocol = Curl_dynhds_cget(&resp->headers,
                                            "capsule-protocol");
       if(capsule_protocol) {
-        if(strncmp(capsule_protocol->value, "?1", 2) == 0 &&
+        if(!strncmp(capsule_protocol->value, "?1", 2) &&
            !capsule_protocol->value[2]) {
           infof(data, "CONNECT-UDP tunnel established, response %d",
                 resp->status);

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -658,7 +658,7 @@ static CURLcode rtsp_filter_rtp(struct Curl_easy *data,
       while(blen && buf[0] != '$') {
         if(!in_body && buf[0] == 'R' &&
            data->set.rtspreq != RTSPREQ_RECEIVE) {
-          if(strncmp(buf, "RTSP/", (blen < 5) ? blen : 5) == 0) {
+          if(!strncmp(buf, "RTSP/", (blen < 5) ? blen : 5)) {
             /* This could be the next response, no consume and return */
             if(*pconsumed) {
               DEBUGF(infof(data, "RTP rtsp_filter_rtp[SKIP] RTSP/ prefix, "

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -379,7 +379,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     return result;
 
   /* We only support md5 sessions */
-  if(strcmp(algorithm, "md5-sess") != 0)
+  if(strcmp(algorithm, "md5-sess"))
     return CURLE_BAD_CONTENT_ENCODING;
 
   /* Get the qop-values from the qop-options */

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -361,8 +361,8 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   ntlm->flags = 0;
 
   if((type2len < 32) ||
-     (memcmp(type2, NTLMSSP_SIGNATURE, 8) != 0) ||
-     (memcmp(type2 + 8, type2_marker, sizeof(type2_marker)) != 0)) {
+     memcmp(type2, NTLMSSP_SIGNATURE, 8) ||
+     memcmp(type2 + 8, type2_marker, sizeof(type2_marker))) {
     /* This was not a good enough type-2 message */
     infof(data, "NTLM handshake failure (bad type-2 message)");
     return CURLE_BAD_CONTENT_ENCODING;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -662,14 +662,14 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data,
             if(!curlx_str_number(&p, &port, 0xffff) &&
                (kh_name_end && (port == conn->origin->port))) {
               kh_name_size = strlen(store->name) - 1 - strlen(kh_name_end);
-              if(strncmp(store->name + 1,
-                         conn->origin->hostname, kh_name_size) == 0) {
+              if(!strncmp(store->name + 1, conn->origin->hostname,
+                          kh_name_size)) {
                 found = TRUE;
                 break;
               }
             }
           }
-          else if(strcmp(store->name, conn->origin->hostname) == 0) {
+          else if(!strcmp(store->name, conn->origin->hostname)) {
             found = TRUE;
             break;
           }

--- a/lib/vtls/cipher_suite.c
+++ b/lib/vtls/cipher_suite.c
@@ -639,7 +639,7 @@ uint16_t Curl_cipher_suite_lookup_id(const char *cs_str, size_t cs_len)
 
   if(cs_len > 0 && cs_str_to_zip(cs_str, cs_len, zip) == 0) {
     for(i = 0; i < CS_LIST_LEN; i++) {
-      if(memcmp(cs_list[i].zip, zip, sizeof(zip)) == 0)
+      if(!memcmp(cs_list[i].zip, zip, sizeof(zip)))
         return cs_list[i].id;
     }
   }

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -205,12 +205,12 @@ static gnutls_datum_t load_file(const char *file)
   f = curlx_fopen(file, "rb");
   if(!f)
     return loaded_file;
-  if(fseek(f, 0, SEEK_END) != 0)
+  if(fseek(f, 0, SEEK_END))
     goto out;
   filelen = ftell(f);
   if(filelen < 0 || filelen > CURL_MAX_INPUT_LENGTH)
     goto out;
-  if(fseek(f, 0, SEEK_SET) != 0)
+  if(fseek(f, 0, SEEK_SET))
     goto out;
   ptr = curlx_malloc((size_t)filelen);
   if(!ptr)

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -307,7 +307,7 @@ static CURLcode mbed_set_selected_ciphers(
     /* Add default TLSv1.3 ciphers to selection */
     for(j = 0; j < supported_len; j++) {
       uint16_t id = (uint16_t)supported[j];
-      if(strncmp(mbedtls_ssl_get_ciphersuite_name(id), "TLS1-3", 6) != 0)
+      if(strncmp(mbedtls_ssl_get_ciphersuite_name(id), "TLS1-3", 6))
         continue;
 
       selected[count++] = id;
@@ -360,7 +360,7 @@ add_ciphers:
     /* Add default TLSv1.2 ciphers to selection */
     for(j = 0; j < supported_len; j++) {
       uint16_t id = (uint16_t)supported[j];
-      if(strncmp(mbedtls_ssl_get_ciphersuite_name(id), "TLS1-3", 6) == 0)
+      if(!strncmp(mbedtls_ssl_get_ciphersuite_name(id), "TLS1-3", 6))
         continue;
 
       /* No duplicates allowed (so selected cannot overflow) */

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -107,7 +107,7 @@ static const char *c_memmem(const void *haystack, size_t haystacklen,
     return NULL;
   first = *(const char *)needle;
   for(p = (const char *)haystack; p <= (str_limit - needlelen); p++)
-    if(((*p) == first) && (memcmp(p, needle, needlelen) == 0))
+    if(((*p) == first) && !memcmp(p, needle, needlelen))
       return p;
 
   return NULL;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -856,7 +856,7 @@ static CURLcode wssl_add_default_ciphers(bool tls13, struct dynbuf *buf)
 
   for(i = 0; (str = wolfSSL_get_cipher_list(i)) != NULL; i++) {
     size_t n;
-    if((strncmp(str, "TLS13", 5) == 0) != tls13)
+    if((!strncmp(str, "TLS13", 5)) != tls13)
       continue;
 
     /* if there already is data in the string, add colon separator */

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -2332,7 +2332,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
           return 1; /* fail */
         if(!ipv4ptr[0])
           return 1; /* fail */
-        if(memcmp(ipv4res, "192.168.100.1", 13) != 0)
+        if(memcmp(ipv4res, "192.168.100.1", 13))
           return 1; /* fail */
         /* - */
         ipv6res[0] = '\0';
@@ -2356,7 +2356,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
           return 1; /* fail */
         if(!ipv6ptr[0])
           return 1; /* fail */
-        if(memcmp(ipv6res, "fe80::214:4fff:fe0b:76c8", 24) != 0)
+        if(memcmp(ipv6res, "fe80::214:4fff:fe0b:76c8", 24))
           return 1; /* fail */
         /* - */
         return 0;

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -507,7 +507,7 @@ AC_DEFUN([CURL_CHECK_FUNC_ALARM], [
       AC_LANG_PROGRAM([[
         $curl_includes_unistd
       ]],[[
-        if(alarm(0) != 0)
+        if(alarm(0))
           return 1;
       ]])
     ],[
@@ -598,7 +598,7 @@ AC_DEFUN([CURL_CHECK_FUNC_BASENAME], [
         $curl_includes_libgen
         $curl_includes_unistd
       ]],[[
-        if(basename(0) != 0)
+        if(basename(0))
           return 1;
       ]])
     ],[
@@ -658,7 +658,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
     ]],[[
-      if(closesocket(0) != 0)
+      if(closesocket(0))
         return 1;
     ]])
   ],[
@@ -688,7 +688,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
       ]],[[
-        if(closesocket(0) != 0)
+        if(closesocket(0))
           return 1;
       ]])
     ],[
@@ -749,7 +749,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET_CAMEL], [
       $curl_includes_bsdsocket
       $curl_includes_sys_socket
     ]],[[
-      if(CloseSocket(0) != 0)
+      if(CloseSocket(0))
         return 1;
     ]])
   ],[
@@ -767,7 +767,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET_CAMEL], [
         $curl_includes_bsdsocket
         $curl_includes_sys_socket
       ]],[[
-        if(CloseSocket(0) != 0)
+        if(CloseSocket(0))
           return 1;
       ]])
     ],[
@@ -850,7 +850,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FCNTL], [
       AC_LANG_PROGRAM([[
         $curl_includes_fcntl
       ]],[[
-        if(fcntl(0, 0, 0) != 0)
+        if(fcntl(0, 0, 0))
           return 1;
       ]])
     ],[
@@ -916,7 +916,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FCNTL_O_NONBLOCK], [
         $curl_includes_fcntl
       ]],[[
         int flags = 0;
-        if(fcntl(0, F_SETFL, flags | O_NONBLOCK) != 0)
+        if(fcntl(0, F_SETFL, flags | O_NONBLOCK))
           return 1;
       ]])
     ],[
@@ -1097,7 +1097,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FSETXATTR], [
         AC_LANG_PROGRAM([[
           $curl_includes_sys_xattr
         ]],[[
-          if(fsetxattr(0, "", 0, 0, 0) != 0)
+          if(fsetxattr(0, "", 0, 0, 0))
             return 1;
         ]])
       ],[
@@ -1115,7 +1115,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FSETXATTR], [
         AC_LANG_PROGRAM([[
           $curl_includes_sys_xattr
         ]],[[
-          if(fsetxattr(0, 0, 0, 0, 0, 0) != 0)
+          if(fsetxattr(0, 0, 0, 0, 0, 0))
             return 1;
         ]])
       ],[
@@ -1205,7 +1205,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
       $curl_includes_netdb
     ]],[[
       struct addrinfo *ai = 0;
-      if(getaddrinfo(0, 0, 0, &ai) != 0)
+      if(getaddrinfo(0, 0, 0, &ai))
         return 1;
     ]])
   ],[
@@ -1240,7 +1240,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         $curl_includes_netdb
       ]],[[
         struct addrinfo *ai = 0;
-        if(getaddrinfo(0, 0, 0, &ai) != 0)
+        if(getaddrinfo(0, 0, 0, &ai))
           return 1;
       ]])
     ],[
@@ -1451,7 +1451,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME_R], [
           $curl_includes_netdb
           $curl_includes_bsdsocket
         ]],[[
-          if(gethostbyname_r(0, 0, 0) != 0)
+          if(gethostbyname_r(0, 0, 0))
             return 1;
         ]])
       ],[
@@ -1470,7 +1470,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME_R], [
           $curl_includes_netdb
           $curl_includes_bsdsocket
         ]],[[
-          if(gethostbyname_r(0, 0, 0, 0, 0) != 0)
+          if(gethostbyname_r(0, 0, 0, 0, 0))
             return 1;
         ]])
       ],[
@@ -1489,7 +1489,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTBYNAME_R], [
           $curl_includes_netdb
           $curl_includes_bsdsocket
         ]],[[
-          if(gethostbyname_r(0, 0, 0, 0, 0, 0) != 0)
+          if(gethostbyname_r(0, 0, 0, 0, 0, 0))
             return 1;
         ]])
       ],[
@@ -1574,7 +1574,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
       $curl_includes_bsdsocket
     ]],[[
       char s[1];
-      if(gethostname((void *)s, 0) != 0)
+      if(gethostname((void *)s, 0))
         return 1;
     ]])
   ],[
@@ -1609,7 +1609,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
         $curl_includes_bsdsocket
       ]],[[
         char s[1];
-        if(gethostname((void *)s, 0) != 0)
+        if(gethostname((void *)s, 0))
           return 1;
       ]])
     ],[
@@ -1641,7 +1641,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
               int FUNCALLCONV gethostname($tst_arg1, $tst_arg2);
             ]],[[
               char s[1];
-              if(gethostname(($tst_arg1)s, 0) != 0)
+              if(gethostname(($tst_arg1)s, 0))
                 return 1;
             ]])
           ],[
@@ -1709,7 +1709,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETPEERNAME], [
       $curl_includes_bsdsocket
       $curl_includes_sys_socket
     ]],[[
-      if(getpeername(0, (void *)0, (void *)0) != 0)
+      if(getpeername(0, (void *)0, (void *)0))
         return 1;
     ]])
   ],[
@@ -1743,7 +1743,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETPEERNAME], [
         $curl_includes_bsdsocket
         $curl_includes_sys_socket
       ]],[[
-        if(getpeername(0, (void *)0, (void *)0) != 0)
+        if(getpeername(0, (void *)0, (void *)0))
           return 1;
       ]])
     ],[
@@ -1807,7 +1807,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETSOCKNAME], [
       $curl_includes_bsdsocket
       $curl_includes_sys_socket
     ]],[[
-      if(getsockname(0, (void *)0, (void *)0) != 0)
+      if(getsockname(0, (void *)0, (void *)0))
         return 1;
     ]])
   ],[
@@ -1841,7 +1841,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETSOCKNAME], [
         $curl_includes_bsdsocket
         $curl_includes_sys_socket
       ]],[[
-        if(getsockname(0, (void *)0, (void *)0) != 0)
+        if(getsockname(0, (void *)0, (void *)0))
           return 1;
       ]])
     ],[
@@ -1928,7 +1928,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETIFADDRS], [
       AC_LANG_PROGRAM([[
         $curl_includes_ifaddrs
       ]],[[
-        if(getifaddrs(0) != 0)
+        if(getifaddrs(0))
           return 1;
       ]])
     ],[
@@ -2168,7 +2168,7 @@ AC_DEFUN([CURL_CHECK_FUNC_LOCALTIME_R], [
       ]],[[
         time_t clock = 1170352587;
         struct tm result;
-        if(localtime_r(&clock, &result) != 0)
+        if(localtime_r(&clock, &result))
           return 1;
         (void)result;
       ]])
@@ -2289,7 +2289,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
       ]],[[
         char ipv4res[sizeof("255.255.255.255")];
         unsigned char ipv4a[5] = "";
-        if(inet_ntop(0, ipv4a, ipv4res, 0) != 0)
+        if(inet_ntop(0, ipv4a, ipv4res, 0))
           return 1;
       ]])
     ],[
@@ -2450,7 +2450,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
       ]],[[
         unsigned char ipv4a[4 + 1] = "";
         const char *ipv4src = "192.168.100.1";
-        if(inet_pton(0, ipv4src, ipv4a) != 0)
+        if(inet_pton(0, ipv4src, ipv4a))
           return 1;
       ]])
     ],[
@@ -2599,7 +2599,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL], [
       AC_LANG_PROGRAM([[
         $curl_includes_stropts
       ]],[[
-        if(ioctl(0, 0, 0) != 0)
+        if(ioctl(0, 0, 0))
           return 1;
       ]])
     ],[
@@ -2657,7 +2657,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL_FIONBIO], [
         $curl_includes_stropts
       ]],[[
         int flags = 0;
-        if(ioctl(0, FIONBIO, &flags) != 0)
+        if(ioctl(0, FIONBIO, &flags))
           return 1;
       ]])
     ],[
@@ -2714,7 +2714,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL_SIOCGIFADDR], [
         #include <net/if.h>
       ]],[[
         struct ifreq ifr;
-        if(ioctl(0, SIOCGIFADDR, &ifr) != 0)
+        if(ioctl(0, SIOCGIFADDR, &ifr))
           return 1;
       ]])
     ],[
@@ -2772,7 +2772,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
     ]],[[
-      if(ioctlsocket(0, 0, 0) != 0)
+      if(ioctlsocket(0, 0, 0))
         return 1;
     ]])
   ],[
@@ -2802,7 +2802,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
       ]],[[
-        if(ioctlsocket(0, 0, 0) != 0)
+        if(ioctlsocket(0, 0, 0))
           return 1;
       ]])
     ],[
@@ -2861,7 +2861,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_FIONBIO], [
         $curl_includes_winsock2
       ]],[[
         unsigned long flags = 0;
-        if(ioctlsocket(0, FIONBIO, &flags) != 0)
+        if(ioctlsocket(0, FIONBIO, &flags))
           return 1;
       ]])
     ],[
@@ -2918,7 +2918,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL], [
     AC_LANG_PROGRAM([[
       $curl_includes_bsdsocket
     ]],[[
-      if(IoctlSocket(0, 0, 0) != 0)
+      if(IoctlSocket(0, 0, 0))
         return 1;
     ]])
   ],[
@@ -2935,7 +2935,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL], [
       AC_LANG_PROGRAM([[
         $curl_includes_bsdsocket
       ]],[[
-        if(IoctlSocket(0, 0, 0) != 0)
+        if(IoctlSocket(0, 0, 0))
           return 1;
       ]])
     ],[
@@ -2993,7 +2993,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL_FIONBIO], [
         $curl_includes_bsdsocket
       ]],[[
         long flags = 0;
-        if(IoctlSocket(0, FIONBIO, &flags) != 0)
+        if(IoctlSocket(0, FIONBIO, &flags))
           return 1;
       ]])
     ],[
@@ -3064,7 +3064,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(memrchr("", 0, 0) != 0)
+        if(memrchr("", 0, 0))
           return 1;
       ]])
     ],[
@@ -3096,7 +3096,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(memrchr("", 0, 0) != 0)
+        if(memrchr("", 0, 0))
           return 1;
       ]])
     ],[
@@ -3181,7 +3181,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGACTION], [
       AC_LANG_PROGRAM([[
         $curl_includes_signal
       ]],[[
-        if(sigaction(0, 0, 0) != 0)
+        if(sigaction(0, 0, 0))
           return 1;
       ]])
     ],[
@@ -3266,7 +3266,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGINTERRUPT], [
       AC_LANG_PROGRAM([[
         $curl_includes_signal
       ]],[[
-        if(siginterrupt(0, 0) != 0)
+        if(siginterrupt(0, 0))
           return 1;
       ]])
     ],[
@@ -3351,7 +3351,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGNAL], [
       AC_LANG_PROGRAM([[
         $curl_includes_signal
       ]],[[
-        if(signal(0, 0) != 0)
+        if(signal(0, 0))
           return 1;
       ]])
     ],[
@@ -3425,7 +3425,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGSETJMP], [
         $curl_includes_setjmp
       ]],[[
         sigjmp_buf env;
-        if(sigsetjmp(env, 0) != 0)
+        if(sigsetjmp(env, 0))
           return 1;
       ]])
     ],[
@@ -3458,7 +3458,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SIGSETJMP], [
         $curl_includes_setjmp
       ]],[[
         sigjmp_buf env;
-        if(sigsetjmp(env, 0) != 0)
+        if(sigsetjmp(env, 0))
           return 1;
       ]])
     ],[
@@ -3521,7 +3521,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
       $curl_includes_bsdsocket
       $curl_includes_sys_socket
     ]],[[
-      if(socket(0, 0, 0) != 0)
+      if(socket(0, 0, 0))
         return 1;
     ]])
   ],[
@@ -3555,7 +3555,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
         $curl_includes_bsdsocket
         $curl_includes_sys_socket
       ]],[[
-        if(socket(0, 0, 0) != 0)
+        if(socket(0, 0, 0))
           return 1;
       ]])
     ],[
@@ -3641,7 +3641,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKETPAIR], [
         $curl_includes_sys_socket
       ]],[[
         int sv[2];
-        if(socketpair(0, 0, 0, sv) != 0)
+        if(socketpair(0, 0, 0, sv))
           return 1;
       ]])
     ],[
@@ -3726,7 +3726,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRCASECMP], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(strcasecmp("", "") != 0)
+        if(strcasecmp("", ""))
           return 1;
       ]])
     ],[
@@ -3919,7 +3919,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
         $curl_includes_string
       ]],[[
         char s[1];
-        if(strerror_r(0, s, 0) != 0)
+        if(strerror_r(0, s, 0))
           return 1;
       ]])
     ],[
@@ -3942,7 +3942,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
             char *strerror_r(int errnum, char *workbuf, $arg3 bufsize);
           ]],[[
             char s[1];
-            if(strerror_r(0, s, 0) != 0)
+            if(strerror_r(0, s, 0))
               return 1;
             (void)s;
           ]])
@@ -4005,7 +4005,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
             int strerror_r(int errnum, char *resultbuf, $arg3 bufsize);
           ]],[[
             char s[1];
-            if(strerror_r(0, s, 0) != 0)
+            if(strerror_r(0, s, 0))
               return 1;
             (void)s;
           ]])
@@ -4160,7 +4160,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRICMP], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(stricmp(0, 0) != 0)
+        if(stricmp(0, 0))
           return 1;
       ]])
     ],[
@@ -4246,7 +4246,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMSET_S], [
         $curl_includes_string
       ]],[[
         char buf[2];
-        if(memset_s(buf, sizeof(buf), 0, sizeof(buf)) != 0)
+        if(memset_s(buf, sizeof(buf), 0, sizeof(buf)))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3810,7 +3810,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRCMPI], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(strcmpi(0, 0) != 0)
+        if(strcmpi(0, 0))
           return 1;
       ]])
     ],[

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -59,7 +59,7 @@ int is_vms_shell(void)
   }
 
   /* Have to make sure some one did not set shell to DCL */
-  if(strcmp(shell, "DCL") == 0) {
+  if(!strcmp(shell, "DCL")) {
     vms_shell = 1;
     return 1;
   }

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -79,7 +79,7 @@ int cgetopt(int argc, const char * const argv[], const char *optstring)
   }
 
   arg = argv[coptind];
-  if(arg && strcmp(arg, "--") == 0) {
+  if(arg && !strcmp(arg, "--")) {
     coptind++;
     return -1;
   }
@@ -248,7 +248,7 @@ int main(int argc, const char **argv)
   entry_name = argv[1];
   entry_func = NULL;
   for(tmp = 0; s_entries[tmp].ptr; ++tmp) {
-    if(strcmp(entry_name, s_entries[tmp].name) == 0) {
+    if(!strcmp(entry_name, s_entries[tmp].name)) {
       entry_func = s_entries[tmp].ptr;
       break;
     }

--- a/tests/libtest/lib1536.c
+++ b/tests/libtest/lib1536.c
@@ -73,7 +73,7 @@ static CURLcode test_lib1536(const char *URL)
                   __FILE__, __LINE__, (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
-  if(!scheme || memcmp(scheme, "http", 5) != 0) {
+  if(!scheme || memcmp(scheme, "http", 5)) {
     curl_mfprintf(stderr, "%s:%d scheme of http resource is incorrect; "
                   "expected 'http' but is %s\n",
                   __FILE__, __LINE__, scheme ? "invalid" : "NULL");

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -2135,7 +2135,7 @@ static int clear_url(void)
 
     rc = curl_url_get(u, clear_url_list[i].part, &p, 0);
     if(rc != clear_url_list[i].ucode ||
-       (p && clear_url_list[i].out && strcmp(p, clear_url_list[i].out) != 0)) {
+       (p && clear_url_list[i].out && strcmp(p, clear_url_list[i].out))) {
 
       curl_mfprintf(stderr, "unexpected return code line %d\n", __LINE__);
       error++;

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -63,7 +63,7 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
       if(last_issuer) {
         /* If the last certificate's issuer matches the current certificate's
          * subject, then the chain is in order */
-        if(strcmp(last_issuer, subject) != 0) {
+        if(strcmp(last_issuer, subject)) {
           curl_mfprintf(stderr,
                         "cert %d issuer does not match cert %d subject\n",
                         cert - 1, cert);

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -99,7 +99,7 @@ static int t518_test_rlimit(int keep_open)
 
   /* get initial open file limits */
 
-  if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+  if(getrlimit(RLIMIT_NOFILE, &rl)) {
     t518_store_errmsg("getrlimit() failed", errno);
     curl_mfprintf(stderr, "%s\n", t518_msgbuff);
     return -1;
@@ -135,7 +135,7 @@ static int t518_test_rlimit(int keep_open)
        (rl.rlim_cur < OPEN_MAX)) {
       curl_mfprintf(stderr, "raising soft limit up to OPEN_MAX\n");
       rl.rlim_cur = OPEN_MAX;
-      if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+      if(setrlimit(RLIMIT_NOFILE, &rl)) {
         /* on failure do not abort, only issue a warning */
         t518_store_errmsg("setrlimit() failed", errno);
         curl_mfprintf(stderr, "%s\n", t518_msgbuff);
@@ -146,7 +146,7 @@ static int t518_test_rlimit(int keep_open)
 
     curl_mfprintf(stderr, "raising soft limit up to hard limit\n");
     rl.rlim_cur = rl.rlim_max;
-    if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    if(setrlimit(RLIMIT_NOFILE, &rl)) {
       /* on failure do not abort, only issue a warning */
       t518_store_errmsg("setrlimit() failed", errno);
       curl_mfprintf(stderr, "%s\n", t518_msgbuff);
@@ -155,7 +155,7 @@ static int t518_test_rlimit(int keep_open)
 
     /* get current open file limits */
 
-    if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    if(getrlimit(RLIMIT_NOFILE, &rl)) {
       t518_store_errmsg("getrlimit() failed", errno);
       curl_mfprintf(stderr, "%s\n", t518_msgbuff);
       return -3;

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -96,7 +96,7 @@ static int t537_test_rlimit(int keep_open)
 
   /* get initial open file limits */
 
-  if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+  if(getrlimit(RLIMIT_NOFILE, &rl)) {
     t537_store_errmsg("getrlimit() failed", errno);
     curl_mfprintf(stderr, "%s\n", t537_msgbuff);
     return -1;
@@ -136,7 +136,7 @@ static int t537_test_rlimit(int keep_open)
        (rl.rlim_cur < OPEN_MAX)) {
       curl_mfprintf(stderr, "raising soft limit up to OPEN_MAX\n");
       rl.rlim_cur = OPEN_MAX;
-      if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+      if(setrlimit(RLIMIT_NOFILE, &rl)) {
         /* on failure do not abort, only issue a warning */
         t537_store_errmsg("setrlimit() failed", errno);
         curl_mfprintf(stderr, "%s\n", t537_msgbuff);
@@ -147,7 +147,7 @@ static int t537_test_rlimit(int keep_open)
 
     curl_mfprintf(stderr, "raising soft limit up to hard limit\n");
     rl.rlim_cur = rl.rlim_max;
-    if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    if(setrlimit(RLIMIT_NOFILE, &rl)) {
       /* on failure do not abort, only issue a warning */
       t537_store_errmsg("setrlimit() failed", errno);
       curl_mfprintf(stderr, "%s\n", t537_msgbuff);
@@ -156,7 +156,7 @@ static int t537_test_rlimit(int keep_open)
 
     /* get current open file limits */
 
-    if(getrlimit(RLIMIT_NOFILE, &rl) != 0) {
+    if(getrlimit(RLIMIT_NOFILE, &rl)) {
       t537_store_errmsg("getrlimit() failed", errno);
       curl_mfprintf(stderr, "%s\n", t537_msgbuff);
       return -3;

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -67,7 +67,7 @@ static size_t rtp_write(char *data, size_t size, size_t nmemb, void *stream)
   data += 4;
   for(i = 0; i < message_size; i += RTP_DATA_SIZE) {
     if(message_size - i > RTP_DATA_SIZE) {
-      if(memcmp(RTP_DATA, data + i, RTP_DATA_SIZE) != 0) {
+      if(memcmp(RTP_DATA, data + i, RTP_DATA_SIZE)) {
         curl_mprintf("RTP PAYLOAD CORRUPTED [%s]\n", data + i);
 #if 0
         return failure;
@@ -75,7 +75,7 @@ static size_t rtp_write(char *data, size_t size, size_t nmemb, void *stream)
       }
     }
     else {
-      if(memcmp(RTP_DATA, data + i, message_size - i) != 0) {
+      if(memcmp(RTP_DATA, data + i, message_size - i)) {
         curl_mprintf("RTP PAYLOAD END CORRUPTED (%d), [%s]\n",
                      message_size - i, data + i);
 #if 0

--- a/tests/libtest/lib576.c
+++ b/tests/libtest/lib576.c
@@ -73,7 +73,7 @@ static long chunk_bgn(const void *f, void *ptr, int remains)
                  "-------------------------------------------"
                  "------------------\n");
   }
-  if(strcmp(finfo->filename, "someothertext.txt") == 0) {
+  if(!strcmp(finfo->filename, "someothertext.txt")) {
     curl_mprintf("# THIS CONTENT WAS SKIPPED IN CHUNK_BGN CALLBACK #\n");
     return CURL_CHUNK_BGN_FUNC_SKIP;
   }

--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -39,7 +39,7 @@ int main(int argc, const char **argv)
   entry_name = argv[1];
   entry_func = NULL;
   for(tmp = 0; s_entries[tmp].ptr; ++tmp) {
-    if(strcmp(entry_name, s_entries[tmp].name) == 0) {
+    if(!strcmp(entry_name, s_entries[tmp].name)) {
       entry_func = s_entries[tmp].ptr;
       break;
     }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -970,7 +970,7 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
   curlx_fclose(server);
 
   for(pf = formata; pf->f_mode; pf++)
-    if(strcmp(pf->f_mode, mode) == 0)
+    if(!strcmp(pf->f_mode, mode))
       break;
   if(!pf->f_mode) {
     nak(TFTP_EBADOP);

--- a/tests/unit/unit1304.c
+++ b/tests/unit/unit1304.c
@@ -119,10 +119,10 @@ static CURLcode test_unit1304(const char *arg)
   Curl_netrc_init(&store);
   res = Curl_netrc_scan(data, &store, "example.com", NULL, arg, &cr_out);
   fail_unless(res == NETRC_OK, "Host should have been found");
-  fail_unless(strncmp(Curl_creds_passwd(cr_out), "passwd", 6) == 0,
+  fail_unless(!strncmp(Curl_creds_passwd(cr_out), "passwd", 6),
               "password should be 'passwd'");
   fail_unless(!t1304_no_user(cr_out), "returned NULL!");
-  fail_unless(strncmp(Curl_creds_user(cr_out), "admin", 5) == 0,
+  fail_unless(!strncmp(Curl_creds_user(cr_out), "admin", 5),
               "login should be 'admin'");
   Curl_netrc_cleanup(&store);
 
@@ -132,10 +132,10 @@ static CURLcode test_unit1304(const char *arg)
   Curl_netrc_init(&store);
   res = Curl_netrc_scan(data, &store, "curl.example.com", NULL, arg, &cr_out);
   fail_unless(res == NETRC_OK, "Host should have been found");
-  fail_unless(strncmp(Curl_creds_passwd(cr_out), "none", 4) == 0,
+  fail_unless(!strncmp(Curl_creds_passwd(cr_out), "none", 4),
                       "password should be 'none'");
   fail_unless(!t1304_no_user(cr_out), "returned NULL!");
-  fail_unless(strncmp(Curl_creds_user(cr_out), "none", 4) == 0,
+  fail_unless(!strncmp(Curl_creds_user(cr_out), "none", 4),
               "login should be 'none'");
   Curl_netrc_cleanup(&store);
 

--- a/tests/unit/unit1620.c
+++ b/tests/unit/unit1620.c
@@ -50,13 +50,13 @@ static void t1620_parse(const char *input,
 
   if(!unitfail) {
     fail_unless(!userstr || !exp_username ||
-                  strcmp(userstr, exp_username) == 0,
+                !strcmp(userstr, exp_username),
                 "userstr should be equal to exp_username");
     fail_unless(!passwdstr || !exp_password ||
-                  strcmp(passwdstr, exp_password) == 0,
+                !strcmp(passwdstr, exp_password),
                 "passwdstr should be equal to exp_password");
     fail_unless(!options || !exp_options ||
-                  strcmp(options, exp_options) == 0,
+                !strcmp(options, exp_options),
                 "options should be equal to exp_options");
   }
 

--- a/tests/unit/unit1663.c
+++ b/tests/unit/unit1663.c
@@ -56,11 +56,11 @@ static void t1663_parse(const char *input_data,
   fail_unless(!!exp_host == !!host, "host expectation failed");
 
   if(!unitfail) {
-    fail_unless(!dev || !exp_dev || strcmp(dev, exp_dev) == 0,
+    fail_unless(!dev || !exp_dev || !strcmp(dev, exp_dev),
                 "dev should be equal to exp_dev");
-    fail_unless(!iface || !exp_iface || strcmp(iface, exp_iface) == 0,
+    fail_unless(!iface || !exp_iface || !strcmp(iface, exp_iface),
                 "iface should be equal to exp_iface");
-    fail_unless(!host || !exp_host || strcmp(host, exp_host) == 0,
+    fail_unless(!host || !exp_host || !strcmp(host, exp_host),
                 "host should be equal to exp_host");
   }
 

--- a/tests/unit/unit1676.c
+++ b/tests/unit/unit1676.c
@@ -103,12 +103,11 @@ static CURLcode test_unit1676(const char *arg)
     abort_unless(dhp_value, "dh(p) not found in certinfo");
     abort_unless(dhg_value, "dh(g) not found in certinfo");
     abort_unless(dhpk_value, "dh(pub_key) not found in certinfo");
-    fail_if(strcmp(dhp_value, dhg_value) == 0,
+    fail_if(!strcmp(dhp_value, dhg_value),
             "dh(p) and dh(g) have the same value (bug: g re-reads p)");
-    fail_unless(strcmp(dhp_value, "17") == 0, "dh(p) expected 17 (0x11)");
-    fail_unless(strcmp(dhg_value, "34") == 0, "dh(g) expected 34 (0x22)");
-    fail_unless(strcmp(dhpk_value, "51") == 0,
-                "dh(pub_key) expected 51 (0x33)");
+    fail_unless(!strcmp(dhp_value, "17"), "dh(p) expected 17 (0x11)");
+    fail_unless(!strcmp(dhg_value, "34"), "dh(g) expected 34 (0x22)");
+    fail_unless(!strcmp(dhpk_value, "51"), "dh(pub_key) expected 51 (0x33)");
   }
 
   curl_easy_cleanup(data);

--- a/tests/unit/unit1676.c
+++ b/tests/unit/unit1676.c
@@ -92,11 +92,11 @@ static CURLcode test_unit1676(const char *arg)
   if(result == CURLE_OK) {
     /* Walk certinfo entries to find dh(p), dh(g), and dh(pub_key) */
     for(slist = data->info.certs.certinfo[0]; slist; slist = slist->next) {
-      if(strncmp(slist->data, "dh(p):", 6) == 0)
+      if(!strncmp(slist->data, "dh(p):", 6))
         dhp_value = slist->data + 6;
-      else if(strncmp(slist->data, "dh(g):", 6) == 0)
+      else if(!strncmp(slist->data, "dh(g):", 6))
         dhg_value = slist->data + 6;
-      else if(strncmp(slist->data, "dh(pub_key):", 12) == 0)
+      else if(!strncmp(slist->data, "dh(pub_key):", 12))
         dhpk_value = slist->data + 12;
     }
 

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -544,7 +544,7 @@ static CURLcode test_unit3205(const char *arg)
 
     Curl_cipher_suite_get_str(test->id, buf, sizeof(buf), TRUE);
 
-    if(expect && strcmp(buf, expect) != 0) {
+    if(expect && strcmp(buf, expect)) {
       curl_mfprintf(stderr, "Curl_cipher_suite_get_str FAILED for 0x%04x, "
                     "result = \"%s\", expected = \"%s\"\n",
                     test->id, buf, expect);
@@ -569,7 +569,7 @@ static CURLcode test_unit3205(const char *arg)
       }
     }
 
-    if(expect && strcmp(buf, expect) != 0) {
+    if(expect && strcmp(buf, expect)) {
       curl_mfprintf(stderr, "Curl_cipher_suite_get_str FAILED for 0x%04x, "
                     "result = \"%s\", expected = \"%s\"\n",
                     test->id, buf, expect);

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -598,7 +598,7 @@ static CURLcode test_unit3205(const char *arg)
                       test->str, id, test->id);
         unitfail++;
       }
-      if(len > 64 || strncmp(ptr, test->str, len) != 0) {
+      if(len > 64 || strncmp(ptr, test->str, len)) {
         curl_mfprintf(stderr, "Curl_cipher_suite_walk_str ABORT for \"%s\" "
                       "unexpected pointers\n",
                       test->str);

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -559,11 +559,11 @@ static CURLcode test_unit3205(const char *arg)
 
     /* suites matched by EDH alias will return the DHE name */
     if(test->id >= 0x0011 && test->id < 0x0017) {
-      if(expect && memcmp(expect, "EDH-", 4) == 0) {
+      if(expect && !memcmp(expect, "EDH-", 4)) {
         curlx_strcopy(alt, sizeof(alt), expect, strlen(expect));
         expect = (const char *)memcpy(alt, "DHE-", sizeof("DHE-") - 1);
       }
-      if(expect && memcmp(expect + 4, "EDH-", 4) == 0) {
+      if(expect && !memcmp(expect + 4, "EDH-", 4)) {
         curlx_strcopy(alt, sizeof(alt), expect, strlen(expect));
         expect = (const char *)memcpy(alt + 4, "DHE-", sizeof("DHE-") - 1) - 4;
       }


### PR DESCRIPTION
Drop from:
- strcmp, strcmpi, strncmp, memcmp, lstat, getrlimit, setrlimit, fseek,
  fstat
- autotools detection snippets.
- smooth-gtk-thread: simplify `!var != 0` expression.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
