### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -735,7 +735,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 2
         run: |
-          if "bld/src/curl.exe" --disable -V 2>/dev/null | grep smb; then
+          if bld/src/curl.exe --disable -V 2>/dev/null | grep smb; then
             python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/requirements.txt
           fi
 

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -391,7 +391,7 @@ if(PICKY_COMPILER)
         list(APPEND _picky "-Wno-conversion")  # Avoid false positives
       endif()
     endif()
-  elseif(MSVC AND MSVC_VERSION LESS_EQUAL 1951)  # Skip for untested/unreleased newer versions
+  elseif(MSVC AND MSVC_VERSION LESS_EQUAL 1951)  # Enable for tested versions only
     list(APPEND _picky "-Wall")
     list(APPEND _picky "-wd4061")  # enumerator 'A' in switch of enum 'B' is not explicitly handled by a case label
     list(APPEND _picky "-wd4191")  # 'type cast': unsafe conversion from 'FARPROC' to 'void (__cdecl *)(void)'

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -32,7 +32,7 @@ We aim to support these or later versions.
 - libidn2      2.0.0 (2017-03-29)
 - libgsasl     1.6.0 (2010-12-14)
 - libpsl       0.16.0 (2016-12-10)
-- LibreSSL     2.9.1 (2019-04-22)
+- LibreSSL     2.9.1 (2019-04-21)
 - libssh       0.9.0 (2019-06-28)
 - libssh2      1.9.0 (2019-06-20)
 - mbedTLS      3.2.0 (2022-07-11)

--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -105,7 +105,7 @@ int main(int argc, const char *argv[])
         case 'm':
         case 'M':
           if(argv[0][2] == '=') {
-            int m = atoi((*argv) + 3);
+            int m = atoi(*argv + 3);
             switch(m) {
             case 1:
               url = URL_1M;

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -176,7 +176,7 @@ static int setup(struct transfer *t, int num)
     /* HTTP/2 please */
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
 
-#if (CURLPIPE_MULTIPLEX > 0)
+#if CURLPIPE_MULTIPLEX > 0
     /* wait for pipe connection to confirm */
     curl_easy_setopt(curl, CURLOPT_PIPEWAIT, 1L);
 #endif

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -275,7 +275,7 @@ static int setup(struct input *t, int num, const char *upload)
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
-#if (CURLPIPE_MULTIPLEX > 0)
+#if CURLPIPE_MULTIPLEX > 0
     /* wait for pipe connection to confirm */
     curl_easy_setopt(curl, CURLOPT_PIPEWAIT, 1L);
 #endif

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -342,7 +342,7 @@ static CURLcode cf_ip_ballers_init(struct cf_ip_ballers *bs,
   bs->cf_create = get_cf_create(transport_peer, !!tunnel_peer);
   if(!bs->cf_create) {
     failf(data, "unsupported transport type %u%s",
-          transport_peer, tunnel_peer ? "to proxy" : "");
+          transport_peer, tunnel_peer ? " to proxy" : "");
     return CURLE_UNSUPPORTED_PROTOCOL;
   }
   Curl_peer_link(&bs->origin, origin);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -47,11 +47,11 @@
 #include "curlx/dynbuf.h"
 #include "headers.h"
 
-#if (NGHTTP2_VERSION_NUM < 0x010c00)
+#if NGHTTP2_VERSION_NUM < 0x010c00
 #error too old nghttp2 version, upgrade!
 #endif
 
-#if (NGHTTP2_VERSION_NUM >= 0x010c00)
+#if NGHTTP2_VERSION_NUM >= 0x010c00
 #define NGHTTP2_HAS_SET_LOCAL_WINDOW_SIZE 1
 #endif
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2504,7 +2504,7 @@ static CURLMcode multistate_connecting(struct Curl_easy *data,
   }
   if(!Curl_xfer_recv_is_paused(data)) {
     *result = Curl_conn_connect(data, FIRSTSOCKET, FALSE, &connected);
-    if(connected && !(*result)) {
+    if(connected && !*result) {
       if(!data->conn->bits.reuse &&
          Curl_conn_is_multiplex(data->conn, FIRSTSOCKET)) {
         /* new connection, can multiplex, wake pending handles */
@@ -2531,7 +2531,7 @@ static CURLMcode multistate_protoconnect(struct Curl_easy *data,
 {
   bool protocol_connected = FALSE;
 
-  if(!(*result) && data->conn->bits.reuse) {
+  if(!*result && data->conn->bits.reuse) {
     /* ftp seems to hang when protoconnect on reused connection since we
      * handle PROTOCONNECT in general inside the filters, it seems wrong to
      * restart this on a reused connection.
@@ -2539,14 +2539,14 @@ static CURLMcode multistate_protoconnect(struct Curl_easy *data,
     multistate(data, MSTATE_DO);
     return CURLM_CALL_MULTI_PERFORM;
   }
-  if(!(*result))
+  if(!*result)
     *result = protocol_connect(data, &protocol_connected);
-  if(!(*result) && !protocol_connected) {
+  if(!*result && !protocol_connected) {
     /* switch to waiting state */
     multistate(data, MSTATE_PROTOCONNECTING);
     return CURLM_CALL_MULTI_PERFORM;
   }
-  else if(!(*result)) {
+  else if(!*result) {
     /* protocol connect has completed, go WAITDO or DO */
     multistate(data, MSTATE_DO);
     return CURLM_CALL_MULTI_PERFORM;
@@ -2567,7 +2567,7 @@ static CURLMcode multistate_protoconnecting(struct Curl_easy *data,
 
   /* protocol-specific connect phase */
   *result = protocol_connecting(data, &protocol_connected);
-  if(!(*result) && protocol_connected) {
+  if(!*result && protocol_connected) {
     /* after the connect has completed, go WAITDO or DO */
     multistate(data, MSTATE_DO);
     return CURLM_CALL_MULTI_PERFORM;
@@ -2590,7 +2590,7 @@ static CURLMcode multistate_doing(struct Curl_easy *data,
   /* we continue DOING until the DO phase is complete */
   DEBUGASSERT(data->conn);
   *result = protocol_doing(data, &dophase_done);
-  if(!(*result)) {
+  if(!*result) {
     if(dophase_done) {
       /* after DO, go DO_DONE or DO_MORE */
       multistate(data, data->conn->bits.do_more ?
@@ -2619,7 +2619,7 @@ static CURLMcode multistate_doing_more(struct Curl_easy *data,
   DEBUGASSERT(data->conn);
   *result = multi_do_more(data, &control);
 
-  if(!(*result)) {
+  if(!*result) {
     if(control != DOMORE_INCOMPLETE) {
       /* if DONE, advance to DO_DONE
          if GOBACK, go back to DOING */

--- a/lib/peer.h
+++ b/lib/peer.h
@@ -78,7 +78,7 @@ void Curl_peer_unlink(struct Curl_peer **ppeer);
 /* TRUE if both peers are NULL or have completely same properties. */
 bool Curl_peer_equal(struct Curl_peer *p1, struct Curl_peer *p2);
 
-/* TRUE if both peers are NULL or have properties except the scheme. */
+/* TRUE if both peers are NULL or have same properties except the scheme. */
 bool Curl_peer_same_destination(struct Curl_peer *p1, struct Curl_peer *p2);
 
 CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -75,8 +75,8 @@
 #define CURL_SB_LEN(x) ((x)->subend - (x)->subpointer)
 
 /* For posterity:
-#define  CURL_SB_PEEK(x) ((*x->subpointer)&0xff)
-#define  CURL_SB_EOF(x) (x->subpointer >= x->subend) */
+#define CURL_SB_PEEK(x) (*(x)->subpointer & 0xff)
+#define CURL_SB_EOF(x)  ((x)->subpointer >= (x)->subend) */
 
 /* For negotiation compliant to RFC 1143 */
 #define CURL_NO          0

--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -583,7 +583,7 @@ static nghttp3_ssize cb_h3_tunnel_read_data(nghttp3_conn *conn,
       nwritten += vec[nvecs].len;
       ++nvecs;
     }
-    DEBUGASSERT(nvecs > 0); /* we SHOULD have been be able to peek */
+    DEBUGASSERT(nvecs > 0); /* we SHOULD have been able to peek */
   }
 
   if(!nwritten) {

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -107,7 +107,7 @@ static const char *c_memmem(const void *haystack, size_t haystacklen,
     return NULL;
   first = *(const char *)needle;
   for(p = (const char *)haystack; p <= (str_limit - needlelen); p++)
-    if(((*p) == first) && !memcmp(p, needle, needlelen))
+    if((*p == first) && !memcmp(p, needle, needlelen))
       return p;
 
   return NULL;

--- a/tests/data/test1922
+++ b/tests/data/test1922
@@ -78,7 +78,7 @@ Proxy-Connection: Keep-Alive
 
 </proxy>
 <stdout>
-First request: HTTPS cache populated
+First request: HSTS cache populated
 Dup effective URL: https://hsts.example.com/%TESTNUMBER
 </stdout>
 # CURLE_COULDNT_CONNECT (7) is intentional: The proxy rejects the CONNECT

--- a/tests/libtest/lib1922.c
+++ b/tests/libtest/lib1922.c
@@ -85,7 +85,7 @@ static CURLcode test_lib1922(const char *URL)
                   (int)result, curl_easy_strerror(result));
     goto test_cleanup;
   }
-  curl_mprintf("First request: HTTPS cache populated\n");
+  curl_mprintf("First request: HSTS cache populated\n");
 
   dup = curl_easy_duphandle(curl);
   if(!dup) {

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -198,8 +198,7 @@ class TestSmbServer(imp_smbserver.SMBSERVER):
 
             # Currently we only support reading files.
             if disposition != imp_smb.FILE_OPEN:
-                raise SmbError(STATUS_ACCESS_DENIED,
-                                   "Only support reading files")
+                raise SmbError(STATUS_ACCESS_DENIED, "Only support reading files")
 
             # Check to see if the path we were given is actually a
             # magic path which needs generating on the fly.
@@ -297,11 +296,9 @@ class TestSmbServer(imp_smbserver.SMBSERVER):
                 if "path" in conn_shares[tid]:
                     path = conn_shares[tid]["path"]
                 else:
-                    raise SmbError(STATUS_ACCESS_DENIED,
-                                       "Connection share had no path")
+                    raise SmbError(STATUS_ACCESS_DENIED, "Connection share had no path")
         else:
-            raise SmbError(imp_smbserver.STATUS_SMB_BAD_TID,
-                               "TID was invalid")
+            raise SmbError(imp_smbserver.STATUS_SMB_BAD_TID, "TID was invalid")
 
         return path
 

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -291,7 +291,7 @@ class TestSmbServer(imp_smbserver.SMBSERVER):
             if root_fid > 0:
                 # If we have a rootFid, the path is relative to that fid
                 path = conn_data["OpenedFiles"][root_fid]["FileName"]
-                log.debug("RootFid present %s!" % path)
+                log.debug(f'RootFid present {path}!')
             else:
                 if "path" in conn_shares[tid]:
                     path = conn_shares[tid]["path"]

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -312,7 +312,7 @@ class TestSmbServer(imp_smbserver.SMBSERVER):
         log.debug("[SMB] Created %s (%d) for storing '%s'",
                   filename, fid, requested_filename)
 
-        contents = ""
+        contents = b''
 
         if requested_filename == VERIFIED_REQ:
             log.debug("[SMB] Verifying server is alive")


### PR DESCRIPTION
- GHA/windows: drop redundant double-quotes.
- CMake/PickyWarnings: improve/shorten comment.
- INTERNALS: fix typo in LibreSSL release date.
- drop redundant parentheses from single variables and sole `#if`
  expressions.
- cf-ip-happy: fix missing space from error string.
- telnet: fix parentheses in commented PP code.
- lib1922: fix typo test output text.
- smbserver: unfold lines.
- smbserver: use f-string.
- smbserver: initialize binary string as b``.
- fix typos in comments.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
