### PR TITLE
socket: use name `sockerr` for socket error variables

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -111,7 +111,7 @@ struct async_thrdd_item {
 #ifdef CURLVERBOSE
   char description[CURL_ASYN_ITEM_DESC_LEN];
 #endif
-  int sock_error;
+  int sockerr;
   uint32_t mid;
   uint32_t resolv_id;
   uint16_t port;
@@ -372,9 +372,9 @@ static void async_thrdd_item_process(void *arg)
 
   rc = Curl_getaddrinfo_ex(item->hostname, service, &hints, &item->res);
   if(rc) {
-    item->sock_error = SOCKERRNO ? SOCKERRNO : rc;
-    if(item->sock_error == 0)
-      item->sock_error = RESOLVER_ENOMEM;
+    item->sockerr = SOCKERRNO ? SOCKERRNO : rc;
+    if(item->sockerr == 0)
+      item->sockerr = RESOLVER_ENOMEM;
   }
   else {
     Curl_addrinfo_set_port(item->res, item->port);
@@ -399,9 +399,9 @@ static void async_thrdd_item_process(void *arg)
 #endif
   item->res = Curl_ipv4_resolve_r(item->hostname, item->port);
   if(!item->res) {
-    item->sock_error = SOCKERRNO;
-    if(item->sock_error == 0)
-      item->sock_error = RESOLVER_ENOMEM;
+    item->sockerr = SOCKERRNO;
+    if(item->sockerr == 0)
+      item->sockerr = RESOLVER_ENOMEM;
   }
 }
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -882,7 +882,7 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
 /*
  * verifyconnect() returns TRUE if the connect really has happened.
  */
-static bool verifyconnect(curl_socket_t sockfd, int *error)
+static bool verifyconnect(curl_socket_t sockfd, int *psockerr)
 {
   bool rc = TRUE;
 #ifdef SO_ERROR
@@ -923,12 +923,12 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
   else
     /* This was not a successful connect */
     rc = FALSE;
-  if(error)
-    *error = sockerr;
+  if(psockerr)
+    *psockerr = sockerr;
 #else
   (void)sockfd;
-  if(error)
-    *error = SOCKERRNO;
+  if(psockerr)
+    *psockerr = SOCKERRNO;
 #endif
   return rc;
 }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1361,7 +1361,7 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
 
   *done = FALSE; /* a negative world view is best */
   if(ctx->sock == CURL_SOCKET_BAD) {
-    int error;
+    int sockerr;
 
     result = cf_socket_open(cf, data);
     if(result)
@@ -1374,13 +1374,13 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
 
     /* Connect TCP socket */
     rc = do_connect(cf, data, (bool)cf->conn->bits.tcp_fastopen);
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     set_local_ip(cf, data);
     CURL_TRC_CF(data, cf, "local address %s port %d...",
                 ctx->ip.local_ip, ctx->ip.local_port);
     if(rc == -1) {
-      ctx->error = error;
-      result = socket_connect_result(data, ctx->ip.remote_ip, error);
+      ctx->error = sockerr;
+      result = socket_connect_result(data, ctx->ip.remote_ip, sockerr);
       goto out;
     }
   }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -912,7 +912,7 @@ static bool verifyconnect(curl_socket_t sockfd, int *psockerr)
     sockerr = SOCKERRNO;
 #if defined(EBADIOCTL) && defined(__minix)
   /* Minix 3.1.x does not support getsockopt on UDP sockets */
-  if(EBADIOCTL == err) {
+  if(EBADIOCTL == sockerr) {
     SET_SOCKERRNO(0);
     sockerr = 0;
   }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1114,6 +1114,9 @@ static CURLcode set_remote_ip(struct Curl_cfilter *cf,
                       ctx->ip.remote_ip, &ctx->ip.remote_port)) {
     char buffer[STRERROR_LEN];
 
+    /* using bare errno instead of SOCKERRNO is safe here, because
+       sockaddr2string's callee inet_ntop is locally implemented in
+       Windows builds and returns the socket error via errno. */
     ctx->sockerr = errno;
     /* malformed address or bug in inet_ntop, try next address */
     failf(data, "curl_sa_addr inet_ntop() failed with errno %d: %s",

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1087,9 +1087,9 @@ static void set_local_ip(struct Curl_cfilter *cf,
 
     memset(&ssloc, 0, sizeof(ssloc));
     if(getsockname(ctx->sock, (struct sockaddr *)&ssloc, &slen)) {
-      VERBOSE(int error = SOCKERRNO);
+      VERBOSE(int sockerr = SOCKERRNO);
       infof(data, "getsockname() failed with errno %d: %s",
-            error, curlx_strerror(error, buffer, sizeof(buffer)));
+            sockerr, curlx_strerror(sockerr, buffer, sizeof(buffer)));
     }
     else if(!sockaddr2string((struct sockaddr *)&ssloc, slen,
                              ctx->ip.local_ip, &ctx->ip.local_port)) {

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -652,7 +652,7 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
   const char *host_input = data->set.str[STRING_BINDHOST];
   const char *iface = iface_input ? iface_input : dev;
   const char *host = host_input ? host_input : dev;
-  int error;
+  int sockerr;
 #ifdef IP_BIND_ADDRESS_NO_PORT
   int on = 1;
 #endif
@@ -715,9 +715,9 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
       if(iface_input && !host_input) {
         /* Do not fall back to treating it as a hostname */
         char buffer[STRERROR_LEN];
-        data->state.os_errno = error = SOCKERRNO;
+        data->state.os_errno = sockerr = SOCKERRNO;
         failf(data, "Could not bind to interface '%s' with errno %d: %s",
-              iface, error, curlx_strerror(error, buffer, sizeof(buffer)));
+              iface, sockerr, curlx_strerror(sockerr, buffer, sizeof(buffer)));
         return CURLE_INTERFACE_FAILED;
       }
       break;
@@ -819,9 +819,9 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
          generic resolve error. */
       char buffer[STRERROR_LEN];
       data->state.errorbuf = FALSE;
-      data->state.os_errno = error = SOCKERRNO;
+      data->state.os_errno = sockerr = SOCKERRNO;
       failf(data, "Could not bind to '%s' with errno %d: %s", host,
-            error, curlx_strerror(error, buffer, sizeof(buffer)));
+            sockerr, curlx_strerror(sockerr, buffer, sizeof(buffer)));
       return CURLE_INTERFACE_FAILED;
     }
   }
@@ -870,9 +870,9 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
   }
   {
     char buffer[STRERROR_LEN];
-    data->state.os_errno = error = SOCKERRNO;
+    data->state.os_errno = sockerr = SOCKERRNO;
     failf(data, "bind failed with errno %d: %s",
-          error, curlx_strerror(error, buffer, sizeof(buffer)));
+          sockerr, curlx_strerror(sockerr, buffer, sizeof(buffer)));
   }
 
   return CURLE_INTERFACE_FAILED;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -937,19 +937,19 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
  * Determine the curl code for a socket connect() == -1 with errno.
  */
 static CURLcode socket_connect_result(struct Curl_easy *data,
-                                      const char *ipaddress, int error)
+                                      const char *ipaddress, int sockerr)
 {
-  if(error == SOCKEINPROGRESS || SOCK_EAGAIN(error))
+  if(sockerr == SOCKEINPROGRESS || SOCK_EAGAIN(sockerr))
     return CURLE_OK;
 
   /* unknown error, fallthrough and try another address! */
   {
     VERBOSE(char buffer[STRERROR_LEN]);
     infof(data, "Immediate connect fail for %s: %s", ipaddress,
-          curlx_strerror(error, buffer, sizeof(buffer)));
+          curlx_strerror(sockerr, buffer, sizeof(buffer)));
     NOVERBOSE((void)ipaddress);
   }
-  data->state.os_errno = error;
+  data->state.os_errno = sockerr;
   /* connect failed */
   return CURLE_COULDNT_CONNECT;
 }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -2108,9 +2108,9 @@ static void cf_tcp_set_accepted_remote_ip(struct Curl_cfilter *cf,
   plen = sizeof(ssrem);
   memset(&ssrem, 0, plen);
   if(getpeername(ctx->sock, (struct sockaddr *)&ssrem, &plen)) {
-    int error = SOCKERRNO;
+    int sockerr = SOCKERRNO;
     failf(data, "getpeername() failed with errno %d: %s",
-          error, curlx_strerror(error, buffer, sizeof(buffer)));
+          sockerr, curlx_strerror(sockerr, buffer, sizeof(buffer)));
     return;
   }
   if(!sockaddr2string((struct sockaddr *)&ssrem, plen,

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1115,8 +1115,8 @@ static CURLcode set_remote_ip(struct Curl_cfilter *cf,
     char buffer[STRERROR_LEN];
 
     /* using bare errno instead of SOCKERRNO is safe here, because
-       sockaddr2string's callee inet_ntop is locally implemented in
-       Windows builds and returns the socket error via errno. */
+       sockaddr2string() calls curlx_inet_ntop(), and they both report failures
+       via errno (even on Windows builds). */
     ctx->sockerr = errno;
     /* malformed address or bug in inet_ntop, try next address */
     failf(data, "curl_sa_addr inet_ntop() failed with errno %d: %s",

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -886,8 +886,8 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
 {
   bool rc = TRUE;
 #ifdef SO_ERROR
-  int err = 0;
-  curl_socklen_t errSize = sizeof(err);
+  int sockerr = 0;
+  curl_socklen_t errSize = sizeof(sockerr);
 
 #ifdef _WIN32
   /*
@@ -908,23 +908,23 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
   SleepEx(0, FALSE);
 #endif
 
-  if(getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (void *)&err, &errSize))
-    err = SOCKERRNO;
+  if(getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (void *)&sockerr, &errSize))
+    sockerr = SOCKERRNO;
 #if defined(EBADIOCTL) && defined(__minix)
   /* Minix 3.1.x does not support getsockopt on UDP sockets */
   if(EBADIOCTL == err) {
     SET_SOCKERRNO(0);
-    err = 0;
+    sockerr = 0;
   }
 #endif
-  if((err == 0) || (SOCKEISCONN == err))
+  if((sockerr == 0) || (SOCKEISCONN == sockerr))
     /* we are connected, awesome! */
     rc = TRUE;
   else
     /* This was not a successful connect */
     rc = FALSE;
   if(error)
-    *error = err;
+    *error = sockerr;
 #else
   (void)sockfd;
   if(error)

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -966,7 +966,7 @@ struct cf_socket_ctx {
   struct curltime last_sndbuf_query_at;  /* when SO_SNDBUF last queried */
   ULONG sndbuf_size;                     /* the last set SO_SNDBUF size */
 #endif
-  int error;                         /* errno of last failure or 0 */
+  int sockerr;                       /* socket error of last failure or 0 */
 #ifdef DEBUGBUILD
   int wblock_percent;                /* percent of writes doing EAGAIN */
   int wpartial_percent;              /* percent of bytes written in send */
@@ -1114,7 +1114,7 @@ static CURLcode set_remote_ip(struct Curl_cfilter *cf,
                       ctx->ip.remote_ip, &ctx->ip.remote_port)) {
     char buffer[STRERROR_LEN];
 
-    ctx->error = errno;
+    ctx->sockerr = errno;
     /* malformed address or bug in inet_ntop, try next address */
     failf(data, "curl_sa_addr inet_ntop() failed with errno %d: %s",
           errno, curlx_strerror(errno, buffer, sizeof(buffer)));
@@ -1258,7 +1258,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   error = curlx_nonblock(ctx->sock, TRUE);
   if(error < 0) {
     result = CURLE_UNSUPPORTED_PROTOCOL;
-    ctx->error = SOCKERRNO;
+    ctx->sockerr = SOCKERRNO;
     goto out;
   }
 #else
@@ -1268,7 +1268,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
     error = curlx_nonblock(ctx->sock, TRUE);
     if(error < 0) {
       result = CURLE_UNSUPPORTED_PROTOCOL;
-      ctx->error = SOCKERRNO;
+      ctx->sockerr = SOCKERRNO;
       goto out;
     }
   }
@@ -1379,7 +1379,7 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
     CURL_TRC_CF(data, cf, "local address %s port %d...",
                 ctx->ip.local_ip, ctx->ip.local_port);
     if(rc == -1) {
-      ctx->error = sockerr;
+      ctx->sockerr = sockerr;
       result = socket_connect_result(data, ctx->ip.remote_ip, sockerr);
       goto out;
     }
@@ -1400,7 +1400,7 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
     return CURLE_OK;
   }
   else if(rc == CURL_CSELECT_OUT || cf->conn->bits.tcp_fastopen) {
-    if(verifyconnect(ctx->sock, &ctx->error)) {
+    if(verifyconnect(ctx->sock, &ctx->sockerr)) {
       /* we are connected with TCP, awesome! */
       ctx->connected_at = *Curl_pgrs_now(data);
       set_local_ip(cf, data);
@@ -1412,7 +1412,7 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
   }
   else if(rc & CURL_CSELECT_ERR) {
     CURL_TRC_CF(data, cf, "poll/select error on fd=%" FMT_SOCKET_T, ctx->sock);
-    (void)verifyconnect(ctx->sock, &ctx->error);
+    (void)verifyconnect(ctx->sock, &ctx->sockerr);
     result = CURLE_COULDNT_CONNECT;
   }
 
@@ -1420,10 +1420,10 @@ out:
   if(result) {
     VERBOSE(char buffer[STRERROR_LEN]);
     set_local_ip(cf, data);
-    if(ctx->error) {
-      data->state.os_errno = ctx->error;
-      SET_SOCKERRNO(ctx->error);
-      VERBOSE(curlx_strerror(ctx->error, buffer, sizeof(buffer)));
+    if(ctx->sockerr) {
+      data->state.os_errno = ctx->sockerr;
+      SET_SOCKERRNO(ctx->sockerr);
+      VERBOSE(curlx_strerror(ctx->sockerr, buffer, sizeof(buffer)));
     }
     else {
       VERBOSE(curlx_strcopy(buffer, sizeof(buffer), STRCONST("peer closed")));
@@ -1435,7 +1435,7 @@ out:
     infof(data, "connect to %s port %u from %s port %d failed: %s",
           ctx->ip.remote_ip, ctx->ip.remote_port,
           ctx->ip.local_ip, ctx->ip.local_port,
-          curlx_strerror(ctx->error, buffer, sizeof(buffer)));
+          curlx_strerror(ctx->sockerr, buffer, sizeof(buffer)));
     *done = FALSE;
   }
   return result;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1083,7 +1083,7 @@ static CURLcode ftp_port_open_socket(struct Curl_easy *data,
                                      curl_socket_t *portsockp)
 {
   char buffer[STRERROR_LEN];
-  int error = 0;
+  int sockerr = 0;
   const struct Curl_addrinfo *ai;
   CURLcode result = CURLE_FTP_PORT_FAILED;
 
@@ -1095,14 +1095,14 @@ static CURLcode ftp_port_open_socket(struct Curl_easy *data,
       if(result == CURLE_OUT_OF_MEMORY)
         return result;
       result = CURLE_FTP_PORT_FAILED;
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       continue;
     }
     break;
   }
   if(!ai) {
     failf(data, "socket failure: %s",
-          curlx_strerror(error, buffer, sizeof(buffer)));
+          curlx_strerror(sockerr, buffer, sizeof(buffer)));
     return CURLE_FTP_PORT_FAILED;
   }
   *aip = ai;
@@ -1131,7 +1131,7 @@ static CURLcode ftp_port_bind_socket(struct Curl_easy *data,
 #endif
   char buffer[STRERROR_LEN];
   unsigned short port;
-  int error;
+  int sockerr;
 
   memcpy(sa, ai->ai_addr, ai->ai_addrlen);
   *sslen_io = ai->ai_addrlen;
@@ -1144,13 +1144,13 @@ static CURLcode ftp_port_bind_socket(struct Curl_easy *data,
       sa6->sin6_port = htons(port);
 #endif
     if(bind(portsock, sa, *sslen_io)) {
-      error = SOCKERRNO;
-      if(non_local && (error == SOCKEADDRNOTAVAIL)) {
+      sockerr = SOCKERRNO;
+      if(non_local && (sockerr == SOCKEADDRNOTAVAIL)) {
         /* The requested bind address is not local. Use the address used for
          * the control connection instead and restart the port loop.
          */
         infof(data, "bind(port=%hu) on non-local address failed: %s", port,
-              curlx_strerror(error, buffer, sizeof(buffer)));
+              curlx_strerror(sockerr, buffer, sizeof(buffer)));
 
         *sslen_io = sizeof(*ss);
         if(getsockname(conn->sock[FIRSTSOCKET], sa, sslen_io)) {
@@ -1162,9 +1162,9 @@ static CURLcode ftp_port_bind_socket(struct Curl_easy *data,
         non_local = FALSE; /* do not try this again */
         continue;
       }
-      if(error != SOCKEADDRINUSE && error != SOCKEACCES) {
+      if(sockerr != SOCKEADDRINUSE && sockerr != SOCKEACCES) {
         failf(data, "bind(port=%hu) failed: %s", port,
-              curlx_strerror(error, buffer, sizeof(buffer)));
+              curlx_strerror(sockerr, buffer, sizeof(buffer)));
         return CURLE_FTP_PORT_FAILED;
       }
     }

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -131,7 +131,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
    * Since there are three different versions of it, the following code is
    * somewhat #ifdef-ridden.
    */
-  int h_errnop;
+  int sockerr;
 
   buf = curlx_calloc(1, CURL_HOSTENT_SIZE);
   if(!buf)
@@ -148,7 +148,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
                       (struct hostent *)buf,
                       (char *)buf + sizeof(struct hostent),
                       CURL_HOSTENT_SIZE - sizeof(struct hostent),
-                      &h_errnop);
+                      &sockerr);
 
   /* If the buffer is too small, it returns NULL and sets errno to
    * ERANGE. The errno is thread-safe if this is compiled with
@@ -168,7 +168,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
                         (char *)buf + sizeof(struct hostent),
                         CURL_HOSTENT_SIZE - sizeof(struct hostent),
                         &h, /* DIFFERENCE */
-                        &h_errnop);
+                        &sockerr);
   /* Redhat 8, using glibc 2.2.93 changed the behavior. Now all of a
    * sudden this function returns EAGAIN if the given buffer size is too
    * small. Previous versions are known to return ERANGE for the same
@@ -234,7 +234,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
                           (struct hostent *)buf,
                           (struct hostent_data *)((char *)buf +
                                                   sizeof(struct hostent)));
-    h_errnop = SOCKERRNO; /* we do not deal with this, but set it anyway */
+    sockerr = SOCKERRNO; /* we do not deal with this, but set it anyway */
   }
   else
     res = -1; /* failure, too smallish buffer size */

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -131,7 +131,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
    * Since there are three different versions of it, the following code is
    * somewhat #ifdef-ridden.
    */
-  int sockerr;
+  int h_errnop;
 
   buf = curlx_calloc(1, CURL_HOSTENT_SIZE);
   if(!buf)
@@ -148,7 +148,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
                       (struct hostent *)buf,
                       (char *)buf + sizeof(struct hostent),
                       CURL_HOSTENT_SIZE - sizeof(struct hostent),
-                      &sockerr);
+                      &h_errnop);
 
   /* If the buffer is too small, it returns NULL and sets errno to
    * ERANGE. The errno is thread-safe if this is compiled with
@@ -168,7 +168,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
                         (char *)buf + sizeof(struct hostent),
                         CURL_HOSTENT_SIZE - sizeof(struct hostent),
                         &h, /* DIFFERENCE */
-                        &sockerr);
+                        &h_errnop);
   /* Redhat 8, using glibc 2.2.93 changed the behavior. Now all of a
    * sudden this function returns EAGAIN if the given buffer size is too
    * small. Previous versions are known to return ERANGE for the same
@@ -234,7 +234,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
                           (struct hostent *)buf,
                           (struct hostent_data *)((char *)buf +
                                                   sizeof(struct hostent)));
-    sockerr = SOCKERRNO; /* we do not deal with this, but set it anyway */
+    h_errnop = SOCKERRNO; /* we do not deal with this, but set it anyway */
   }
   else
     res = -1; /* failure, too smallish buffer size */

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -302,7 +302,7 @@ int Curl_wakeup_init(curl_socket_t socks[2], bool nonblocking)
 
 int Curl_wakeup_signal(curl_socket_t socks[2])
 {
-  int err = 0;
+  int sockerr = 0;
 #ifdef USE_EVENTFD
   const uint64_t buf[1] = { 1 };
 #else
@@ -310,19 +310,19 @@ int Curl_wakeup_signal(curl_socket_t socks[2])
 #endif
 
   while(1) {
-    err = 0;
+    sockerr = 0;
     if(wakeup_write(socks[1], buf, sizeof(buf)) < 0) {
-      err = SOCKERRNO;
+      sockerr = SOCKERRNO;
 #ifndef USE_WINSOCK
-      if(err == SOCKEINTR)
+      if(sockerr == SOCKEINTR)
         continue;
 #endif
-      if(SOCK_EAGAIN(err))
-        err = 0; /* wakeup is already ongoing */
+      if(SOCK_EAGAIN(sockerr))
+        sockerr = 0; /* wakeup is already ongoing */
     }
     break;
   }
-  return err;
+  return sockerr;
 }
 
 CURLcode Curl_wakeup_consume(curl_socket_t socks[2], bool all)

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1372,9 +1372,9 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case WAIT_OBJECT_0: {
       events.lNetworkEvents = 0;
       if(WSAEnumNetworkEvents(sockfd, event_handle, &events) != 0) {
-        int err = SOCKERRNO;
-        if(err != SOCKEINPROGRESS) {
-          infof(data, "WSAEnumNetworkEvents failed (%d)", err);
+        int sockerr = SOCKERRNO;
+        if(sockerr != SOCKEINPROGRESS) {
+          infof(data, "WSAEnumNetworkEvents failed (%d)", sockerr);
           keepon = FALSE;
           result = CURLE_READ_ERROR;
         }

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1197,9 +1197,9 @@ static CURLcode tftp_multi_statemach(struct Curl_easy *data, bool *done)
 
     if(rc == -1) {
       /* bail out */
-      int error = SOCKERRNO;
+      int sockerr = SOCKERRNO;
       char buffer[STRERROR_LEN];
-      failf(data, "%s", curlx_strerror(error, buffer, sizeof(buffer)));
+      failf(data, "%s", curlx_strerror(sockerr, buffer, sizeof(buffer)));
       state->event = TFTP_EVENT_ERROR;
     }
     else if(rc) {

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -484,12 +484,12 @@ void ws_close(CURL *curl);  /* close the connection */
 #define exe_select_test(A, B, C, D, E, Y, Z)                             \
   do {                                                                   \
     if(select_wrapper(A, B, C, D, E) == -1) {                            \
-      int ec = SOCKERRNO;                                                \
-      char ecbuf[STRERROR_LEN];                                          \
+      int sockerr = SOCKERRNO;                                           \
+      char sockerrbuf[STRERROR_LEN];                                     \
       curl_mfprintf(stderr,                                              \
-                    "%s:%d select() failed, with "                       \
-                    "errno %d (%s)\n",                                   \
-                    Y, Z, ec, curlx_strerror(ec, ecbuf, sizeof(ecbuf))); \
+                    "%s:%d select() failed, with errno %d (%s)\n", Y, Z, \
+                    sockerr, curlx_strerror(sockerr, sockerrbuf,         \
+                                            sizeof(sockerrbuf)));        \
       result = TEST_ERR_SELECT;                                          \
     }                                                                    \
   } while(0)

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -742,7 +742,7 @@ static int test_dnsd(int argc, const char **argv)
   curl_socket_t sock = CURL_SOCKET_BAD;
   int flag;
   int rc;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int result = 0;
   struct resp *resp;
@@ -840,18 +840,18 @@ static int test_dnsd(int argc, const char **argv)
 #endif
 
   if(sock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error creating socket (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto dnsd_cleanup;
   }
 
   flag = 1;
   if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&flag, sizeof(flag))) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("setsockopt(SO_REUSEADDR) failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto dnsd_cleanup;
   }
@@ -875,9 +875,9 @@ static int test_dnsd(int argc, const char **argv)
   }
 #endif /* USE_IPV6 */
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error binding socket on port %hu (%d) %s", port,
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto dnsd_cleanup;
   }
@@ -897,9 +897,9 @@ static int test_dnsd(int argc, const char **argv)
       la_size = sizeof(localaddr.sa6);
 #endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       sclose(sock);
       goto dnsd_cleanup;
     }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -713,7 +713,7 @@ static bool mqttd_incoming(curl_socket_t listenfd)
 
   do {
     ssize_t rc;
-    int error = 0;
+    int sockerr = 0;
     char errbuf[STRERROR_LEN];
     curl_socket_t sockfd = listenfd;
     int maxfd = (int)sockfd;
@@ -732,20 +732,20 @@ static bool mqttd_incoming(curl_socket_t listenfd)
         logmsg("signalled to die, exiting...");
         return FALSE;
       }
-    } while((rc == -1) && ((error = SOCKERRNO) == SOCKEINTR));
+    } while((rc == -1) && ((sockerr = SOCKERRNO) == SOCKEINTR));
 
     if(rc < 0) {
       logmsg("select() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       return FALSE;
     }
 
     if(FD_ISSET(sockfd, &fds_read)) {
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(newfd == CURL_SOCKET_BAD) {
-        error = SOCKERRNO;
+        sockerr = SOCKERRNO;
         logmsg("accept() failed with error (%d) %s",
-               error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+               sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       }
       else {
         logmsg("====> Client connect, fd %ld. "
@@ -770,7 +770,7 @@ static int test_mqttd(int argc, const char *argv[])
   int wrotepidfile = 0;
   int wroteportfile = 0;
   bool juggle_again;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int arg = 1;
 
@@ -872,9 +872,9 @@ static int test_mqttd(int argc, const char *argv[])
   sock = socket(socket_domain, SOCK_STREAM, 0);
 
   if(sock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error creating socket (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto mqttd_cleanup;
   }
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1014,7 +1014,7 @@ static int test_rtspd(int argc, const char *argv[])
   unsigned short port = 8999;
   struct rtspd_httprequest req;
   int rc;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int arg = 1;
 
@@ -1118,17 +1118,17 @@ static int test_rtspd(int argc, const char *argv[])
 #endif
 
   if(sock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error creating socket (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto server_cleanup;
   }
 
   flag = 1;
   if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&flag, sizeof(flag))) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("setsockopt(SO_REUSEADDR) failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto server_cleanup;
   }
 
@@ -1151,9 +1151,9 @@ static int test_rtspd(int argc, const char *argv[])
   }
 #endif /* USE_IPV6 */
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error binding socket on port %hu (%d) %s", port,
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto server_cleanup;
   }
 
@@ -1172,9 +1172,9 @@ static int test_rtspd(int argc, const char *argv[])
       la_size = sizeof(localaddr.sa6);
 #endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       sclose(sock);
       goto server_cleanup;
     }
@@ -1205,9 +1205,9 @@ static int test_rtspd(int argc, const char *argv[])
   /* start accepting connections */
   rc = listen(sock, 5);
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("listen() failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto server_cleanup;
   }
 
@@ -1232,9 +1232,9 @@ static int test_rtspd(int argc, const char *argv[])
     if(got_exit_signal)
       break;
     if(msgsock == CURL_SOCKET_BAD) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("MAJOR ERROR, accept() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       break;
     }
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -604,7 +604,7 @@ storerequest_cleanup:
 /* return 0 on success, non-zero on failure */
 static int rtspd_get_request(curl_socket_t sock, struct rtspd_httprequest *req)
 {
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int fail = 0;
   int done_processing = 0;
@@ -665,9 +665,9 @@ static int rtspd_get_request(curl_socket_t sock, struct rtspd_httprequest *req)
       fail = 1;
     }
     else if(got < 0) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("recv() returned error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       fail = 1;
     }
     if(fail) {
@@ -975,9 +975,9 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
               break;
             if(res) {
               /* should not happen */
-              error = SOCKERRNO;
+              int sockerr = SOCKERRNO;
               logmsg("curlx_wait_ms() failed with error (%d) %s",
-                     error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+                     sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
               break;
             }
           }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -928,7 +928,7 @@ static bool juggle(curl_socket_t *sockfdp,
   curl_socket_t sockfd = CURL_SOCKET_BAD;
   int maxfd = -99;
   ssize_t rc;
-  int error = 0;
+  int sockerr = 0;
   char errbuf[STRERROR_LEN];
 
   unsigned char buffer[BUFFER_SIZE];
@@ -1014,11 +1014,11 @@ static bool juggle(curl_socket_t *sockfdp,
       logmsg("signalled to die, exiting...");
       return FALSE;
     }
-  } while((rc == -1) && ((error = SOCKERRNO) == SOCKEINTR));
+  } while((rc == -1) && ((sockerr = SOCKERRNO) == SOCKEINTR));
 
   if(rc < 0) {
     logmsg("select() failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     return FALSE;
   }
 
@@ -1120,9 +1120,9 @@ static bool juggle(curl_socket_t *sockfdp,
          client connecting. */
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(newfd == CURL_SOCKET_BAD) {
-        error = SOCKERRNO;
+        sockerr = SOCKERRNO;
         logmsg("accept() failed with error (%d) %s",
-               error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+               sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       }
       else {
         logmsg("====> Client connect");
@@ -1174,7 +1174,7 @@ static int test_sockfilt(int argc, const char *argv[])
   int wroteportfile = 0;
   bool juggle_again;
   int rc;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int arg = 1;
   enum sockmode mode = PASSIVE_LISTEN; /* default */
@@ -1293,9 +1293,9 @@ static int test_sockfilt(int argc, const char *argv[])
   sock = socket(socket_domain, SOCK_STREAM, 0);
 
   if(sock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error creating socket (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     write_stdout("FAIL\n", 5);
     goto sockfilt_cleanup;
   }
@@ -1331,9 +1331,9 @@ static int test_sockfilt(int argc, const char *argv[])
       rc = 1;
     }
     if(rc) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("Error connecting to port %hu (%d) %s", server_connectport,
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;
     }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -228,9 +228,9 @@ static curl_socket_t socksconnect(unsigned short connectport,
 
   if(rc) {
     char errbuf[STRERROR_LEN];
-    int error = SOCKERRNO;
+    int sockerr = SOCKERRNO;
     logmsg("Failed connecting to %s:%hu (%d) %s", connectaddr, connectport,
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     return CURL_SOCKET_BAD;
   }
   logmsg("Connected fine to %s:%d", connectaddr, connectport);
@@ -636,7 +636,7 @@ static bool socksd_incoming(curl_socket_t listenfd)
   do {
     int i;
     ssize_t rc;
-    int error = 0;
+    int sockerr = 0;
     char errbuf[STRERROR_LEN];
     curl_socket_t sockfd = listenfd;
     int maxfd = (int)sockfd;
@@ -668,20 +668,20 @@ static bool socksd_incoming(curl_socket_t listenfd)
         logmsg("signalled to die, exiting...");
         return FALSE;
       }
-    } while((rc == -1) && ((error = SOCKERRNO) == SOCKEINTR));
+    } while((rc == -1) && ((sockerr = SOCKERRNO) == SOCKEINTR));
 
     if(rc < 0) {
       logmsg("select() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       return FALSE;
     }
 
     if((clients < 2) && FD_ISSET(sockfd, &fds_read)) {
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(newfd == CURL_SOCKET_BAD) {
-        error = SOCKERRNO;
+        sockerr = SOCKERRNO;
         logmsg("accept() failed with error (%d) %s",
-               error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+               sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       }
       else {
         curl_socket_t remotefd;
@@ -732,7 +732,6 @@ static int test_socksd(int argc, const char *argv[])
   int wrotepidfile = 0;
   int wroteportfile = 0;
   bool juggle_again;
-  int error;
   char errbuf[STRERROR_LEN];
   int arg = 1;
 
@@ -866,9 +865,9 @@ static int test_socksd(int argc, const char *argv[])
   sock = socket(socket_domain, SOCK_STREAM, 0);
 
   if(sock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    int sockerr = SOCKERRNO;
     logmsg("Error creating socket (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto socks5_cleanup;
   }
 
@@ -919,7 +918,7 @@ socks5_cleanup:
 
 #ifdef USE_UNIX_SOCKETS
   if(unlink_socket && socket_domain == AF_UNIX && unix_socket) {
-    error = unlink(unix_socket);
+    int error = unlink(unix_socket);
     logmsg("unlink(%s) = %d (%s)", unix_socket,
            error, curlx_strerror(error, errbuf, sizeof(errbuf)));
   }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1048,9 +1048,9 @@ retry:
             res = curlx_wait_ms(250);
             if(res) {
               /* should not happen */
-              error = SOCKERRNO;
+              int sockerr = SOCKERRNO;
               logmsg("curlx_wait_ms() failed with error (%d) %s",
-                     error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+                     sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
               break;
             }
           }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1802,7 +1802,7 @@ static void http_upgrade(struct sws_httprequest *req)
 static curl_socket_t accept_connection(curl_socket_t sock)
 {
   curl_socket_t msgsock = CURL_SOCKET_BAD;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int flag = 1;
 
@@ -1820,20 +1820,20 @@ static curl_socket_t accept_connection(curl_socket_t sock)
   }
 
   if(msgsock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
-    if(SOCK_EAGAIN(error)) {
+    sockerr = SOCKERRNO;
+    if(SOCK_EAGAIN(sockerr)) {
       /* nothing to accept */
       return 0;
     }
     logmsg("MAJOR ERROR, accept() failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     return CURL_SOCKET_BAD;
   }
 
   if(curlx_nonblock(msgsock, TRUE)) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("curlx_nonblock failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     sclose(msgsock);
     return CURL_SOCKET_BAD;
   }
@@ -1843,9 +1843,9 @@ static curl_socket_t accept_connection(curl_socket_t sock)
 #endif
     if(setsockopt(msgsock, SOL_SOCKET, SO_KEEPALIVE,
                   (void *)&flag, sizeof(flag))) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("setsockopt(SO_KEEPALIVE) failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       sclose(msgsock);
       return CURL_SOCKET_BAD;
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1192,13 +1192,13 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
     }
     else if(got < 0) {
       char errbuf[STRERROR_LEN];
-      int error = SOCKERRNO;
-      if(SOCK_EAGAIN(error)) {
+      int sockerr = SOCKERRNO;
+      if(SOCK_EAGAIN(sockerr)) {
         /* nothing to read at the moment */
         return 0;
       }
       logmsg("recv() returned error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       fail = 1;
     }
     if(fail) {
@@ -1974,7 +1974,7 @@ static int test_sws(int argc, const char *argv[])
 #endif
   struct sws_httprequest *req = NULL;
   int rc = 0;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int arg = 1;
   const char *connecthost = "127.0.0.1";
@@ -2146,9 +2146,9 @@ static int test_sws(int argc, const char *argv[])
   num_sockets = 1;
 
   if(sock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error creating socket (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto sws_cleanup;
   }
 
@@ -2158,18 +2158,18 @@ static int test_sws(int argc, const char *argv[])
     flag = 1;
     if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
                   (void *)&flag, sizeof(flag))) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("setsockopt(SO_REUSEADDR) failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       goto sws_cleanup;
     }
 #if defined(_WIN32) && defined(USE_UNIX_SOCKETS)
   }
 #endif
   if(curlx_nonblock(sock, TRUE)) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("curlx_nonblock failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto sws_cleanup;
   }
 
@@ -2196,15 +2196,15 @@ static int test_sws(int argc, const char *argv[])
 #endif /* USE_UNIX_SOCKETS */
   }
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
 #ifdef USE_UNIX_SOCKETS
     if(socket_domain == AF_UNIX)
       logmsg("Error binding socket on path %s (%d) %s", unix_socket,
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     else
 #endif
       logmsg("Error binding socket on port %hu (%d) %s", port,
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto sws_cleanup;
   }
 
@@ -2223,9 +2223,9 @@ static int test_sws(int argc, const char *argv[])
       la_size = sizeof(localaddr.sa6);
 #endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       sclose(sock);
       goto sws_cleanup;
     }
@@ -2262,9 +2262,9 @@ static int test_sws(int argc, const char *argv[])
   /* start accepting connections */
   rc = listen(sock, 50);
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("listen() failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto sws_cleanup;
   }
 
@@ -2336,9 +2336,9 @@ static int test_sws(int argc, const char *argv[])
       goto sws_cleanup;
 
     if(rc < 0) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("select() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       goto sws_cleanup;
     }
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1246,7 +1246,7 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
 {
   srvr_sockaddr_union_t serveraddr;
   curl_socket_t serverfd;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   int rc = 0;
   const char *op_br = "";
@@ -1266,9 +1266,9 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
 
   serverfd = socket(socket_domain, SOCK_STREAM, 0);
   if(serverfd == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error creating socket for server connection (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     return CURL_SOCKET_BAD;
   }
 
@@ -1286,9 +1286,9 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
    * Windows has an internal retry logic that may lead to long
    * timeouts if the peer is not listening. */
   if(curlx_nonblock(serverfd, TRUE)) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("curlx_nonblock(TRUE) failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     sclose(serverfd);
     return CURL_SOCKET_BAD;
   }
@@ -1333,8 +1333,8 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
   }
 
   if(rc) {
-    error = SOCKERRNO;
-    if((error == SOCKEINPROGRESS) || SOCK_EAGAIN(error)) {
+    sockerr = SOCKERRNO;
+    if((sockerr == SOCKEINPROGRESS) || SOCK_EAGAIN(sockerr)) {
       fd_set output;
       struct timeval timeout = { 0 };
       timeout.tv_sec = 1; /* 1000 ms */
@@ -1346,13 +1346,13 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
         if(rc < 0 && SOCKERRNO != SOCKEINTR)
           goto error;
         else if(rc > 0) {
-          curl_socklen_t errSize = sizeof(error);
+          curl_socklen_t errSize = sizeof(sockerr);
           if(getsockopt(serverfd, SOL_SOCKET, SO_ERROR,
-                        (void *)&error, &errSize))
-            error = SOCKERRNO;
-          if((error == 0) || (SOCKEISCONN == error))
+                        (void *)&sockerr, &errSize))
+            sockerr = SOCKERRNO;
+          if((sockerr == 0) || (SOCKEISCONN == sockerr))
             goto success;
-          else if((error != SOCKEINPROGRESS) && !SOCK_EAGAIN(error))
+          else if((sockerr != SOCKEINPROGRESS) && !SOCK_EAGAIN(sockerr))
             goto error;
         }
         else if(!rc) {
@@ -1364,7 +1364,7 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
     }
 error:
     logmsg("Error connecting to server port %hu (%d) %s", port,
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     sclose(serverfd);
     return CURL_SOCKET_BAD;
   }
@@ -1373,9 +1373,9 @@ success:
          op_br, ipaddr, cl_br, port);
 
   if(curlx_nonblock(serverfd, FALSE)) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("curlx_nonblock(FALSE) failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     sclose(serverfd);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1015,7 +1015,7 @@ static int test_tftpd(int argc, const char **argv)
   curl_socket_t sock = CURL_SOCKET_BAD;
   int flag;
   int rc;
-  int error;
+  int sockerr;
   char errbuf[STRERROR_LEN];
   struct testcase test;
   int result = 0;
@@ -1121,18 +1121,18 @@ static int test_tftpd(int argc, const char **argv)
 #endif
 
   if(sock == CURL_SOCKET_BAD) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error creating socket (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto tftpd_cleanup;
   }
 
   flag = 1;
   if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&flag, sizeof(flag))) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("setsockopt(SO_REUSEADDR) failed with error (%d) %s",
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto tftpd_cleanup;
   }
@@ -1156,9 +1156,9 @@ static int test_tftpd(int argc, const char **argv)
   }
 #endif /* USE_IPV6 */
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("Error binding socket on port %hu (%d) %s", port,
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto tftpd_cleanup;
   }
@@ -1178,9 +1178,9 @@ static int test_tftpd(int argc, const char **argv)
       la_size = sizeof(localaddr.sa6);
 #endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       sclose(sock);
       goto tftpd_cleanup;
     }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -656,7 +656,6 @@ void restore_signal_handlers(bool keep_sigalrm)
 int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
                      struct sockaddr_un *sau)
 {
-  int error;
   char errbuf[STRERROR_LEN];
   int rc;
   size_t len;
@@ -678,6 +677,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
   rc = bind(sock, (struct sockaddr *)sau, sizeof(struct sockaddr_un));
   if(rc && SOCKERRNO == SOCKEADDRINUSE) {
     curlx_struct_stat statbuf;
+    int sockerr;
     /* socket already exists. Perhaps it is stale? */
     curl_socket_t unixfd = socket(AF_UNIX, SOCK_STREAM, 0);
     if(unixfd == CURL_SOCKET_BAD) {
@@ -687,11 +687,11 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     }
     /* check whether the server is alive */
     rc = connect(unixfd, (struct sockaddr*)sau, sizeof(struct sockaddr_un));
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     sclose(unixfd);
-    if(rc && error != SOCKECONNREFUSED) {
+    if(rc && sockerr != SOCKECONNREFUSED) {
       logmsg("Failed to connect to %s (%d) %s", unix_socket,
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       return rc;
     }
     /* socket server is not alive, now check if it was actually a socket. */

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -681,8 +681,9 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     /* socket already exists. Perhaps it is stale? */
     curl_socket_t unixfd = socket(AF_UNIX, SOCK_STREAM, 0);
     if(unixfd == CURL_SOCKET_BAD) {
+      sockerr = SOCKERRNO;
       logmsg("Failed to create socket at %s (%d) %s", unix_socket,
-             SOCKERRNO, curlx_strerror(SOCKERRNO, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       return -1;
     }
     /* check whether the server is alive */

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -739,7 +739,7 @@ curl_socket_t sockdaemon(curl_socket_t sock,
   int maxretr = 10;
   int delay = 20;
   int attempt = 0;
-  int error = 0;
+  int sockerr = 0;
   char errbuf[STRERROR_LEN];
 
 #ifndef USE_UNIX_SOCKETS
@@ -755,16 +755,16 @@ curl_socket_t sockdaemon(curl_socket_t sock,
       rc = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
                       (void *)&flag, sizeof(flag));
       if(rc) {
-        error = SOCKERRNO;
+        sockerr = SOCKERRNO;
         logmsg("setsockopt(SO_REUSEADDR) failed with error (%d) %s",
-               error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+               sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
         if(maxretr) {
           rc = curlx_wait_ms(delay);
           if(rc) {
             /* should not happen */
-            error = SOCKERRNO;
+            sockerr = SOCKERRNO;
             logmsg("curlx_wait_ms() failed with error (%d) %s",
-                   error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+                   sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
             sclose(sock);
             return CURL_SOCKET_BAD;
           }
@@ -782,7 +782,7 @@ curl_socket_t sockdaemon(curl_socket_t sock,
     if(rc) {
       logmsg("setsockopt(SO_REUSEADDR) failed %d times in %d ms. "
              "Error (%d) %s", attempt, totdelay,
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       logmsg("Continuing anyway...");
     }
 #if defined(_WIN32) && defined(USE_UNIX_SOCKETS)
@@ -819,15 +819,15 @@ curl_socket_t sockdaemon(curl_socket_t sock,
   }
 
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
 #ifdef USE_UNIX_SOCKETS
     if(socket_domain == AF_UNIX)
       logmsg("Error binding socket on path %s (%d) %s", unix_socket,
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     else
 #endif
       logmsg("Error binding socket on port %hu (%d) %s", *listenport,
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }
@@ -849,9 +849,9 @@ curl_socket_t sockdaemon(curl_socket_t sock,
 #endif
       la_size = sizeof(localaddr.sa4);
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
-      error = SOCKERRNO;
+      sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",
-             error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+             sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       sclose(sock);
       return CURL_SOCKET_BAD;
     }
@@ -887,9 +887,9 @@ curl_socket_t sockdaemon(curl_socket_t sock,
   /* start accepting connections */
   rc = listen(sock, 5);
   if(rc) {
-    error = SOCKERRNO;
+    sockerr = SOCKERRNO;
     logmsg("listen(%ld, 5) failed with error (%d) %s", (long)sock,
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }


### PR DESCRIPTION
Also:
- add comment explaining a `sockerr = errno` (vs. `SOCKERRNO`)
  assigment.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
