### PR TITLE
pingpong: reject nul byte in server response line

### DIFF
--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -292,6 +292,13 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
            the line is not really terminated until the LF comes */
         size_t length = nl - line + 1;
 
+        if(memchr(line, 0, length)) {
+          /* The response line is passed on as a "header" below, so reject an
+             embedded nul the same way verify_header() does for HTTP. */
+          failf(data, "Nul byte in server response line");
+          return CURLE_WEIRD_SERVER_REPLY;
+        }
+
         /* output debug output if that is requested */
         Curl_debug(data, CURLINFO_HEADER_IN, line, length);
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -254,6 +254,7 @@ test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
+test2108 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 \

--- a/tests/data/test2108
+++ b/tests/data/test2108
@@ -3,14 +3,12 @@
 <info>
 <keywords>
 FTP
-PASV
-RETR
 </keywords>
 </info>
 # Server-side
 <reply>
 <servercmd>
-REPLY PASS 633 XXXXXXXXXXXXXXXX
+REPLY PASS 230 logged\x00 in
 </servercmd>
 </reply>
 
@@ -20,7 +18,7 @@ REPLY PASS 633 XXXXXXXXXXXXXXXX
 ftp
 </server>
 <name>
-FTP with 633 response to auth
+FTP rejects a nul byte in a server response line
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
@@ -35,9 +33,9 @@ USER anonymous
 PASS ftp@example.com
 </protocol>
 
-# 67 == CURLE_LOGIN_DENIED
+# 8 == CURLE_WEIRD_SERVER_REPLY
 <errorcode>
-67
+8
 </errorcode>
 </verify>
 </testcase>


### PR DESCRIPTION
Repro: point curl at an FTP/IMAP/SMTP/POP3 server that sends a response line with an embedded nul before the LF, e.g. a POP3 greeting `+OK ready\u0000injected\r\n`. Before this patch curl returns `0` and the line (nul and all) is handed to `CURLOPT_HEADERFUNCTION`; after it the transfer fails with `CURLE_WEIRD_SERVER_REPLY`.

Cause: `Curl_pp_readresp()` finds the line end with `memchr` on the LF only and passes each line to `Curl_client_write(CLIENTWRITE_INFO)`, which is delivered to the header callback (the response lines are treated as a kind of header). The pingpong path has no nul check, so a malicious or MITM server can smuggle an embedded nul into the header callback. Regular HTTP headers are guarded against this by `verify_header()`; these control responses are not.

Fix: reject a nul byte in the response line before delivery. `verify_header()` itself is not reused here as it also enforces a trailing-`CR`/colon shape that pingpong lines do not have.