### PR TITLE
rtspd: sync up sleep loop with sws

### DIFF
--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -968,11 +968,9 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
         if(!strcmp("wait", command)) {
           logmsg("Told to sleep for %d seconds", num);
           quarters = num * 4;
-          while(quarters > 0) {
+          while((quarters > 0) && !got_exit_signal) {
             quarters--;
             res = curlx_wait_ms(250);
-            if(got_exit_signal)
-              break;
             if(res) {
               /* should not happen */
               int sockerr = SOCKERRNO;


### PR DESCRIPTION
Check for `!got_exit_signal` as part of the `while()` expression,
instead of doing it after calling `curlx_wait_ms()`. To simplify and
improve consistency with rest of code.

Follow-up to 0653fa107f6fb03555d49da86a1fbfc659873f5b
Follow-up to 123c92c904b2f258ae69e211aa2663e80cb5429a

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
