### PR TITLE
ldap: base64 encode binary LDIF values with WinLDAP

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -239,8 +239,8 @@ static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
     return TRUE;
 
   /* check for leading or trailing whitespace */
-  if(val->bv_len &&
-     (ISBLANK(val->bv_val[0]) || ISBLANK(val->bv_val[val->bv_len - 1])))
+  if(val->bv_len && (ISBLANK(val->bv_val[0]) ||
+                     ISBLANK(val->bv_val[val->bv_len - 1])))
     return TRUE;
 
   /* check for unprintable characters */

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -558,7 +558,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
               goto quit;
             }
 
-            if(val_b64_sz > 0) {
+            if(val_b64_sz) {
               result = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
                                          val_b64_sz);
               if(result) {

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -560,7 +560,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 
             if(val_b64_sz > 0) {
               result = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
-                                          val_b64_sz);
+                                         val_b64_sz);
               if(result) {
                 curlx_free(val_b64);
                 ldap_value_free_len(vals);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -235,8 +235,7 @@ static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
 {
   unsigned int j;
 
-  if((attr_len > 7) &&
-     curl_strequal(";binary", attr + (attr_len - 7)))
+  if((attr_len > 7) && curl_strequal(";binary", attr + attr_len - 7))
     return TRUE;
 
   /* check for leading or trailing whitespace */

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -582,7 +582,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
             }
 
             result = Curl_client_write(data, CLIENTWRITE_BODY,
-                                      vals[i]->bv_val, vals[i]->bv_len);
+                                       vals[i]->bv_val, vals[i]->bv_len);
             if(result) {
               ldap_value_free_len(vals);
               FREE_ON_WINLDAP(attr);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -233,7 +233,7 @@ static ULONG ldap_win_bind(struct Curl_easy *data, LDAP *server,
 static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
                                     const BerValue *val)
 {
-  unsigned int j;
+  ber_len_t j;
 
   if((attr_len > 7) && curl_strequal(";binary", attr + attr_len - 7))
     return TRUE;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -230,6 +230,28 @@ static ULONG ldap_win_bind(struct Curl_easy *data, LDAP *server,
 }
 #endif /* USE_WIN32_LDAP */
 
+static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
+                                    const BerValue *val)
+{
+  unsigned int j;
+
+  if((attr_len > 7) &&
+     curl_strequal(";binary", attr + (attr_len - 7)))
+    return TRUE;
+
+  /* check for leading or trailing whitespace */
+  if(val->bv_len &&
+     (ISBLANK(val->bv_val[0]) || ISBLANK(val->bv_val[val->bv_len - 1])))
+    return TRUE;
+
+  /* check for unprintable characters */
+  for(j = 0; j < val->bv_len; j++)
+    if(!ISPRINT(val->bv_val[j]))
+      return TRUE;
+
+  return FALSE;
+}
+
 static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 {
   CURLcode result = CURLE_OK;
@@ -242,8 +264,6 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
   struct connectdata *conn = data->conn;
   int ldap_proto = LDAP_VERSION3;
   int ldap_ssl = 0;
-  char *val_b64 = NULL;
-  size_t val_b64_sz = 0;
 #ifdef LDAP_OPT_NETWORK_TIMEOUT
   struct timeval ldap_timeout = {10, 0}; /* 10 sec connection/search timeout */
 #endif
@@ -505,7 +525,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
             goto quit;
           }
 
-          result = Curl_client_write(data, CLIENTWRITE_BODY, ": ", 2);
+          result = Curl_client_write(data, CLIENTWRITE_BODY, ":", 1);
           if(result) {
             ldap_value_free_len(vals);
             FREE_ON_WINLDAP(attr);
@@ -513,8 +533,10 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
             goto quit;
           }
 
-          if((attr_len > 7) &&
-             curl_strequal(";binary", attr + (attr_len - 7))) {
+          if(ldap_value_needs_base64(attr, attr_len, vals[i])) {
+            char *val_b64 = NULL;
+            size_t val_b64_sz = 0;
+
             /* Binary attribute, encode to base64. */
             if(vals[i]->bv_len) {
               result = curlx_base64_encode((uint8_t *)vals[i]->bv_val,
@@ -526,28 +548,42 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
                 ldap_memfree(attribute);
                 goto quit;
               }
-
-              if(val_b64_sz > 0) {
-                result = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
-                                           val_b64_sz);
-                curlx_free(val_b64);
-                if(result) {
-                  ldap_value_free_len(vals);
-                  FREE_ON_WINLDAP(attr);
-                  ldap_memfree(attribute);
-                  goto quit;
-                }
-              }
             }
-          }
-          else {
-            result = Curl_client_write(data, CLIENTWRITE_BODY, vals[i]->bv_val,
-                                       vals[i]->bv_len);
+
+            result = Curl_client_write(data, CLIENTWRITE_BODY, ": ", 2);
             if(result) {
+              curlx_free(val_b64);
               ldap_value_free_len(vals);
               FREE_ON_WINLDAP(attr);
               ldap_memfree(attribute);
               goto quit;
+            }
+
+            if(val_b64_sz > 0) {
+              result = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
+                                          val_b64_sz);
+              if(result) {
+                curlx_free(val_b64);
+                ldap_value_free_len(vals);
+                FREE_ON_WINLDAP(attr);
+                ldap_memfree(attribute);
+                goto quit;
+              }
+            }
+
+            curlx_free(val_b64);
+          }
+          else {
+            result = Curl_client_write(data, CLIENTWRITE_BODY, " ", 1);
+            if(!result) {
+              result = Curl_client_write(data, CLIENTWRITE_BODY,
+                                        vals[i]->bv_val, vals[i]->bv_len);
+              if(result) {
+                ldap_value_free_len(vals);
+                FREE_ON_WINLDAP(attr);
+                ldap_memfree(attribute);
+                goto quit;
+              }
             }
           }
 

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -574,16 +574,16 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
           }
           else {
             result = Curl_client_write(data, CLIENTWRITE_BODY, " ", 1);
-            if(!result) {
-              result = Curl_client_write(data, CLIENTWRITE_BODY,
-                                        vals[i]->bv_val, vals[i]->bv_len);
-              if(result) {
-                ldap_value_free_len(vals);
-                FREE_ON_WINLDAP(attr);
-                ldap_memfree(attribute);
-                goto quit;
-              }
-            }else{
+            if(result) {
+              ldap_value_free_len(vals);
+              FREE_ON_WINLDAP(attr);
+              ldap_memfree(attribute);
+              goto quit;
+            }
+
+            result = Curl_client_write(data, CLIENTWRITE_BODY,
+                                      vals[i]->bv_val, vals[i]->bv_len);
+            if(result) {
               ldap_value_free_len(vals);
               FREE_ON_WINLDAP(attr);
               ldap_memfree(attribute);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -583,6 +583,11 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
                 ldap_memfree(attribute);
                 goto quit;
               }
+            }else{
+              ldap_value_free_len(vals);
+              FREE_ON_WINLDAP(attr);
+              ldap_memfree(attribute);
+              goto quit;
             }
           }
 


### PR DESCRIPTION
The WinLDAP backend (ldap.c) only base64 encoded LDAP values when the attribute name ended in ;binary. 
This made attributes such as jpegPhoto get written as raw bytes, producing malformed LDIF output.

Matched the OpenLDAP backend (openldap.c) by also base64 encoding values with leading or trailing blanks or non-printable bytes.

Tested manually on Windows 11 with WinLDAP against a local OpenLDAP fixture.

Before: jpegPhoto triggered curl's binary-output warning.
After: jpegPhoto is emitted as jpegPhoto:: base64.

Fixes #21926