### PR TITLE
digest: flush proxy state on proxy or credential change

### DIFF
--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -87,6 +87,24 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
 #ifdef CURL_DISABLE_PROXY
     return CURLE_NOT_BUILT_IN;
 #else
+    bool flush = FALSE;
+    if(data->state.proxydigest.origin &&
+       !Curl_peer_same_destination(data->conn->http_proxy.peer,
+                                   data->state.proxydigest.origin))
+      flush = TRUE;
+    else if(data->state.proxydigest.creds &&
+            !Curl_creds_same(data->conn->http_proxy.creds,
+                             data->state.proxydigest.creds))
+      flush = TRUE;
+
+    if(flush)
+      /* flush proxy Digest state */
+      Curl_auth_digest_cleanup(&data->state.proxydigest);
+
+    Curl_peer_link(&data->state.proxydigest.origin,
+                   data->conn->http_proxy.peer);
+    Curl_creds_link(&data->state.proxydigest.creds,
+                    data->conn->http_proxy.creds);
     digest = &data->state.proxydigest;
     allocuserpwd = &data->req.hd_proxy_auth;
     creds = data->conn->http_proxy.creds;

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -62,6 +62,27 @@ CURLcode Curl_input_digest(struct Curl_easy *data,
   return Curl_auth_decode_digest_http_message(header, digest);
 }
 
+/* Flush the Digest state if it was created for a different origin or with
+   different credentials than the ones now in use, then link the current
+   ones. */
+static void digest_flush_stale(struct digestdata *digest,
+                               struct Curl_peer *peer,
+                               struct Curl_creds *creds)
+{
+  bool flush = FALSE;
+  if(digest->origin && !Curl_peer_same_destination(peer, digest->origin))
+    flush = TRUE;
+  else if(digest->creds && !Curl_creds_same(creds, digest->creds))
+    flush = TRUE;
+
+  if(flush)
+    /* flush Digest state */
+    Curl_auth_digest_cleanup(digest);
+
+  Curl_peer_link(&digest->origin, peer);
+  Curl_creds_link(&digest->creds, creds);
+}
+
 CURLcode Curl_output_digest(struct Curl_easy *data,
                             bool proxy,
                             const unsigned char *request,
@@ -87,48 +108,18 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
 #ifdef CURL_DISABLE_PROXY
     return CURLE_NOT_BUILT_IN;
 #else
-    bool flush = FALSE;
-    if(data->state.proxydigest.origin &&
-       !Curl_peer_same_destination(data->conn->http_proxy.peer,
-                                   data->state.proxydigest.origin))
-      flush = TRUE;
-    else if(data->state.proxydigest.creds &&
-            !Curl_creds_same(data->conn->http_proxy.creds,
-                             data->state.proxydigest.creds))
-      flush = TRUE;
-
-    if(flush)
-      /* flush proxy Digest state */
-      Curl_auth_digest_cleanup(&data->state.proxydigest);
-
-    Curl_peer_link(&data->state.proxydigest.origin,
-                   data->conn->http_proxy.peer);
-    Curl_creds_link(&data->state.proxydigest.creds,
-                    data->conn->http_proxy.creds);
     digest = &data->state.proxydigest;
+    digest_flush_stale(digest, data->conn->http_proxy.peer,
+                       data->conn->http_proxy.creds);
     allocuserpwd = &data->req.hd_proxy_auth;
     creds = data->conn->http_proxy.creds;
     authp = &data->state.authproxy;
 #endif
   }
   else {
-    bool flush = FALSE;
     DEBUGASSERT(data->conn->origin);
-    if(data->state.digest.origin &&
-       !Curl_peer_same_destination(data->conn->origin,
-                                   data->state.digest.origin))
-      flush = TRUE;
-    else if(data->state.digest.creds &&
-            !Curl_creds_same(data->state.creds, data->state.digest.creds))
-      flush = TRUE;
-
-    if(flush)
-      /* flush host Digest state */
-      Curl_auth_digest_cleanup(&data->state.digest);
-
-    Curl_peer_link(&data->state.digest.origin, data->conn->origin);
-    Curl_creds_link(&data->state.digest.creds, data->state.creds);
     digest = &data->state.digest;
+    digest_flush_stale(digest, data->conn->origin, data->state.creds);
     allocuserpwd = &data->req.hd_auth;
     creds = data->state.creds;
     authp = &data->state.authhost;


### PR DESCRIPTION
`Repro:` reuse one easy handle with `CURLOPT_PROXYAUTH = CURLAUTH_DIGEST`, drive a request through one digest proxy, then point `CURLOPT_PROXY` at a different proxy (or change `CURLOPT_PROXYUSERPWD`) and perform again.

`Cause:` `Curl_output_digest()` flushes `data->state.digest` when the host origin or credentials change, but the proxy branch reuses `data->state.proxydigest` unconditionally, so a stale `nonce`/`nc`/`realm` from the previous proxy is carried into the next `Proxy-Authorization`. 5c6b488 added the guard for the host branch only.

`Fix:` mirror that guard in the proxy branch, comparing the stored state against `data->conn->http_proxy.peer` and `data->conn->http_proxy.creds` and flushing on a mismatch.