### PR TITLE
tests/servers: do not interpret `unlink()` retval as `errno`

### DIFF
--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -918,9 +918,9 @@ socks5_cleanup:
 
 #ifdef USE_UNIX_SOCKETS
   if(unlink_socket && socket_domain == AF_UNIX && unix_socket) {
-    int error = unlink(unix_socket);
-    logmsg("unlink(%s) = %d (%s)", unix_socket,
-           error, curlx_strerror(error, errbuf, sizeof(errbuf)));
+    int rc = unlink(unix_socket);
+    logmsg("unlink(%s) = %d %d (%s)", unix_socket, rc,
+           errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
   }
 #endif
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -917,11 +917,10 @@ socks5_cleanup:
     sclose(sock);
 
 #ifdef USE_UNIX_SOCKETS
-  if(unlink_socket && socket_domain == AF_UNIX && unix_socket) {
-    int rc = unlink(unix_socket);
-    logmsg("unlink(%s) = %d %d (%s)", unix_socket, rc,
+  if(unlink_socket && socket_domain == AF_UNIX && unix_socket &&
+     unlink(unix_socket))
+    logmsg("unlink(%s) = %d (%s)", unix_socket,
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
-  }
 #endif
 
   if(wrotepidfile)

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -919,7 +919,7 @@ socks5_cleanup:
 #ifdef USE_UNIX_SOCKETS
   if(unlink_socket && socket_domain == AF_UNIX && unix_socket &&
      unlink(unix_socket))
-    logmsg("unlink(%s) = %d (%s)", unix_socket,
+    logmsg("unlink(%s): %d (%s)", unix_socket,
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 #endif
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2443,7 +2443,7 @@ sws_cleanup:
 
 #ifdef USE_UNIX_SOCKETS
   if(unlink_socket && socket_domain == AF_UNIX && unix_socket) {
-    int rc = unlink(unix_socket);
+    rc = unlink(unix_socket);
     logmsg("unlink(%s) = %d %d (%s)", unix_socket, rc,
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
   }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2442,11 +2442,10 @@ sws_cleanup:
     sclose(sock);
 
 #ifdef USE_UNIX_SOCKETS
-  if(unlink_socket && socket_domain == AF_UNIX && unix_socket) {
-    rc = unlink(unix_socket);
-    logmsg("unlink(%s) = %d %d (%s)", unix_socket, rc,
+  if(unlink_socket && socket_domain == AF_UNIX && unix_socket &&
+     unlink(unix_socket))
+    logmsg("unlink(%s) = %d (%s)", unix_socket,
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
-  }
 #endif
 
   free(req);

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2443,9 +2443,9 @@ sws_cleanup:
 
 #ifdef USE_UNIX_SOCKETS
   if(unlink_socket && socket_domain == AF_UNIX && unix_socket) {
-    rc = unlink(unix_socket);
-    logmsg("unlink(%s) = %d (%s)", unix_socket,
-           rc, curlx_strerror(rc, errbuf, sizeof(errbuf)));
+    int rc = unlink(unix_socket);
+    logmsg("unlink(%s) = %d %d (%s)", unix_socket, rc,
+           errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
   }
 #endif
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2444,7 +2444,7 @@ sws_cleanup:
 #ifdef USE_UNIX_SOCKETS
   if(unlink_socket && socket_domain == AF_UNIX && unix_socket &&
      unlink(unix_socket))
-    logmsg("unlink(%s) = %d (%s)", unix_socket,
+    logmsg("unlink(%s): %d (%s)", unix_socket,
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 #endif
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -716,8 +716,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     /* dead socket, cleanup and retry bind */
     rc = unlink(unix_socket);
     if(rc) {
-      logmsg("Error binding socket, failed to unlink(%s) = %d %d (%s)",
-             unix_socket, rc,
+      logmsg("Error binding socket, failed to unlink %s: %d (%s)", unix_socket,
              errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
       return rc;
     }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -251,7 +251,7 @@ void set_advisor_read_lock(const char *filename)
 void clear_advisor_read_lock(const char *filename)
 {
   int error = 0;
-  int res;
+  int rc;
 
   /*
    * Log all removal failures. Even those due to file not existing.
@@ -260,10 +260,10 @@ void clear_advisor_read_lock(const char *filename)
    */
 
   do {
-    res = unlink(filename);
+    rc = unlink(filename);
     /* !checksrc! disable ERRNOVAR 1 */
-  } while(res && ((error = errno) == EINTR));
-  if(res) {
+  } while(rc && ((error = errno) == EINTR));
+  if(rc) {
     char errbuf[STRERROR_LEN];
     logmsg("Error removing lock file %s error (%d) %s", filename,
            error, curlx_strerror(error, errbuf, sizeof(errbuf)));

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -716,7 +716,8 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     /* dead socket, cleanup and retry bind */
     rc = unlink(unix_socket);
     if(rc) {
-      logmsg("Error binding socket, failed to unlink %s (%d) %s", unix_socket,
+      logmsg("Error binding socket, failed to unlink(%s) = %d %d (%s)",
+             unix_socket, rc,
              errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
       return rc;
     }


### PR DESCRIPTION
In `socksd` and `sws` error messages.

Also:
- show the messages only if `unlink()` failed.
- rename a return code variable and sync a message text for consistency.

Ref: https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlink.html

Spotted by Copilot in `socksd.c`
Bug: https://github.com/curl/curl/pull/21998#discussion_r3409395013
Follow-up to 80eb71a3f5146f2ab5c5f8d8655d6861b5472668 #8687

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
