### PR TITLE
krb5_sspi: fix error message on `DecryptMessage()` fail

### DIFF
--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -297,7 +297,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
      SECBUFFER_STREAM. */
   status = Curl_pSecFn->DecryptMessage(krb5->context, &input_desc, 0, &qop);
   if(status != SEC_E_OK) {
-    infof(data, "GSSAPI handshake failure (empty security message)");
+    infof(data, "GSSAPI handshake failure (decryption failed)");
     return CURLE_BAD_CONTENT_ENCODING;
   }
 


### PR DESCRIPTION
Spotted by GitHub Code Quality

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
