### PR TITLE
GHA/windows: bump Cygwin Action and adjust version number

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,7 +95,7 @@ jobs:
               install: 'libssl-devel libssh2-devel' }
       fail-fast: false
     steps:
-      - uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6.1
+      - uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6.0.2
         with:
           platform: ${{ matrix.platform }}
           work-vol: 'D:'


### PR DESCRIPTION
It seems the commit hash behind the v6.1 tag is changing, and the latest
version is actually v6.0.2, which is currently mapped to the v6.1 hash.

Fixing:
```
warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> .github/workflows/windows.yml:98:87
   |
98 |       - uses: cygwin/cygwin-install-action@711d29f3da23c9f4a1798e369a6f01198c13b11a # v6.1
   |         ---------------------------------------------------------------------------   ^^^^ points to commit 3f0a3f9f988f
   |         |
   |         is pointed to by tag v6.0.1
```

Ref: https://github.com/cygwin/cygwin-install-action/issues/59

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
