### PR TITLE
socks_sspi: store socks5_gssapi_enctype

### DIFF
--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -462,7 +462,7 @@ static CURLcode socks5_sspi_encrypt(struct Curl_cfilter *cf,
         ((socksreq[0] == 1) ? " GSS-API integrity" :
          " GSS-API confidentiality"));
 
-  conn->socks5_gssapi_enctype = socksreq[0];
+  data->conn->socks5_gssapi_enctype = socksreq[0];
   return CURLE_OK;
 
 fail:

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -462,6 +462,7 @@ static CURLcode socks5_sspi_encrypt(struct Curl_cfilter *cf,
         ((socksreq[0] == 1) ? " GSS-API integrity" :
          " GSS-API confidentiality"));
 
+  conn->socks5_gssapi_enctype = socksreq[0];
   return CURLE_OK;
 
 fail:

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -462,7 +462,7 @@ static CURLcode socks5_sspi_encrypt(struct Curl_cfilter *cf,
         ((socksreq[0] == 1) ? " GSS-API integrity" :
          " GSS-API confidentiality"));
 
-  data->conn->socks5_gssapi_enctype = socksreq[0];
+  cf->conn->socks5_gssapi_enctype = socksreq[0];
   return CURLE_OK;
 
 fail:


### PR DESCRIPTION
Store the unwrapped protection level in `conn->socks5_gssapi_enctype` to prevent the proxy from contuning unprotected. Matches the GSSAPI version of the code.

Reported-by: Trail of Bits

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
