### PR TITLE
libtests: add and use tutil_throwaway_cb

### DIFF
--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -31,6 +31,7 @@
    we need both of them in the include path), so that we get good in-depth
    knowledge about the system we are building this on */
 #include "curl_setup.h"
+#include "testutil.h"
 
 typedef CURLcode (*entry_func_t)(const char *);
 

--- a/tests/libtest/lib1518.c
+++ b/tests/libtest/lib1518.c
@@ -25,16 +25,6 @@
 
 /* Test inspired by github issue 3340 */
 
-static size_t t1518_write_cb(char *buffer, size_t size, size_t nitems,
-                             void *outstream)
-{
-  (void)buffer;
-  (void)size;
-  (void)nitems;
-  (void)outstream;
-  return 0;
-}
-
 static CURLcode test_lib1518(const char *URL)
 {
   CURL *curl;
@@ -77,7 +67,7 @@ static CURLcode test_lib1518(const char *URL)
   curl_easy_getinfo(curl, CURLINFO_REDIRECT_COUNT, &curlRedirectCount);
   curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &effectiveUrl);
   curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirectUrl);
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, t1518_write_cb);
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   curl_mprintf("result %d\n"
                "status %ld\n"

--- a/tests/libtest/lib1523.c
+++ b/tests/libtest/lib1523.c
@@ -36,14 +36,6 @@ static int dload_progress_cb(void *a, curl_off_t b, curl_off_t c,
   return 0;
 }
 
-static size_t t1523_write_cb(char *d, size_t n, size_t l, void *p)
-{
-  /* take care of the data here, ignored in this example */
-  (void)d;
-  (void)p;
-  return n * l;
-}
-
 static CURLcode run(CURL *curl, long limit, long time)
 {
   curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, limit);
@@ -59,7 +51,7 @@ static CURLcode test_lib1523(const char *URL)
   curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   curl_easy_setopt(curl, CURLOPT_URL, URL);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, t1523_write_cb);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, buffer);
   curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
   curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, dload_progress_cb);

--- a/tests/libtest/lib1686.c
+++ b/tests/libtest/lib1686.c
@@ -23,13 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-static size_t devnull_1686(char *p, size_t s, size_t n, void *u)
-{
-  (void)p;
-  (void)u;
-  return s * n;
-}
-
 #define FIRSTHOST "first.test"
 #define SECONDHOST "second.test"
 
@@ -75,7 +68,7 @@ static CURLcode test_lib1686(const char *hostip)
     easy_setopt(curl, CURLOPT_RESOLVE, host);
     easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
     easy_setopt(curl, CURLOPT_USERPWD, "alice:bond");
-    easy_setopt(curl, CURLOPT_WRITEFUNCTION, devnull_1686);
+    easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
     easy_setopt(curl, CURLOPT_URL, firsturl);
     result = curl_easy_perform(curl);

--- a/tests/libtest/lib1922.c
+++ b/tests/libtest/lib1922.c
@@ -23,13 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-static size_t test_lib1922_discard_write(char *ptr, size_t size, size_t nmemb,
-  void *ud)
-{
-  (void)ptr; (void)ud;
-  return size * nmemb;
-}
-
 static CURLcode test_lib1922(const char *URL)
 {
   CURLcode result = CURLE_OK;
@@ -71,7 +64,7 @@ static CURLcode test_lib1922(const char *URL)
   global_init(CURL_GLOBAL_ALL);
   easy_init(curl);
 
-  easy_setopt(curl, CURLOPT_WRITEFUNCTION, test_lib1922_discard_write);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
   easy_setopt(curl, CURLOPT_RESOLVE, resolve);
   easy_setopt(curl, CURLOPT_URL, direct_url);
   easy_setopt(curl, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);

--- a/tests/libtest/lib1940.c
+++ b/tests/libtest/lib1940.c
@@ -23,14 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-static size_t t1940_write_cb(char *data, size_t n, size_t l, void *userp)
-{
-  /* take care of the data here, ignored in this example */
-  (void)data;
-  (void)userp;
-  return n * l;
-}
-
 static void t1940_showem(CURL *curl, int header_request, unsigned int type)
 {
   static const char *testdata[] = {
@@ -95,7 +87,7 @@ static CURLcode test_lib1940(const char *URL)
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   /* ignores any content */
-  easy_setopt(curl, CURLOPT_WRITEFUNCTION, t1940_write_cb);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   /* if there is a proxy set, use it */
   if(libtest_arg2 && *libtest_arg2) {

--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -36,14 +36,6 @@ static void t1945_showem(CURL *curl, unsigned int type)
   }
 }
 
-static size_t t1945_write_cb(char *data, size_t n, size_t l, void *userp)
-{
-  /* take care of the data here, ignored in this example */
-  (void)data;
-  (void)userp;
-  return n * l;
-}
-
 static CURLcode test_lib1945(const char *URL)
 {
   CURL *curl;
@@ -56,7 +48,7 @@ static CURLcode test_lib1945(const char *URL)
   curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   /* ignores any content */
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, t1945_write_cb);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   /* if there is a proxy set, use it */
   if(libtest_arg2 && *libtest_arg2) {

--- a/tests/libtest/lib1947.c
+++ b/tests/libtest/lib1947.c
@@ -23,14 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-static size_t t1947_write_cb(char *data, size_t n, size_t l, void *userp)
-{
-  /* ignore the data */
-  (void)data;
-  (void)userp;
-  return n * l;
-}
-
 static CURLcode test_lib1947(const char *URL)
 {
   CURL *curl;
@@ -45,7 +37,7 @@ static CURLcode test_lib1947(const char *URL)
 
   /* perform a request that involves redirection */
   easy_setopt(curl, CURLOPT_URL, URL);
-  easy_setopt(curl, CURLOPT_WRITEFUNCTION, t1947_write_cb);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
   easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   result = curl_easy_perform(curl);
   if(result) {

--- a/tests/libtest/lib2032.c
+++ b/tests/libtest/lib2032.c
@@ -30,7 +30,7 @@ static CURL *ntlm_curls[MAX_EASY_HANDLES];
 static curl_socket_t ntlm_sockets[MAX_EASY_HANDLES];
 static CURLcode ntlmcb_res = CURLE_OK;
 
-static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
+static size_t cb2032(char *ptr, size_t size, size_t nmemb, void *data)
 {
   ssize_t idx = ((CURL **)data) - ntlm_curls;
   curl_socket_t sock;
@@ -139,7 +139,7 @@ static CURLcode test_lib2032(const char *URL) /* libntlmconnect */
       easy_setopt(ntlm_curls[num_handles], CURLOPT_HTTPGET, 1L);
       easy_setopt(ntlm_curls[num_handles], CURLOPT_USERPWD,
                   "testuser:testpass");
-      easy_setopt(ntlm_curls[num_handles], CURLOPT_WRITEFUNCTION, callback);
+      easy_setopt(ntlm_curls[num_handles], CURLOPT_WRITEFUNCTION, cb2032);
       easy_setopt(ntlm_curls[num_handles], CURLOPT_WRITEDATA,
                   (void *)(ntlm_curls + num_handles));
       easy_setopt(ntlm_curls[num_handles], CURLOPT_HEADER, 1L);

--- a/tests/libtest/lib2405.c
+++ b/tests/libtest/lib2405.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) Dmitry Karpov <dkarpov1970, 2025@gmail.com>
+ * Copyright (C) Dmitry Karpov <dkarpov1970@gmail.com>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -67,13 +67,6 @@ enum {
   TEST_USE_HTTP2_MPLEX
 };
 
-static size_t emptyWriteFunc(char *ptr, size_t size, size_t nmemb, void *data)
-{
-  (void)ptr;
-  (void)data;
-  return size * nmemb;
-}
-
 static CURLcode set_easy(const char *URL, CURL *curl, long option)
 {
   CURLcode result = CURLE_OK;
@@ -110,7 +103,7 @@ static CURLcode set_easy(const char *URL, CURL *curl, long option)
   easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* empty write function */
-  easy_setopt(curl, CURLOPT_WRITEFUNCTION, emptyWriteFunc);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
 test_cleanup:
   return result;

--- a/tests/libtest/lib2504.c
+++ b/tests/libtest/lib2504.c
@@ -25,13 +25,6 @@
 
 #include "testtrace.h"
 
-static size_t sink2504(char *ptr, size_t size, size_t nmemb, void *ud)
-{
-  (void)ptr;
-  (void)ud;
-  return size * nmemb;
-}
-
 static void dump_cookies2504(CURL *h, const char *tag)
 {
   struct curl_slist *cookies = NULL;
@@ -68,7 +61,7 @@ static CURLcode test_lib2504(const char *URL)
 
   hdrs = curl_slist_append(hdrs, "Host: victim.internal");
   if(hdrs) {
-    test_setopt(curl, CURLOPT_WRITEFUNCTION, sink2504);
+    test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
     test_setopt(curl, CURLOPT_COOKIEFILE, "");
     test_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
     test_setopt(curl, CURLOPT_URL, URL);

--- a/tests/libtest/lib2505.c
+++ b/tests/libtest/lib2505.c
@@ -25,13 +25,6 @@
 
 #include "testtrace.h"
 
-static size_t sink2505(char *ptr, size_t size, size_t nmemb, void *ud)
-{
-  (void)ptr;
-  (void)ud;
-  return size * nmemb;
-}
-
 static CURLcode test_lib2505(const char *URL)
 {
   CURL *curl;
@@ -49,7 +42,7 @@ static CURLcode test_lib2505(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, sink2505);
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
   test_setopt(curl, CURLOPT_AUTOREFERER, 1L);
   test_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   test_setopt(curl, CURLOPT_URL, URL);

--- a/tests/libtest/lib2506.c
+++ b/tests/libtest/lib2506.c
@@ -25,13 +25,6 @@
 
 #include "testtrace.h"
 
-static size_t sink2506(char *ptr, size_t size, size_t nmemb, void *ud)
-{
-  (void)ptr;
-  (void)ud;
-  return size * nmemb;
-}
-
 static CURLcode test_lib2506(const char *URL)
 {
   CURL *curl;
@@ -49,7 +42,7 @@ static CURLcode test_lib2506(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, sink2506);
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
   test_setopt(curl, CURLOPT_PROXY, URL);
   test_setopt(curl, CURLOPT_URL, libtest_arg2);
   test_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -80,13 +80,6 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
   return TRUE;
 }
 
-static size_t wrfu(char *ptr, size_t size, size_t nmemb, void *stream)
-{
-  (void)stream;
-  (void)ptr;
-  return size * nmemb;
-}
-
 static CURLcode test_lib3102(const char *URL)
 {
   CURL *curl;
@@ -111,7 +104,7 @@ static CURLcode test_lib3102(const char *URL)
   test_setopt(curl, CURLOPT_CERTINFO, 1L);
 
   /* Ignore output */
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, wrfu);
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   /* No peer verify */
   test_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-#include "testutil.h"
-
 #define THREADS 2
 
 /* struct containing data of a thread */

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -25,8 +25,6 @@
 
 #if defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT)
 
-#include "testutil.h"
-
 #define T518_SAFETY_MARGIN 16
 
 #define NUM_OPEN   (FD_SETSIZE + 10)

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -25,8 +25,6 @@
 
 #if defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT)
 
-#include "testutil.h"
-
 #define T537_SAFETY_MARGIN 11
 
 #if defined(_WIN32) || defined(MSDOS)

--- a/tests/libtest/lib568.c
+++ b/tests/libtest/lib568.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-#include "testutil.h"
-
 /*
  * Test the Client->Server ANNOUNCE functionality (PUT style)
  */

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-#include "testutil.h"
-
 /*
  * Test Session ID capture
  */

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-#include "testutil.h"
-
 static CURLcode test_lib570(const char *URL)
 {
   CURLcode result;

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -33,8 +33,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include "testutil.h"
-
 #define RTP_PKT_CHANNEL(p)   ((int)((unsigned char)((p)[1])))
 
 #define RTP_PKT_LENGTH(p)  ((((int)((unsigned char)((p)[2]))) << 8) | \

--- a/tests/libtest/lib572.c
+++ b/tests/libtest/lib572.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-#include "testutil.h"
-
 /*
  * Test GET_PARAMETER: PUT, HEARTBEAT, and POST
  */

--- a/tests/libtest/lib695.c
+++ b/tests/libtest/lib695.c
@@ -23,14 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-/* write callback that does nothing */
-static size_t write_it(char *ptr, size_t size, size_t nmemb, void *userdata)
-{
-  (void)ptr;
-  (void)userdata;
-  return size * nmemb;
-}
-
 static CURLcode test_lib695(const char *URL)
 {
   CURL *curl = NULL;
@@ -57,7 +49,7 @@ static CURLcode test_lib695(const char *URL)
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* Do not write anything. */
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_it);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   /* Build the first mime structure. */
   mime1 = curl_mime_init(curl);

--- a/tests/libtest/lib757.c
+++ b/tests/libtest/lib757.c
@@ -23,14 +23,6 @@
  ***************************************************************************/
 #include "first.h"
 
-/* write callback that does nothing */
-static size_t write_757(char *ptr, size_t size, size_t nmemb, void *userdata)
-{
-  (void)ptr;
-  (void)userdata;
-  return size * nmemb;
-}
-
 static const char t757_data[] = "<title>fun-times</title>";
 static size_t const t757_datalen = sizeof(t757_data) - 1;
 
@@ -78,7 +70,7 @@ static CURLcode test_lib757(const char *URL)
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* Do not write anything. */
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_757);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   /* Build the first mime structure. */
   mime1 = curl_mime_init(curl);

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -21,7 +21,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#include "testutil.h"
+#include "first.h"
 
 /* build request URL */
 char *tutil_suburl(const char *base, int i)

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -54,5 +54,4 @@ size_t tutil_throwaway_cb(char *data, size_t n, size_t l, void *userp)
   (void)data;
   (void)userp;
   return n * l;
-
 }

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -44,3 +44,15 @@ void tutil_rlim2str(char *buf, size_t len, rlim_t val)
     curl_msnprintf(buf, len, "%lu", (unsigned long)val);
 }
 #endif
+
+/*
+ * Handy CURLOPT_WRITEFUNCTION for tests that don't need to keep received
+ * data.
+ */
+size_t tutil_throwaway_cb(char *data, size_t n, size_t l, void *userp)
+{
+  (void)data;
+  (void)userp;
+  return n * l;
+
+}

--- a/tests/libtest/testutil.h
+++ b/tests/libtest/testutil.h
@@ -36,4 +36,10 @@ char *tutil_suburl(const char *base, int i);
 void tutil_rlim2str(char *buf, size_t len, rlim_t val);
 #endif
 
+/*
+ * Handy CURLOPT_WRITEFUNCTION for tests that don't need to keep received
+ * data.
+ */
+size_t tutil_throwaway_cb(char *data, size_t n, size_t l, void *userp);
+
 #endif /* HEADER_CURL_LIBTEST_TESTUTIL_H */

--- a/tests/libtest/testutil.h
+++ b/tests/libtest/testutil.h
@@ -23,7 +23,6 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#include "first.h"
 
 /* build request URL */
 char *tutil_suburl(const char *base, int i);


### PR DESCRIPTION
This is an implementation of a CURLOPT_WRITEFUNCTION callback that just throws away the content and returns success. Saves us from having to reimplement it many times in different tests.