### PR TITLE
content_encoding: fix non-last chunked rejection

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -789,17 +789,6 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       }
 
       cwt = find_unencode_writer(name, namelen, phase);
-      if(cwt && is_chunked && Curl_cwriter_get_by_type(data, cwt)) {
-        /* A 'chunked' transfer encoding has already been added.
-         * Ignore duplicates. See #13451.
-         * Also RFC 9112, ch. 6.1:
-         * "A sender MUST NOT apply the chunked transfer coding more than
-         *  once to a message body."
-         */
-        CURL_TRC_WRITE(data, "ignoring duplicate 'chunked' decoder");
-        return CURLE_OK;
-      }
-
       if(is_transfer && !is_chunked &&
          Curl_cwriter_get_by_name(data, "chunked")) {
         /* RFC 9112, ch. 6.1:
@@ -814,21 +803,31 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
               "Transfer-Encoding");
         return CURLE_BAD_CONTENT_ENCODING;
       }
+      if(cwt && is_chunked && Curl_cwriter_get_by_type(data, cwt)) {
+        /* A 'chunked' transfer encoding has already been added.
+         * Ignore duplicates. See #13451.
+         * Also RFC 9112, ch. 6.1:
+         * "A sender MUST NOT apply the chunked transfer coding more than
+         *  once to a message body."
+         */
+        CURL_TRC_WRITE(data, "ignoring duplicate 'chunked' decoder");
+      }
+      else {
+        if(!cwt)
+          cwt = &error_writer; /* Defer error at use. */
 
-      if(!cwt)
-        cwt = &error_writer; /* Defer error at use. */
+        result = Curl_cwriter_create(&writer, data, cwt, phase);
+        CURL_TRC_WRITE(data, "added %s decoder %s -> %d",
+                       is_transfer ? "transfer" : "content", cwt->name,
+                       (int)result);
+        if(result)
+          return result;
 
-      result = Curl_cwriter_create(&writer, data, cwt, phase);
-      CURL_TRC_WRITE(data, "added %s decoder %s -> %d",
-                     is_transfer ? "transfer" : "content", cwt->name,
-                     (int)result);
-      if(result)
-        return result;
-
-      result = Curl_cwriter_add(data, writer);
-      if(result) {
-        Curl_cwriter_free(data, writer);
-        return result;
+        result = Curl_cwriter_add(data, writer);
+        if(result) {
+          Curl_cwriter_free(data, writer);
+          return result;
+        }
       }
       if(is_chunked)
         has_chunked = TRUE;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -225,7 +225,7 @@ test1685 test1686 \
 \
 test1700 test1701 test1702 test1703 test1704 test1705 test1706 test1707 \
 test1708 test1709 test1710 test1711 test1712 test1713 test1714 test1715 \
-test1720 test1721 \
+test1720 test1721 test1722 test1723 \
 \
 test1800 test1801 test1802 test1847 test1848 test1849 test1850 test1851 \
 \

--- a/tests/data/test1722
+++ b/tests/data/test1722
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+chunked Transfer-Encoding
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked, another
+Connection: mooo
+
+40%CR
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa%CR
+30%CR
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb%CR
+21;heresatest=moooo%CR
+cccccccccccccccccccccccccccccccc
+%CR
+0%CR
+%CR
+</data>
+<datacheck>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with chunked Transfer-Encoding not listed last
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<errorcode>
+61
+</errorcode>
+</verify>
+
+</testcase>

--- a/tests/data/test1723
+++ b/tests/data/test1723
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+chunked Transfer-Encoding
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked, chunked, another
+Connection: mooo
+
+40%CR
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa%CR
+30%CR
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb%CR
+21;heresatest=moooo%CR
+cccccccccccccccccccccccccccccccc
+%CR
+0%CR
+%CR
+</data>
+<datacheck>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP with two chunked Transfer-Encoding not listed last
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<errorcode>
+61
+</errorcode>
+</verify>
+
+</testcase>


### PR DESCRIPTION
Even when two 'chunked' are listed and neither is the last encoding the transfer is rejected.

Verified by test 1722 and 1723

Reported-by: violet12331 on hackerone
