### PR TITLE
lib695, lib757: fix truncated newline in error messages

### DIFF
--- a/tests/libtest/lib695.c
+++ b/tests/libtest/lib695.c
@@ -80,7 +80,7 @@ static CURLcode test_lib695(const char *URL)
     result = curl_mime_subparts(part, mime1);
 
     if(result != CURLE_OK)
-      curl_mfprintf(stderr, "curl_mime_subparts() failed: %sn",
+      curl_mfprintf(stderr, "curl_mime_subparts() failed: %s\n",
                     curl_easy_strerror(result));
     else {
       mime1 = NULL;

--- a/tests/libtest/lib757.c
+++ b/tests/libtest/lib757.c
@@ -101,7 +101,7 @@ static CURLcode test_lib757(const char *URL)
     result = curl_mime_subparts(part, mime1);
 
     if(result != CURLE_OK)
-      curl_mfprintf(stderr, "curl_mime_subparts() failed: %sn",
+      curl_mfprintf(stderr, "curl_mime_subparts() failed: %s\n",
                     curl_easy_strerror(result));
     else {
       mime1 = NULL;


### PR DESCRIPTION
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
