### PR TITLE
socket: introduce `SOCK_EAGAIN()` and use it

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1562,14 +1562,14 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(
 #ifdef USE_WINSOCK
       /* This is how Windows does it */
-      (SOCKEWOULDBLOCK == sockerr)
+      (sockerr == SOCKEWOULDBLOCK)
 #else
       /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
       SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
-      (SOCKEINTR == sockerr) ||
-      (SOCKEINPROGRESS == sockerr)
+      (sockerr == SOCKEINTR) ||
+      (sockerr == SOCKEINPROGRESS)
 #endif
       ) {
       /* EWOULDBLOCK */
@@ -1628,13 +1628,13 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(
 #ifdef USE_WINSOCK
       /* This is how Windows does it */
-      (SOCKEWOULDBLOCK == sockerr)
+      (sockerr == SOCKEWOULDBLOCK)
 #else
       /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
       SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
-      (SOCKEINTR == sockerr)
+      (sockerr == SOCKEINTR)
 #endif
       ) {
       /* EWOULDBLOCK */

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -942,7 +942,7 @@ static CURLcode socket_connect_result(struct Curl_easy *data,
   switch(error) {
   case SOCKEINPROGRESS:
   case SOCKEWOULDBLOCK:
-#if !defined(USE_WINSOCK) && defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
+#if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
     /* On some platforms EAGAIN and EWOULDBLOCK are the
      * same value, and on others they are different, hence
      * the odd #if

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -939,7 +939,7 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
 static CURLcode socket_connect_result(struct Curl_easy *data,
                                       const char *ipaddress, int error)
 {
-  if(SOCK_EWOULDBLOCK_EAGAIN(error) || error == SOCKEINPROGRESS)
+  if(SOCK_EAGAIN(error) || error == SOCKEINPROGRESS)
     return CURLE_OK;
 
   /* unknown error, fallthrough and try another address! */
@@ -1550,7 +1550,7 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
        it returned due to its inability to send off data without blocking.
        We therefore treat both error codes the same here */
-    if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
+    if(SOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
        || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
 #endif
@@ -1609,7 +1609,7 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
        it returned due to its inability to read data without blocking.
        We therefore treat both error codes the same here */
-    if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
+    if(SOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
        || (sockerr == SOCKEINTR)
 #endif

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1547,9 +1547,6 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   if(!curlx_sztouz(rv, pnwritten)) {
     int sockerr = SOCKERRNO;
-    /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
-       it returned due to its inability to send off data without blocking.
-       We therefore treat both error codes the same here */
     if(SOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
        || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
@@ -1606,9 +1603,6 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   if(!curlx_sztouz(rv, pnread)) {
     int sockerr = SOCKERRNO;
-    /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
-       it returned due to its inability to read data without blocking.
-       We therefore treat both error codes the same here */
     if(SOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
        || (sockerr == SOCKEINTR)

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1569,10 +1569,7 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
-      (SOCKEWOULDBLOCK == sockerr) ||
-#if EAGAIN != SOCKEWOULDBLOCK
-      (EAGAIN == sockerr) ||
-#endif
+      SOCK_EAGAIN_EWOULDBLOCK(sockerr) ||
       (SOCKEINTR == sockerr) ||
       (SOCKEINPROGRESS == sockerr)
 #endif
@@ -1638,10 +1635,7 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
       /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
-      (SOCKEWOULDBLOCK == sockerr) ||
-#if EAGAIN != SOCKEWOULDBLOCK
-      (EAGAIN == sockerr) ||
-#endif
+      SOCK_EAGAIN_EWOULDBLOCK(sockerr) ||
       (SOCKEINTR == sockerr)
 #endif
       ) {

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1567,8 +1567,7 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
        || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
 #endif
       ) {
-      /* EWOULDBLOCK */
-      result = CURLE_AGAIN;
+      result = CURLE_AGAIN;  /* EWOULDBLOCK */
     }
     else {
       char buffer[STRERROR_LEN];
@@ -1628,8 +1627,7 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
        || (sockerr == SOCKEINTR)
 #endif
       ) {
-      /* EWOULDBLOCK */
-      result = CURLE_AGAIN;
+      result = CURLE_AGAIN;  /* EWOULDBLOCK */
     }
     else {
       char buffer[STRERROR_LEN];

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -939,7 +939,7 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
 static CURLcode socket_connect_result(struct Curl_easy *data,
                                       const char *ipaddress, int error)
 {
-  if(SOCK_EAGAIN(error) || error == SOCKEINPROGRESS)
+  if(error == SOCKEINPROGRESS || SOCK_EAGAIN(error))
     return CURLE_OK;
 
   /* unknown error, fallthrough and try another address! */

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1548,7 +1548,7 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!curlx_sztouz(rv, pnwritten)) {
     int sockerr = SOCKERRNO;
     /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
-       it returned due to its inability to read data without blocking.
+       it returned due to its inability to send off data without blocking.
        We therefore treat both error codes the same here */
     if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
@@ -1607,7 +1607,7 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!curlx_sztouz(rv, pnread)) {
     int sockerr = SOCKERRNO;
     /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
-       it returned due to its inability to send off data without blocking.
+       it returned due to its inability to read data without blocking.
        We therefore treat both error codes the same here */
     if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1547,10 +1547,9 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   if(!curlx_sztouz(rv, pnwritten)) {
     int sockerr = SOCKERRNO;
-
-    /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
-       due to its inability to send off data without blocking. We therefore
-       treat both error codes the same here */
+    /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when it
+       returned due to its inability to read data without blocking. We
+       therefore treat both error codes the same here */
     if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
        || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1547,9 +1547,9 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   if(!curlx_sztouz(rv, pnwritten)) {
     int sockerr = SOCKERRNO;
-    /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when it
-       returned due to its inability to read data without blocking. We
-       therefore treat both error codes the same here */
+    /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
+       it returned due to its inability to read data without blocking.
+       We therefore treat both error codes the same here */
     if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
        || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
@@ -1606,10 +1606,9 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   if(!curlx_sztouz(rv, pnread)) {
     int sockerr = SOCKERRNO;
-
-    /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
-       due to its inability to send off data without blocking. We therefore
-       treat both error codes the same here */
+    /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
+       it returned due to its inability to send off data without blocking.
+       We therefore treat both error codes the same here */
     if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
        || (sockerr == SOCKEINTR)

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1570,7 +1570,10 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
       (SOCKEWOULDBLOCK == sockerr) ||
-      (EAGAIN == sockerr) || (SOCKEINTR == sockerr) ||
+#if EAGAIN != SOCKEWOULDBLOCK
+      (EAGAIN == sockerr) ||
+#endif
+      (SOCKEINTR == sockerr) ||
       (SOCKEINPROGRESS == sockerr)
 #endif
       ) {
@@ -1636,7 +1639,10 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
       (SOCKEWOULDBLOCK == sockerr) ||
-      (EAGAIN == sockerr) || (SOCKEINTR == sockerr)
+#if EAGAIN != SOCKEWOULDBLOCK
+      (EAGAIN == sockerr) ||
+#endif
+      (SOCKEINTR == sockerr)
 #endif
       ) {
       /* EWOULDBLOCK */

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -939,30 +939,19 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
 static CURLcode socket_connect_result(struct Curl_easy *data,
                                       const char *ipaddress, int error)
 {
-  switch(error) {
-  case SOCKEINPROGRESS:
-  case SOCKEWOULDBLOCK:
-#if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
-    /* On some platforms EAGAIN and EWOULDBLOCK are the
-     * same value, and on others they are different, hence
-     * the odd #if
-     */
-  case EAGAIN:
-#endif
+  if(SOCK_EWOULDBLOCK_EAGAIN(error) || error == SOCKEINPROGRESS)
     return CURLE_OK;
 
-  default:
-    /* unknown error, fallthrough and try another address! */
-    {
-      VERBOSE(char buffer[STRERROR_LEN]);
-      infof(data, "Immediate connect fail for %s: %s", ipaddress,
-            curlx_strerror(error, buffer, sizeof(buffer)));
-      NOVERBOSE((void)ipaddress);
-    }
-    data->state.os_errno = error;
-    /* connect failed */
-    return CURLE_COULDNT_CONNECT;
+  /* unknown error, fallthrough and try another address! */
+  {
+    VERBOSE(char buffer[STRERROR_LEN]);
+    infof(data, "Immediate connect fail for %s: %s", ipaddress,
+          curlx_strerror(error, buffer, sizeof(buffer)));
+    NOVERBOSE((void)ipaddress);
   }
+  data->state.os_errno = error;
+  /* connect failed */
+  return CURLE_COULDNT_CONNECT;
 }
 
 struct cf_socket_ctx {

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1564,7 +1564,7 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
        treat both error codes the same here */
     if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
-      || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
+       || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
 #endif
       ) {
       /* EWOULDBLOCK */
@@ -1625,7 +1625,7 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
        treat both error codes the same here */
     if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
-      || (sockerr == SOCKEINTR)
+       || (sockerr == SOCKEINTR)
 #endif
       ) {
       /* EWOULDBLOCK */

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -942,7 +942,7 @@ static CURLcode socket_connect_result(struct Curl_easy *data,
   switch(error) {
   case SOCKEINPROGRESS:
   case SOCKEWOULDBLOCK:
-#if defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
+#if !defined(USE_WINSOCK) && defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
     /* On some platforms EAGAIN and EWOULDBLOCK are the
      * same value, and on others they are different, hence
      * the odd #if

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1567,7 +1567,7 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
-      SOCK_EAGAIN_EWOULDBLOCK(sockerr) ||
+      SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
       (SOCKEINTR == sockerr) ||
       (SOCKEINPROGRESS == sockerr)
 #endif
@@ -1633,7 +1633,7 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
       /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
          due to its inability to send off data without blocking. We therefore
          treat both error codes the same here */
-      SOCK_EAGAIN_EWOULDBLOCK(sockerr) ||
+      SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
       (SOCKEINTR == sockerr)
 #endif
       ) {

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1559,17 +1559,12 @@ static CURLcode cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!curlx_sztouz(rv, pnwritten)) {
     int sockerr = SOCKERRNO;
 
-    if(
-#ifdef USE_WINSOCK
-      /* This is how Windows does it */
-      (sockerr == SOCKEWOULDBLOCK)
-#else
-      /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
-         due to its inability to send off data without blocking. We therefore
-         treat both error codes the same here */
-      SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
-      (sockerr == SOCKEINTR) ||
-      (sockerr == SOCKEINPROGRESS)
+    /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
+       due to its inability to send off data without blocking. We therefore
+       treat both error codes the same here */
+    if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
+#ifndef USE_WINSOCK
+      || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
 #endif
       ) {
       /* EWOULDBLOCK */
@@ -1625,16 +1620,12 @@ static CURLcode cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!curlx_sztouz(rv, pnread)) {
     int sockerr = SOCKERRNO;
 
-    if(
-#ifdef USE_WINSOCK
-      /* This is how Windows does it */
-      (sockerr == SOCKEWOULDBLOCK)
-#else
-      /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
-         due to its inability to send off data without blocking. We therefore
-         treat both error codes the same here */
-      SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
-      (sockerr == SOCKEINTR)
+    /* errno may be EWOULDBLOCK or on some systems EAGAIN when it returned
+       due to its inability to send off data without blocking. We therefore
+       treat both error codes the same here */
+    if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
+#ifndef USE_WINSOCK
+      || (sockerr == SOCKEINTR)
 #endif
       ) {
       /* EWOULDBLOCK */

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -942,14 +942,12 @@ static CURLcode socket_connect_result(struct Curl_easy *data,
   switch(error) {
   case SOCKEINPROGRESS:
   case SOCKEWOULDBLOCK:
-#ifdef EAGAIN
-#if (EAGAIN) != (SOCKEWOULDBLOCK)
+#if defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
     /* On some platforms EAGAIN and EWOULDBLOCK are the
      * same value, and on others they are different, hence
      * the odd #if
      */
   case EAGAIN:
-#endif
 #endif
     return CURLE_OK;
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1137,6 +1137,12 @@ typedef unsigned int curl_bit;
 #define SOCKEWOULDBLOCK   EWOULDBLOCK
 #endif
 
+#if EAGAIN != SOCKEWOULDBLOCK
+#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == EAGAIN || (e) == SOCKEWOULDBLOCK)
+#else
+#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == EAGAIN)
+#endif
+
 /*
  * Macro argv_item_t hides platform details to code using it.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1137,7 +1137,7 @@ typedef unsigned int curl_bit;
 #define SOCKEWOULDBLOCK   EWOULDBLOCK
 #endif
 
-#if EAGAIN != SOCKEWOULDBLOCK
+#if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
 #define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
 #else
 #define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1138,11 +1138,11 @@ typedef unsigned int curl_bit;
 #endif
 
 #if EAGAIN != SOCKEWOULDBLOCK
-#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == EAGAIN || (e) == SOCKEWOULDBLOCK)
-#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EAGAIN || (e) == EWOULDBLOCK)
+#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
+#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
-#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == EAGAIN)
-#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EAGAIN)
+#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK)
+#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK)
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1138,9 +1138,9 @@ typedef unsigned int curl_bit;
 #endif
 
 #if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
-#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
+#define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
 #else
-#define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK)
+#define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK)
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1138,9 +1138,9 @@ typedef unsigned int curl_bit;
 #endif
 
 #if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
-#define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
+#define SOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
 #else
-#define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK)
+#define SOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK)
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1139,8 +1139,10 @@ typedef unsigned int curl_bit;
 
 #if EAGAIN != SOCKEWOULDBLOCK
 #define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == EAGAIN || (e) == SOCKEWOULDBLOCK)
+#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EAGAIN || (e) == EWOULDBLOCK)
 #else
 #define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == EAGAIN)
+#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EAGAIN)
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1137,7 +1137,7 @@ typedef unsigned int curl_bit;
 #define SOCKEWOULDBLOCK   EWOULDBLOCK
 #endif
 
-#if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
+#if !defined(USE_WINSOCK) && defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
 #define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
 #else
 #define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1139,7 +1139,7 @@ typedef unsigned int curl_bit;
 
 /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
    it returned due to its inability to send/read data without blocking.
-   We therefore treat both error codes the same here */
+   We treat both error codes the same here. */
 #if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
 #define SOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
 #else

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1137,7 +1137,7 @@ typedef unsigned int curl_bit;
 #define SOCKEWOULDBLOCK   EWOULDBLOCK
 #endif
 
-#if !defined(USE_WINSOCK) && defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
+#if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
 #define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
 #else
 #define SOCK_EWOULDBLOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1139,10 +1139,8 @@ typedef unsigned int curl_bit;
 
 #if EAGAIN != SOCKEWOULDBLOCK
 #define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
-#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
 #define SOCK_EAGAIN_EWOULDBLOCK(e) ((e) == SOCKEWOULDBLOCK)
-#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK)
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1137,6 +1137,9 @@ typedef unsigned int curl_bit;
 #define SOCKEWOULDBLOCK   EWOULDBLOCK
 #endif
 
+/* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
+   it returned due to its inability to send/read data without blocking.
+   We therefore treat both error codes the same here */
 #if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
 #define SOCK_EAGAIN(e) ((e) == SOCKEWOULDBLOCK || (e) == EAGAIN)
 #else

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -235,13 +235,13 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
         if(
 #ifdef USE_WINSOCK
            /* This is how Windows does it */
-           (SOCKEWOULDBLOCK == sockerr)
+           (sockerr == SOCKEWOULDBLOCK)
 #else
            /* errno may be EWOULDBLOCK or on some systems EAGAIN when it
               returned due to its inability to send off data without
               blocking. We therefore treat both error codes the same here */
            SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
-           (SOCKEINTR == sockerr) || (SOCKEINPROGRESS == sockerr)
+           (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
 #endif
           ) {
           continue;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -232,16 +232,12 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
         /* Do not block forever */
         if(curlx_timediff_ms(curlx_now(), start) > (60 * 1000))
           goto error;
-        if(
-#ifdef USE_WINSOCK
-           /* This is how Windows does it */
-           (sockerr == SOCKEWOULDBLOCK)
-#else
-           /* errno may be EWOULDBLOCK or on some systems EAGAIN when it
-              returned due to its inability to send off data without
-              blocking. We therefore treat both error codes the same here */
-           SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
-           (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
+        /* errno may be EWOULDBLOCK or on some systems EAGAIN when it
+           returned due to its inability to send off data without
+           blocking. We therefore treat both error codes the same here */
+        if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
+#ifndef USE_WINSOCK
+           || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
 #endif
           ) {
           continue;
@@ -320,15 +316,12 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
     err = 0;
     if(wakeup_write(socks[1], buf, sizeof(buf)) < 0) {
       err = SOCKERRNO;
-#ifdef USE_WINSOCK
-      if(err == SOCKEWOULDBLOCK)
-        err = 0; /* wakeup is already ongoing */
-#else
+#ifndef USE_WINSOCK
       if(err == SOCKEINTR)
         continue;
+#endif
       if(SOCK_EWOULDBLOCK_EAGAIN(err))
         err = 0; /* wakeup is already ongoing */
-#endif
     }
     break;
   }
@@ -346,15 +339,12 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
     if(!rc)
       break;
     else if(rc < 0) {
-#ifdef USE_WINSOCK
-      if(SOCKERRNO == SOCKEWOULDBLOCK)
-        break;
-#else
+#ifndef USE_WINSOCK
       if(SOCKERRNO == SOCKEINTR)
         continue;
+#endif
       if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO))
         break;
-#endif
       result = CURLE_READ_ERROR;
       break;
     }

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -356,7 +356,11 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
 #else
       if(SOCKEINTR == SOCKERRNO)
         continue;
-      if((SOCKERRNO == SOCKEWOULDBLOCK) || (SOCKERRNO == EAGAIN))
+      if((SOCKERRNO == SOCKEWOULDBLOCK)
+#if EAGAIN != SOCKEWOULDBLOCK
+         || (SOCKERRNO == EAGAIN)
+#endif
+        )
         break;
 #endif
       result = CURLE_READ_ERROR;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -233,7 +233,7 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
         if(curlx_timediff_ms(curlx_now(), start) > (60 * 1000))
           goto error;
         /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
-           it returned due to its inability to send off data without blocking.
+           it returned due to its inability to read data without blocking.
            We therefore treat both error codes the same here */
         if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -336,12 +336,12 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
     if(!rc)
       break;
     else if(rc < 0) {
-      int err = SOCKERRNO;
+      int sockerr = SOCKERRNO;
 #ifndef USE_WINSOCK
-      if(err == SOCKEINTR)
+      if(sockerr == SOCKEINTR)
         continue;
 #endif
-      if(SOCK_EAGAIN(err))
+      if(SOCK_EAGAIN(sockerr))
         break;
       result = CURLE_READ_ERROR;
       break;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -235,7 +235,7 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
         /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
            it returned due to its inability to read data without blocking.
            We therefore treat both error codes the same here */
-        if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
+        if(SOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
            || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)
 #endif
@@ -320,7 +320,7 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
       if(err == SOCKEINTR)
         continue;
 #endif
-      if(SOCK_EWOULDBLOCK_EAGAIN(err))
+      if(SOCK_EAGAIN(err))
         err = 0; /* wakeup is already ongoing */
     }
     break;
@@ -344,7 +344,7 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
       if(err == SOCKEINTR)
         continue;
 #endif
-      if(SOCK_EWOULDBLOCK_EAGAIN(err))
+      if(SOCK_EAGAIN(err))
         break;
       result = CURLE_READ_ERROR;
       break;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -326,11 +326,7 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
 #else
       if(err == SOCKEINTR)
         continue;
-      if(err == SOCKEWOULDBLOCK
-#if EAGAIN != SOCKEWOULDBLOCK
-         || err == EAGAIN
-#endif
-        )
+      if(SOCK_EAGAIN_EWOULDBLOCK(err))
         err = 0; /* wakeup is already ongoing */
 #endif
     }
@@ -356,11 +352,7 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
 #else
       if(SOCKERRNO == SOCKEINTR)
         continue;
-      if(SOCKERRNO == SOCKEWOULDBLOCK
-#if EAGAIN != SOCKEWOULDBLOCK
-         || SOCKERRNO == EAGAIN
-#endif
-        )
+      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO))
         break;
 #endif
       result = CURLE_READ_ERROR;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -232,9 +232,9 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
         /* Do not block forever */
         if(curlx_timediff_ms(curlx_now(), start) > (60 * 1000))
           goto error;
-        /* errno may be EWOULDBLOCK or on some systems EAGAIN when it
-           returned due to its inability to send off data without
-           blocking. We therefore treat both error codes the same here */
+        /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
+           it returned due to its inability to send off data without blocking.
+           We therefore treat both error codes the same here */
         if(SOCK_EWOULDBLOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
            || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -326,9 +326,9 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
 #else
       if(SOCKEINTR == err)
         continue;
-      if((err == SOCKEWOULDBLOCK)
+      if(err == SOCKEWOULDBLOCK
 #if EAGAIN != SOCKEWOULDBLOCK
-         || (err == EAGAIN)
+         || err == EAGAIN
 #endif
         )
         err = 0; /* wakeup is already ongoing */
@@ -356,9 +356,9 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
 #else
       if(SOCKEINTR == SOCKERRNO)
         continue;
-      if((SOCKERRNO == SOCKEWOULDBLOCK)
+      if(SOCKERRNO == SOCKEWOULDBLOCK
 #if EAGAIN != SOCKEWOULDBLOCK
-         || (SOCKERRNO == EAGAIN)
+         || SOCKERRNO == EAGAIN
 #endif
         )
         break;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -339,7 +339,7 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
     if(!rc)
       break;
     else if(rc < 0) {
-      err = SOCKERRNO;
+      int err = SOCKERRNO;
 #ifndef USE_WINSOCK
       if(err == SOCKEINTR)
         continue;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -240,7 +240,7 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
            /* errno may be EWOULDBLOCK or on some systems EAGAIN when it
               returned due to its inability to send off data without
               blocking. We therefore treat both error codes the same here */
-           SOCK_EAGAIN_EWOULDBLOCK(sockerr) ||
+           SOCK_EWOULDBLOCK_EAGAIN(sockerr) ||
            (SOCKEINTR == sockerr) || (SOCKEINPROGRESS == sockerr)
 #endif
           ) {
@@ -326,7 +326,7 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
 #else
       if(err == SOCKEINTR)
         continue;
-      if(SOCK_EAGAIN_EWOULDBLOCK(err))
+      if(SOCK_EWOULDBLOCK_EAGAIN(err))
         err = 0; /* wakeup is already ongoing */
 #endif
     }
@@ -352,7 +352,7 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
 #else
       if(SOCKERRNO == SOCKEINTR)
         continue;
-      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO))
+      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO))
         break;
 #endif
       result = CURLE_READ_ERROR;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -339,11 +339,12 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
     if(!rc)
       break;
     else if(rc < 0) {
+      err = SOCKERRNO;
 #ifndef USE_WINSOCK
-      if(SOCKERRNO == SOCKEINTR)
+      if(err == SOCKEINTR)
         continue;
 #endif
-      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO))
+      if(SOCK_EWOULDBLOCK_EAGAIN(err))
         break;
       result = CURLE_READ_ERROR;
       break;

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -232,9 +232,6 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
         /* Do not block forever */
         if(curlx_timediff_ms(curlx_now(), start) > (60 * 1000))
           goto error;
-        /* The socket error may be EWOULDBLOCK or on some systems EAGAIN when
-           it returned due to its inability to read data without blocking.
-           We therefore treat both error codes the same here */
         if(SOCK_EAGAIN(sockerr)
 #ifndef USE_WINSOCK
            || (sockerr == SOCKEINTR) || (sockerr == SOCKEINPROGRESS)

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -240,7 +240,7 @@ static int wakeup_inet(curl_socket_t socks[2], bool nonblocking)
            /* errno may be EWOULDBLOCK or on some systems EAGAIN when it
               returned due to its inability to send off data without
               blocking. We therefore treat both error codes the same here */
-           (SOCKEWOULDBLOCK == sockerr) || (EAGAIN == sockerr) ||
+           SOCK_EAGAIN_EWOULDBLOCK(sockerr) ||
            (SOCKEINTR == sockerr) || (SOCKEINPROGRESS == sockerr)
 #endif
           ) {

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -324,7 +324,7 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
       if(err == SOCKEWOULDBLOCK)
         err = 0; /* wakeup is already ongoing */
 #else
-      if(SOCKEINTR == err)
+      if(err == SOCKEINTR)
         continue;
       if(err == SOCKEWOULDBLOCK
 #if EAGAIN != SOCKEWOULDBLOCK
@@ -354,7 +354,7 @@ CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)
       if(SOCKERRNO == SOCKEWOULDBLOCK)
         break;
 #else
-      if(SOCKEINTR == SOCKERRNO)
+      if(SOCKERRNO == SOCKEINTR)
         continue;
       if(SOCKERRNO == SOCKEWOULDBLOCK
 #if EAGAIN != SOCKEWOULDBLOCK

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -326,7 +326,11 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
 #else
       if(SOCKEINTR == err)
         continue;
-      if((err == SOCKEWOULDBLOCK) || (err == EAGAIN))
+      if((err == SOCKEWOULDBLOCK)
+#if EAGAIN != SOCKEWOULDBLOCK
+         || (err == EAGAIN)
+#endif
+        )
         err = 0; /* wakeup is already ongoing */
 #endif
     }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -165,12 +165,10 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     ;
 
   if(!curlx_sztouz(rv, psent)) {
-    switch(SOCKERRNO) {
-    case SOCKEWOULDBLOCK:
-#if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
-    case EAGAIN:
-#endif
+    int err = SOCKERRNO;
+    if(SOCK_EWOULDBLOCK_EAGAIN(err))
       return CURLE_AGAIN;
+    switch(err) {
     case SOCKEMSGSIZE:
       /* UDP datagram is too large; caused by PMTUD. Let it be lost. */
       *psent = pktlen;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -206,7 +206,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     ;
 
   if(!curlx_sztouz(rv, psent)) {
-    if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
+    if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
       result = CURLE_AGAIN;
       goto out;
     }
@@ -487,7 +487,7 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(mcount == -1) {
-      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
+      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
         CURL_TRC_CF(data, cf, "ingress, recvmmsg -> EAGAIN");
         goto out;
       }
@@ -574,7 +574,7 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(!curlx_sztouz(rc, &nread)) {
-      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
+      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
         goto out;
       }
       if(!cf->connected && SOCKERRNO == SOCKECONNREFUSED) {
@@ -644,7 +644,7 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(!curlx_sztouz(rv, &nread)) {
-      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
+      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
         CURL_TRC_CF(data, cf, "ingress, recvfrom -> EAGAIN");
         goto out;
       }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -206,7 +206,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     ;
 
   if(!curlx_sztouz(rv, psent)) {
-    if(SOCKERRNO == EAGAIN || SOCKERRNO == SOCKEWOULDBLOCK) {
+    if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
       result = CURLE_AGAIN;
       goto out;
     }
@@ -487,7 +487,7 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(mcount == -1) {
-      if(SOCKERRNO == EAGAIN || SOCKERRNO == SOCKEWOULDBLOCK) {
+      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
         CURL_TRC_CF(data, cf, "ingress, recvmmsg -> EAGAIN");
         goto out;
       }
@@ -574,7 +574,7 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(!curlx_sztouz(rc, &nread)) {
-      if(SOCKERRNO == EAGAIN || SOCKERRNO == SOCKEWOULDBLOCK) {
+      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
         goto out;
       }
       if(!cf->connected && SOCKERRNO == SOCKECONNREFUSED) {
@@ -644,7 +644,7 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(!curlx_sztouz(rv, &nread)) {
-      if(SOCKERRNO == EAGAIN || SOCKERRNO == SOCKEWOULDBLOCK) {
+      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
         CURL_TRC_CF(data, cf, "ingress, recvfrom -> EAGAIN");
         goto out;
       }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -165,10 +165,10 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     ;
 
   if(!curlx_sztouz(rv, psent)) {
-    int err = SOCKERRNO;
-    if(SOCK_EAGAIN(err))
+    int sockerr = SOCKERRNO;
+    if(SOCK_EAGAIN(sockerr))
       return CURLE_AGAIN;
-    switch(err) {
+    switch(sockerr) {
     case SOCKEMSGSIZE:
       /* UDP datagram is too large; caused by PMTUD. Let it be lost. */
       *psent = pktlen;
@@ -176,13 +176,14 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     case EIO:
       if(pktlen > gsolen) {
         /* GSO failure */
-        infof(data, "sendmsg() returned %zd (errno %d); disable GSO", rv, err);
+        infof(data, "sendmsg() returned %zd (errno %d); disable GSO", rv,
+              sockerr);
         qctx->no_gso = TRUE;
         return send_packet_no_gso(cf, data, qctx, pkt, pktlen, gsolen, psent);
       }
       FALLTHROUGH();
     default:
-      failf(data, "sendmsg() returned %zd (errno %d)", rv, err);
+      failf(data, "sendmsg() returned %zd (errno %d)", rv, sockerr);
       result = CURLE_SEND_ERROR;
       goto out;
     }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -167,7 +167,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
   if(!curlx_sztouz(rv, psent)) {
     switch(SOCKERRNO) {
     case SOCKEWOULDBLOCK:
-#if !defined(USE_WINSOCK) && defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
+#if !defined(USE_WINSOCK) && EAGAIN != SOCKEWOULDBLOCK
     case EAGAIN:
 #endif
       return CURLE_AGAIN;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -166,7 +166,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
 
   if(!curlx_sztouz(rv, psent)) {
     int err = SOCKERRNO;
-    if(SOCK_EWOULDBLOCK_EAGAIN(err))
+    if(SOCK_EAGAIN(err))
       return CURLE_AGAIN;
     switch(err) {
     case SOCKEMSGSIZE:
@@ -203,7 +203,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     ;
 
   if(!curlx_sztouz(rv, psent)) {
-    if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
+    if(SOCK_EAGAIN(SOCKERRNO)) {
       result = CURLE_AGAIN;
       goto out;
     }
@@ -484,7 +484,7 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(mcount == -1) {
-      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
+      if(SOCK_EAGAIN(SOCKERRNO)) {
         CURL_TRC_CF(data, cf, "ingress, recvmmsg -> EAGAIN");
         goto out;
       }
@@ -571,7 +571,7 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(!curlx_sztouz(rc, &nread)) {
-      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
+      if(SOCK_EAGAIN(SOCKERRNO)) {
         goto out;
       }
       if(!cf->connected && SOCKERRNO == SOCKECONNREFUSED) {
@@ -641,7 +641,7 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
           (SOCKERRNO == SOCKEINTR || SOCKERRNO == SOCKEMSGSIZE))
       ;
     if(!curlx_sztouz(rv, &nread)) {
-      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
+      if(SOCK_EAGAIN(SOCKERRNO)) {
         CURL_TRC_CF(data, cf, "ingress, recvfrom -> EAGAIN");
         goto out;
       }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -166,9 +166,9 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
 
   if(!curlx_sztouz(rv, psent)) {
     switch(SOCKERRNO) {
-    case EAGAIN:
-#if EAGAIN != SOCKEWOULDBLOCK
     case SOCKEWOULDBLOCK:
+#if EAGAIN != SOCKEWOULDBLOCK
+    case EAGAIN:
 #endif
       return CURLE_AGAIN;
     case SOCKEMSGSIZE:

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -167,7 +167,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
   if(!curlx_sztouz(rv, psent)) {
     switch(SOCKERRNO) {
     case SOCKEWOULDBLOCK:
-#if EAGAIN != SOCKEWOULDBLOCK
+#if !defined(USE_WINSOCK) && defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
     case EAGAIN:
 #endif
       return CURLE_AGAIN;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -176,14 +176,13 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     case EIO:
       if(pktlen > gsolen) {
         /* GSO failure */
-        infof(data, "sendmsg() returned %zd (errno %d); disable GSO", rv,
-              SOCKERRNO);
+        infof(data, "sendmsg() returned %zd (errno %d); disable GSO", rv, err);
         qctx->no_gso = TRUE;
         return send_packet_no_gso(cf, data, qctx, pkt, pktlen, gsolen, psent);
       }
       FALLTHROUGH();
     default:
-      failf(data, "sendmsg() returned %zd (errno %d)", rv, SOCKERRNO);
+      failf(data, "sendmsg() returned %zd (errno %d)", rv, err);
       result = CURLE_SEND_ERROR;
       goto out;
     }

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -160,7 +160,11 @@ static ssize_t tls_recv_more(struct Curl_cfilter *cf,
   io_ctx.data = data;
   io_error = rustls_connection_read_tls(backend->conn, read_cb, &io_ctx,
                                         &tls_bytes_read);
-  if(io_error == EAGAIN || io_error == EWOULDBLOCK) {
+  if(io_error == EWOULDBLOCK
+#if EAGAIN != EWOULDBLOCK
+     || io_error == EAGAIN
+#endif
+    ) {
     *err = CURLE_AGAIN;
     return -1;
   }
@@ -270,7 +274,11 @@ static CURLcode cr_flush_out(struct Curl_cfilter *cf, struct Curl_easy *data,
   while(rustls_connection_wants_write(rconn)) {
     io_error = rustls_connection_write_tls(rconn, write_cb, &io_ctx,
                                            &tlswritten);
-    if(io_error == EAGAIN || io_error == EWOULDBLOCK) {
+    if(io_error == EWOULDBLOCK
+#if EAGAIN != EWOULDBLOCK
+       || io_error == EAGAIN
+#endif
+      ) {
       CURL_TRC_CF(data, cf, "cf_send: EAGAIN after %zu bytes",
                   tlswritten_total);
       return CURLE_AGAIN;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -45,7 +45,7 @@
 #include "curlx/base64.h"
 #endif
 
-#if EAGAIN != SOCKEWOULDBLOCK
+#if EAGAIN != EWOULDBLOCK
 #define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
 #define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK)

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -46,9 +46,9 @@
 #endif
 
 #if EAGAIN != EWOULDBLOCK
-#define RAW_EAGAIN(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
+#define RAW_EAGAIN(e) ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
-#define RAW_EAGAIN(e)  ((e) == EWOULDBLOCK)
+#define RAW_EAGAIN(e) ((e) == EWOULDBLOCK)
 #endif
 
 struct rustls_ssl_backend_data {

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -46,9 +46,9 @@
 #endif
 
 #if EAGAIN != EWOULDBLOCK
-#define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
+#define RAW_EAGAIN(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
-#define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK)
+#define RAW_EAGAIN(e)  ((e) == EWOULDBLOCK)
 #endif
 
 struct rustls_ssl_backend_data {
@@ -166,7 +166,7 @@ static ssize_t tls_recv_more(struct Curl_cfilter *cf,
   io_ctx.data = data;
   io_error = rustls_connection_read_tls(backend->conn, read_cb, &io_ctx,
                                         &tls_bytes_read);
-  if(RAW_EWOULDBLOCK_EAGAIN(io_error)) {
+  if(RAW_EAGAIN(io_error)) {
     *err = CURLE_AGAIN;
     return -1;
   }
@@ -276,7 +276,7 @@ static CURLcode cr_flush_out(struct Curl_cfilter *cf, struct Curl_easy *data,
   while(rustls_connection_wants_write(rconn)) {
     io_error = rustls_connection_write_tls(rconn, write_cb, &io_ctx,
                                            &tlswritten);
-    if(RAW_EWOULDBLOCK_EAGAIN(io_error)) {
+    if(RAW_EAGAIN(io_error)) {
       CURL_TRC_CF(data, cf, "cf_send: EAGAIN after %zu bytes",
                   tlswritten_total);
       return CURLE_AGAIN;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -45,6 +45,12 @@
 #include "curlx/base64.h"
 #endif
 
+#if EAGAIN != SOCKEWOULDBLOCK
+#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
+#else
+#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK)
+#endif
+
 struct rustls_ssl_backend_data {
   const struct rustls_client_config *config;
   struct rustls_connection *conn;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -45,7 +45,7 @@
 #include "curlx/base64.h"
 #endif
 
-#if defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
+#if EAGAIN != SOCKEWOULDBLOCK
 #define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
 #define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK)

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -46,9 +46,9 @@
 #endif
 
 #if EAGAIN != SOCKEWOULDBLOCK
-#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
+#define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
-#define RAW_EAGAIN_EWOULDBLOCK(e)  ((e) == EWOULDBLOCK)
+#define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK)
 #endif
 
 struct rustls_ssl_backend_data {
@@ -166,7 +166,7 @@ static ssize_t tls_recv_more(struct Curl_cfilter *cf,
   io_ctx.data = data;
   io_error = rustls_connection_read_tls(backend->conn, read_cb, &io_ctx,
                                         &tls_bytes_read);
-  if(RAW_EAGAIN_EWOULDBLOCK(io_error)) {
+  if(RAW_EWOULDBLOCK_EAGAIN(io_error)) {
     *err = CURLE_AGAIN;
     return -1;
   }
@@ -276,7 +276,7 @@ static CURLcode cr_flush_out(struct Curl_cfilter *cf, struct Curl_easy *data,
   while(rustls_connection_wants_write(rconn)) {
     io_error = rustls_connection_write_tls(rconn, write_cb, &io_ctx,
                                            &tlswritten);
-    if(RAW_EAGAIN_EWOULDBLOCK(io_error)) {
+    if(RAW_EWOULDBLOCK_EAGAIN(io_error)) {
       CURL_TRC_CF(data, cf, "cf_send: EAGAIN after %zu bytes",
                   tlswritten_total);
       return CURLE_AGAIN;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -160,11 +160,7 @@ static ssize_t tls_recv_more(struct Curl_cfilter *cf,
   io_ctx.data = data;
   io_error = rustls_connection_read_tls(backend->conn, read_cb, &io_ctx,
                                         &tls_bytes_read);
-  if(io_error == EWOULDBLOCK
-#if EAGAIN != EWOULDBLOCK
-     || io_error == EAGAIN
-#endif
-    ) {
+  if(RAW_EAGAIN_EWOULDBLOCK(io_error)) {
     *err = CURLE_AGAIN;
     return -1;
   }
@@ -274,11 +270,7 @@ static CURLcode cr_flush_out(struct Curl_cfilter *cf, struct Curl_easy *data,
   while(rustls_connection_wants_write(rconn)) {
     io_error = rustls_connection_write_tls(rconn, write_cb, &io_ctx,
                                            &tlswritten);
-    if(io_error == EWOULDBLOCK
-#if EAGAIN != EWOULDBLOCK
-       || io_error == EAGAIN
-#endif
-      ) {
+    if(RAW_EAGAIN_EWOULDBLOCK(io_error)) {
       CURL_TRC_CF(data, cf, "cf_send: EAGAIN after %zu bytes",
                   tlswritten_total);
       return CURLE_AGAIN;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -45,7 +45,7 @@
 #include "curlx/base64.h"
 #endif
 
-#if EAGAIN != SOCKEWOULDBLOCK
+#if defined(EAGAIN) && EAGAIN != SOCKEWOULDBLOCK
 #define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK || (e) == EAGAIN)
 #else
 #define RAW_EWOULDBLOCK_EAGAIN(e)  ((e) == EWOULDBLOCK)

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -109,7 +109,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 #ifndef CURL_WINDOWS_UWP
     rc = sread(per->infd, buffer, curlx_uztosi(sz * nmemb));
     if(rc < 0) {
-      if(SOCKERRNO == SOCKEWOULDBLOCK) {
+      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
         errno = 0;
         config->readbusy = TRUE;
         return CURL_READFUNC_PAUSE;

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -109,7 +109,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 #ifndef CURL_WINDOWS_UWP
     rc = sread(per->infd, buffer, curlx_uztosi(sz * nmemb));
     if(rc < 0) {
-      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
+      if(SOCK_EAGAIN(SOCKERRNO)) {
         errno = 0;
         config->readbusy = TRUE;
         return CURL_READFUNC_PAUSE;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -976,7 +976,7 @@ static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
 retry:
     written = swrite(sock, buffer, num);
     if(written < 0) {
-      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
+      if(SOCK_EAGAIN(SOCKERRNO)) {
         curlx_wait_ms(10);
         goto retry;
       }
@@ -1133,7 +1133,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
           logmsg("Got %zd bytes from client", got);
         }
 
-        if((got == -1) && SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
+        if((got == -1) && SOCK_EAGAIN(SOCKERRNO)) {
           int rc;
           fd_set input;
           fd_set output;
@@ -1193,7 +1193,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
     else if(got < 0) {
       char errbuf[STRERROR_LEN];
       int error = SOCKERRNO;
-      if(SOCK_EWOULDBLOCK_EAGAIN(error)) {
+      if(SOCK_EAGAIN(error)) {
         /* nothing to read at the moment */
         return 0;
       }
@@ -1334,7 +1334,7 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
 
   if(rc) {
     error = SOCKERRNO;
-    if((error == SOCKEINPROGRESS) || SOCK_EWOULDBLOCK_EAGAIN(error)) {
+    if((error == SOCKEINPROGRESS) || SOCK_EAGAIN(error)) {
       fd_set output;
       struct timeval timeout = { 0 };
       timeout.tv_sec = 1; /* 1000 ms */
@@ -1352,8 +1352,7 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
             error = SOCKERRNO;
           if((error == 0) || (SOCKEISCONN == error))
             goto success;
-          else if((error != SOCKEINPROGRESS) &&
-                  !SOCK_EWOULDBLOCK_EAGAIN(error))
+          else if((error != SOCKEINPROGRESS) && !SOCK_EAGAIN(error))
             goto error;
         }
         else if(!rc) {
@@ -1822,7 +1821,7 @@ static curl_socket_t accept_connection(curl_socket_t sock)
 
   if(msgsock == CURL_SOCKET_BAD) {
     error = SOCKERRNO;
-    if(SOCK_EWOULDBLOCK_EAGAIN(error)) {
+    if(SOCK_EAGAIN(error)) {
       /* nothing to accept */
       return 0;
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -976,7 +976,7 @@ static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
 retry:
     written = swrite(sock, buffer, num);
     if(written < 0) {
-      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
+      if(SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
         curlx_wait_ms(10);
         goto retry;
       }
@@ -1133,7 +1133,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
           logmsg("Got %zd bytes from client", got);
         }
 
-        if((got == -1) && SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
+        if((got == -1) && SOCK_EWOULDBLOCK_EAGAIN(SOCKERRNO)) {
           int rc;
           fd_set input;
           fd_set output;
@@ -1193,7 +1193,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
     else if(got < 0) {
       char errbuf[STRERROR_LEN];
       int error = SOCKERRNO;
-      if(SOCK_EAGAIN_EWOULDBLOCK(error)) {
+      if(SOCK_EWOULDBLOCK_EAGAIN(error)) {
         /* nothing to read at the moment */
         return 0;
       }
@@ -1821,7 +1821,7 @@ static curl_socket_t accept_connection(curl_socket_t sock)
 
   if(msgsock == CURL_SOCKET_BAD) {
     error = SOCKERRNO;
-    if(SOCK_EAGAIN_EWOULDBLOCK(error)) {
+    if(SOCK_EWOULDBLOCK_EAGAIN(error)) {
       /* nothing to accept */
       return 0;
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1334,7 +1334,7 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
 
   if(rc) {
     error = SOCKERRNO;
-    if((error == SOCKEINPROGRESS) || (error == SOCKEWOULDBLOCK)) {
+    if((error == SOCKEINPROGRESS) || SOCK_EWOULDBLOCK_EAGAIN(error)) {
       fd_set output;
       struct timeval timeout = { 0 };
       timeout.tv_sec = 1; /* 1000 ms */
@@ -1352,7 +1352,8 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
             error = SOCKERRNO;
           if((error == 0) || (SOCKEISCONN == error))
             goto success;
-          else if((error != SOCKEINPROGRESS) && (error != SOCKEWOULDBLOCK))
+          else if((error != SOCKEINPROGRESS) &&
+                  !SOCK_EWOULDBLOCK_EAGAIN(error))
             goto error;
         }
         else if(!rc) {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -976,7 +976,11 @@ static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
 retry:
     written = swrite(sock, buffer, num);
     if(written < 0) {
-      if((SOCKEWOULDBLOCK == SOCKERRNO) || (EAGAIN == SOCKERRNO)) {
+      if(SOCKERRNO == SOCKEWOULDBLOCK
+#if EAGAIN != SOCKEWOULDBLOCK
+         || SOCKERRNO == EAGAIN
+#endif
+        ) {
         curlx_wait_ms(10);
         goto retry;
       }
@@ -1134,7 +1138,12 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
         }
 
         if((got == -1) &&
-           ((SOCKERRNO == EAGAIN) || (SOCKERRNO == SOCKEWOULDBLOCK))) {
+           (SOCKERRNO == SOCKEWOULDBLOCK
+#if EAGAIN != SOCKEWOULDBLOCK
+            || SOCKERRNO == EAGAIN
+#endif
+           )
+          ) {
           int rc;
           fd_set input;
           fd_set output;
@@ -1194,7 +1203,11 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
     else if(got < 0) {
       char errbuf[STRERROR_LEN];
       int error = SOCKERRNO;
-      if(EAGAIN == error || SOCKEWOULDBLOCK == error) {
+      if(error == SOCKEWOULDBLOCK
+#if EAGAIN != SOCKEWOULDBLOCK
+         || error == EAGAIN
+#endif
+        ) {
         /* nothing to read at the moment */
         return 0;
       }
@@ -1822,7 +1835,11 @@ static curl_socket_t accept_connection(curl_socket_t sock)
 
   if(msgsock == CURL_SOCKET_BAD) {
     error = SOCKERRNO;
-    if(EAGAIN == error || SOCKEWOULDBLOCK == error) {
+    if(error == SOCKEWOULDBLOCK
+#if EAGAIN != SOCKEWOULDBLOCK
+       || error == EAGAIN
+#endif
+      ) {
       /* nothing to accept */
       return 0;
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -976,11 +976,7 @@ static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
 retry:
     written = swrite(sock, buffer, num);
     if(written < 0) {
-      if(SOCKERRNO == SOCKEWOULDBLOCK
-#if EAGAIN != SOCKEWOULDBLOCK
-         || SOCKERRNO == EAGAIN
-#endif
-        ) {
+      if(SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
         curlx_wait_ms(10);
         goto retry;
       }
@@ -1137,13 +1133,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
           logmsg("Got %zd bytes from client", got);
         }
 
-        if((got == -1) &&
-           (SOCKERRNO == SOCKEWOULDBLOCK
-#if EAGAIN != SOCKEWOULDBLOCK
-            || SOCKERRNO == EAGAIN
-#endif
-           )
-          ) {
+        if((got == -1) && SOCK_EAGAIN_EWOULDBLOCK(SOCKERRNO)) {
           int rc;
           fd_set input;
           fd_set output;
@@ -1203,11 +1193,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
     else if(got < 0) {
       char errbuf[STRERROR_LEN];
       int error = SOCKERRNO;
-      if(error == SOCKEWOULDBLOCK
-#if EAGAIN != SOCKEWOULDBLOCK
-         || error == EAGAIN
-#endif
-        ) {
+      if(SOCK_EAGAIN_EWOULDBLOCK(error)) {
         /* nothing to read at the moment */
         return 0;
       }
@@ -1835,11 +1821,7 @@ static curl_socket_t accept_connection(curl_socket_t sock)
 
   if(msgsock == CURL_SOCKET_BAD) {
     error = SOCKERRNO;
-    if(error == SOCKEWOULDBLOCK
-#if EAGAIN != SOCKEWOULDBLOCK
-       || error == EAGAIN
-#endif
-      ) {
+    if(SOCK_EAGAIN_EWOULDBLOCK(error)) {
       /* nothing to accept */
       return 0;
     }


### PR DESCRIPTION
To contain the logic of checking for both `EWOULDBLOCK` and/or `EAGAIN`
depending on platform/availability. Also to avoid checking for both if
they mapp to the same value, and to avoid PP guards around use.

This also ensures `EAGAIN` is consistently not checked on Windows, where
headers defined it, but `SOCKERRNO` never returns it, because curl maps
it to `WSAGetLastError()`.

If they map to the same value, checking them both in an `if` expression
trips GCC warning `-Wlogical-op` (the same way it triggers duplicate
case value error in `switch`).

Also:
- replace two `switch()` statements with the new macro.
- tests/server/sws: make two outliers use the new macro that were only
  checking for `EWOULDBLOCK` before this patch, in `connect_to()`.
- move variables to the left-side of expressions, where missing.
- rustls: use a variant of this macro that uses raw `EWOULDBLOCK`.
  Tried tracing it back to the origins, but I couldn't figure out if
  this is working as expected on all supported Windows versions in
  Rust. It seems to be using `GetLastError()`, according to
  https://docs.rs/system_error/0.2.0/system_error/, which would be
  probably incorrect.

Notes:
- it's probably a good idea to assign `SOCKERRNO` to a variable before
  passing it to this macro.

Cherry-picked from #21893

---

https://github.com/curl/curl/pull/21992/files?w=1

- [x] better name than `SOCK_EWOULDBLOCK_EAGAIN()` for the macro? I figure it's nice to include both names
  it's covering, but don't feel strongly about it. → [trying `SOCK_EAGAIN()` for short]
- [x] cf-socket: maybe turn a 3-way `switch` into an `if` and use this macro? [DONE, also for another instance]
- [x] there was indication in code/history that some rare platforms may not 
  have `EWOULDBLOCK` but do have `EAGAIN`. This wasn't consistently
  supported and this patch leaves it as-is. If this causes an issue, it
  should be easy to support this case with the new macro.
  https://github.com/libssh2/libssh2/issues/171
  https://github.com/libssh2/libssh2/pull/172
  https://github.com/libssh2/libssh2/commit/92f76866a81883db86e7595c0b86181b25cabbfa
  On a second read this seem overkill, and `EWOULDBLOCK` was added for VMS-only
  then later extended to more platforms but keeping a check for `EWOULDBLOCK`.
  POSIX should have this macro. Also curl never handled a build without it.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
