### PR TITLE
telnet: drop an `int` cast no longer necessary

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1034,7 +1034,7 @@ static CURLcode suboption(struct Curl_easy *data, struct TELNET *tn)
       if(bad_option(v->data))
         return CURLE_BAD_FUNCTION_ARGUMENT;
       /* Add the variable if it fits */
-      if(len + tmplen < (int)sizeof(temp) - 6) {
+      if(len + tmplen < sizeof(temp) - 6) {
         const char *s = strchr(v->data, ',');
         if(!s)
           len += curl_msnprintf((char *)&temp[len], sizeof(temp) - len,


### PR DESCRIPTION
Spotted-by GitHub Code Quality

Follow-up to c5637baa06046d317c383d420f6cbc9ddb3b0870
Follow-up to 83a5e390654fb1e77c7c5d7bd32ba147ff022cbd

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
