### PR TITLE
http_digest: return better error

### DIFF
--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -54,7 +54,7 @@ CURLcode Curl_input_digest(struct Curl_easy *data,
   }
 
   if(!checkprefix("Digest", header) || !ISBLANK(header[6]))
-    return CURLE_BAD_CONTENT_ENCODING;
+    return CURLE_AUTH_ERROR;
 
   header += strlen("Digest");
   curlx_str_passblanks(&header);


### PR DESCRIPTION
It is not a content encoding error.

Found by the GitHub AI thing.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
