### PR TITLE
CURLOPT_WRITEFUNCTION.md: remove stray reference to HSTS

### DIFF
--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.md
@@ -72,9 +72,6 @@ Set this option to NULL to get the internal default function used instead of
 your callback. The internal default function writes the data to the FILE *
 given with CURLOPT_WRITEDATA(3).
 
-This option does not enable HSTS, you need to use CURLOPT_HSTS_CTRL(3) to
-do that.
-
 # DEFAULT
 
 fwrite(3)


### PR DESCRIPTION
It appears to have landed here by mistake