### PR TITLE
GHA/distcheck: fix parsing the download page

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -393,7 +393,7 @@ jobs:
         run: |
           echo "--- Detecting latest curl tarball version..."
           curl_version="$(curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused https://curl.se/download.html \
-            | grep -o -E 'curl [0-9]+\.[0-9]+\.[0-9]+' | cut -c 6-)"
+            | grep -o -E 'curl [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | cut -c 6-)"
 
           for suffix in .tar.bz2 .tar.gz .tar.xz .zip; do
             echo "--- Downloading ${curl_version} ${suffix}..."


### PR DESCRIPTION
Fixing:
```
curl: (3) URL rejected: Malformed input to a URL function
```
Ref: https://github.com/curl/curl/actions/runs/27370389568/job/80880800780

Refs:
https://github.com/curl/curl-www/commit/1735f6af6ae75af08e646c0407cdc69cf6a0855d
https://github.com/curl/curl-www/pull/593

Follow-up to 2cc171cbd4a9eac84f5c62c5b987347e5f8880e1 #21759

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
