### PR TITLE
h3proxy, no stream userdata

### DIFF
--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -934,18 +934,17 @@ static CURLcode cf_h3_proxy_submit(struct Curl_cfilter *cf,
     int rv;
 
     DEBUGASSERT(stream->id == -1);
-    rv = ngtcp2_conn_open_bidi_stream(ctx->qconn, &sid, data);
+    /* Do NOT set `data` as stream user data. The transfer `data` may
+     * get cleaned up long before the tunnel goes down. */
+    rv = ngtcp2_conn_open_bidi_stream(ctx->qconn, &sid, NULL);
     if(rv) {
       failf(data, "cannot get bidi streams: %s", ngtcp2_strerror(rv));
       result = CURLE_SEND_ERROR;
       goto out;
     }
     stream->id = sid;
-    ++ctx->used_bidi_streams;
-
-    /* Do NOT set `data` as stream user data. The transfer `data` may
-     * get cleaned up long before the tunnel goes down. */
     ts->stream = stream;
+    ++ctx->used_bidi_streams;
     CURL_TRC_CF(data, cf, "[%" PRId64 "] opened bidi stream", sid);
   }
 


### PR DESCRIPTION
Do not set the easy handle opening a proxy tunnel as userdata on the stream. The ease handle might go out of scope long before the tunnel stream is closed.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
