### PR TITLE
telnet: drop redundant interim variables

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1372,9 +1372,9 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case WAIT_OBJECT_0: {
       events.lNetworkEvents = 0;
       if(WSAEnumNetworkEvents(sockfd, event_handle, &events) != 0) {
-        int sockerr = SOCKERRNO;
-        if(sockerr != SOCKEINPROGRESS) {
-          infof(data, "WSAEnumNetworkEvents failed (%d)", sockerr);
+        int err = SOCKERRNO;
+        if(err != SOCKEINPROGRESS) {
+          infof(data, "WSAEnumNetworkEvents failed (%d)", err);
           keepon = FALSE;
           result = CURLE_READ_ERROR;
         }

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -239,10 +239,8 @@ static void send_negotiation(struct Curl_easy *data, int cmd, int option)
   buf[2] = (unsigned char)option;
 
   bytes_written = swrite(conn->sock[FIRSTSOCKET], buf, 3);
-  if(bytes_written < 0) {
-    int sockerr = SOCKERRNO;
-    failf(data, "Sending data failed (%d)", sockerr);
-  }
+  if(bytes_written < 0)
+    failf(data, "Sending data failed (%d)", SOCKERRNO);
 
   printoption(data, "SENT", cmd, option);
 }
@@ -680,7 +678,6 @@ static void sendsuboption(struct Curl_easy *data,
                           struct TELNET *tn, int option)
 {
   ssize_t bytes_written;
-  int sockerr;
   unsigned short x, y;
   const unsigned char *uc1, *uc2;
   struct connectdata *conn = data->conn;
@@ -713,19 +710,15 @@ static void sendsuboption(struct Curl_easy *data,
 
     /* we send the header of the suboption... */
     bytes_written = swrite(conn->sock[FIRSTSOCKET], tn->subbuffer, 3);
-    if(bytes_written < 0) {
-      sockerr = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", sockerr);
-    }
+    if(bytes_written < 0)
+      failf(data, "Sending data failed (%d)", SOCKERRNO);
     /* ... then the window size with the send_telnet_data() function
        to deal with 0xFF cases ... */
     send_telnet_data(data, tn, (const char *)tn->subbuffer + 3, 4);
     /* ... and the footer */
     bytes_written = swrite(conn->sock[FIRSTSOCKET], tn->subbuffer + 7, 2);
-    if(bytes_written < 0) {
-      sockerr = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", sockerr);
-    }
+    if(bytes_written < 0)
+      failf(data, "Sending data failed (%d)", SOCKERRNO);
     break;
   }
 }
@@ -987,7 +980,6 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
   unsigned char temp[2048];
   ssize_t bytes_written;
   size_t len;
-  int sockerr;
   struct connectdata *conn = data->conn;
 
   if(!CURL_SB_LEN(tn)) /* ignore empty suboption */
@@ -1010,8 +1002,7 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
     bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
 
     if(bytes_written < 0) {
-      sockerr = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", sockerr);
+      failf(data, "Sending data failed (%d)", SOCKERRNO);
       return CURLE_SEND_ERROR;
     }
     printsub(data, '>', &temp[2], len-2);
@@ -1029,8 +1020,7 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
                          CURL_SE);
     bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
     if(bytes_written < 0) {
-      sockerr = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", sockerr);
+      failf(data, "Sending data failed (%d)", SOCKERRNO);
       return CURLE_SEND_ERROR;
     }
     printsub(data, '>', &temp[2], len - 2);
@@ -1061,10 +1051,8 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
                    "%c%c", CURL_IAC, CURL_SE);
     len += 2;
     bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
-    if(bytes_written < 0) {
-      sockerr = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", sockerr);
-    }
+    if(bytes_written < 0)
+      failf(data, "Sending data failed (%d)", SOCKERRNO);
     printsub(data, '>', &temp[2], len - 2);
     break;
   }
@@ -1247,7 +1235,6 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
   DWORD obj_count;
   DWORD wait_timeout;
   DWORD readfile_read;
-  int sockerr;
 #else
   timediff_t interval_ms;
   struct pollfd pfd[2];
@@ -1385,7 +1372,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case WAIT_OBJECT_0: {
       events.lNetworkEvents = 0;
       if(WSAEnumNetworkEvents(sockfd, event_handle, &events) != 0) {
-        sockerr = SOCKERRNO;
+        int sockerr = SOCKERRNO;
         if(sockerr != SOCKEINPROGRESS) {
           infof(data, "WSAEnumNetworkEvents failed (%d)", sockerr);
           keepon = FALSE;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -240,8 +240,8 @@ static void send_negotiation(struct Curl_easy *data, int cmd, int option)
 
   bytes_written = swrite(conn->sock[FIRSTSOCKET], buf, 3);
   if(bytes_written < 0) {
-    int err = SOCKERRNO;
-    failf(data, "Sending data failed (%d)", err);
+    int sockerr = SOCKERRNO;
+    failf(data, "Sending data failed (%d)", sockerr);
   }
 
   printoption(data, "SENT", cmd, option);
@@ -680,7 +680,7 @@ static void sendsuboption(struct Curl_easy *data,
                           struct TELNET *tn, int option)
 {
   ssize_t bytes_written;
-  int err;
+  int sockerr;
   unsigned short x, y;
   const unsigned char *uc1, *uc2;
   struct connectdata *conn = data->conn;
@@ -714,8 +714,8 @@ static void sendsuboption(struct Curl_easy *data,
     /* we send the header of the suboption... */
     bytes_written = swrite(conn->sock[FIRSTSOCKET], tn->subbuffer, 3);
     if(bytes_written < 0) {
-      err = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", err);
+      sockerr = SOCKERRNO;
+      failf(data, "Sending data failed (%d)", sockerr);
     }
     /* ... then the window size with the send_telnet_data() function
        to deal with 0xFF cases ... */
@@ -723,8 +723,8 @@ static void sendsuboption(struct Curl_easy *data,
     /* ... and the footer */
     bytes_written = swrite(conn->sock[FIRSTSOCKET], tn->subbuffer + 7, 2);
     if(bytes_written < 0) {
-      err = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", err);
+      sockerr = SOCKERRNO;
+      failf(data, "Sending data failed (%d)", sockerr);
     }
     break;
   }
@@ -987,7 +987,7 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
   unsigned char temp[2048];
   ssize_t bytes_written;
   size_t len;
-  int err;
+  int sockerr;
   struct connectdata *conn = data->conn;
 
   if(!CURL_SB_LEN(tn)) /* ignore empty suboption */
@@ -1010,8 +1010,8 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
     bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
 
     if(bytes_written < 0) {
-      err = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", err);
+      sockerr = SOCKERRNO;
+      failf(data, "Sending data failed (%d)", sockerr);
       return CURLE_SEND_ERROR;
     }
     printsub(data, '>', &temp[2], len-2);
@@ -1029,8 +1029,8 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
                          CURL_SE);
     bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
     if(bytes_written < 0) {
-      err = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", err);
+      sockerr = SOCKERRNO;
+      failf(data, "Sending data failed (%d)", sockerr);
       return CURLE_SEND_ERROR;
     }
     printsub(data, '>', &temp[2], len - 2);
@@ -1062,8 +1062,8 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
     len += 2;
     bytes_written = swrite(conn->sock[FIRSTSOCKET], temp, len);
     if(bytes_written < 0) {
-      err = SOCKERRNO;
-      failf(data, "Sending data failed (%d)", err);
+      sockerr = SOCKERRNO;
+      failf(data, "Sending data failed (%d)", sockerr);
     }
     printsub(data, '>', &temp[2], len - 2);
     break;
@@ -1247,7 +1247,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
   DWORD obj_count;
   DWORD wait_timeout;
   DWORD readfile_read;
-  int err;
+  int sockerr;
 #else
   timediff_t interval_ms;
   struct pollfd pfd[2];
@@ -1385,9 +1385,9 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case WAIT_OBJECT_0: {
       events.lNetworkEvents = 0;
       if(WSAEnumNetworkEvents(sockfd, event_handle, &events) != 0) {
-        err = SOCKERRNO;
-        if(err != SOCKEINPROGRESS) {
-          infof(data, "WSAEnumNetworkEvents failed (%d)", err);
+        sockerr = SOCKERRNO;
+        if(sockerr != SOCKEINPROGRESS) {
+          infof(data, "WSAEnumNetworkEvents failed (%d)", sockerr);
           keepon = FALSE;
           result = CURLE_READ_ERROR;
         }


### PR DESCRIPTION
Also reduce scope of a declaration.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
