### PR TITLE
tidy-up: add spaces around equal operators where missing

### DIFF
--- a/.github/scripts/randcurl.pl
+++ b/.github/scripts/randcurl.pl
@@ -142,7 +142,7 @@ sub runone {
         $a .= " ".addarg();
     }
 
-    my $cmd="$curl$a $url";
+    my $cmd = "$curl$a $url";
 
     my $rc = system("$cmd >curl-output 2>&1 </dev/null -M 0.1") >> 8;
     #my $rc = system("valgrind -q $cmd >/dev/null 2>&1 </dev/null -M 0.1") >> 8;
@@ -194,7 +194,7 @@ sub runconfig {
     print C "$a\n";
     close(C);
 
-    my $cmd="$curl -K config $url";
+    my $cmd = "$curl -K config $url";
 
     my $rc = system("$cmd >curl-output 2>&1 </dev/null -M 0.1") >> 8;
 

--- a/docs/examples/adddocsref.pl
+++ b/docs/examples/adddocsref.pl
@@ -30,7 +30,7 @@ use warnings;
 
 use File::Copy;
 
-my $docroot="https://curl.se/libcurl/c";
+my $docroot = "https://curl.se/libcurl/c";
 
 for my $f (@ARGV) {
     open(NEW, ">$f.new");

--- a/docs/examples/version-check.pl
+++ b/docs/examples/version-check.pl
@@ -47,15 +47,15 @@ my %doc;
 my %rem;
 while(<S>) {
     if(/(^CURL[^ \n]*) *(.*)/) {
-        my ($sym, $rest)=($1, $2);
-        my @a=split(/ +/, $rest);
+        my ($sym, $rest) = ($1, $2);
+        my @a = split(/ +/, $rest);
 
-        $doc{$sym}=$a[0]; # when it was introduced
+        $doc{$sym} = $a[0]; # when it was introduced
 
         if($a[2]) {
             # this symbol is documented to have been present the last time
             # in this release
-            $rem{$sym}=$a[2];
+            $rem{$sym} = $a[2];
         }
     }
 }
@@ -63,9 +63,9 @@ while(<S>) {
 close(S);
 
 sub age {
-    my ($ver)=@_;
+    my ($ver) = @_;
 
-    my @s=split(/\./, $ver);
+    my @s = split(/\./, $ver);
     return $s[0]*10000+$s[1]*100+($s[2] || 0);
 }
 

--- a/docs/libcurl/mksymbolsmanpage.pl
+++ b/docs/libcurl/mksymbolsmanpage.pl
@@ -70,7 +70,7 @@ HEADER
     ;
 
 sub nameref {
-    my ($n)=@_;
+    my ($n) = @_;
     if($n =~ /^CURLOPT_/) {
         if($n eq "CURLOPT_RTSPHEADER") {
             $n = "CURLOPT_HTTPHEADER";
@@ -289,7 +289,7 @@ sub nameref {
 
 while(<STDIN>) {
     if($_ =~ /^(CURL[A-Z0-9_.]*) *(.*)/i) {
-        my ($symbol, $rest)=($1,$2);
+        my ($symbol, $rest) = ($1, $2);
         my ($intro, $dep, $rem);
         if($rest =~ s/^([0-9.]*) *//) {
            $intro = $1;

--- a/docs/libcurl/symbols.pl
+++ b/docs/libcurl/symbols.pl
@@ -50,7 +50,7 @@ use warnings;
 open F, "<symbols-in-versions";
 
 sub str2num {
-    my ($str)=@_;
+    my ($str) = @_;
     if($str && $str =~ /([0-9]*)\.([0-9]*)\.*([0-9]*)/) {
         return sprintf("0x%06x", $1 << 16 | $2 << 8 | ($3 || '0'));
     }
@@ -69,7 +69,7 @@ EOS
 
 while(<F>) {
     if(/^(CURL[^ ]*)[ \t]*(.*)/) {
-        my ($sym, $vers)=($1, $2);
+        my ($sym, $vers) = ($1, $2);
 
         my $intr;
         my $rm;
@@ -77,11 +77,11 @@ while(<F>) {
 
         # is there removed info?
         if($vers =~ /([\d.]+)[ \t-]+([\d.-]+)[ \t]+([\d.]+)/) {
-            ($intr, $dep, $rm)=($1, $2, $3);
+            ($intr, $dep, $rm) = ($1, $2, $3);
         }
         # is it a dep-only line?
         elsif($vers =~ /([\d.]+)[ \t-]+([\d.]+)/) {
-            ($intr, $dep)=($1, $2);
+            ($intr, $dep) = ($1, $2);
         }
         else {
             $intr = $vers;

--- a/lib/optiontable.pl
+++ b/lib/optiontable.pl
@@ -39,7 +39,7 @@ const struct curl_easyoption Curl_easyopts[] = {
 HEAD
     ;
 
-my $lastnum=0;
+my $lastnum = 0;
 
 my %opt;
 my %type;
@@ -47,7 +47,7 @@ my @names;
 my %alias;
 
 sub add {
-    my($optstr, $typestr, $num)=@_;
+    my($optstr, $typestr, $num) = @_;
     my $name;
     # remove all spaces from the type
     $typestr =~ s/ //g;
@@ -59,7 +59,7 @@ sub add {
     }
 
     if($optstr =~ /^CURLOPT_(.*)/) {
-        $name=$1;
+        $name = $1;
     }
     $ext =~ s/CURLOPTTYPE_//;
     $ext =~ s/CBPOINT/CBPTR/;
@@ -89,7 +89,7 @@ while(<CURL_H>) {
             $fl .= $1;
 
             # the end
-            my @p=split(/, */, $fl);
+            my @p = split(/, */, $fl);
             add($p[0], $p[1], $p[2]);
             undef $fl;
         }
@@ -106,14 +106,14 @@ while(<CURL_H>) {
     }
 
     if(/^ *CURLOPT\(([^,]*), ([^,]*), (\d+)\)/) {
-        my($opt, $type, $num)=($1,$2,$3);
+        my($opt, $type, $num) = ($1, $2, $3);
         add($opt, $type, $num);
     }
 
     # alias for an older option
     # old = new
     if(/^#define (CURLOPT_[^ ]*) *(CURLOPT_\S*)/) {
-        my ($o, $n)=($1, $2);
+        my ($o, $n) = ($1, $2);
         # skip obsolete ones
         if(($n !~ /OBSOLETE/) && ($o !~ /OBSOLETE/)) {
             $o =~ s/^CURLOPT_//;

--- a/scripts/badwords
+++ b/scripts/badwords
@@ -184,14 +184,14 @@ while(<CONFIG>) {
     if(/^---:([^:]*):(.*)/) {
         # whitelist file + word
         my $word = lc($2);
-        $wl{"$1:$word"}=1;
+        $wl{"$1:$word"} = 1;
     }
     elsif($_ =~ /^---(.+)/) {
         # whitelist word
         push @whitelist, $1;
     }
     elsif($_ =~ /^(.*)([:=])(.*)/) {
-        my ($bad, $sep, $better)=($1, $2, $3);
+        my ($bad, $sep, $better) = ($1, $2, $3);
         if($sep eq "=") {
             $alt{$bad} = $better;
             push @exact, $bad;

--- a/scripts/cd2cd
+++ b/scripts/cd2cd
@@ -79,7 +79,7 @@ sub outseealso {
 sub single {
     my @head;
     my @seealso;
-    my ($f)=@_;
+    my ($f) = @_;
     my $title;
     my $section;
     my $source;
@@ -103,13 +103,13 @@ sub single {
             next;
         }
         if(/^Title: *(.*)/i) {
-            $title=$1;
+            $title = $1;
         }
         elsif(/^Section: *(.*)/i) {
-            $section=$1;
+            $section = $1;
         }
         elsif(/^Source: *(.*)/i) {
-            $source=$1;
+            $source = $1;
         }
         elsif(/^See-also: +(.*)/i) {
             $salist = 0;
@@ -130,10 +130,10 @@ sub single {
         }
         # REUSE-IgnoreStart
         elsif(/^C: (.*)/i) {
-            $copyright=$1;
+            $copyright = $1;
         }
         elsif(/^SPDX-License-Identifier: (.*)/i) {
-            $spdx=$1;
+            $spdx = $1;
         }
         # REUSE-IgnoreEnd
         elsif(/^---/) {

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -199,7 +199,7 @@ sub single {
     my @proto;
     my @tls;
     my $d;
-    my ($f)=@_;
+    my ($f) = @_;
     my $copyright;
     my $errors = 0;
     my $fh;
@@ -234,13 +234,13 @@ sub single {
             next;
         }
         if(/^Title: *(.*)/i) {
-            $title=$1;
+            $title = $1;
         }
         elsif(/^Section: *(.*)/i) {
-            $section=$1;
+            $section = $1;
         }
         elsif(/^Source: *(.*)/i) {
-            $source=$1;
+            $source = $1;
         }
         elsif(/^See-also: +(.*)/i) {
             $list = 1; # 1 for see-also
@@ -260,7 +260,7 @@ sub single {
             $list = 3; # 3 for TLS backend
         }
         elsif(/^Added-in: *(.*)/i) {
-            $addedin=$1;
+            $addedin = $1;
             if(($addedin !~ /^[0-9.]+[0-9]\z/) &&
                ($addedin ne "n/a")) {
                 print STDERR "$f:$line:1:ERROR: invalid version number in Added-in line: $addedin\n";
@@ -285,10 +285,10 @@ sub single {
         }
         # REUSE-IgnoreStart
         elsif(/^C: (.*)/i) {
-            $copyright=$1;
+            $copyright = $1;
         }
         elsif(/^SPDX-License-Identifier: (.*)/i) {
-            $spdx=$1;
+            $spdx = $1;
         }
         # REUSE-IgnoreEnd
         elsif(/^---/) {

--- a/scripts/cdall
+++ b/scripts/cdall
@@ -29,7 +29,7 @@ use strict;
 use warnings;
 
 sub convert {
-    my ($dir)=@_;
+    my ($dir) = @_;
     opendir(my $dh, $dir) || die "could not open $dir";
     my @cd = grep { /\.md\z/ && -f "$dir/$_" } readdir($dh);
     closedir $dh;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -35,8 +35,8 @@ my $errors = 0;
 my $serrors = 0;
 my $suppressed; # skipped problems
 my $file;
-my $dir=".";
-my $wlist="";
+my $dir = ".";
+my $wlist = "";
 my @alist;
 my $windows_os = $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys';
 my $verbose = 0;
@@ -206,10 +206,10 @@ my %warnings = (
 
 sub readskiplist {
     open(my $W, '<', "$dir/checksrc.skip") or return;
-    my @all=<$W>;
+    my @all = <$W>;
     for(@all) {
         $windows_os ? $_ =~ s/\r?\n$// : chomp;
-        $skiplist{$_}=1;
+        $skiplist{$_} = 1;
     }
     close($W);
 }
@@ -431,8 +431,8 @@ sub accept_violations {
             print "'$r' is not a warning to accept!\n";
             exit;
         }
-        $ignore{$r}=999999;
-        $ignore_used{$r}=0;
+        $ignore{$r} = 999999;
+        $ignore_used{$r} = 0;
     }
 }
 
@@ -463,9 +463,9 @@ sub enable_warn {
                   $line, length($what) + 11, $file, $l,
                   "No warning was inhibited!");
     }
-    $ignore_set{$what}=0;
-    $ignore_used{$what}=0;
-    $ignore{$what}=0;
+    $ignore_set{$what} = 0;
+    $ignore_used{$what} = 0;
+    $ignore{$what} = 0;
 }
 sub checksrc {
     my ($cmd, $line, $file, $l) = @_;
@@ -474,9 +474,9 @@ sub checksrc {
         $what =~ s: *\*/$::; # cut off end of C comment
         # print "ENABLE $enable WHAT $what\n";
         if($enable eq "disable") {
-            my ($warn, $scope)=($1, $2);
+            my ($warn, $scope) = ($1, $2);
             if($what =~ /([^ ]*) +(.*)/) {
-                ($warn, $scope)=($1, $2);
+                ($warn, $scope) = ($1, $2);
             }
             else {
                 $warn = $what;
@@ -484,7 +484,7 @@ sub checksrc {
             }
             # print "IGNORE $warn for SCOPE $scope\n";
             if($scope eq "all") {
-                $scope=999999;
+                $scope = 999999;
             }
 
             # Comparing for a literal zero rather than the scalar value zero
@@ -502,9 +502,9 @@ sub checksrc {
                           "$warn already disabled from line $ignore_set{$warn}");
             }
             else {
-                $ignore{$warn}=$scope;
-                $ignore_set{$warn}=$line;
-                $ignore_line[$line]=$l;
+                $ignore{$warn} = $scope;
+                $ignore_set{$warn} = $line;
+                $ignore_line[$line] = $l;
             }
         }
         elsif($enable eq "enable") {
@@ -528,8 +528,8 @@ sub scanfile {
     my ($file) = @_;
 
     my $line = 1;
-    my $prevl="";
-    my $prevpl="";
+    my $prevl = "";
+    my $prevpl = "";
     my $l = "";
     my $prep = 0;
     my $prevp = 0;
@@ -542,8 +542,8 @@ sub scanfile {
 
     open(my $R, '<', $file) || die "failed to open $file";
 
-    my $incomment=0;
-    my @copyright=();
+    my $incomment = 0;
+    my @copyright = ();
     my %includes;
     checksrc_clear(); # for file based ignores
     accept_violations();
@@ -649,7 +649,7 @@ sub scanfile {
             }
             else {
                 # still within a comment
-                $l="";
+                $l = "";
             }
         }
 
@@ -702,7 +702,7 @@ sub scanfile {
         my $nostr = nostrings($l);
         # check spaces after for/if/while/function call
         if($nostr =~ /^(.*)(for|if|while|switch| ([a-zA-Z0-9_]+)) \((.)/) {
-            my ($leading, $word, $extra, $first)=($1,$2,$3,$4);
+            my ($leading, $word, $extra, $first) = ($1, $2, $3, $4);
             if($1 =~ / *\#/) {
                 # this is a #if, treat it differently
             }
@@ -898,15 +898,15 @@ sub scanfile {
 
         # check for comma without space
         if($l =~ /^(.*),[^ \n]/) {
-            my $pref=$1;
-            my $ign=0;
+            my $pref = $1;
+            my $ign = 0;
             if($pref =~ / *\#/) {
                 # this is a #if, treat it differently
-                $ign=1;
+                $ign = 1;
             }
             elsif($pref =~ /\/\*/) {
                 # this is a comment
-                $ign=1;
+                $ign = 1;
             }
             elsif($pref =~ /[\"\']/) {
                 $ign = 1;

--- a/scripts/managen
+++ b/scripts/managen
@@ -66,7 +66,7 @@ my $indent = 4;
 
 # get the long name version, return the man page string
 sub manpageify {
-    my ($k, $manpage)=@_;
+    my ($k, $manpage) = @_;
     my $trail = '';
     # the matching pattern might include a trailing dot that cannot be part of
     # the option name
@@ -85,7 +85,7 @@ sub manpageify {
     return "--$k$trail";
 }
 
-my $colwidth=79; # max number of columns
+my $colwidth = 79; # max number of columns
 
 sub prefixline {
     my ($num) = @_;
@@ -220,7 +220,7 @@ sub printdesc {
 }
 
 sub seealso {
-    my($standalone, $data)=@_;
+    my($standalone, $data) = @_;
     if($standalone) {
         return sprintf
             ".SH \"SEE ALSO\"\n$data\n";
@@ -231,7 +231,7 @@ sub seealso {
 }
 
 sub overrides {
-    my ($standalone, $data)=@_;
+    my ($standalone, $data) = @_;
     if($standalone) {
         return ".SH \"OVERRIDES\"\n$data\n";
     }
@@ -263,7 +263,7 @@ my %protexists = (
     );
 
 sub protocols {
-    my ($f, $line, $manpage, $standalone, $data)=@_;
+    my ($f, $line, $manpage, $standalone, $data) = @_;
     my @e = split(/ +/, $data);
     for my $pr (@e) {
         if(!$protexists{$pr}) {
@@ -282,7 +282,7 @@ sub protocols {
 }
 
 sub too_old {
-    my ($version)=@_;
+    my ($version) = @_;
     my $a = 999999;
     if($version =~ /^(\d+)\.(\d+)\.(\d+)/) {
         $a = $1 * 1000 + $2 * 10 + $3;
@@ -299,7 +299,7 @@ sub too_old {
 }
 
 sub added {
-    my ($standalone, $data)=@_;
+    my ($standalone, $data) = @_;
     if(too_old($data)) {
         # do not mention ancient additions
         return "";
@@ -560,7 +560,7 @@ sub maybespace {
 }
 
 sub single {
-    my ($dir, $manpage, $f, $standalone)=@_;
+    my ($dir, $manpage, $f, $standalone) = @_;
     my $fh;
     open($fh, "<:crlf", "$dir/$f") ||
         die "could not find $dir/$f";
@@ -597,28 +597,28 @@ sub single {
             next;
         }
         if(/^Short: *(.)/i) {
-            $short=$1;
+            $short = $1;
         }
         elsif(/^Long: *(.*)/i) {
-            $long=$1;
+            $long = $1;
         }
         elsif(/^Added: *(.*)/i) {
-            $added=$1;
+            $added = $1;
         }
         elsif(/^Tags: *(.*)/i) {
-            $tags=$1;
+            $tags = $1;
         }
         elsif(/^Arg: *(.*)/i) {
-            $arg=$1;
+            $arg = $1;
         }
         elsif(/^Magic: *(.*)/i) {
-            $magic=$1;
+            $magic = $1;
         }
         elsif(/^Mutexed: *(.*)/i) {
-            $mutexed=$1;
+            $mutexed = $1;
         }
         elsif(/^Protocols: *(.*)/i) {
-            $protocols=$1;
+            $protocols = $1;
         }
         elsif(/^See-also: +(.+)/i) {
             if(@seealso) {
@@ -628,16 +628,16 @@ sub single {
             push @seealso, $1;
         }
         elsif(/^See-also:/i) {
-            $list=2;
+            $list = 2;
         }
         elsif(/^  *- (.*)/i && ($list == 2)) {
             push @seealso, $1;
         }
         elsif(/^Requires: *(.*)/i) {
-            $requires=$1;
+            $requires = $1;
         }
         elsif(/^Category: *(.*)/i) {
-            $category=$1;
+            $category = $1;
         }
         elsif(/^Example: +(.+)/i) {
             push @examples, $1;
@@ -650,20 +650,20 @@ sub single {
             push @examples, $1;
         }
         elsif(/^Multi: *(.*)/i) {
-            $multi=$1;
+            $multi = $1;
         }
         elsif(/^Scope: *(.*)/i) {
-            $scope=$1;
+            $scope = $1;
         }
         elsif(/^Experimental: yes/i) {
-            $experimental=1;
+            $experimental = 1;
         }
         # REUSE-IgnoreStart
         elsif(/^C: (.*)/i) {
-            $copyright=$1;
+            $copyright = $1;
         }
         elsif(/^SPDX-License-Identifier: (.*)/i) {
-            $spdx=$1;
+            $spdx = $1;
         }
         # REUSE-IgnoreEnd
         elsif(/^Help: *(.*)/i) {
@@ -855,7 +855,7 @@ sub single {
             " is built to support $requires.\n";
     }
     if($mutexed) {
-        my @m=split(/ /, $mutexed);
+        my @m = split(/ /, $mutexed);
         my $mstr;
         my $num = scalar(@m);
         my $count = 0;
@@ -875,8 +875,8 @@ sub single {
                               "This option is mutually exclusive with $mstr.\n");
     }
     if($examples[0]) {
-        my $s ="";
-        $s="s" if($examples[1]);
+        my $s = "";
+        $s = "s" if($examples[1]);
         foreach my $e (@examples) {
             my $check = $e;
             # verify the used options
@@ -933,7 +933,7 @@ sub single {
                         if(length($e) > $maxwidth) {
                             $r = maybespace($r);
                         }
-                        my $slash ="";
+                        my $slash = "";
                         $e = substr($e, length($r));
                         if(length($e) > 0) {
                             $slash = "\\";
@@ -967,7 +967,7 @@ sub single {
 }
 
 sub getshortlong {
-    my ($dir, $f)=@_;
+    my ($dir, $f) = @_;
     $f =~ s/^.*\///;
     open(F, "<:crlf", "$dir/$f") ||
         die "could not find $dir/$f";
@@ -988,13 +988,13 @@ sub getshortlong {
             next;
         }
         if(/^Short: (.)/i) {
-            $short=$1;
+            $short = $1;
         }
         elsif(/^Long: (.*)/i) {
-            $long=$1;
+            $long = $1;
         }
         elsif(/^Help: (.*)/i) {
-            $help=$1;
+            $help = $1;
             my $len = length($help);
             if($len >= 49) {
                 printf STDERR "$f:$line:1:WARN: oversized help text: %d characters\n",
@@ -1002,13 +1002,13 @@ sub getshortlong {
             }
         }
         elsif(/^Arg: (.*)/i) {
-            $arg=$1;
+            $arg = $1;
         }
         elsif(/^Protocols: (.*)/i) {
-            $protocols=$1;
+            $protocols = $1;
         }
         elsif(/^Category: (.*)/i) {
-            $category=$1;
+            $category = $1;
         }
         elsif(/^---/) {
             last;
@@ -1016,14 +1016,14 @@ sub getshortlong {
     }
     close(F);
     if($short) {
-        $optshort{$short}=$long;
+        $optshort{$short} = $long;
     }
     if($long) {
-        $optlong{$long}=$short;
-        $helplong{$long}=$help;
-        $arglong{$long}=$arg;
-        $protolong{$long}=$protocols;
-        $catlong{$long}=$category;
+        $optlong{$long} = $short;
+        $helplong{$long} = $help;
+        $arglong{$long} = $arg;
+        $protolong{$long} = $protocols;
+        $catlong{$long} = $category;
     }
 }
 
@@ -1035,7 +1035,7 @@ sub indexoptions {
 }
 
 sub header {
-    my ($dir, $manpage, $f)=@_;
+    my ($dir, $manpage, $f) = @_;
     my $fh;
     open($fh, "<:crlf", "$dir/$f") ||
         die "could not find $dir/$f";
@@ -1192,7 +1192,7 @@ sub listglobals {
                 }
             }
             if(/^Long: *(.*)/i) {
-                $long=$1;
+                $long = $1;
             }
             elsif(/^Scope: global/i) {
                 push @globalopts, $long;

--- a/scripts/mdlinkcheck
+++ b/scripts/mdlinkcheck
@@ -90,7 +90,7 @@ if(defined $ARGV[0] && $ARGV[0] eq "--dry-run") {
 }
 
 # list all files to scan for links
-my @files=`git ls-files docs include lib scripts src`;
+my @files = `git ls-files docs include lib scripts src`;
 
 sub storelink {
     my ($f, $line, $link) = @_;

--- a/scripts/nroff2cd
+++ b/scripts/nroff2cd
@@ -42,7 +42,7 @@ use warnings;
 my $nroff2cd = "0.1"; # to keep check
 
 sub single {
-    my ($f)=@_;
+    my ($f) = @_;
     open(F, "<:crlf", $f) ||
         return 1;
     my $line;

--- a/scripts/release-notes.pl
+++ b/scripts/release-notes.pl
@@ -58,8 +58,8 @@ use strict;
 use warnings;
 
 my $cleanup = (@ARGV && $ARGV[0] eq "cleanup");
-my @gitlog=`git log @^{/RELEASE-NOTES:.synced}..` if(!$cleanup);
-my @releasenotes=`cat RELEASE-NOTES`;
+my @gitlog = `git log @^{/RELEASE-NOTES:.synced}..` if(!$cleanup);
+my @releasenotes = `cat RELEASE-NOTES`;
 
 my @o; # the entire new RELEASE-NOTES
 my @refused; # [num] = [2 bits of use info]
@@ -68,7 +68,7 @@ my %dupe;
 for my $l (@releasenotes) {
     if($l =~ /^ o .*\[(\d+)\]/) {
         # referenced, set bit 0
-        $refused[$1]=1;
+        $refused[$1] = 1;
         my $m = $l;
         chomp $m;
         $m =~ s/^ o //;
@@ -107,7 +107,7 @@ sub getref {
 # 'https://elsewhere.example.com/discussion'
 
 sub extract {
-    my ($ref)=@_;
+    my ($ref) = @_;
     if($ref =~ /^(\#|)(\d+)/) {
         # return the plain number
         return $2;
@@ -175,7 +175,7 @@ if($first) {
 
 # call at the end of a parsed commit
 sub onecommit {
-    my ($short)=@_;
+    my ($short) = @_;
     my $ref = '';
 
     if($dupe{$short}) {
@@ -199,7 +199,7 @@ sub onecommit {
     if($ref) {
         my $r = getref();
         $refs[$r] = $ref;
-        $moreinfo{$short}=$r;
+        $moreinfo{$short} = $r;
         $refused[$r] |= 1;
     }
 }
@@ -220,7 +220,7 @@ for my $l (@releasenotes) {
             push @o, sprintf " o %s%s\n", $f,
                 $moreinfo{$f}? sprintf(" [%d]", $moreinfo{$f}): "";
             if($moreinfo{$f}) {
-                $refused[$moreinfo{$f}]=3;
+                $refused[$moreinfo{$f}] = 3;
             }
         }
         push @o, " --- new entries are listed above this ---";

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -198,13 +198,13 @@ while(<N>) {
         $file = $1;
     }
     if($l =~ /^([0-9a-f]+) T _?(.*)/) {
-        my ($name)=($2);
+        my ($name) = ($2);
         #print "Define $name in $file\n";
         $file =~ s/^libcurl_la-//;
         $exist{$name} = $file;
     }
     elsif($l =~ /^                 U _?(.*)/) {
-        my ($name)=($1);
+        my ($name) = ($1);
         #print "Uses $name in $file\n";
         $uses{$name} .= "$file, ";
     }

--- a/scripts/top-complexity
+++ b/scripts/top-complexity
@@ -30,15 +30,15 @@ use warnings;
 # Check for a command in the PATH of the test server.
 #
 sub checkcmd {
-    my ($cmd)=@_;
+    my ($cmd) = @_;
     my @paths;
     if($^O eq 'MSWin32' || $^O eq 'dos' || $^O eq 'os2') {
         # PATH separator is different
-        @paths=(split(';', $ENV{'PATH'}));
+        @paths = (split(';', $ENV{'PATH'}));
     }
     else {
-        @paths=(split(':', $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
-                "/sbin", "/usr/bin", "/usr/local/bin");
+        @paths = (split(':', $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
+                  "/sbin", "/usr/bin", "/usr/local/bin");
     }
     for(@paths) {
         if(-x "$_/$cmd" && ! -d "$_/$cmd") {
@@ -97,15 +97,15 @@ my $alllines = 0;
 for my $l (@output) {
     chomp $l;
     if($l =~/^(\d+)\t\d+\t\d+\t\d+\t(\d+)\t([^\(]+).*: ([^ ]*)/) {
-        my ($score, $len, $path, $func)=($1, $2, $3, $4);
+        my ($score, $len, $path, $func) = ($1, $2, $3, $4);
 
         my $allow = 0;
         if($whitelist{$func} &&
            ($score <= $whitelist{$func})) {
             $allow = 1;
         }
-        $where{"$path:$func"}=$score;
-        $perm{"$path:$func"}=$allow;
+        $where{"$path:$func"} = $score;
+        $perm{"$path:$func"} = $allow;
         if(($score > $cutoff) && !$allow) {
             $error++;
         }

--- a/scripts/top-length
+++ b/scripts/top-length
@@ -30,15 +30,15 @@ use warnings;
 # Check for a command in the PATH of the test server.
 #
 sub checkcmd {
-    my ($cmd)=@_;
+    my ($cmd) = @_;
     my @paths;
     if($^O eq 'MSWin32' || $^O eq 'dos' || $^O eq 'os2') {
         # PATH separator is different
-        @paths=(split(';', $ENV{'PATH'}));
+        @paths = (split(';', $ENV{'PATH'}));
     }
     else {
-        @paths=(split(':', $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
-                "/sbin", "/usr/bin", "/usr/local/bin");
+        @paths = (split(':', $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
+                  "/sbin", "/usr/bin", "/usr/local/bin");
     }
     for(@paths) {
         if(-x "$_/$cmd" && ! -d "$_/$cmd") {
@@ -97,15 +97,15 @@ my $alllines = 0;
 for my $l (@output) {
     chomp $l;
     if($l =~/^(\d+)\t\d+\t\d+\t\d+\t(\d+)\t([^\(]+).*: ([^ ]*)/) {
-        my ($score, $length, $path, $func)=($1, $2, $3, $4);
+        my ($score, $length, $path, $func) = ($1, $2, $3, $4);
 
         my $allow = 0;
         if($whitelist{$func} &&
            ($length <= $whitelist{$func})) {
             $allow = 1;
         }
-        $where{"$path:$func"}=$length;
-        $perm{"$path:$func"}=$allow;
+        $where{"$path:$func"} = $length;
+        $perm{"$path:$func"} = $allow;
         if(($length > $cutoff) && !$allow) {
             $error++;
         }

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -86,9 +86,9 @@ static const unsigned char hugehelpgz[] = {
 HEAD
 ;
 
-    my $c=0;
+    my $c = 0;
     for(split(//, $gzippedContent)) {
-        my $num=ord($_);
+        my $num = ord($_);
         if(!($c % 12)) {
             print " ";
         }

--- a/tests/allversions.pm
+++ b/tests/allversions.pm
@@ -42,7 +42,7 @@ sub allversions {
         }
         elsif(!$before &&
               /^- ([0-9.]+): (.*)/) {
-            $pastversion{$1}=$2;
+            $pastversion{$1} = $2;
             $relcount++;
         }
     }

--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -65,7 +65,7 @@ sub appveyor_create_test_result {
     ' \\
     '$appveyor_baseurl/api/tests'`;
     print "AppVeyor API result: $appveyor_result\n" if($appveyor_result);
-    $APPVEYOR_TEST_NAMES{$testnum}=$testname;
+    $APPVEYOR_TEST_NAMES{$testnum} = $testname;
 }
 
 sub appveyor_update_test_result {

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -106,7 +106,7 @@ my $listenaddr = '127.0.0.1';  # default address for listener port
 #**********************************************************************
 # global vars used for filenames
 #
-my $PORTFILE="ftpserver.port"; # server port filename
+my $PORTFILE = "ftpserver.port"; # server port filename
 my $portfile;           # server port file path
 my $pidfile;            # server pid filename
 my $mainsockf_pidfile;  # pid file for primary connection sockfilt process
@@ -171,7 +171,7 @@ my %delayreply;    #
 # $ftptargetdir is keeping the fake "name" of LIST directory.
 #
 my $ftplistparserstate;
-my $ftptargetdir="";
+my $ftptargetdir = "";
 
 #**********************************************************************
 # global variables used when running an FTP server to keep state info
@@ -712,7 +712,7 @@ sub disc_handshake {
 }
 
 sub close_dataconn {
-    my ($closed)=@_; # non-zero if already disconnected
+    my ($closed) = @_; # non-zero if already disconnected
 
     my $datapid = processexists($datasockf_pidfile);
 
@@ -944,8 +944,8 @@ sub DATA_smtp {
             return 0; # failed to open output
 
         my $line;
-        my $ulsize=0;
-        my $disc=0;
+        my $ulsize = 0;
+        my $disc = 0;
         my $raw;
         while(5 == (sysread \*SFREAD, $line, 5)) {
             if($line eq "DATA\n") {
@@ -978,7 +978,7 @@ sub DATA_smtp {
             }
             elsif($line eq "DISC\n") {
                 # disconnect!
-                $disc=1;
+                $disc = 1;
                 printf SFWRITE "ACKD\n";
                 last;
             }
@@ -2018,7 +2018,7 @@ sub QUIT_pop3 {
 ################
 ################ FTP commands
 ################
-my $rest=0;
+my $rest = 0;
 sub REST_ftp {
     $rest = $_[0];
     logmsg "Set REST position to $rest\n"
@@ -2135,7 +2135,7 @@ sub LIST_ftp {
 }
 
 sub NLST_ftp {
-    my @ftpdir=("file", "with space", "fake", "..", " ..", "funny", "README");
+    my @ftpdir = ("file", "with space", "fake", "..", " ..", "funny", "README");
 
     if($datasockf_conn eq 'no') {
         if($nodataconn425) {
@@ -2242,7 +2242,7 @@ sub SIZE_ftp {
         }
     }
     else {
-        $size=0;
+        $size = 0;
         @data = getpart("reply", "data$testpart");
         for(@data) {
             $size += length($_);
@@ -2320,7 +2320,7 @@ sub RETR_ftp {
 
     my @data = getpart("reply", "data$testpart");
 
-    my $size=0;
+    my $size = 0;
     for(@data) {
         $size += length($_);
     }
@@ -2344,7 +2344,7 @@ sub RETR_ftp {
                 senddata $send;
             }
             close_dataconn(0);
-            $retrweirdo=0; # switch off the weirdo again!
+            $retrweirdo = 0; # switch off the weirdo again!
         }
         else {
             my $sz = "($size bytes)";
@@ -2372,7 +2372,7 @@ sub RETR_ftp {
 }
 
 sub STOR_ftp {
-    my $testno=$_[0];
+    my $testno = $_[0];
 
     my $filename = "$logdir/upload.$testno";
 
@@ -2403,8 +2403,8 @@ sub STOR_ftp {
         return 0; # failed to open output
 
     my $line;
-    my $ulsize=0;
-    my $disc=0;
+    my $ulsize = 0;
+    my $disc = 0;
     while(5 == (sysread DREAD, $line, 5)) {
         if($line eq "DATA\n") {
             my $i;
@@ -2425,7 +2425,7 @@ sub STOR_ftp {
         }
         elsif($line eq "DISC\n") {
             # disconnect!
-            $disc=1;
+            $disc = 1;
             printf DWRITE "ACKD\n";
             last;
         }
@@ -2454,7 +2454,7 @@ sub STOR_ftp {
 }
 
 sub PASV_ftp {
-    my ($arg, $cmd)=@_;
+    my ($arg, $cmd) = @_;
     my $pasvport;
 
     # kill previous data connection sockfilt when alive
@@ -2561,10 +2561,10 @@ sub PASV_ftp {
 
     if($cmd ne "EPSV") {
         # PASV reply
-        my $p=$listenaddr;
+        my $p = $listenaddr;
         $p =~ s/\./,/g;
         if($pasvbadip) {
-            $p="1,2,3,4";
+            $p = "1,2,3,4";
         }
         sendcontrol sprintf("227 Entering Passive Mode ($p,%d,%d)\r\n",
                             int($pasvport / 256), int($pasvport % 256));
@@ -2833,16 +2833,16 @@ sub customize {
 
     while(<$custom>) {
         if($_ =~ /REPLY \"([A-Z]+ [A-Za-z0-9+-\/=\*. ]+)\" (.*)/) {
-            $fulltextreply{$1}=eval "qq{$2}";
+            $fulltextreply{$1} = eval "qq{$2}";
             logmsg "FTPD: set custom reply for $1\n";
         }
         elsif($_ =~ /REPLY(LF|) ([A-Za-z0-9+\/=\*]*) (.*)/) {
-            $commandreply{$2}=eval "qq{$3}";
+            $commandreply{$2} = eval "qq{$3}";
             if($1 ne "LF") {
-                $commandreply{$2}.="\r\n";
+                $commandreply{$2} .= "\r\n";
             }
             else {
-                $commandreply{$2}.="\n";
+                $commandreply{$2} .= "\n";
             }
             if($2 eq "") {
                 logmsg "FTPD: set custom reply for empty command\n";
@@ -2854,11 +2854,11 @@ sub customize {
         elsif($_ =~ /COUNT ([A-Z]+) (.*)/) {
             # we blank the custom reply for this command when having
             # been used this number of times
-            $customcount{$1}=$2;
+            $customcount{$1} = $2;
             logmsg "FTPD: blank custom reply for $1 command after $2 uses\n";
         }
         elsif($_ =~ /DELAY ([A-Z]+) (\d*)/) {
-            $delayreply{$1}=$2;
+            $delayreply{$1} = $2;
             logmsg "FTPD: delay reply for $1 with $2 seconds\n";
         }
         elsif($_ =~ /POSTFETCH (.*)/) {
@@ -2866,22 +2866,22 @@ sub customize {
             $postfetch = $1;
         }
         elsif($_ =~ /SLOWDOWNDATA/) {
-            $ctrldelay=0;
-            $datadelay=0.005;
+            $ctrldelay = 0;
+            $datadelay = 0.005;
             logmsg "FTPD: send response data with 5ms delay per byte\n";
         }
         elsif($_ =~ /SLOWDOWN/) {
-            $ctrldelay=0.005;
-            $datadelay=0.005;
+            $ctrldelay = 0.005;
+            $datadelay = 0.005;
             logmsg "FTPD: send response with 5ms delay between each byte\n";
         }
         elsif($_ =~ /RETRWEIRDO/) {
             logmsg "FTPD: instructed to use RETRWEIRDO\n";
-            $retrweirdo=1;
+            $retrweirdo = 1;
         }
         elsif($_ =~ /RETRNOSIZE/) {
             logmsg "FTPD: instructed to use RETRNOSIZE\n";
-            $retrnosize=1;
+            $retrnosize = 1;
         }
         elsif($_ =~ /RETRSIZE (\d+)/) {
             $retrsize= $1;
@@ -2889,33 +2889,33 @@ sub customize {
         }
         elsif($_ =~ /PASVBADIP/) {
             logmsg "FTPD: instructed to use PASVBADIP\n";
-            $pasvbadip=1;
+            $pasvbadip = 1;
         }
         elsif($_ =~ /NODATACONN425/) {
             # applies to both active and passive FTP modes
             logmsg "FTPD: instructed to use NODATACONN425\n";
-            $nodataconn425=1;
-            $nodataconn=1;
+            $nodataconn425 = 1;
+            $nodataconn = 1;
         }
         elsif($_ =~ /NODATACONN421/) {
             # applies to both active and passive FTP modes
             logmsg "FTPD: instructed to use NODATACONN421\n";
-            $nodataconn421=1;
-            $nodataconn=1;
+            $nodataconn421 = 1;
+            $nodataconn = 1;
         }
         elsif($_ =~ /NODATACONN150/) {
             # applies to both active and passive FTP modes
             logmsg "FTPD: instructed to use NODATACONN150\n";
-            $nodataconn150=1;
-            $nodataconn=1;
+            $nodataconn150 = 1;
+            $nodataconn = 1;
         }
         elsif($_ =~ /NODATACONN/) {
             # applies to both active and passive FTP modes
             logmsg "FTPD: instructed to use NODATACONN\n";
-            $nodataconn=1;
+            $nodataconn = 1;
         }
         elsif($_ =~ /^STOR (.*)/) {
-            $storeresp=$1;
+            $storeresp = $1;
             logmsg "FTPD: instructed to use respond to STOR with '$storeresp'\n";
         }
         elsif($_ =~ /CAPA (.*)/) {
@@ -3150,7 +3150,7 @@ while(1) {
     }
     else {
         # clear it after use
-        $commandreply{"welcome"}="";
+        $commandreply{"welcome"} = "";
         if($welcome !~ /\r\n\z/) {
             $welcome .= "\r\n";
         }
@@ -3217,21 +3217,21 @@ while(1) {
             # IMAP is different with its identifier first on the command line
             if(($full =~ /^([^ ]+) ([^ ]+) (.*)/) ||
                ($full =~ /^([^ ]+) ([^ ]+)/)) {
-                $cmdid=$1; # set the global variable
-                $FTPCMD=$2;
-                $FTPARG=$3;
+                $cmdid = $1; # set the global variable
+                $FTPCMD = $2;
+                $FTPARG = $3;
             }
             # IMAP authentication cancellation
             elsif($full =~ /^\*$/) {
                 # Command id has already been set
-                $FTPCMD="*";
-                $FTPARG="";
+                $FTPCMD = "*";
+                $FTPARG = "";
             }
             # IMAP long "commands" are base64 authentication data
             elsif($full =~ /^[A-Z0-9+\/]*={0,2}$/i) {
                 # Command id has already been set
-                $FTPCMD=$full;
-                $FTPARG="";
+                $FTPCMD = $full;
+                $FTPARG = "";
             }
             else {
                 sendcontrol "$full BAD Command\r\n";
@@ -3239,19 +3239,19 @@ while(1) {
             }
         }
         elsif($full =~ /^([A-Z]{3,4})(\s(.*))?$/i) {
-            $FTPCMD=$1;
-            $FTPARG=$3;
+            $FTPCMD = $1;
+            $FTPARG = $3;
         }
         elsif($proto eq "pop3") {
             # POP3 authentication cancellation
             if($full =~ /^\*$/) {
-                $FTPCMD="*";
-                $FTPARG="";
+                $FTPCMD = "*";
+                $FTPARG = "";
             }
             # POP3 long "commands" are base64 authentication data
             elsif($full =~ /^[A-Z0-9+\/]*={0,2}$/i) {
-                $FTPCMD=$full;
-                $FTPARG="";
+                $FTPCMD = $full;
+                $FTPARG = "";
             }
             else {
                 sendcontrol "-ERR Unrecognized command\r\n";
@@ -3261,13 +3261,13 @@ while(1) {
         elsif($proto eq "smtp") {
             # SMTP authentication cancellation
             if($full =~ /^\*$/) {
-                $FTPCMD="*";
-                $FTPARG="";
+                $FTPCMD = "*";
+                $FTPARG = "";
             }
             # SMTP long "commands" are base64 authentication data
             elsif($full =~ /^[A-Z0-9+\/]{0,512}={0,2}$/i) {
-                $FTPCMD=$full;
-                $FTPARG="";
+                $FTPCMD = $full;
+                $FTPARG = "";
             }
             else {
                 sendcontrol "500 Unrecognized command\r\n";
@@ -3312,7 +3312,7 @@ while(1) {
             if($text && ($text ne "")) {
                 if($customcount{$FTPCMD} && (!--$customcount{$FTPCMD})) {
                     # used enough times so blank the custom command reply
-                    $commandreply{$FTPCMD}="";
+                    $commandreply{$FTPCMD} = "";
                 }
 
                 sendcontrol $text;

--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -49,8 +49,8 @@ use Memoize;
 my @xml;      # test data file contents
 my $xmlfile;  # test data filename
 
-my $warning=0;
-my $trace=0;
+my $warning = 0;
+my $trace = 0;
 
 # Normalize the part function arguments for proper caching. This includes the
 # filename in the arguments since that is an implied parameter that affects the
@@ -66,12 +66,12 @@ sub testcaseattr {
     my %hash;
     for(@xml) {
         if(($_ =~ /^ *\<testcase ([^>]*)/)) {
-            my $attr=$1;
+            my $attr = $1;
             while($attr =~ s/ *([^=]*)= *(\"([^\"]*)\"|\'([^\']*)\')//) {
-                my ($var, $cont)=($1, $2);
+                my ($var, $cont) = ($1, $2);
                 $cont =~ s/^\"(.*)\"$/$1/;
                 $cont =~ s/^\'(.*)\'$/$1/;
-                $hash{$var}=$cont;
+                $hash{$var} = $cont;
             }
         }
     }
@@ -82,10 +82,10 @@ sub getpartattr {
     # if $part is undefined (ie only one argument) then
     # return the attributes of the section
 
-    my ($section, $part)=@_;
+    my ($section, $part) = @_;
 
     my %hash;
-    my $inside=0;
+    my $inside = 0;
 
   # print "Section: $section, part: $part\n";
 
@@ -98,13 +98,13 @@ sub getpartattr {
                               !(defined($part)))
              ) {
             $inside++;
-            my $attr=$1;
+            my $attr = $1;
 
             while($attr =~ s/ *([^=]*)= *(\"([^\"]*)\"|\'([^\']*)\')//) {
-                my ($var, $cont)=($1, $2);
+                my ($var, $cont) = ($1, $2);
                 $cont =~ s/^\"(.*)\"$/$1/;
                 $cont =~ s/^\'(.*)\'$/$1/;
-                $hash{$var}=$cont;
+                $hash{$var} = $cont;
             }
             last;
         }
@@ -121,10 +121,10 @@ sub getpartattr {
 memoize('getpartattr', NORMALIZER => 'normalize_part');  # cache each result
 
 sub getpart {
-    my ($section, $part)=@_;
+    my ($section, $part) = @_;
 
     my @this;
-    my $inside=0;
+    my $inside = 0;
     my $line;
 
     for(@xml) {
@@ -176,7 +176,7 @@ sub getpart {
 memoize('getpart', NORMALIZER => 'normalize_part');  # cache each result
 
 sub partexists {
-    my ($section, $part)=@_;
+    my ($section, $part) = @_;
 
     my $inside = 0;
 
@@ -199,7 +199,7 @@ sub partexists {
 # memoize('partexists', NORMALIZER => 'normalize_part');  # cache each result
 
 sub loadtest {
-    my ($file, $original)=@_;
+    my ($file, $original) = @_;
 
     if(defined $xmlfile && $file eq $xmlfile) {
         # This test is already loaded
@@ -288,7 +288,7 @@ sub checktest {
 
 # write the test to the given file
 sub savetest {
-    my ($file)=@_;
+    my ($file) = @_;
 
     if(open(my $xmlh, ">", $file)) {
         binmode $xmlh; # for crapage systems, use binary
@@ -328,7 +328,7 @@ sub striparray {
 # pass array *REFERENCES* !
 #
 sub compareparts {
-    my ($firstref, $secondref)=@_;
+    my ($firstref, $secondref) = @_;
 
     # we cannot compare arrays index per index since with data chunks,
     # they may not be "evenly" distributed
@@ -384,7 +384,7 @@ sub compareparts {
 # Write a given array to the specified file
 #
 sub writearray {
-    my ($filename, $arrayref)=@_;
+    my ($filename, $arrayref) = @_;
 
     open(my $temp, ">", $filename) || die "Failure writing file";
     binmode($temp,":raw");  # Cygwin fix
@@ -398,7 +398,7 @@ sub writearray {
 # Load a specified file and return it as an array
 #
 sub loadarray {
-    my ($filename)=@_;
+    my ($filename) = @_;
     my @array;
 
     if(open(my $temp, "<", $filename)) {

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -90,54 +90,54 @@ use File::Spec;
 #
 
 # config variables overridden by command-line options
-our $verbose;         # 1 to show verbose test output
-our $torture;         # 1 to enable torture testing
-our $proxy_address;   # external HTTP proxy address
-our $listonly;        # only list the tests
-our $buildinfo;       # dump buildinfo.txt
-our $run_duphandle;   # run curl with --test-duphandle to verify handle duplication
-our $run_event_based; # run curl with --test-event to test the event API
-our $automakestyle;   # use automake-like test status output format
-our $anyway;          # continue anyway, even if a test fail
-our $CURLVERSION="";  # curl's reported version number
-our $CURLVERNUM="";   # curl's reported version number (without -DEV)
-our $randseed = 0;    # random number seed
-our $maxtime;         # curl command timeout override
-our $mintotal;        # minimum number of tests to run
+our $verbose;          # 1 to show verbose test output
+our $torture;          # 1 to enable torture testing
+our $proxy_address;    # external HTTP proxy address
+our $listonly;         # only list the tests
+our $buildinfo;        # dump buildinfo.txt
+our $run_duphandle;    # run curl with --test-duphandle to verify handle duplication
+our $run_event_based;  # run curl with --test-event to test the event API
+our $automakestyle;    # use automake-like test status output format
+our $anyway;           # continue anyway, even if a test fail
+our $CURLVERSION = ""; # curl's reported version number
+our $CURLVERNUM = "";  # curl's reported version number (without -DEV)
+our $randseed = 0;     # random number seed
+our $maxtime;          # curl command timeout override
+our $mintotal;         # minimum number of tests to run
 
 # paths
 our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
-our $perlcmd=shell_quote($^X);
-our $perl="$perlcmd -I. " . shell_quote("-I$srcdir"); # invoke perl like this
-our $LOGDIR="log";  # root of the log directory; this is different for
-                    # each runner in multiprocess mode
-our $LIBDIR=dirsepadd("./libtest/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
-our $UNITDIR=dirsepadd("./unit/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
-our $TUNITDIR=dirsepadd("./tunit/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
-our $SRVDIR=dirsepadd("./server/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
-our $TESTDIR="$srcdir/data";
-our $CURL=dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
+our $perlcmd = shell_quote($^X);
+our $perl = "$perlcmd -I. " . shell_quote("-I$srcdir"); # invoke perl like this
+our $LOGDIR = "log";  # root of the log directory; this is different for
+                      # each runner in multiprocess mode
+our $LIBDIR = dirsepadd("./libtest/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
+our $UNITDIR = dirsepadd("./unit/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
+our $TUNITDIR = dirsepadd("./tunit/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
+our $SRVDIR = dirsepadd("./server/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
+our $TESTDIR = "$srcdir/data";
+our $CURL = dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
     "curl".exe_ext('TOOL'); # what curl binary to run on the tests
-our $CURLINFO=dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
+our $CURLINFO = dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
     "curlinfo".exe_ext('TOOL'); # what curlinfo binary to run on the tests
 
-our $VCURL=$CURL;  # what curl binary to use to verify the servers with
-                   # VCURL is handy to set to the system one when the one you
-                   # built hangs or crashes and thus prevent verification
+our $VCURL = $CURL;  # what curl binary to use to verify the servers with
+                     # VCURL is handy to set to the system one when the one you
+                     # built hangs or crashes and thus prevent verification
 # the path to the script that analyzes the memory debug output file
-our $memanalyze="$perl " . shell_quote("$srcdir/memanalyze.pl");
+our $memanalyze = "$perl " . shell_quote("$srcdir/memanalyze.pl");
 our $valgrind;     # path to valgrind, or empty if disabled
 our $dev_null = File::Spec->devnull();   # null device path, eg: /dev/null
 
 # paths in $LOGDIR
-our $LOCKDIR = "lock";          # root of the server directory with lock files
-our $PIDDIR = "server";         # root of the server directory with PID files
-our $SERVERIN="server.input";   # what curl sent the server
-our $PROXYIN="proxy.input";     # what curl sent the proxy
-our $MEMDUMP="memdump";         # file that the memory debugging creates
-our $SERVERCMD="server.cmd";    # copy server instructions here
-our $DNSCMD="dnsd.cmd";         # write DNS instructions here
+our $LOCKDIR = "lock";           # root of the server directory with lock files
+our $PIDDIR = "server";          # root of the server directory with PID files
+our $SERVERIN = "server.input";  # what curl sent the server
+our $PROXYIN = "proxy.input";    # what curl sent the proxy
+our $MEMDUMP = "memdump";        # file that the memory debugging creates
+our $SERVERCMD = "server.cmd";   # copy server instructions here
+our $DNSCMD = "dnsd.cmd";        # write DNS instructions here
 
 # other config variables
 our @protocols;   # array of lowercase supported protocol servers

--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -110,7 +110,7 @@ while(@ARGV) {
 my $certfile = abs_path("certs/$cert.pem");
 my $keyfile = abs_path("certs/$cert.key");
 
-my $cmdline="$nghttpx --backend=$connect ".
+my $cmdline = "$nghttpx --backend=$connect ".
     "--backend-keep-alive-timeout=500ms ".
     "--frontend=\"*,$listenport;no-tls\" ".
     "--frontend=\"*,$listenport2\" ".

--- a/tests/http3-server.pl
+++ b/tests/http3-server.pl
@@ -110,7 +110,7 @@ while(@ARGV) {
 my $certfile = abs_path("certs/$cert.pem");
 my $keyfile = abs_path("certs/$cert.key");
 
-my $cmdline="$nghttpx --http2-proxy --backend=$connect ".
+my $cmdline = "$nghttpx --http2-proxy --backend=$connect ".
     "--backend-keep-alive-timeout=500ms ".
     "--frontend=\"*,$listenport\" ".
     "--frontend=\"*,$listenport;quic\" ".

--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -442,10 +442,10 @@ while(<STDIN>) {
         next;
     }
     if($_ =~ /^CURLOPT(?:DEPRECATED)?\(([^ ]*), ([^ ]*), (\d*)[,)]/) {
-        my ($name, $type, $val)=($1, $2, $3);
-        my $w="  ";
-        my $w2="$w$w";
-        my $w3="$w$w$w";
+        my ($name, $type, $val) = ($1, $2, $3);
+        my $w = "  ";
+        my $w2 = "$w$w";
+        my $w3 = "$w$w$w";
         my $opt = $name;
         $opt =~ s/^CURLOPT_//;
         my $exists = "${w}{\n";
@@ -563,7 +563,7 @@ MOO
         }
         elsif($type eq "CURLOPTTYPE_FUNCTIONPOINT") {
             if($name =~ /([^ ]*)FUNCTION/) {
-                my $l=lc($1);
+                my $l = lc($1);
                 $l =~ s/^curlopt_//;
                 print $fh "${fpref}\n$i${l}cb);\n$fcheck";
             }
@@ -594,7 +594,7 @@ MOO
     }
     elsif($infomode &&
           ($_ =~ /^CURLINFO_([^ ]*) *= *CURLINFO_([^ ]*)/)) {
-       my ($info, $type)=($1, $2);
+       my ($info, $type) = ($1, $2);
        my $c = "  result = curl_easy_getinfo(curl, CURLINFO_$info,";
        my $check = "  if(result)\n    t1521_geterr(\"$info\", result, __LINE__);\n";
        if($type eq "STRING") {

--- a/tests/libtest/test1013.pl
+++ b/tests/libtest/test1013.pl
@@ -32,10 +32,10 @@ if($#ARGV != 2) {
     exit 3;
 }
 
-my $what=$ARGV[2];
+my $what = $ARGV[2];
 
 # Read the output of curl --version
-my $curl_protocols="";
+my $curl_protocols = "";
 open(CURL, $ARGV[1]) || die "Cannot get curl $what list\n";
 while(<CURL>) {
     $curl_protocols = $_ if(/$what:/i);

--- a/tests/libtest/test1022.pl
+++ b/tests/libtest/test1022.pl
@@ -31,7 +31,7 @@ if($#ARGV != 2) {
     exit 3;
 }
 
-my $what=$ARGV[2];
+my $what = $ARGV[2];
 
 # Read the output of curl --version
 open(CURL, $ARGV[1]) || die "Cannot open curl --version list in $ARGV[1]\n";
@@ -47,7 +47,7 @@ my $curlconfigversion;
 open(CURLCONFIG, '-|', 'sh', $ARGV[0], "--$what") || die "Cannot get curl-config --$what list\n";
 $_ = <CURLCONFIG>;
 chomp;
-my $filever=$_;
+my $filever = $_;
 if($what eq "version") {
     if($filever =~ /^libcurl ([\.\d]+((-DEV)|(-rc\d)|(-\d+))?)$/) {
         $curlconfigversion = $1;

--- a/tests/memanalyze.pl
+++ b/tests/memanalyze.pl
@@ -34,16 +34,16 @@ my $trace = 0;
 
 while(@ARGV) {
     if($ARGV[0] eq "-v") {
-        $verbose=1;
+        $verbose = 1;
         shift @ARGV;
     }
     elsif($ARGV[0] eq "-t") {
-        $trace=1;
+        $trace = 1;
         shift @ARGV;
     }
     elsif($ARGV[0] eq "-l") {
         # only show what alloc that caused a memlimit failure
-        $showlimit=1;
+        $showlimit = 1;
         shift @ARGV;
     }
     else {

--- a/tests/memanalyzer.pm
+++ b/tests/memanalyzer.pm
@@ -46,7 +46,7 @@ my $memsum;
 my $maxmem;
 
 sub newtotal {
-    my ($newtot)=@_;
+    my ($newtot) = @_;
     # count a max here
 
     if($newtot > $maxmem) {
@@ -152,8 +152,8 @@ sub memanalyze {
                     newtotal($totalmem);
                     $frees++;
 
-                    $sizeataddr{$addr}=-1; # set -1 to mark as freed
-                    $getmem{$addr}="$source:$linenum";
+                    $sizeataddr{$addr} = -1; # set -1 to mark as freed
+                    $getmem{$addr} = "$source:$linenum";
                 }
             }
             elsif($function =~ /malloc\((\d*)\) = 0x([0-9a-f]*)/) {
@@ -177,7 +177,7 @@ sub memanalyze {
                 newtotal($totalmem);
                 $mallocs++;
 
-                $getmem{$addr}="$source:$linenum";
+                $getmem{$addr} = "$source:$linenum";
             }
             elsif($function =~ /calloc\((\d*),(\d*)\) = 0x([0-9a-f]*)/) {
                 $size = $1 * $2;
@@ -203,7 +203,7 @@ sub memanalyze {
                 newtotal($totalmem);
                 $callocs++;
 
-                $getmem{$addr}="$source:$linenum";
+                $getmem{$addr} = "$source:$linenum";
             }
             elsif($function =~ /realloc\((\(nil\)|0x([0-9a-f]*)), (\d*)\) = 0x([0-9a-f]*)/) {
                 my ($oldaddr, $newsize, $newaddr) = ($2, $3, $4);
@@ -231,7 +231,7 @@ sub memanalyze {
                 newtotal($totalmem);
                 $reallocs++;
 
-                $getmem{$newaddr}="$source:$linenum";
+                $getmem{$newaddr} = "$source:$linenum";
             }
             elsif($function =~ /strdup\(0x([0-9a-f]*)\) \((\d*)\) = 0x([0-9a-f]*)/) {
                 # strdup(a5b50) (8) = df7c0
@@ -258,8 +258,8 @@ sub memanalyze {
                 $dup = $1;
                 $size = $2;
                 $addr = $3;
-                $getmem{$addr}="$source:$linenum";
-                $sizeataddr{$addr}=$size;
+                $getmem{$addr} = "$source:$linenum";
+                $sizeataddr{$addr} = $size;
 
                 $totalmem += $size;
                 $memsum += $size;
@@ -306,7 +306,7 @@ sub memanalyze {
                     push @res, "Close without open: $line\n";
                 }
                 else {
-                    $filedes{$1}=0; # closed now
+                    $filedes{$1} = 0; # closed now
                     $openfile--;
                 }
             }

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -197,7 +197,7 @@ sub dirsepadd {
 # This does the same thing as String::ShellQuote but does not need a package.
 #
 sub shell_quote {
-    my ($s)=@_;
+    my ($s) = @_;
     if($^O eq 'MSWin32') {
         $s = '"' . $s . '"';
     }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -106,16 +106,16 @@ use memanalyzer;
 
 my %custom_skip_reasons;
 
-my $ACURL=$VCURL;  # what curl binary to use to talk to APIs (relevant for CI)
-                   # ACURL is handy to set to the system one for reliability
-my $CURLCONFIG="../curl-config"; # curl-config from current build
+my $ACURL = $VCURL;  # what curl binary to use to talk to APIs (relevant for CI)
+                     # ACURL is handy to set to the system one for reliability
+my $CURLCONFIG = "../curl-config"; # curl-config from current build
 
 # Normally, all test cases should be run, but at times it is handy to
 # run a particular one:
-my $TESTCASES="all";
+my $TESTCASES = "all";
 
 # To run specific test cases, set them like:
-# $TESTCASES="1 2 3 7 8";
+# $TESTCASES = "1 2 3 7 8";
 
 #######################################################################
 # No variables below this point should need to be modified
@@ -214,7 +214,7 @@ sub logmsg {
 # enable logmsg buffering for the given runner ID
 #
 sub logmsg_bufferfortest {
-    my ($runnerid)=@_;
+    my ($runnerid) = @_;
     if($jobs) {
         # Only enable buffering in multiprocess mode
         $singletest_bufferedrunner = $runnerid;
@@ -321,7 +321,7 @@ if(!$ENV{"NGHTTPX"}) {
 }
 if($ENV{"NGHTTPX"}) {
     my $cmd = "\"$ENV{'NGHTTPX'}\" -v 2>$dev_null";
-    my $nghttpx_version=join(' ', `$cmd`);
+    my $nghttpx_version = join(' ', `$cmd`);
     $nghttpx_h3 = $nghttpx_version =~ /nghttp3\//;
     chomp $nghttpx_h3;
 }
@@ -384,10 +384,10 @@ sub cleardir {
 # Given two array references, this function will store them in two temporary
 # files, run 'diff' on them, store the result and return the diff output!
 sub showdiff {
-    my ($logdir, $firstref, $secondref)=@_;
+    my ($logdir, $firstref, $secondref) = @_;
 
-    my $file1="$logdir/check-generated";
-    my $file2="$logdir/check-expected";
+    my $file1 = "$logdir/check-generated";
+    my $file2 = "$logdir/check-expected";
 
     open(my $temp, ">", $file1) || die "Failure writing diff file";
     for(@$firstref) {
@@ -427,7 +427,7 @@ sub showdiff {
 # some pattern that is allowed to differ, output test results
 #
 sub compare {
-    my ($runnerid, $testnum, $testname, $subject, $firstref, $secondref)=@_;
+    my ($runnerid, $testnum, $testname, $subject, $firstref, $secondref) = @_;
 
     my $result = compareparts($firstref, $secondref);
 
@@ -454,14 +454,14 @@ sub compare {
 #######################################################################
 # Numeric-sort words in a string
 sub numsortwords {
-    my ($string)=@_;
+    my ($string) = @_;
     return join(' ', sort { $a <=> $b } split(' ', $string));
 }
 
 #######################################################################
 # Parse and store the protocols in curl's Protocols: line
 sub parseprotocols {
-    my ($line)=@_;
+    my ($line) = @_;
 
     @protocols = split(' ', lc($line));
 
@@ -512,13 +512,13 @@ sub checksystemfeatures {
     my $libcurl;
     my $versretval;
     my $versnoexec;
-    my @version=();
+    my @version = ();
     my @disabled;
     my $dis = "";
 
-    my $curlverout="$LOGDIR/curlverout.log";
-    my $curlvererr="$LOGDIR/curlvererr.log";
-    my $versioncmd=exerunner() . shell_quote($CURL) . " --version 1>$curlverout 2>$curlvererr";
+    my $curlverout = "$LOGDIR/curlverout.log";
+    my $curlvererr = "$LOGDIR/curlvererr.log";
+    my $versioncmd = exerunner() . shell_quote($CURL) . " --version 1>$curlverout 2>$curlvererr";
 
     unlink($curlverout);
     unlink($curlvererr);
@@ -549,7 +549,7 @@ sub checksystemfeatures {
         $dis = join(", ", @disabled);
     }
 
-    $resolver="stock";
+    $resolver = "stock";
     for(@version) {
         chomp;
 
@@ -610,7 +610,7 @@ sub checksystemfeatures {
             }
             if($libcurl =~ /ares/i) {
                 $feature{"c-ares"} = 1;
-                $resolver="c-ares";
+                $resolver = "c-ares";
             }
             if($libcurl =~ /nghttp2/i) {
                 # nghttp2 supports h2c
@@ -707,7 +707,7 @@ sub checksystemfeatures {
                 if(!$feature{"c-ares"} || $feature{"asyn-rr"}) {
                     # this means threaded resolver
                     $feature{"threaded-resolver"} = 1;
-                    $resolver="threaded";
+                    $resolver = "threaded";
 
                     # does not count as "real" c-ares
                     $feature{"c-ares"} = 0;
@@ -748,7 +748,7 @@ sub checksystemfeatures {
             my $add_httptls;
             for(@protocols) {
                 if($_ =~ /^https(-ipv6|)$/) {
-                    $add_httptls=1;
+                    $add_httptls = 1;
                     last;
                 }
             }
@@ -857,11 +857,11 @@ sub checksystemfeatures {
             "TrackMemory feature (--enable-debug)";
     }
 
-    my $hostname=join(' ', runclientoutput("hostname"));
+    my $hostname = join(' ', runclientoutput("hostname"));
     chomp $hostname;
-    my $hosttype=join(' ', runclientoutput("uname -a"));
+    my $hosttype = join(' ', runclientoutput("uname -a"));
     chomp $hosttype;
-    my $hostos=$^O;
+    my $hostos = $^O;
 
     # display summary information about curl and the test host
     logmsg("********* System characteristics ******** \n",
@@ -1008,7 +1008,7 @@ sub citest_finishtestrun {
 
 # add one set of test timings from the runner to global set
 sub updatetesttimings {
-    my ($testnum, %testtimings)=@_;
+    my ($testnum, %testtimings) = @_;
 
     if(defined $testtimings{"timeprepini"}) {
         $timeprepini{$testnum} = $testtimings{"timeprepini"};
@@ -1205,7 +1205,7 @@ sub singletest_count {
     if($why && !$listonly) {
         # there is a problem, count it as "skipped"
         $skipped{$why}++;
-        $teststat[$testnum]=$why; # store reason for this test case
+        $teststat[$testnum] = $why; # store reason for this test case
 
         if(!$short) {
             if($skipped{$why} <= 3) {
@@ -1242,7 +1242,7 @@ sub normalize_text {
 #######################################################################
 # Verify test succeeded
 sub singletest_check {
-    my ($runnerid, $testnum, $cmdres, $CURLOUT, $tool, $usedvalgrind)=@_;
+    my ($runnerid, $testnum, $cmdres, $CURLOUT, $tool, $usedvalgrind) = @_;
 
     # Skip all the verification on torture tests
     if($torture) {
@@ -1254,7 +1254,7 @@ sub singletest_check {
     my $logdir = getrunnerlogdir($runnerid);
     my @err = getpart("verify", "errorcode");
     my $errorcode = $err[0] || "0";
-    my $ok="";
+    my $ok = "";
     my $res;
     chomp $errorcode;
     my $testname= (getpart("client", "name"))[0];
@@ -1297,7 +1297,7 @@ sub singletest_check {
         }
 
         # get the mode attribute
-        my $filemode=$hash{'mode'};
+        my $filemode = $hash{'mode'};
         if($filemode && ($filemode eq "text")) {
             normalize_text(\@validstdout);
             normalize_text(\@actual);
@@ -1351,7 +1351,7 @@ sub singletest_check {
         my %hash = getpartattr("verify", "stderr");
 
         # get the mode attribute
-        my $filemode=$hash{'mode'};
+        my $filemode = $hash{'mode'};
         if($filemode && ($filemode eq "text")) {
             normalize_text(\@validstderr);
             normalize_text(\@actual);
@@ -1470,7 +1470,7 @@ sub singletest_check {
             if(@replycheckpart) {
                 my %replycheckpartattr = getpartattr("reply", "datacheck".$partsuffix);
                 # get the mode attribute
-                my $filemode=$replycheckpartattr{'mode'};
+                my $filemode = $replycheckpartattr{'mode'};
                 if($filemode && ($filemode eq "text")) {
                     normalize_text(\@replycheckpart);
                 }
@@ -1501,7 +1501,7 @@ sub singletest_check {
             }
         }
         # get the mode attribute
-        my $filemode=$replyattr{'mode'};
+        my $filemode = $replyattr{'mode'};
         if($filemode && ($filemode eq "text")) {
             normalize_text(\@reply);
         }
@@ -1520,7 +1520,7 @@ sub singletest_check {
         my @out = loadarray($CURLOUT);
 
         # get the mode attribute
-        my $filemode=$replyattr{'mode'};
+        my $filemode = $replyattr{'mode'};
         if($filemode && ($filemode eq "text")) {
             normalize_text(\@out);
         }
@@ -1625,12 +1625,12 @@ sub singletest_check {
 
     my $outputok;
     for my $partsuffix (('', '1', '2', '3', '4')) {
-        my @outfile=getpart("verify", "file".$partsuffix);
+        my @outfile = getpart("verify", "file".$partsuffix);
         if(@outfile || partexists("verify", "file".$partsuffix) ) {
             # we are supposed to verify a dynamically generated file!
             my %hash = getpartattr("verify", "file".$partsuffix);
 
-            my $filename=$hash{'name'};
+            my $filename = $hash{'name'};
             if(!$filename) {
                 logmsg " $testnum: IGNORED: section verify=>file$partsuffix ".
                        "has no name attribute\n";
@@ -1655,12 +1655,12 @@ sub singletest_check {
                 $timevrfyend{$testnum} = Time::HiRes::time();
                 return -1;
             }
-            my @generated=loadarray($filename);
+            my @generated = loadarray($filename);
 
             # what parts to cut off from the file
             my @stripfilepar = getpart("verify", "stripfile".$partsuffix);
 
-            my $filemode=$hash{'mode'};
+            my $filemode = $hash{'mode'};
             if($filemode && ($filemode eq "text")) {
                 normalize_text(\@outfile);
                 normalize_text(\@generated);
@@ -1720,7 +1720,7 @@ sub singletest_check {
     if(@dnsd) {
         # we are supposed to verify a dynamically generated file!
         my %hash = getpartattr("verify", "dns");
-        my $hostname=$hash{'host'};
+        my $hostname = $hash{'host'};
 
         # Verify the sent DNS requests
         my @out = loadarray("$logdir/dnsd.input");
@@ -1775,12 +1775,12 @@ sub singletest_check {
         }
         else {
             my @memdata = memanalyze("$logdir/$MEMDUMP", 0, 0, 0);
-            my $leak=0;
+            my $leak = 0;
             for(@memdata) {
                 if($_ ne "") {
                     # well it could be other memory problems as well, but
                     # we call it leak for short here
-                    $leak=1;
+                    $leak = 1;
                 }
             }
             if($leak) {
@@ -1925,12 +1925,12 @@ sub singletest_check {
 #######################################################################
 # Report a successful test
 sub singletest_success {
-    my ($testnum, $count, $total, $errorreturncode)=@_;
+    my ($testnum, $count, $total, $errorreturncode) = @_;
 
     my $sofar= time()-$start;
     my $esttotal = $sofar/$count * $total;
     my $estleft = $esttotal - $sofar;
-    my $timeleft=sprintf("remaining: %02d:%02d",
+    my $timeleft = sprintf("remaining: %02d:%02d",
                      $estleft / 60,
                      $estleft % 60);
     my $took = $timevrfyend{$testnum} - $timeprepini{$testnum};
@@ -1946,7 +1946,7 @@ sub singletest_success {
         logmsg "PASS: $testnum - $testname\n";
     }
 
-    if($errorreturncode==2) {
+    if($errorreturncode == 2) {
         # ignored test success
         $passedign .= "$testnum ";
         logmsg "Warning: test$testnum result is ignored, but passed!\n";
@@ -1962,7 +1962,7 @@ sub singletest_success {
 # arrived.
 #
 sub singletest {
-    my ($runnerid, $testnum, $count, $total)=@_;
+    my ($runnerid, $testnum, $count, $total) = @_;
 
     # start buffering logmsg; stop it on return
     logmsg_bufferfortest($runnerid);
@@ -2283,7 +2283,7 @@ sub runtimestats {
 # 0=unknown test, 1=use test result, 2=ignore test result
 #
 sub ignoreresultcode {
-    my ($testnum)=@_;
+    my ($testnum) = @_;
     if(defined $ignoretestcodes{$testnum}) {
         return $ignoretestcodes{$testnum};
     }
@@ -2294,7 +2294,7 @@ sub ignoreresultcode {
 # Put the given runner ID onto the queue of runners ready for a new task
 #
 sub runnerready {
-    my ($runnerid)=@_;
+    my ($runnerid) = @_;
     push @runnersidle, $runnerid;
 }
 
@@ -2302,7 +2302,7 @@ sub runnerready {
 # Create test runners
 #
 sub createrunners {
-    my ($numrunners)=@_;
+    my ($numrunners) = @_;
     if(! $numrunners) {
         $numrunners++;
     }
@@ -2320,7 +2320,7 @@ sub createrunners {
 # Pick a test runner for the given test
 #
 sub pickrunner {
-    my ($testnum)=@_;
+    my ($testnum) = @_;
     scalar(@runnersidle) || die "No runners available";
 
     return pop @runnersidle;
@@ -2340,17 +2340,17 @@ if(@ARGV && $ARGV[-1] eq '$TFLAGS') {
 $args = join(' ', @ARGV);
 
 $valgrind = checktestcmd("valgrind");
-my $number=0;
-my $fromnum=-1;
+my $number = 0;
+my $fromnum = -1;
 my @testthis;
 while(@ARGV) {
     if($ARGV[0] eq "-v") {
         # verbose output
-        $verbose=1;
+        $verbose = 1;
     }
     elsif($ARGV[0] eq "-c") {
         # use this path to curl instead of default
-        $DBGCURL=$CURL=$ARGV[1];
+        $DBGCURL = $CURL = $ARGV[1];
         shift @ARGV;
     }
     elsif($ARGV[0] eq "-vc") {
@@ -2360,29 +2360,29 @@ while(@ARGV) {
         # the development version as then it will not be able to run any tests
         # since it cannot verify the servers!
 
-        $VCURL=shell_quote($ARGV[1]);
+        $VCURL = shell_quote($ARGV[1]);
         shift @ARGV;
     }
     elsif($ARGV[0] eq "-ac") {
         # use this curl only to talk to APIs (currently only CI test APIs)
-        $ACURL=shell_quote($ARGV[1]);
+        $ACURL = shell_quote($ARGV[1]);
         shift @ARGV;
     }
     elsif($ARGV[0] eq "-d") {
         # have the servers display protocol output
-        $debugprotocol=1;
+        $debugprotocol = 1;
     }
     elsif(($ARGV[0] eq "-e") || ($ARGV[0] eq "--test-event")) {
         # run the tests cases event based if possible
-        $run_event_based=1;
+        $run_event_based = 1;
     }
     elsif($ARGV[0] eq "--test-duphandle") {
         # run the tests with --test-duphandle
-        $run_duphandle=1;
+        $run_duphandle = 1;
     }
     elsif($ARGV[0] eq "-f") {
         # force - run the test case even if listed in DISABLED
-        $run_disabled=1;
+        $run_disabled = 1;
     }
     elsif($ARGV[0] eq "-E") {
         # load additional reasons to skip tests
@@ -2408,33 +2408,33 @@ while(@ARGV) {
     }
     elsif($ARGV[0] eq "-g") {
         # run this test with gdb
-        $gdbthis=1;
+        $gdbthis = 1;
     }
     elsif($ARGV[0] eq "-gl") {
         # run this test with lldb
-        $gdbthis=2;
+        $gdbthis = 2;
     }
     elsif($ARGV[0] eq "-gw") {
         # run this test with windowed gdb
-        $gdbthis=1;
-        $gdbxwin=1;
+        $gdbthis = 1;
+        $gdbxwin = 1;
     }
     elsif($ARGV[0] eq "-s") {
         # short output
-        $short=1;
+        $short = 1;
     }
     elsif($ARGV[0] eq "-am") {
         # automake-style output
-        $short=1;
-        $automakestyle=1;
+        $short = 1;
+        $automakestyle = 1;
     }
     elsif($ARGV[0] =~ /-m=(\d+)/) {
-        my ($num)=($1);
-        $maxtime=$num;
+        my ($num) = ($1);
+        $maxtime = $num;
     }
     elsif($ARGV[0] =~ /--min=(\d+)/) {
-        my ($num)=($1);
-        $mintotal=$num;
+        my ($num) = ($1);
+        $mintotal = $num;
     }
     elsif($ARGV[0] eq "-n") {
         # no valgrind
@@ -2446,11 +2446,11 @@ while(@ARGV) {
     }
     elsif($ARGV[0] eq "-R") {
         # execute in scrambled order
-        $scrambleorder=1;
+        $scrambleorder = 1;
     }
     elsif($ARGV[0] =~ /^-t(.*)/) {
         # torture
-        $torture=1;
+        $torture = 1;
         my $xtra = $1;
 
         if($xtra =~ s/(\d+)$//) {
@@ -2460,8 +2460,8 @@ while(@ARGV) {
     elsif($ARGV[0] =~ /--shallow=(\d+)/) {
         # Fail no more than this amount per tests when running
         # torture.
-        my ($num)=($1);
-        $shallow=$num;
+        my ($num) = ($1);
+        $shallow = $num;
     }
     elsif($ARGV[0] =~ /--repeat=(\d+)/) {
         # Repeat-run the given tests this many times
@@ -2477,7 +2477,7 @@ while(@ARGV) {
     }
     elsif($ARGV[0] eq "-a") {
         # continue anyway, even if a test fail
-        $anyway=1;
+        $anyway = 1;
     }
     elsif($ARGV[0] eq "-o") {
         shift @ARGV;
@@ -2489,11 +2489,11 @@ while(@ARGV) {
         }
     }
     elsif($ARGV[0] eq "-p") {
-        $postmortem=1;
+        $postmortem = 1;
     }
     elsif($ARGV[0] eq "-P") {
         shift @ARGV;
-        $proxy_address=$ARGV[0];
+        $proxy_address = $ARGV[0];
     }
     elsif($ARGV[0] eq "-L") {
         # require additional library file
@@ -2502,14 +2502,14 @@ while(@ARGV) {
     }
     elsif($ARGV[0] eq "-l") {
         # lists the test case names only
-        $listonly=1;
+        $listonly = 1;
     }
     elsif($ARGV[0] eq "--buildinfo") {
-        $buildinfo=1;
+        $buildinfo = 1;
     }
     elsif($ARGV[0] =~ /^-j(.*)/) {
         # parallel jobs
-        $jobs=1;
+        $jobs = 1;
         my $xtra = $1;
         if($xtra =~ s/(\d+)$//) {
             $jobs = $1;
@@ -2517,7 +2517,7 @@ while(@ARGV) {
     }
     elsif($ARGV[0] eq "-k") {
         # keep stdout and stderr files after tests
-        $keepoutfiles=1;
+        $keepoutfiles = 1;
     }
     elsif($ARGV[0] eq "-r") {
         # run time statistics needs Time::HiRes
@@ -2530,8 +2530,8 @@ while(@ARGV) {
             keys(%timetoolend) = 2000;
             keys(%timesrvrlog) = 2000;
             keys(%timevrfyend) = 2000;
-            $timestats=1;
-            $fullstats=0;
+            $timestats = 1;
+            $fullstats = 0;
         }
     }
     elsif($ARGV[0] eq "-rf") {
@@ -2545,13 +2545,13 @@ while(@ARGV) {
             keys(%timetoolend) = 2000;
             keys(%timesrvrlog) = 2000;
             keys(%timevrfyend) = 2000;
-            $timestats=1;
-            $fullstats=1;
+            $timestats = 1;
+            $fullstats = 1;
         }
     }
     elsif($ARGV[0] eq "-u") {
         # error instead of warning on server unexpectedly alive
-        $err_unexpected=1;
+        $err_unexpected = 1;
     }
     elsif(($ARGV[0] eq "-h") || ($ARGV[0] eq "--help")) {
         # show help text
@@ -2620,20 +2620,20 @@ EOHELP
     }
     elsif($ARGV[0] =~ /^!(\d+)/) {
         $fromnum = -1;
-        $disabled{$1}=$1;
+        $disabled{$1} = $1;
     }
     elsif($ARGV[0] =~ /^~(\d+)/) {
         $fromnum = -1;
-        $ignored{$1}=$1;
+        $ignored{$1} = $1;
     }
     elsif($ARGV[0] =~ /^!(.+)/) {
-        $disabled_keywords{lc($1)}=$1;
+        $disabled_keywords{lc($1)} = $1;
     }
     elsif($ARGV[0] =~ /^~(.+)/) {
-        $ignored_keywords{lc($1)}=$1;
+        $ignored_keywords{lc($1)} = $1;
     }
     elsif($ARGV[0] =~ /^([-[{a-zA-Z].*)/) {
-        $enabled_keywords{lc($1)}=$1;
+        $enabled_keywords{lc($1)} = $1;
     }
     else {
         print "Unknown option: $ARGV[0]\n";
@@ -2645,8 +2645,7 @@ EOHELP
 delete $ENV{'DEBUGINFOD_URLS'} if($ENV{'DEBUGINFOD_URLS'} && $no_debuginfod);
 
 if(!$randseed) {
-    my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
-        localtime(time);
+    my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst) = localtime(time);
     # seed of the month. December 2019 becomes 201912
     $randseed = ($year + 1900) * 100 + $mon + 1;
     print "Using curl: $CURL\n";
@@ -2661,7 +2660,7 @@ if(!$randseed) {
 srand $randseed;
 
 if(@testthis && ($testthis[0] ne "")) {
-    $TESTCASES=join(" ", @testthis);
+    $TESTCASES = join(" ", @testthis);
 }
 
 if($valgrind) {
@@ -2681,27 +2680,27 @@ if($valgrind) {
         # that old version any longer and delete this check)
         runclient("valgrind --help 2>&1 | grep -- --tool >$dev_null 2>&1");
         if(($? >> 8)) {
-            $valgrind_tool="";
+            $valgrind_tool = "";
         }
         open(my $curlh, "<", $CURL);
         my $l = <$curlh>;
         if($l =~ /^\#\!/) {
             # A shell script. This is typically when built with libtool,
-            $valgrind="../libtool --mode=execute $valgrind";
+            $valgrind = "../libtool --mode=execute $valgrind";
         }
         close($curlh);
 
         # valgrind 3 renamed the --logfile option to --log-file!!!
         # (this happened in 2005, so we could probably do not need to care about
         # that old version any longer and delete this check)
-        my $ver=join(' ', runclientoutput("valgrind --version"));
+        my $ver = join(' ', runclientoutput("valgrind --version"));
         # cut off all but digits and dots
         $ver =~ s/[^0-9.]//g;
 
         if($ver =~ /^(\d+)/) {
             $ver = $1;
             if($ver < 3) {
-                $valgrind_logfile="--logfile";
+                $valgrind_logfile = "--logfile";
             }
         }
     }
@@ -2804,7 +2803,7 @@ sub disabledtests {
         for my $t (@pp) {
             if($t =~ /(\d+)/) {
                 my ($n) = $1;
-                $disabled{$n}=$n; # disable this test number
+                $disabled{$n} = $n; # disable this test number
                 if(! -f "$srcdir/data/test$n") {
                     print STDERR "WARNING! Non-existing test $n in $file!\n";
                     # fail hard to make user notice
@@ -2834,7 +2833,7 @@ if($TESTCASES eq "all") {
     my @cmds = grep { /^test([0-9]+)$/ && -f "$TESTDIR/$_" } readdir(DIR);
     closedir(DIR);
 
-    $TESTCASES=""; # start with no test cases
+    $TESTCASES = ""; # start with no test cases
 
     # cut off everything but the digits
     for(@cmds) {
@@ -2846,17 +2845,17 @@ if($TESTCASES eq "all") {
             # skip disabled test cases
             my $why = "configured as DISABLED";
             $skipped{$why}++;
-            $teststat[$n]=$why; # store reason for this test case
+            $teststat[$n] = $why; # store reason for this test case
             next;
         }
         $TESTCASES .= " $n";
     }
 }
 else {
-    my $verified="";
+    my $verified = "";
     for(split(" ", $TESTCASES)) {
         if(-e "$TESTDIR/test$_") {
-            $verified.="$_ ";
+            $verified .= "$_ ";
         }
     }
     if($verified eq "") {
@@ -2884,7 +2883,7 @@ if($scrambleorder) {
         }
         my $r = rand @all;
         push @rand, $all[$r];
-        $all[$r]="";
+        $all[$r] = "";
         $TESTCASES = join(" ", @all);
     }
     $TESTCASES = join(" ", @rand);
@@ -2893,7 +2892,7 @@ if($scrambleorder) {
 # Display the contents of the given file.  Line endings are canonicalized
 # and excessively long files are elided
 sub displaylogcontent {
-    my ($file)=@_;
+    my ($file) = @_;
     if(open(my $single, "<", $file)) {
         my $linecount = 0;
         my $truncate;
@@ -2931,7 +2930,7 @@ sub displaylogcontent {
 }
 
 sub displaylogs {
-    my ($runnerid, $testnum)=@_;
+    my ($runnerid, $testnum) = @_;
     my $logdir = getrunnerlogdir($runnerid);
     opendir(DIR, $logdir) ||
         die "cannot open dir: $!";
@@ -2995,15 +2994,15 @@ sub displaylogs {
 my $failed;
 my $failedign;
 my $failedre;
-my $ok=0;
-my $ign=0;
-my $total=0;
-my $executed=0;
-my $retry_done=0;
-my $lasttest=0;
+my $ok = 0;
+my $ign = 0;
+my $total = 0;
+my $executed = 0;
+my $retry_done = 0;
+my $lasttest = 0;
 my @at = split(" ", $TESTCASES);
-my $count=0;
-my $endwaitcnt=0;
+my $count = 0;
+my $endwaitcnt = 0;
 
 $start = time();
 
@@ -3265,7 +3264,7 @@ if($all) {
 }
 
 if(%skipped && !$short) {
-    my $s=0;
+    my $s = 0;
     # Temporary hash to print the restraints sorted by the number
     # of their occurrences
     my %restraints;
@@ -3279,7 +3278,7 @@ if(%skipped && !$short) {
 
         # now gather all test case numbers that had this reason for being
         # skipped
-        my $c=0;
+        my $c = 0;
         my $max = 9;
         for(0 .. scalar @teststat) {
             my $t = $_;

--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -48,7 +48,7 @@ use pathhelp;
 
 my $stunnel = "stunnel";
 
-my $verbose=0; # set to 1 for debugging
+my $verbose = 0; # set to 1 for debugging
 
 my $accept_port = 8991; # our default, weird enough
 my $target_port = 8999; # default test http-server port

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -77,8 +77,7 @@ our $logfile;  # server log filename, for logmsg
 #
 sub logmsg {
     my ($seconds, $usec) = Time::HiRes::gettimeofday();
-    my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
-        localtime($seconds);
+    my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday, $isdst) = localtime($seconds);
     my $now = sprintf("%02d:%02d:%02d.%06d ", $hour, $min, $sec, $usec);
     # we see warnings on Windows run that $logfile is used uninitialized
     # TODO: not found yet where this comes from

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -119,32 +119,32 @@ use testutil qw(
 
 my %serverpidfile; # all server pid filenames, identified by server id
 my %serverportfile;# all server port filenames, identified by server id
-my $sshdvernum;  # for socks server, ssh daemon version number
-my $sshdverstr;  # for socks server, ssh daemon version string
-my $sshderror;   # for socks server, ssh daemon version error
-my %doesntrun;    # servers that do not work, identified by pidfile
+my $sshdvernum;    # for socks server, ssh daemon version number
+my $sshdverstr;    # for socks server, ssh daemon version string
+my $sshderror;     # for socks server, ssh daemon version error
+my %doesntrun;     # servers that do not work, identified by pidfile
 my %PORT = (nolisten => 47); # port we use for a local non-listening service
-my $server_response_maxtime=13;
+my $server_response_maxtime = 13;
 my $httptlssrv = find_httptlssrv();
-my %run;          # running server
-my %runcert;      # cert file currently in use by an SSL running server
-my $CLIENTIP="127.0.0.1";  # address which curl uses for incoming connections
-my $CLIENT6IP="[::1]";     # address which curl uses for incoming connections
+my %run;           # running server
+my %runcert;       # cert file currently in use by an SSL running server
+my $CLIENTIP = "127.0.0.1";  # address which curl uses for incoming connections
+my $CLIENT6IP = "[::1]";     # address which curl uses for incoming connections
 my $posix_pwd = build_sys_abs_path($pwd);  # current working directory in POSIX format
-my $h2cver = "h2c"; # this version is decided by the nghttp2 lib being used
-my $HOSTIP="127.0.0.1";    # address on which the test server listens
-my $HOST6IP="[::1]";       # address on which the test server listens
-my $HTTPUNIXPATH;          # HTTP server Unix domain socket path
-my $SOCKSUNIXPATH;         # socks server Unix domain socket path
+my $h2cver = "h2c";          # this version is decided by the nghttp2 lib being used
+my $HOSTIP = "127.0.0.1";    # address on which the test server listens
+my $HOST6IP = "[::1]";       # address on which the test server listens
+my $HTTPUNIXPATH;            # HTTP server Unix domain socket path
+my $SOCKSUNIXPATH;           # socks server Unix domain socket path
 my $SSHSRVMD5 = "[uninitialized]";    # MD5 of ssh server public key
 my $SSHSRVSHA256 = "[uninitialized]"; # SHA256 of ssh server public key
-my $USER;                  # name of the current user
-my $sshdid;                # for socks server, ssh daemon version id
-my $ftpchecktime=1;        # time it took to verify our test FTP server
+my $USER;                    # name of the current user
+my $sshdid;                  # for socks server, ssh daemon version id
+my $ftpchecktime = 1;        # time it took to verify our test FTP server
 my $SERVER_TIMEOUT_SEC = 15; # time for a server to spin up
 
 # Variables shared with runtests.pl
-our $SOCKSIN="socksd-request.log"; # what curl sent to the SOCKS proxy
+our $SOCKSIN = "socksd-request.log"; # what curl sent to the SOCKS proxy
 our $err_unexpected; # error instead of warning on server unexpectedly alive
 our $debugprotocol;  # nonzero for verbose server logs
 our $stunnel;        # path to stunnel command
@@ -153,15 +153,15 @@ our $stunnel;        # path to stunnel command
 # Check for a command in the PATH of the test server.
 #
 sub checkcmd {
-    my ($cmd, @extrapaths)=@_;
+    my ($cmd, @extrapaths) = @_;
     my @paths;
     if($^O eq 'MSWin32' || $^O eq 'dos' || $^O eq 'os2') {
         # PATH separator is different
-        @paths=(split(';', $ENV{'PATH'}), @extrapaths);
+        @paths = (split(';', $ENV{'PATH'}), @extrapaths);
     }
     else {
-        @paths=(split(':', $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
-                "/sbin", "/usr/bin", "/usr/local/bin", @extrapaths);
+        @paths = (split(':', $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
+                  "/sbin", "/usr/bin", "/usr/local/bin", @extrapaths);
     }
     for(@paths) {
         if(-x "$_/$cmd" . exe_ext('SYS') && ! -d "$_/$cmd" . exe_ext('SYS')) {
@@ -291,7 +291,7 @@ sub checkdied {
 #          4 for an unsupported server type
 #
 sub serverfortest {
-    my (@what)=@_;
+    my (@what) = @_;
 
     for(my $i = scalar(@what) - 1; $i >= 0; $i--) {
         my $srvrline = $what[$i];
@@ -332,7 +332,7 @@ sub serverfortest {
 # Return the pids (yes plural) of the new child process to the parent.
 #
 sub startnew {
-    my ($cmd, $pidfile, $timeout, $fakepidfile)=@_;
+    my ($cmd, $pidfile, $timeout, $fakepidfile) = @_;
 
     logmsg "startnew: $cmd\n" if($verbose);
 
@@ -515,7 +515,7 @@ sub getexternalproxyflags {
 sub verifyhttp {
     my ($proto, $ipvnum, $idnum, $ip, $port_or_path, $do_http3) = @_;
     my $server = servername_id($proto, $ipvnum, $idnum);
-    my $bonus="";
+    my $bonus = "";
     # $port_or_path contains a path for Unix sockets, sws ignores the port
     my $port = ($ipvnum eq "unix") ? 80 : $port_or_path;
     my $infix = ($do_http3) ? "_h3" : "";
@@ -530,7 +530,7 @@ sub verifyhttp {
 
     if($proto eq "gopher") {
         # gopher is funny
-        $bonus="1/";
+        $bonus = "1/";
     }
 
     my $flags = "--max-time $server_response_maxtime ";
@@ -602,8 +602,8 @@ sub verifyhttp {
 sub verifyftp {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
     my $server = servername_id($proto, $ipvnum, $idnum);
-    my $time=time();
-    my $extra="";
+    my $time = time();
+    my $extra = "";
 
     my $verifylog = "$LOGDIR/".
         servername_canon($proto, $ipvnum, $idnum) .'_verify.log';
@@ -894,8 +894,8 @@ sub verifypid {
 sub verifysmb {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
     my $server = servername_id($proto, $ipvnum, $idnum);
-    my $time=time();
-    my $extra="";
+    my $time = time();
+    my $extra = "";
 
     my $verifylog = "$LOGDIR/".
         servername_canon($proto, $ipvnum, $idnum) .'_verify.log';
@@ -954,8 +954,8 @@ sub verifysmb {
 sub verifytelnet {
     my ($proto, $ipvnum, $idnum, $ip, $port) = @_;
     my $server = servername_id($proto, $ipvnum, $idnum);
-    my $time=time();
-    my $extra="";
+    my $time = time();
+    my $extra = "";
 
     my $verifylog = "$LOGDIR/".
         servername_canon($proto, $ipvnum, $idnum) .'_verify.log';
@@ -1164,7 +1164,7 @@ sub runhttpserver {
 #
 sub runhttp2server {
     my ($verb) = @_;
-    my $proto="http/2";
+    my $proto = "http/2";
     my $ipvnum = 4;
     my $idnum = 0;
     my $exe = "$perl " . shell_quote("$srcdir/http2-server.pl");
@@ -1225,7 +1225,7 @@ sub runhttp2server {
 #
 sub runhttp3server {
     my ($verb, $cert) = @_;
-    my $proto="http/3";
+    my $proto = "http/3";
     my $ipvnum = 4;
     my $idnum = 0;
     my $exe = "$perl " . shell_quote("$srcdir/http3-server.pl");
@@ -1676,7 +1676,7 @@ sub rundnsserver {
     my $portfile = $serverportfile{$server};
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
 
-    my $cmd=server_exe('dnsd');
+    my $cmd = server_exe('dnsd');
     $cmd .= " --port 0";
     $cmd .= " --verbose" if($debugprotocol);
     $cmd .= " --pidfile \"$pidfile\"";
@@ -1800,7 +1800,7 @@ sub sshkeyalgostr {
 #
 sub runsshserver {
     my ($id, $verb, $ipv6) = @_;
-    my $ip=$HOSTIP;
+    my $ip = $HOSTIP;
     my $proto = 'ssh';
     my $ipvnum = 4;
     my $idnum = ($id && ($id =~ /^(\d+)$/) && ($id > 1)) ? $id : 1;
@@ -1925,7 +1925,7 @@ sub runsshserver {
 #
 sub runmqttserver {
     my ($id, $verb, $ipv6) = @_;
-    my $ip=$HOSTIP;
+    my $ip = $HOSTIP;
     my $proto = 'mqtt';
     my $port = protoport($proto);
     my $ipvnum = 4;
@@ -1951,7 +1951,7 @@ sub runmqttserver {
 
     unlink($portfile); # need to see a new one
     # start our MQTT server - on a random port!
-    my $cmd=server_exe('mqttd').
+    my $cmd = server_exe('mqttd').
         " --port 0".
         " --pidfile $pidfile".
         " --portfile $portfile".
@@ -1988,7 +1988,7 @@ sub runmqttserver {
 #
 sub runsocksserver {
     my ($id, $verb, $ipv6, $is_unix) = @_;
-    my $ip=$HOSTIP;
+    my $ip = $HOSTIP;
     my $proto = 'socks';
     my $ipvnum = 4;
     my $idnum = ($id && ($id =~ /^(\d+)$/) && ($id > 1)) ? $id : 1;
@@ -2014,9 +2014,9 @@ sub runsocksserver {
 
     unlink($portfile); # need to see a new one
     # start our socks server, get commands from the FTP cmd file
-    my $cmd="";
+    my $cmd = "";
     if($is_unix) {
-        $cmd=server_exe('socksd').
+        $cmd = server_exe('socksd').
             " --pidfile $pidfile".
             " --reqfile $LOGDIR/$SOCKSIN".
             " --logfile $logfile".
@@ -2025,7 +2025,7 @@ sub runsocksserver {
             " --config $LOGDIR/$SERVERCMD";
         $portfile = "none";
     } else {
-        $cmd=server_exe('socksd').
+        $cmd = server_exe('socksd').
             " --port 0".
             " --pidfile $pidfile".
             " --portfile $portfile".
@@ -2433,7 +2433,7 @@ sub startservers {
                     return ("failed starting ". uc($what) ." server", $serr);
                 }
                 logmsg sprintf("* pid $what => %d %d\n", $pid, $pid2) if($verbose);
-                $run{$what}="$pid $pid2";
+                $run{$what} = "$pid $pid2";
             }
         }
         elsif($what eq "ftp-ipv6") {
@@ -2450,7 +2450,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid ftp-ipv6 => %d %d\n", $pid,
                        $pid2) if($verbose);
-                $run{'ftp-ipv6'}="$pid $pid2";
+                $run{'ftp-ipv6'} = "$pid $pid2";
             }
         }
         elsif($what eq "gopher") {
@@ -2469,7 +2469,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid gopher => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'gopher'}="$pid $pid2";
+                $run{'gopher'} = "$pid $pid2";
             }
         }
         elsif($what eq "gopher-ipv6") {
@@ -2488,7 +2488,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid gopher-ipv6 => %d %d\n", $pid,
                                $pid2) if($verbose);
-                $run{'gopher-ipv6'}="$pid $pid2";
+                $run{'gopher-ipv6'} = "$pid $pid2";
             }
         }
         elsif($what eq "http") {
@@ -2507,7 +2507,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid http => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'http'}="$pid $pid2";
+                $run{'http'} = "$pid $pid2";
             }
         }
         elsif($what eq "http-proxy") {
@@ -2526,7 +2526,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid http-proxy => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'http-proxy'}="$pid $pid2";
+                $run{'http-proxy'} = "$pid $pid2";
             }
         }
         elsif($what eq "http-ipv6") {
@@ -2545,7 +2545,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid http-ipv6 => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'http-ipv6'}="$pid $pid2";
+                $run{'http-ipv6'} = "$pid $pid2";
             }
         }
         elsif($what eq "rtsp") {
@@ -2561,7 +2561,7 @@ sub startservers {
                     return ("failed starting RTSP server", $serr);
                 }
                 logmsg sprintf("* pid rtsp => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'rtsp'}="$pid $pid2";
+                $run{'rtsp'} = "$pid $pid2";
             }
         }
         elsif($what eq "rtsp-ipv6") {
@@ -2578,7 +2578,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid rtsp-ipv6 => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'rtsp-ipv6'}="$pid $pid2";
+                $run{'rtsp-ipv6'} = "$pid $pid2";
             }
         }
         elsif($what =~ /^(ftp|imap|pop3|smtp)s$/) {
@@ -2605,7 +2605,7 @@ sub startservers {
                     return ("failed starting $cproto server", $serr);
                 }
                 logmsg sprintf("* pid $cproto => %d %d\n", $pid, $pid2) if($verbose);
-                $run{$cproto}="$pid $pid2";
+                $run{$cproto} = "$pid $pid2";
             }
             if(!$run{$what}) {
                 ($serr, $pid, $pid2, $PORT{$what}) =
@@ -2616,7 +2616,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid $what => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{$what}="$pid $pid2";
+                $run{$what} = "$pid $pid2";
             }
         }
         elsif($what eq "file") {
@@ -2663,7 +2663,7 @@ sub startservers {
                     return ("failed starting HTTP server (for https/https-mtls)", $serr);
                 }
                 logmsg sprintf("* pid http => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'http'}="$pid $pid2";
+                $run{'http'} = "$pid $pid2";
             }
             if(!$run{$what}) {
                 ($serr, $pid, $pid2, $PORT{$what}) =
@@ -2673,7 +2673,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid $what => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{$what}="$pid $pid2";
+                $run{$what} = "$pid $pid2";
             }
         }
         elsif($what eq "http/2") {
@@ -2704,7 +2704,7 @@ sub startservers {
                     return ("failed starting HTTP server (for http/2)", $serr);
                 }
                 logmsg sprintf("* pid http => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'http'}="$pid $pid2";
+                $run{'http'} = "$pid $pid2";
             }
             if(!$run{'http/2'}) {
                 ($serr, $pid, $pid2, $PORT{"http2"}, $PORT{"http2tls"}) =
@@ -2714,7 +2714,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid http/2 => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'http/2'}="$pid $pid2";
+                $run{'http/2'} = "$pid $pid2";
             }
         }
         elsif($what eq "http/3") {
@@ -2745,7 +2745,7 @@ sub startservers {
                     return ("failed starting HTTP server (for http/3)", $serr);
                 }
                 logmsg sprintf("* pid http => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'http'}="$pid $pid2";
+                $run{'http'} = "$pid $pid2";
             }
             if(!$run{'http/3'}) {
                 ($serr, $pid, $pid2, $PORT{"http3"}) = runhttp3server($verbose);
@@ -2754,7 +2754,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid http/3 => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'http/3'}="$pid $pid2";
+                $run{'http/3'} = "$pid $pid2";
             }
         }
         elsif($what eq "gophers") {
@@ -2777,15 +2777,14 @@ sub startservers {
             }
             if(!$run{'gopher'}) {
                 my $port;
-                ($serr, $pid, $pid2, $port) =
-                    runhttpserver("gopher", $verbose, 0);
+                ($serr, $pid, $pid2, $port) = runhttpserver("gopher", $verbose, 0);
                 $PORT{'gopher'} = $port;
                 if($pid <= 0) {
                     return ("failed starting GOPHER server", $serr);
                 }
                 logmsg sprintf("* pid gopher => %d %d\n", $pid, $pid2) if($verbose);
                 logmsg "GOPHERPORT => $port\n" if($verbose);
-                $run{'gopher'}="$pid $pid2";
+                $run{'gopher'} = "$pid $pid2";
             }
             if(!$run{'gophers'}) {
                 my $port;
@@ -2798,7 +2797,7 @@ sub startservers {
                 logmsg sprintf("* pid gophers => %d %d\n", $pid, $pid2)
                     if($verbose);
                 logmsg "GOPHERSPORT => $port\n" if($verbose);
-                $run{'gophers'}="$pid $pid2";
+                $run{'gophers'} = "$pid $pid2";
             }
         }
         elsif($what eq "https-proxy") {
@@ -2829,7 +2828,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid https-proxy => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'https-proxy'}="$pid $pid2";
+                $run{'https-proxy'} = "$pid $pid2";
             }
         }
         elsif($what eq "httptls") {
@@ -2851,7 +2850,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid httptls => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'httptls'}="$pid $pid2";
+                $run{'httptls'} = "$pid $pid2";
             }
         }
         elsif($what eq "httptls-ipv6") {
@@ -2873,7 +2872,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid httptls-ipv6 => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'httptls-ipv6'}="$pid $pid2";
+                $run{'httptls-ipv6'} = "$pid $pid2";
             }
         }
         elsif($what eq "dns") {
@@ -2890,7 +2889,7 @@ sub startservers {
                     return ("failed starting DNS server", $serr);
                 }
                 logmsg sprintf("* pid dns => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'dns'}="$pid $pid2";
+                $run{'dns'} = "$pid $pid2";
             }
         }
         elsif($what eq "tftp") {
@@ -2907,7 +2906,7 @@ sub startservers {
                     return ("failed starting TFTP server", $serr);
                 }
                 logmsg sprintf("* pid tftp => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'tftp'}="$pid $pid2";
+                $run{'tftp'} = "$pid $pid2";
             }
         }
         elsif($what eq "tftp-ipv6") {
@@ -2924,7 +2923,7 @@ sub startservers {
                     return ("failed starting TFTP-IPv6 server", $serr);
                 }
                 logmsg sprintf("* pid tftp-ipv6 => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'tftp-ipv6'}="$pid $pid2";
+                $run{'tftp-ipv6'} = "$pid $pid2";
             }
         }
         elsif($what eq "sftp" || $what eq "scp") {
@@ -2934,7 +2933,7 @@ sub startservers {
                     return ("failed starting SSH server", $serr);
                 }
                 logmsg sprintf("* pid ssh => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'ssh'}="$pid $pid2";
+                $run{'ssh'} = "$pid $pid2";
             }
         }
         elsif($what eq "socks4" || $what eq "socks5" ) {
@@ -2944,7 +2943,7 @@ sub startservers {
                     return ("failed starting socks server", $serr);
                 }
                 logmsg sprintf("* pid socks => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'socks'}="$pid $pid2";
+                $run{'socks'} = "$pid $pid2";
             }
         }
         elsif($what eq "socks5unix") {
@@ -2954,7 +2953,7 @@ sub startservers {
                     return ("failed starting socks5unix server", $serr);
                 }
                 logmsg sprintf("* pid socks5unix => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'socks5unix'}="$pid $pid2";
+                $run{'socks5unix'} = "$pid $pid2";
             }
         }
         elsif($what eq "mqtt" ) {
@@ -2970,7 +2969,7 @@ sub startservers {
                     return ("failed starting mqtt server", $serr);
                 }
                 logmsg sprintf("* pid mqtt => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'mqtt'}="$pid $pid2";
+                $run{'mqtt'} = "$pid $pid2";
             }
         }
         elsif($what eq "mqtts" ) {
@@ -2990,7 +2989,7 @@ sub startservers {
                     return ("failed starting mqtt server", $serr);
                 }
                 logmsg sprintf("* pid mqtt => %d %d\n", $pid, $pid2) if($verbose);
-                $run{'mqtt'}="$pid $pid2";
+                $run{'mqtt'} = "$pid $pid2";
             }
             if(!$run{$what}) {
                 ($serr, $pid, $pid2, $PORT{$what}) =
@@ -3000,7 +2999,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid $what => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{$what}="$pid $pid2";
+                $run{$what} = "$pid $pid2";
             }
         }
         elsif($what eq "http-unix") {
@@ -3019,7 +3018,7 @@ sub startservers {
                 }
                 logmsg sprintf("* pid http-unix => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'http-unix'}="$pid $pid2";
+                $run{'http-unix'} = "$pid $pid2";
             }
         }
         elsif($what eq "dict") {
@@ -3030,7 +3029,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid DICT => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'dict'}="$pid $pid2";
+                $run{'dict'} = "$pid $pid2";
             }
         }
         elsif($what eq "smb") {
@@ -3041,7 +3040,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid SMB => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'smb'}="$pid $pid2";
+                $run{'smb'} = "$pid $pid2";
             }
         }
         elsif($what eq "telnet") {
@@ -3053,7 +3052,7 @@ sub startservers {
                 }
                 logmsg sprintf ("* pid neg TELNET => %d %d\n", $pid, $pid2)
                     if($verbose);
-                $run{'telnet'}="$pid $pid2";
+                $run{'telnet'} = "$pid $pid2";
             }
         }
         else {

--- a/tests/test1119.pl
+++ b/tests/test1119.pl
@@ -48,14 +48,14 @@ if(!$rc) {
 }
 
 # we may get the directory root pointed out
-my $root=$ARGV[0] || ".";
+my $root = $ARGV[0] || ".";
 
 # need an include directory when building out-of-tree
 my $i = ($ARGV[1]) ? "-I$ARGV[1] " : '';
 
-my $verbose=0;
-my $summary=0;
-my $misses=0;
+my $verbose = 0;
+my $summary = 0;
+my $misses = 0;
 
 my @manrefs;
 my @syms;
@@ -80,7 +80,7 @@ sub scanenum {
 }
 
 sub scanheader {
-    my ($f)=@_;
+    my ($f) = @_;
     open(my $h, "<", $f);
     while(<$h>) {
         if(/^#define ((LIB|)CURL[A-Za-z0-9_]*)/) {
@@ -146,24 +146,24 @@ scanman_md_dir("$root/docs/libcurl/opts");
 open(my $s, "<", "$root/docs/libcurl/symbols-in-versions");
 while(<$s>) {
     if(/(^[^ \n]+) +(.*)/) {
-        my ($sym, $rest)=($1, $2);
+        my ($sym, $rest) = ($1, $2);
         if($doc{$sym}) {
             print "Detected duplicate symbol: $sym\n";
             $misses++;
             next;
         }
-        $doc{$sym}=$sym;
-        my @a=split(/ +/, $rest);
+        $doc{$sym} = $sym;
+        my @a = split(/ +/, $rest);
         if($a[2]) {
             # this symbol is documented to have been present the last time
             # in this release
-            $rem{$sym}=$a[2];
+            $rem{$sym} = $a[2];
         }
     }
 }
 close $s;
 
-my $ignored=0;
+my $ignored = 0;
 for my $e (sort @syms) {
     # OBSOLETE - names that are placeholders for a position where we
     # previously had a name, that is now removed. The OBSOLETE names should
@@ -188,7 +188,7 @@ for my $e (sort @syms) {
         if($verbose) {
             print $e."\n";
         }
-        $doc{$e}="used";
+        $doc{$e} = "used";
         next;
     }
     else {
@@ -223,7 +223,7 @@ for my $e (sort keys %doc) {
 my %warned;
 for my $r (@manrefs) {
     if($r =~ /^([^:]+):(.*)/) {
-        my ($sym, $file)=($1, $2);
+        my ($sym, $file) = ($1, $2);
         if(!$doc{$sym} && !$warned{$sym, $file}) {
             print "$file: $sym is not a public symbol\n";
             $warned{$sym, $file} = 1;

--- a/tests/test1135.pl
+++ b/tests/test1135.pl
@@ -62,9 +62,9 @@ foreach (sort(@dir)) {
     }
 }
 
-my $verbose=0;
-my $summary=0;
-my $misses=0;
+my $verbose = 0;
+my $summary = 0;
+my $misses = 0;
 
 my @out;
 foreach my $f (@incs) {

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -42,11 +42,11 @@ use strict;
 use warnings;
 
 # we may get the directory roots pointed out
-my $root=$ARGV[0] || ".";
-my $buildroot=$ARGV[1] || ".";
+my $root = $ARGV[0] || ".";
+my $buildroot = $ARGV[1] || ".";
 my $syms = "$root/docs/libcurl/symbols-in-versions";
 my $curlh = "$root/include/curl/curl.h";
-my $errors=0;
+my $errors = 0;
 
 # the prepopulated alias list is the CURLINFO_* defines that are used for the
 # debug function callback and the fact that they use the same prefix as the
@@ -105,7 +105,7 @@ open($r, "<", $curlh) ||
     die "no curl.h";
 while(<$r>) {
     if(/^\#define (CURL(OPT|INFO|MOPT)_\w+) (.*)/) {
-        $alias{$1}=$3;
+        $alias{$1} = $3;
     }
 }
 close($r);
@@ -198,11 +198,11 @@ while(<$r>) {
     $no++;
     chomp;
     if(/struct LongShort aliases/) {
-        $list=1;
+        $list = 1;
     }
     elsif($list) {
         if(/^  \{(\"[^,]*\").*\'(.)\',/) {
-            my ($l, $s)=($1, $2);
+            my ($l, $s) = ($1, $2);
             my $sh;
             my $lo;
             my $title;
@@ -212,12 +212,12 @@ while(<$r>) {
             if($l =~ /\"(.*)\"/) {
                 # long option
                 $lo = $1;
-                $title="--$lo";
+                $title = "--$lo";
             }
             if($s ne " ") {
                 # a short option
                 $sh = $s;
-                $title="-$sh, $title";
+                $title = "-$sh, $title";
             }
             push @getparam, $title;
             $opts{$title} |= 1;
@@ -265,7 +265,7 @@ while(<$r>) {
     chomp;
     my $l= $_;
     if(/^  \{ \" *(.*)/) {
-        my $str=$1;
+        my $str = $1;
         my $combo;
         if($str =~ /^-(.), --([a-z0-9.-]*)/) {
             # figure out the -short, --long combo
@@ -295,10 +295,10 @@ foreach my $o (keys %opts) {
         my $exists;
         my $missing;
         if($where & 1) {
-            $exists=" tool_getparam.c";
+            $exists = " tool_getparam.c";
         }
         else {
-            $missing=" tool_getparam.c";
+            $missing = " tool_getparam.c";
         }
         if($where & 2) {
             $exists.= " curl.1";

--- a/tests/test1140.pl
+++ b/tests/test1140.pl
@@ -50,7 +50,7 @@ sub manpresent {
     elsif(-r "$docsroot/$man" ||
           -r "$docsroot/libcurl/$man" ||
           -r "$docsroot/libcurl/opts/$man") {
-        $manp{$man}=1;
+        $manp{$man} = 1;
         return 1;
     }
     return 0;
@@ -65,7 +65,7 @@ sub file {
         chomp;
         my $l = $_;
         while($l =~ s/\\f(.)([^ ]*)\\f(.)//) {
-            my ($pre, $str, $post)=($1, $2, $3);
+            my ($pre, $str, $post) = ($1, $2, $3);
             if($str =~ /^\\f[ib]/i) {
                 print "error: $f:$line: double-highlight\n";
                 $errors++;

--- a/tests/test1165.pl
+++ b/tests/test1165.pl
@@ -38,15 +38,15 @@ my %file;
 my %docs;
 
 # we may get the directory root pointed out
-my $root=$ARGV[0] || ".";
-my $DOCS="CURL-DISABLE.md";
+my $root = $ARGV[0] || ".";
+my $DOCS = "CURL-DISABLE.md";
 
 sub scanconf {
-    my ($f)=@_;
+    my ($f) = @_;
     open S, "<$f";
     while(<S>) {
         if(/(CURL_DISABLE_[A-Z0-9_]+)/g) {
-            my ($sym)=($1);
+            my ($sym) = ($1);
             if(not $sym =~ /^(CURL_DISABLE_TYPECHECK)$/) {
                 $disable{$sym} = 1;
             }
@@ -67,11 +67,11 @@ sub scan_configure {
 }
 
 sub scanconf_cmake {
-    my ($hashr, $f)=@_;
+    my ($hashr, $f) = @_;
     open S, "<$f";
     while(<S>) {
         if(/(CURL_DISABLE_[A-Z0-9_]+)/g) {
-            my ($sym)=($1);
+            my ($sym) = ($1);
             if(not $sym =~ /^(CURL_DISABLE_INSTALL|CURL_DISABLE_SRP|CURL_DISABLE_TYPECHECK)$/) {
                 $hashr->{$sym} = 1;
             }
@@ -94,11 +94,11 @@ my %whitelisted = (
 );
 
 sub scan_file {
-    my ($source)=@_;
+    my ($source) = @_;
     open F, "<$source";
     while(<F>) {
         while(s/(CURL_DISABLE_[A-Z0-9_]+)//) {
-            my ($sym)=($1);
+            my ($sym) = ($1);
 
             if(!$whitelisted{$sym}) {
                 $file{$sym} = $source;
@@ -109,7 +109,7 @@ sub scan_file {
 }
 
 sub scan_dir {
-    my ($dir)=@_;
+    my ($dir) = @_;
     opendir(my $dh, $dir) || die "Cannot opendir $dir: $!";
     my @cfiles = grep { /\.[ch]\z/ && -f "$dir/$_" } readdir($dh);
     closedir $dh;
@@ -132,7 +132,7 @@ sub scan_docs {
     while(<F>) {
         $line++;
         if(/^## `(CURL_DISABLE_[A-Z0-9_]+)`/g) {
-            my ($sym)=($1);
+            my ($sym) = ($1);
             if(not $sym =~ /^(CURL_DISABLE_TYPECHECK)$/) {
                 $docs{$sym} = $line;
             }

--- a/tests/test1167.pl
+++ b/tests/test1167.pl
@@ -47,29 +47,29 @@ if(!$rc) {
     $Cpreprocessor = 'cpp';
 }
 
-my $verbose=0;
+my $verbose = 0;
 
 # verbose mode when -v is the first argument
 if($ARGV[0] eq "-v") {
-    $verbose=1;
+    $verbose = 1;
     shift;
 }
 
 # we may get the directory root pointed out
-my $root=$ARGV[0] || ".";
+my $root = $ARGV[0] || ".";
 
 # need an include directory when building out-of-tree
 my $i = ($ARGV[1]) ? "-I$ARGV[1] " : '';
 
 my $incdir = "$root/include/curl";
 
-my $summary=0;
-my $misses=0;
+my $summary = 0;
+my $misses = 0;
 
 my @syms;
 
 sub scanenums {
-    my ($file)=@_;
+    my ($file) = @_;
     my $skipit = 0;
 
     open H_IN, "-|", "$Cpreprocessor -DCURL_DISABLE_DEPRECATION $i$file" ||
@@ -117,7 +117,7 @@ sub scanenums {
 }
 
 sub scanheader {
-    my ($f)=@_;
+    my ($f) = @_;
     scanenums($f);
     open(H, '<', $f);
     while(<H>) {

--- a/tests/test1173.pl
+++ b/tests/test1173.pl
@@ -32,10 +32,10 @@ use warnings;
 use File::Basename;
 
 # get the filename first
-my $symbolsinversions=shift @ARGV;
+my $symbolsinversions = shift @ARGV;
 
 # we may get the directory roots pointed out
-my @manpages=@ARGV;
+my @manpages = @ARGV;
 my $errors = 0;
 
 my %docsdirs;
@@ -84,10 +84,10 @@ sub allsymbols {
     while(<$f>) {
         if($_ =~ /^([^ ]*) +(.*)/) {
             my ($name, $info) = ($1, $2);
-            $symbol{$name}=$name;
+            $symbol{$name} = $name;
 
             if($info =~ /([0-9.]+) +([0-9.]+)/) {
-                $deprecated{$name}=$info;
+                $deprecated{$name} = $info;
             }
         }
     }
@@ -98,7 +98,7 @@ my %ref = (
     'curl.1' => 1
     );
 sub checkref {
-    my ($f, $sec, $file, $line)=@_;
+    my ($f, $sec, $file, $line) = @_;
     my $present = 0;
     #print STDERR "check $f.$sec\n";
     if($ref{"$f.$sec"}) {
@@ -108,7 +108,7 @@ sub checkref {
     foreach my $d (keys %docsdirs) {
         if(-f "$d/$f.$sec") {
             $present = 1;
-            $ref{"$f.$sec"}=1;
+            $ref{"$f.$sec"} = 1;
             last;
         }
     }
@@ -140,7 +140,7 @@ sub scanmanpage {
     my $shc = 0;
     my $optpage = 0; # option or function
     my @sh;
-    my $SH="";
+    my $SH = "";
     my @separators;
     my @sepline;
 

--- a/tests/test1175.pl
+++ b/tests/test1175.pl
@@ -41,7 +41,7 @@ sub getdocserrors {
                 ;
             }
             else {
-                $docs{$symbol}=1;
+                $docs{$symbol} = 1;
             }
         }
     }
@@ -57,7 +57,7 @@ sub getincludeerrors {
                 # removed!
             }
             else {
-                $error{$symbol}=$added;
+                $error{$symbol} = $added;
             }
         }
     }

--- a/tests/test1177.pl
+++ b/tests/test1177.pl
@@ -30,14 +30,14 @@
 use strict;
 use warnings;
 
-my $manpage=$ARGV[0];
-my $header=$ARGV[1];
-my $source=$ARGV[2];
+my $manpage = $ARGV[0];
+my $header = $ARGV[1];
+my $source = $ARGV[2];
 my %manversion;
 my %headerversion;
 my %manname;
 my %sourcename;
-my $error=0;
+my $error = 0;
 
 open(my $m, "<", $manpage);
 while(<$m>) {

--- a/tests/test1222.pl
+++ b/tests/test1222.pl
@@ -54,7 +54,7 @@ my %optman;         # Option man pages deprecations.
 # Scan header file for public function and enum values. Flag them with
 # the version they are deprecated in, if some.
 sub scan_header {
-    my ($f)=@_;
+    my ($f) = @_;
     my $line = "";
     my $incomment = 0;
     my $inenum = 0;
@@ -147,7 +147,7 @@ sub scan_header {
 # Each option has to be declared as ".IP <option>" where <option> starts with
 # the prefix. Flag each option with its deprecation version, if some.
 sub scan_man_for_opts {
-    my ($f, $prefix)=@_;
+    my ($f, $prefix) = @_;
     my $opt = "";
     my $line = "";
 
@@ -184,7 +184,7 @@ sub scan_man_for_opts {
 
 # Scan man page for deprecation in DESCRIPTION and/or AVAILABILITY sections.
 sub scan_man_page {
-    my ($path, $sym, $table)=@_;
+    my ($path, $sym, $table) = @_;
     my $version = "X";
 
     if(open(my $fh, "<", $path)) {

--- a/tests/test1275.pl
+++ b/tests/test1275.pl
@@ -26,7 +26,7 @@
 use strict;
 use warnings;
 
-my $root=$ARGV[0] || "..";
+my $root = $ARGV[0] || "..";
 
 my @m;
 if(open(O, '-|', 'git', 'ls-files', '--', $root)) {
@@ -36,13 +36,13 @@ if(open(O, '-|', 'git', 'ls-files', '--', $root)) {
 
 my $errors = 0;
 
-my %accepted=('curl' => 1,
-              'libcurl' => 1,
-              'macOS' => 1,
-              'wolfSSL' => 1,
-              'mbedTLS' => 1,
-              'rustls' => 1,
-              'c-ares' => 1);
+my %accepted = ('curl' => 1,
+                'libcurl' => 1,
+                'macOS' => 1,
+                'wolfSSL' => 1,
+                'mbedTLS' => 1,
+                'rustls' => 1,
+                'c-ares' => 1);
 
 sub checkfile {
     my ($f) = @_;

--- a/tests/test1276.pl
+++ b/tests/test1276.pl
@@ -36,12 +36,12 @@ my $root = $ARGV[0] || '..';
 
 open(my $fh, "-|", 'perl', "$root/lib/optiontable.pl", "$root/include/curl/curl.h");
 binmode $fh;
-my @gen=<$fh>;
+my @gen = <$fh>;
 close($fh);
 
 open($fh, "<", "$root/lib/easyoptions.c");
 binmode $fh;
-my @file=<$fh>;
+my @file = <$fh>;
 close($fh);
 
 if(join("", @gen) ne join("", @file)) {

--- a/tests/test1477.pl
+++ b/tests/test1477.pl
@@ -30,11 +30,11 @@ use strict;
 use warnings;
 
 # we may get the directory roots pointed out
-my $root=$ARGV[0] || ".";
-my $buildroot=$ARGV[1] || ".";
+my $root = $ARGV[0] || ".";
+my $buildroot = $ARGV[1] || ".";
 my $manpge = "$buildroot/docs/libcurl/libcurl-errors.3";
 my $curlh = "$root/include/curl";
-my $errors=0;
+my $errors = 0;
 
 my @hnames;
 my %wherefrom;
@@ -42,19 +42,19 @@ my @mnames;
 my %manfrom;
 
 sub scanheader {
-    my ($file)=@_;
+    my ($file) = @_;
     open H, "<$file";
     my $line = 0;
     while(<H>) {
         $line++;
         if($_ =~ /^  (CURL(E|UE|SHE|HE|M)_[A-Z0-9_]*)/) {
-            my ($name)=($1);
+            my ($name) = ($1);
             if(($name !~ /(OBSOLETE|CURLE_RESERVED)/) && ($name !~ /_LAST\z/)) {
                 push @hnames, $name;
                 if($wherefrom{$name}) {
                     print STDERR "double: $name\n";
                 }
-                $wherefrom{$name}="$file:$line";
+                $wherefrom{$name} = "$file:$line";
             }
         }
     }
@@ -62,16 +62,16 @@ sub scanheader {
 }
 
 sub scanmanpage {
-    my ($file)=@_;
+    my ($file) = @_;
     open H, "<$file";
     my $line = 0;
     while(<H>) {
         $line++;
         if($_ =~ /^\.IP \"(CURL(E|UE|SHE|HE|M)_[A-Z0-9_]*)/) {
-            my ($name)=($1);
+            my ($name) = ($1);
             if($name !~ /(CURLM_CALL_MULTI_SOCKET)/) {
                 push @mnames, $name;
-                $manfrom{$name}="$file:$line";
+                $manfrom{$name} = "$file:$line";
             }
         }
     }

--- a/tests/test1486.pl
+++ b/tests/test1486.pl
@@ -27,7 +27,7 @@ use strict;
 use warnings;
 
 # we may get the directory root pointed out
-my $root=$ARGV[0] || ".";
+my $root = $ARGV[0] || ".";
 
 my %insrc; # variable set in source
 my %indocs; # variable described in docs

--- a/tests/test1488.pl
+++ b/tests/test1488.pl
@@ -49,7 +49,7 @@ if(!$rc) {
 }
 
 # we may get the directory root pointed out
-my $root=$ARGV[0] || ".";
+my $root = $ARGV[0] || ".";
 
 # need an include directory when building out-of-tree
 my $i = ($ARGV[1]) ? "-I$ARGV[1] " : '';
@@ -116,10 +116,10 @@ open my $s, "<", "$root/docs/libcurl/symbols-in-versions";
 while(<$s>) {
     chomp;
     if(/^(\S+) +([0-9.]*)/) {
-        my ($sym, $ver)=($1, $2);
+        my ($sym, $ver) = ($1, $2);
         push @syms, $sym;
 
-        $symadded{$sym}=$ver;
+        $symadded{$sym} = $ver;
         if(!$pastversion{$ver}) {
             printf "SIV: says $sym was added in non-existing %s\n", $ver;
             $error++;
@@ -128,7 +128,7 @@ while(<$s>) {
 }
 close $s;
 
-my $ignored=0;
+my $ignored = 0;
 for my $e (sort @syms) {
     if($manpage{$e}) {
         if($manpage{$e} ne $symadded{$e}) {

--- a/tests/test1544.pl
+++ b/tests/test1544.pl
@@ -30,14 +30,14 @@
 use strict;
 use warnings;
 
-my $root=$ARGV[0] || ".";
+my $root = $ARGV[0] || ".";
 my $incdir = "$root/include/curl";
 my $os400dir = "$root/projects/OS400";
 my $errcount = 0;
 
 # Scan header file for string option definitions.
 sub scan_header {
-    my ($f)=@_;
+    my ($f) = @_;
     my $line = "";
     my $incomment = 0;
     my @stringopts;
@@ -92,7 +92,7 @@ sub scan_header {
 
 # Scan projects/OS400/ccsidcurl.c for translatable string option cases.
 sub scan_wrapper_for_strings {
-    my ($f)=@_;
+    my ($f) = @_;
     my $inarmor = 0;
     my @stringopts;
 

--- a/tests/test745.pl
+++ b/tests/test745.pl
@@ -27,7 +27,7 @@ use strict;
 use warnings;
 
 # we may get the directory root pointed out
-my $root=$ARGV[0] || ".";
+my $root = $ARGV[0] || ".";
 
 my %typecheck; # from the include file
 my %enum; # from libcurl-errors.3

--- a/tests/test971.pl
+++ b/tests/test971.pl
@@ -43,7 +43,7 @@ my %oiv;
 my $error = 0;
 
 sub cmdfiles {
-    my ($dir)=@_;
+    my ($dir) = @_;
 
     opendir(my $dh, $dir) || die "Cannot opendir $dir: $!";
     my @opts = grep { /[a-z0-9].*\.md$/ && -f "$dir/$_" } readdir($dh);
@@ -51,7 +51,7 @@ sub cmdfiles {
 
     for(@opts) {
         $_ =~ s/\.md$//;
-        $file{$_}=1;
+        $file{$_} = 1;
     }
     return @opts;
 }
@@ -63,7 +63,7 @@ sub mentions {
     while(<$fh>) {
         chomp;
         if(/(.*) +([0-9.]+)/) {
-            my ($flag, $version)=($1, $2);
+            my ($flag, $version) = ($1, $2);
 
             # store the name without the leading dashes
             $flag =~ s/^--//;
@@ -85,7 +85,7 @@ sub mentions {
 }
 
 sub versioncheck {
-    my ($f, $v)=@_;
+    my ($f, $v) = @_;
     open(my $fh, "<", "$cmddir/$f.md");
     while(<$fh>) {
         chomp;

--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -78,21 +78,21 @@ use vars qw($name $email $desc $confopts $runtestopts $setupfile $mktarball
             $extvercmd $nogitpull $nobuildconf $crosscompile
             $timestamp $notes);
 
-$notes='';
-$runtestopts='';
+$notes = '';
+$runtestopts = '';
 
 # version of this script
-$version='2024-11-28';
-$fixed=0;
+$version = '2024-11-28';
+$fixed = 0;
 
 # Determine if we are running from git or a canned copy of curl,
 # or if we got a specific target option or setup file option.
-$CURLDIR="curl";
+$CURLDIR = "curl";
 if(-f ".git/config") {
     $CURLDIR = "./";
 }
 
-$git=1;
+$git = 1;
 $setupfile = 'setup';
 $configurebuild = 1;
 while($ARGV[0]) {
@@ -125,27 +125,27 @@ while($ARGV[0]) {
         shift @ARGV;
     }
     elsif(($ARGV[0] eq "--nocvsup") || ($ARGV[0] eq "--nogitpull")) {
-        $nogitpull=1;
+        $nogitpull = 1;
         shift @ARGV;
     }
     elsif($ARGV[0] =~ /--nobuildconf/) {
-        $nobuildconf=1;
+        $nobuildconf = 1;
         shift @ARGV;
     }
     elsif($ARGV[0] =~ /--noconfigure/) {
-        $configurebuild=0;
+        $configurebuild = 0;
         shift @ARGV;
     }
     elsif($ARGV[0] =~ /--crosscompile/) {
-        $crosscompile=1;
+        $crosscompile = 1;
         shift @ARGV;
     }
     elsif($ARGV[0] =~ /--runtestopts=/) {
         $runtestopts = (split(/=/, shift @ARGV, 2))[1];
     }
     else {
-        $CURLDIR=shift @ARGV;
-        $git=0; # a given dir, assume not using git
+        $CURLDIR = shift @ARGV;
+        $git = 0; # a given dir, assume not using git
     }
 }
 
@@ -182,9 +182,9 @@ if(($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys') &&
   $confheader = 'config-win32.h';
 }
 
-$ENV{LC_ALL}="C" if(($ENV{LC_ALL}) && ($ENV{LC_ALL} !~ /^C$/));
-$ENV{LC_CTYPE}="C" if(($ENV{LC_CTYPE}) && ($ENV{LC_CTYPE} !~ /^C$/));
-$ENV{LANG}="C";
+$ENV{LC_ALL} = "C" if(($ENV{LC_ALL}) && ($ENV{LC_ALL} !~ /^C$/));
+$ENV{LC_CTYPE} = "C" if(($ENV{LC_CTYPE}) && ($ENV{LC_CTYPE} !~ /^C$/));
+$ENV{LANG} = "C";
 
 sub grepfile($$) {
     my ($target, $fn) = @_;
@@ -200,21 +200,21 @@ sub grepfile($$) {
 }
 
 sub logit($) {
-    my $text=$_[0];
+    my $text = $_[0];
     if($text) {
         print "testcurl: $text\n";
     }
 }
 
 sub logit_spaced($) {
-    my $text=$_[0];
+    my $text = $_[0];
     if($text) {
         print "\ntestcurl: $text\n\n";
     }
 }
 
 sub mydie($){
-    my $text=$_[0];
+    my $text = $_[0];
     logit $text;
     chdir $pwd; # cd back to the original root dir
 
@@ -251,8 +251,8 @@ sub get_host_triplet {
 if($name && $email && $desc) {
     # having these fields set are enough to continue, skip reading the setup
     # file
-    $infixed=4;
-    $fixed=4;
+    $infixed = 4;
+    $fixed = 4;
 }
 elsif(open(my $f, "<", $setupfile)) {
     while(<$f>) {
@@ -261,31 +261,31 @@ elsif(open(my $f, "<", $setupfile)) {
         }
     }
     close($f);
-    $infixed=$fixed;
+    $infixed = $fixed;
 }
 else {
-    $infixed=0;    # so that "additional args to configure" works properly first time...
+    $infixed = 0;    # so that "additional args to configure" works properly first time...
 }
 
 if(!$name) {
     print "please enter your name\n";
     $name = <>;
     chomp $name;
-    $fixed=1;
+    $fixed = 1;
 }
 
 if(!$email) {
     print "please enter your contact email address\n";
     $email = <>;
     chomp $email;
-    $fixed=2;
+    $fixed = 2;
 }
 
 if(!$desc) {
     print "please enter a one line system description\n";
     $desc = <>;
     chomp $desc;
-    $fixed=3;
+    $fixed = 3;
 }
 
 if(!$confopts) {
@@ -298,7 +298,7 @@ if(!$confopts) {
 }
 
 if($fixed < 4) {
-    $fixed=4;
+    $fixed = 4;
     open(my $f, ">", $setupfile) or die;
     print $f "name='$name'\n";
     print $f "email='$email'\n";
@@ -376,9 +376,9 @@ if(-d $CURLDIR) {
 # make the path absolute so we can use it everywhere
 $CURLDIR = File::Spec->rel2abs($CURLDIR);
 
-$build="build-$$";
-$buildlogname="buildlog-$$";
-$buildlog="$pwd/$buildlogname";
+$build = "build-$$";
+$buildlogname = "buildlog-$$";
+$buildlog = "$pwd/$buildlogname";
 
 # remove any previous left-overs
 foreach(glob("build-*")) { rmtree $_; }
@@ -418,7 +418,7 @@ if($git) {
     }
 
     # get the last 5 commits for show (even if no pull was made)
-    @commits=`git log --pretty=oneline --abbrev-commit -5`;
+    @commits = `git log --pretty=oneline --abbrev-commit -5`;
     logit "The most recent curl git commits:";
     for(@commits) {
         chomp ($_);
@@ -441,7 +441,7 @@ if($git) {
         }
 
         # get the last 5 commits for show (even if no pull was made)
-        @commits=`git log --pretty=oneline --abbrev-commit -5`;
+        @commits = `git log --pretty=oneline --abbrev-commit -5`;
         logit "The most recent ares git commits:";
         for (@commits) {
             chomp ($_);
@@ -523,7 +523,7 @@ sub findinpath {
     my $e;
     my $x = ($^O eq 'MSWin32') ? '.exe' : '';
     my $s = ($^O eq 'MSWin32') ? ';' : ':';
-    my $p=$ENV{'PATH'};
+    my $p = $ENV{'PATH'};
     my @pa = split($s, $p);
     for $c (@_) {
         for $e (@pa) {

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -86,7 +86,7 @@ sub logmsg {
 #######################################################################
 # Set the function to use for logging
 sub setlogfunc {
-    ($logfunc)=@_;
+    ($logfunc) = @_;
 }
 
 #######################################################################
@@ -207,7 +207,7 @@ sub subnewlines {
 # Run the application under test and return its return code
 #
 sub runclient {
-    my ($cmd)=@_;
+    my ($cmd) = @_;
     my $ret = system($cmd);
     print "CMD ($ret): $cmd\n" if($verbose && !$torture);
     return $ret;
@@ -222,7 +222,7 @@ sub runclient {
 # Run the application under test and return its stdout
 #
 sub runclientoutput {
-    my ($cmd)=@_;
+    my ($cmd) = @_;
     return `$cmd 2>$dev_null`;
 
 # This is one way to test curl on a remote machine


### PR DESCRIPTION
Found via regex search: `=[^~>= ]`

---

https://github.com/curl/curl/pull/21975/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
