### PR TITLE
perl: switch from backticks to `qx()`

### DIFF
--- a/.github/scripts/randcurl.pl
+++ b/.github/scripts/randcurl.pl
@@ -61,7 +61,7 @@ sub storedata {
 }
 
 sub getoptions {
-    my @all = `$curl --help all`;
+    my @all = qx($curl --help all);
     for my $o (@all) {
         chomp $o;
         if($o =~ /^ -(.), --([^ ]*) (.*)/) {

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -1226,12 +1226,12 @@ sub scanfile {
         @copyright = sort {$$b{year} cmp $$a{year}} @copyright;
 
         # if the file is modified, assume commit year this year
-        if(`git status -s -- "$file"` =~ /^ [MARCU]/) {
+        if(qx(git status -s -- "$file") =~ /^ [MARCU]/) {
             $commityear = (localtime(time))[5] + 1900;
         }
         else {
             # min-parents=1 to ignore wrong initial commit in truncated repos
-            my $grl = `git rev-list --max-count=1 --min-parents=1 --timestamp HEAD -- "$file"`;
+            my $grl = qx(git rev-list --max-count=1 --min-parents=1 --timestamp HEAD -- "$file");
             if($grl) {
                 chomp $grl;
                 $commityear = (localtime((split(/ /, $grl))[0]))[5] + 1900;

--- a/scripts/mdlinkcheck
+++ b/scripts/mdlinkcheck
@@ -90,7 +90,7 @@ if(defined $ARGV[0] && $ARGV[0] eq "--dry-run") {
 }
 
 # list all files to scan for links
-my @files = `git ls-files docs include lib scripts src`;
+my @files = qx(git ls-files docs include lib scripts src);
 
 sub storelink {
     my ($f, $line, $link) = @_;

--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -309,7 +309,7 @@ if(!$opt_n) {
 
     # If we have an HTTPS URL then use curl
     if($url =~ /^https:\/\//i) {
-        my $curl = `curl -V`;
+        my $curl = qx(curl -V);
         if($curl) {
             if($curl =~ /^Protocols:.* https( |$)/m) {
                 report "Get certdata with curl!";

--- a/scripts/randdisable
+++ b/scripts/randdisable
@@ -28,7 +28,7 @@ use List::Util qw/shuffle/;
 my @disable;
 
 sub getoptions {
-    my @all = `./configure --help`;
+    my @all = qx(./configure --help);
     for my $o (@all) {
         chomp $o;
         if($o =~ /(--disable-[^ ]*)/) {

--- a/scripts/release-notes.pl
+++ b/scripts/release-notes.pl
@@ -58,8 +58,8 @@ use strict;
 use warnings;
 
 my $cleanup = (@ARGV && $ARGV[0] eq "cleanup");
-my @gitlog = `git log @^{/RELEASE-NOTES:.synced}..` if(!$cleanup);
-my @releasenotes = `cat RELEASE-NOTES`;
+my @gitlog = qx(git log @^{/RELEASE-NOTES:.synced}..) if(!$cleanup);
+my @releasenotes = qx(cat RELEASE-NOTES);
 
 my @o; # the entire new RELEASE-NOTES
 my @refused; # [num] = [2 bits of use info]

--- a/tests/appveyor.pm
+++ b/tests/appveyor.pm
@@ -53,7 +53,7 @@ sub appveyor_create_test_result {
     $testname =~ s/\"/\\\"/g;
     $testname =~ s/\'/'"'"'/g;
     my $appveyor_baseurl = $ENV{'APPVEYOR_API_URL'};
-    my $appveyor_result = `$curl --silent --noproxy '*' \\
+    my $appveyor_result = qx($curl --silent --noproxy '*' \\
     --header 'Content-Type: application/json' \\
     --data '
         {
@@ -63,7 +63,7 @@ sub appveyor_create_test_result {
             "outcome": "Running"
         }
     ' \\
-    '$appveyor_baseurl/api/tests'`;
+    '$appveyor_baseurl/api/tests');
     print "AppVeyor API result: $appveyor_result\n" if($appveyor_result);
     $APPVEYOR_TEST_NAMES{$testnum} = $testname;
 }
@@ -97,7 +97,7 @@ sub appveyor_update_test_result {
         $appveyor_category = 'Error';
     }
     my $appveyor_baseurl = $ENV{'APPVEYOR_API_URL'};
-    my $appveyor_result = `$curl --silent --noproxy '*' --request PUT \\
+    my $appveyor_result = qx($curl --silent --noproxy '*' --request PUT \\
     --header 'Content-Type: application/json' \\
     --data '
         {
@@ -109,10 +109,10 @@ sub appveyor_update_test_result {
             "ErrorMessage": "Test $testnum $appveyor_outcome"
         }
     ' \\
-    '$appveyor_baseurl/api/tests'`;
+    '$appveyor_baseurl/api/tests');
     print "AppVeyor API result: $appveyor_result\n" if($appveyor_result);
     if($appveyor_category eq 'Error') {
-        $appveyor_result = `$curl --silent --noproxy '*' \\
+        $appveyor_result = qx($curl --silent --noproxy '*' \\
         --header 'Content-Type: application/json' \\
         --data '
             {
@@ -121,7 +121,7 @@ sub appveyor_update_test_result {
                 "details": "Test $testnum $appveyor_outcome"
             }
         ' \\
-        '$appveyor_baseurl/api/build/messages'`;
+        '$appveyor_baseurl/api/build/messages');
         print "AppVeyor API result: $appveyor_result\n" if($appveyor_result);
     }
 }

--- a/tests/azure.pm
+++ b/tests/azure.pm
@@ -55,7 +55,7 @@ sub azure_check_environment {
 sub azure_create_test_run {
     my ($curl) = @_;
     my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run = `$curl --silent --noproxy "*" \\
+    my $azure_run = qx($curl --silent --noproxy "*" \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data "
@@ -65,7 +65,7 @@ sub azure_create_test_run {
             'build': {'id': '$ENV{'BUILD_BUILDID'}'}
         }
     " \\
-    "$azure_baseurl/_apis/test/runs?api-version=5.1"`;
+    "$azure_baseurl/_apis/test/runs?api-version=5.1");
     if($azure_run =~ /"id":(\d+)/) {
         return $1;
     }
@@ -79,7 +79,7 @@ sub azure_create_test_result {
     $testname =~ s/\'/'"'"'/g;
     my $title_testnum = sprintf("%04d", $testnum);
     my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result = `$curl --silent --noproxy '*' \\
+    my $azure_result = qx($curl --silent --noproxy '*' \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header 'Content-Type: application/json' \\
     --data '
@@ -94,7 +94,7 @@ sub azure_create_test_result {
             }
         ]
     ' \\
-    '$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1'`;
+    '$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1');
     if($azure_result =~ /\[\{"id":(\d+)/) {
         return $1;
     }
@@ -123,7 +123,7 @@ sub azure_update_test_result {
         $azure_outcome = 'Failed';
     }
     my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_result = `$curl --silent --noproxy '*' --request PATCH \\
+    my $azure_result = qx($curl --silent --noproxy '*' --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header "Content-Type: application/json" \\
     --data '
@@ -137,7 +137,7 @@ sub azure_update_test_result {
             }
         ]
     ' \\
-    '$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1'`;
+    '$azure_baseurl/_apis/test/runs/$azure_run_id/results?api-version=5.1');
     if($azure_result =~ /\[\{"id":(\d+)/) {
         return $1;
     }
@@ -147,7 +147,7 @@ sub azure_update_test_result {
 sub azure_update_test_run {
     my ($curl, $azure_run_id) = @_;
     my $azure_baseurl = "$ENV{'SYSTEM_TEAMFOUNDATIONCOLLECTIONURI'}$ENV{'SYSTEM_TEAMPROJECTID'}";
-    my $azure_run = `$curl --silent --noproxy '*' --request PATCH \\
+    my $azure_run = qx($curl --silent --noproxy '*' --request PATCH \\
     --header "Authorization: Bearer $ENV{'AZURE_ACCESS_TOKEN'}" \\
     --header 'Content-Type: application/json' \\
     --data '
@@ -155,7 +155,7 @@ sub azure_update_test_run {
             "state": "Completed"
         }
     ' \\
-    '$azure_baseurl/_apis/test/runs/$azure_run_id?api-version=5.1'`;
+    '$azure_baseurl/_apis/test/runs/$azure_run_id?api-version=5.1');
     if($azure_run =~ /"id":(\d+)/) {
         return $1;
     }

--- a/tests/devtest.pl
+++ b/tests/devtest.pl
@@ -69,7 +69,7 @@ use getpart;
 # This function is currently required to be here by servers.pm
 # This is copied from runtests.pl
 #
-my $uname_release = `uname -r`;
+my $uname_release = qx(uname -r);
 my $is_wsl = $uname_release =~ /Microsoft$/;
 sub logmsg {
     for(@_) {
@@ -108,7 +108,7 @@ sub parseprotocols {
 # Initialize @protocols from the curl binary under test
 #
 sub init_protocols {
-    for (`$CURL -V 2>$dev_null`) {
+    for (qx($CURL -V 2>$dev_null)) {
         if(m/^Protocols: (.*)$/) {
             parseprotocols($1);
         }

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -136,7 +136,7 @@ sub pidexists {
                 } else {
                     my $filter = "PID eq $pid";
                     # https://ss64.com/nt/tasklist.html
-                    my $result = `tasklist -fi \"$filter\" 2>$dev_null`;
+                    my $result = qx(tasklist -fi \"$filter\" 2>$dev_null);
                     if(index($result, $pid) != -1) {
                         return -$pid;
                     }
@@ -170,12 +170,12 @@ sub pidterm {
                     Win32::Process::KillProcess($pid, 0);
                 } else {
                     # https://ss64.com/nt/tasklist.html
-                    my $result = `tasklist -v -fo list -fi "PID eq $pid" 2>&1`;
+                    my $result = qx(tasklist -v -fo list -fi "PID eq $pid" 2>&1);
                     $result =~ s/\r//g;
                     $result =~ s/\n/ | /g;
                     print "Task info for $pid before taskkill: '$result'\n";
 
-                    $result = `powershell -Command "Get-CimInstance -ClassName Win32_Process -Filter 'ParentProcessId=$pid' | Select ProcessId,ParentProcessId,Name,CommandLine"`;
+                    $result = qx(powershell -Command "Get-CimInstance -ClassName Win32_Process -Filter 'ParentProcessId=$pid' | Select ProcessId,ParentProcessId,Name,CommandLine");
                     $result =~ s/\r//g;
                     print "Task child processes for $pid before taskkill:\n";
                     print "$result\n";
@@ -221,12 +221,12 @@ sub pidkill {
                     Win32::Process::KillProcess($pid, 0);
                 } else {
                     # https://ss64.com/nt/tasklist.html
-                    my $result = `tasklist -v -fo list -fi "PID eq $pid" 2>&1`;
+                    my $result = qx(tasklist -v -fo list -fi "PID eq $pid" 2>&1);
                     $result =~ s/\r//g;
                     $result =~ s/\n/ | /g;
                     print "Task info for $pid before taskkill: '$result'\n";
 
-                    $result = `powershell -Command "Get-CimInstance -ClassName Win32_Process -Filter 'ParentProcessId=$pid' | Select ProcessId,ParentProcessId,Name,CommandLine"`;
+                    $result = qx(powershell -Command "Get-CimInstance -ClassName Win32_Process -Filter 'ParentProcessId=$pid' | Select ProcessId,ParentProcessId,Name,CommandLine");
                     $result =~ s/\r//g;
                     print "Task child processes for $pid before taskkill:\n";
                     print "$result\n";

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -714,7 +714,7 @@ sub singletest_precheck {
             # provide an environment variable
             $ENV{'CURL_TESTNUM'} = $testnum;
 
-            my @o = `$cmd 2> $LOGDIR/precheck-$testnum`;
+            my @o = qx($cmd 2> $LOGDIR/precheck-$testnum);
             if($o[0]) {
                 $why = $o[0];
                 $why =~ s/[\r\n]//g;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -128,7 +128,7 @@ my $retry = 0;
 my $start;          # time at which testing started
 my $args;           # command-line arguments
 
-my $uname_release = `uname -r`;
+my $uname_release = qx(uname -r);
 my $is_wsl = $uname_release =~ /Microsoft$/;
 
 my $http_ipv6;      # set if HTTP server has IPv6 support
@@ -324,7 +324,7 @@ if(!$ENV{"NGHTTPX"}) {
 }
 if($ENV{"NGHTTPX"}) {
     my $cmd = "\"$ENV{'NGHTTPX'}\" -v 2>$dev_null";
-    my $nghttpx_version = join(' ', `$cmd`);
+    my $nghttpx_version = join(' ', qx($cmd));
     $nghttpx_h3 = $nghttpx_version =~ /nghttp3\//;
     chomp $nghttpx_h3;
 }
@@ -413,10 +413,10 @@ sub showdiff {
         print $temp "\n";
     }
     close($temp) || die "Failure writing diff file";
-    my @out = `diff -u $file2 $file1 2>$dev_null`;
+    my @out = qx(diff -u $file2 $file1 2>$dev_null);
 
     if(!$out[0]) {
-        @out = `diff -c $file2 $file1 2>$dev_null`;
+        @out = qx(diff -c $file2 $file1 2>$dev_null);
         if(!$out[0]) {
             logmsg "Failed to show diff. The diff tool may be missing.\n";
         }
@@ -638,7 +638,7 @@ sub checksystemfeatures {
                 $feature{"sshkeyalgo"} = ($ENV{'CURL_TEST_SSH_KEYALGO'} and
                     $ENV{'CURL_TEST_SSH_KEYALGO'} =~ /^(?:rsa|ecdsa|ed25519)$/) ? $ENV{'CURL_TEST_SSH_KEYALGO'} : 'rsa';
                 # Detect simple cases of default libssh configuration files ending up
-                # setting `StrictHostKeyChecking no`. include files, quoted values,
+                # setting 'StrictHostKeyChecking no'. include files, quoted values,
                 # '=value' format not implemented.
                 $feature{"badlibssh"} = 0;
                 foreach my $libssh_configfile (('/etc/ssh/ssh_config', $ENV{'HOME'} . '/.ssh/config')) {
@@ -806,7 +806,7 @@ sub checksystemfeatures {
 
         # check if the HTTP server has it!
         my $cmd = server_exe('sws')." --version";
-        my @sws = `$cmd`;
+        my @sws = qx($cmd);
         if($sws[0] =~ /IPv6/) {
             # HTTP server has IPv6 support!
             $http_ipv6 = 1;
@@ -814,7 +814,7 @@ sub checksystemfeatures {
 
         # check if the FTP server has it!
         $cmd = server_exe('sockfilt')." --version";
-        @sws = `$cmd`;
+        @sws = qx($cmd);
         if($sws[0] =~ /IPv6/) {
             # FTP server has IPv6 support!
             $ftp_ipv6 = 1;
@@ -824,7 +824,7 @@ sub checksystemfeatures {
     if($feature{"UnixSockets"}) {
         # client has Unix sockets support, check whether the HTTP server has it
         my $cmd = server_exe('sws')." --version";
-        my @sws = `$cmd`;
+        my @sws = qx($cmd);
         $http_unix = 1 if($sws[0] =~ /unix/);
     }
 

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -206,11 +206,11 @@ sub initserverconfig {
         $USER = $ENV{LOGNAME};  # Some Unix (I think)
     }
     if(!$USER) {
-        $USER = `whoami`;
+        $USER = qx(whoami);
         chomp $USER;
     }
     if(!$USER) {
-        $USER = `id -un`;
+        $USER = qx(id -un);
         chomp $USER;
     }
     init_serverpidfile_hash();

--- a/tests/sshhelp.pm
+++ b/tests/sshhelp.pm
@@ -342,7 +342,7 @@ sub find_sshkeygen {
 sub find_httptlssrv {
     my $p = find_exe_file_hpath($httptlssrvexe);
     if($p) {
-        my @o = `"$p" -l`;
+        my @o = qx("$p" -l);
         my $found;
         for(@o) {
             if(/Key exchange: SRP/) {

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -677,7 +677,7 @@ sub sshd_supports_opt {
         ($sshdid =~ /SunSSH/)) {
         # ssh daemon supports command line options -t -f and -o
         $err = grep /((Unsupported)|(Bad configuration)|(Deprecated)) option.*$option/,
-                    `\"$sshd\" -t -f $sshdconfig_abs -o \"$option=$value\" 2>&1`;
+                    qx(\"$sshd\" -t -f $sshdconfig_abs -o \"$option=$value\" 2>&1);
         return !$err;
     }
     if(($sshdid =~ /OpenSSH/) && ($sshdvernum >= 299)) {
@@ -688,7 +688,7 @@ sub sshd_supports_opt {
             return 0;
         }
         $err = grep /((Unsupported)|(Bad configuration)|(Deprecated)) option.*$option/,
-                    `\"$sshd\" -t -f $sshdconfig_abs 2>&1`;
+                    qx(\"$sshd\" -t -f $sshdconfig_abs 2>&1);
         unlink $sshdconfig;
         return !$err;
     }

--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -418,7 +418,7 @@ if($git) {
     }
 
     # get the last 5 commits for show (even if no pull was made)
-    @commits = `git log --pretty=oneline --abbrev-commit -5`;
+    @commits = qx(git log --pretty=oneline --abbrev-commit -5);
     logit "The most recent curl git commits:";
     for(@commits) {
         chomp ($_);
@@ -441,7 +441,7 @@ if($git) {
         }
 
         # get the last 5 commits for show (even if no pull was made)
-        @commits = `git log --pretty=oneline --abbrev-commit -5`;
+        @commits = qx(git log --pretty=oneline --abbrev-commit -5);
         logit "The most recent ares git commits:";
         for (@commits) {
             chomp ($_);
@@ -547,7 +547,7 @@ chdir "$pwd/$build";
 
 if($configurebuild) {
     # run configure script
-    print `$CURLDIR/configure $confopts 2>&1`;
+    print qx($CURLDIR/configure $confopts 2>&1);
 
     if(-f "lib/Makefile") {
         logit "configure seems to have finished fine";

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -223,10 +223,10 @@ sub runclient {
 #
 sub runclientoutput {
     my ($cmd) = @_;
-    return `$cmd 2>$dev_null`;
+    return qx($cmd 2>$dev_null);
 
 # This is one way to test curl on a remote machine
-#    my @out = `ssh $CLIENTIP cd \'$pwd\' \\; \'$cmd\'`;
+#    my @out = qx(ssh $CLIENTIP cd \'$pwd\' \\; \'$cmd\');
 #    sleep 2;    # time to allow the NFS server to be updated
 #    return @out;
 }


### PR DESCRIPTION
To make it easier to find external command invocation in the source.

Also drop backticks from a comment.

To find external command invocations in Perl code use:
```sh
git grep -E "((exec|qx|open2|open3|system)\(|open\(.+-\|)" $(<perlfiles>)
```

Refs:
https://perldoc.perl.org/functions/qx
https://perldoc.perl.org/perlop#Simpler-Quote-Like-Operators
