### PR TITLE
telnet: fix old copy-paste typo in variable name

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -780,7 +780,7 @@ static void rec_do(struct Curl_easy *data, struct TELNET *tn, int option)
       break;
     case CURL_OPPOSITE:
       tn->us[option] = CURL_WANTNO;
-      tn->himq[option] = CURL_EMPTY;
+      tn->usq[option] = CURL_EMPTY;
       send_negotiation(data, CURL_WONT, option);
       break;
     }


### PR DESCRIPTION
This code lacks tests, though we agreed it looks plausible enough to
merge it based on surrounding code. Even though this line has been
present for a long time. If you use this code, please report any results
or issues.

Reported by GitHub Code Quality

Follow-up to ae1912cb0d494b48d514d937826c9fe83ec96c4d

---

(It seems plausible, but not knowing the code, I can't tell for sure.
It's also been there for possibly 3 decades without someone noticing.)

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
