### PR TITLE
winldap: avoid NULL pointer deref on `ldap_get_dn()` fail

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -460,11 +460,15 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
       size_t name_len = 0;
 #ifdef USE_WIN32_LDAP
       TCHAR *dn = ldap_get_dn(server, entryIterator);
-      name = curlx_convert_tchar_to_UTF8(dn);
-      if(!name) {
-        ldap_memfree(dn);
-        result = CURLE_OUT_OF_MEMORY;
-        goto quit;
+      if(!dn)
+        name = NULL;
+      else {
+        name = curlx_convert_tchar_to_UTF8(dn);
+        if(!name) {
+          ldap_memfree(dn);
+          result = CURLE_OUT_OF_MEMORY;
+          goto quit;
+        }
       }
 #else
       char *dn = name = ldap_get_dn(server, entryIterator);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -466,7 +466,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
       char *dn = name = ldap_get_dn(server, entryIterator);
 #endif
       if(!name)
-        result = dn ? CURLE_FAILED_INIT : CURLE_OUT_OF_MEMORY;
+        result = dn ? CURLE_OUT_OF_MEMORY : CURLE_FAILED_INIT;
       else {
         name_len = strlen(name);
         result = Curl_client_write(data, CLIENTWRITE_BODY, "DN: ", 4);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -466,7 +466,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
       char *dn = name = ldap_get_dn(server, entryIterator);
 #endif
       if(!name)
-        result = CURLE_FAILED_INIT;
+        result = dn ? CURLE_FAILED_INIT : CURLE_OUT_OF_MEMORY;
       else {
         name_len = strlen(name);
         result = Curl_client_write(data, CLIENTWRITE_BODY, "DN: ", 4);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -456,20 +456,12 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 
     /* Get the DN and write it to the client */
     {
-      char *name;
+      char *name = NULL;
       size_t name_len = 0;
 #ifdef USE_WIN32_LDAP
       TCHAR *dn = ldap_get_dn(server, entryIterator);
-      if(!dn)
-        name = NULL;
-      else {
+      if(dn)
         name = curlx_convert_tchar_to_UTF8(dn);
-        if(!name) {
-          ldap_memfree(dn);
-          result = CURLE_OUT_OF_MEMORY;
-          goto quit;
-        }
-      }
 #else
       char *dn = name = ldap_get_dn(server, entryIterator);
 #endif


### PR DESCRIPTION
In non-Unicode builds.

Assisted-by: Jay Satiro

---

https://github.com/curl/curl/pull/22000/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
