### PR TITLE
GHA: drop `brew update` from all jobs

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -74,7 +74,6 @@ jobs:
       - name: 'typos'
         timeout-minutes: 2
         run: |
-          /home/linuxbrew/.linuxbrew/bin/brew update
           /home/linuxbrew/.linuxbrew/bin/brew install typos-cli
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           typos --version
@@ -150,9 +149,7 @@ jobs:
     steps:
       - name: 'install prereqs'
         timeout-minutes: 2
-        run: |
-          /home/linuxbrew/.linuxbrew/bin/brew update
-          /home/linuxbrew/.linuxbrew/bin/brew install actionlint shellcheck zizmor
+        run: /home/linuxbrew/.linuxbrew/bin/brew install actionlint shellcheck zizmor
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,6 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev \
             libnghttp2-dev libldap-dev libkrb5-dev libgnutls28-dev libwolfssl-dev
-          /home/linuxbrew/.linuxbrew/bin/brew update
           /home/linuxbrew/.linuxbrew/bin/brew install c-ares gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -89,7 +89,7 @@ jobs:
           # shellcheck disable=SC2181
           while [[ $? == 0 ]]; do
             for i in 1 2 3; do
-              if brew update && brew install automake libtool; then
+              if brew install automake libtool; then
                 break 2
               else
                 echo "Error: wait to try again: $i"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -473,7 +473,6 @@ jobs:
             ${INSTALL_PACKAGES} \
             ${MATRIX_INSTALL_PACKAGES}
           if [ -n "${INSTALL_PACKAGES_BREW}" ]; then
-            /home/linuxbrew/.linuxbrew/bin/brew update
             /home/linuxbrew/.linuxbrew/bin/brew install ${INSTALL_PACKAGES_BREW}
           fi
           # Workaround for ubuntu-24.04-arm images having 0777 for /home/runner,

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -91,7 +91,7 @@ jobs:
           # shellcheck disable=SC2181
           while [[ $? == 0 ]]; do
             for i in 1 2 3; do
-              if brew update && brew install automake libtool; then
+              if brew install automake libtool; then
                 break 2
               else
                 echo "Error: wait to try again: $i"
@@ -416,7 +416,7 @@ jobs:
           # shellcheck disable=SC2181
           while [[ $? == 0 ]]; do
             for i in 1 2 3; do
-              if brew update && brew install pkgconf libpsl libssh2 ${INSTALL_PACKAGES} ${MATRIX_INSTALL}; then
+              if brew install pkgconf libpsl libssh2 ${INSTALL_PACKAGES} ${MATRIX_INSTALL}; then
                 break 2
               else
                 echo "Error: wait to try again: $i"
@@ -674,7 +674,7 @@ jobs:
           # shellcheck disable=SC2181
           while [[ $? == 0 ]]; do
             for i in 1 2 3; do
-              if brew update && brew install automake libtool; then
+              if brew install automake libtool; then
                 break 2
               else
                 echo "Error: wait to try again: $i"


### PR DESCRIPTION
After adding it a month ago (where missing) to fix a failure.

Removing this time to fix a different failure (on Linux), and also to 
improve CI performance. Some install steps take over a minute, most of
that spent on `brew update`.

GH runner images also enabled extra taps which may contribute to further
delays, and seen to make it more fragile if GH itself struggles (taps
are hosted there.)

Refs:
https://github.com/curl/curl/actions/runs/27384213554/job/80927624171
https://github.com/curl/curl/actions/runs/27382368348/job/80921910973

Follow-up to db5d8886738ca8a335898c497ae4808f65ea7781 #21608

---

The brew install step is often over 1 minute. I consider this overly high.
It's also broken since today, e.g.:
https://github.com/curl/curl/actions/runs/27384213554/job/80927624171
(on Linux, while trying to install components named bubblewrap and
libcap, as a dependency of libssh2. I find this unexpected.)

It also seems that extra taps have been enabled on the runner images.
These are not marked trusted, but accessed nevertheless and increasing
the chance of a failure when github is flaky, e.g.:
https://github.com/curl/curl/actions/runs/27382368348/job/80921910973?pr=21979

```
fatal: unable to access 'https://github.com/aws/homebrew-tap/': The requested URL returned error: 403
fatal: unable to access 'https://github.com/Homebrew/brew/': The requested URL returned error: 403
fatal: unable to access 'https://github.com/azure/homebrew-bicep/': The requested URL returned error: 403
fatal: unable to access 'https://github.com/hashicorp/homebrew-tap/': The requested URL returned error: 403
```

Not yet sure what how to deal with all these issues.

Last time I added `brew update` to fix an install failure with ca-certificates
(or around).
