### PR TITLE
AmigaOS : curl_setup avoid explicit_bzero with clib2

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1641,7 +1641,8 @@ typedef struct sockaddr_un {
 #define curlx_memzero(buf, size)  (void)memset_s(buf, size, 0, size)
 #elif defined(HAVE_MEMSET_EXPLICIT)
 #define curlx_memzero(buf, size)  (void)memset_explicit(buf, 0, size)
-#elif defined(__CYGWIN__) || defined(__NEWLIB__) || \
+#elif defined(__CYGWIN__) || \
+  (defined(__NEWLIB__) && !defined(__CLIB2__)) || \
   (defined(__GLIBC__) && \
     (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))) || \
   (defined(__DragonFly__) && __DragonFly_version >= 500600 /* v5.6+ */) || \


### PR DESCRIPTION
clib2 defines __NEWLIB__ after its system headers are included, but it does not provide explicit_bzero().

curl therefore selects the explicit_bzero() path and fails to build with m68k-amigaos-gcc:

```
In file included from curlx/strdup.c:24:
curlx/strdup.c: In function 'curlx_freezero':
../lib/curl_setup.h:1650:35: error: implicit declaration of function 'explicit_bzero' [-Werror=implicit-function-declaration]
 1650 | #define curlx_memzero(buf, size)  explicit_bzero(buf, size)
      |                                   ^~~~~~~~~~~~~~
curlx/strdup.c:115:5: note: in expansion of macro 'curlx_memzero'
  115 |     curlx_memzero(buf, size);
      |     ^~~~~~~~~~~~~
```

Excluding __CLIB2__ from the generic __NEWLIB__ branch makes curl use its existing portable curlx_memzero() fallback.
The full AmigaOS build then completes successfully.

I've tested the following on Amiga OS 3.2.3 with this patch and latest build.

- HTTP and HTTPS transfers
- AmiSSL certificate handling
- redirects
- downloads and file output
- timeout handling with the expected exit code 28
- repeated execution with clean exits
- no crashes or regressions observed

Follow-up to 066478f6346a2d987a9ecc3bd3bf45764d69c1c4 #21598
