### PR TITLE
servers: minor socket error handling fixes

### DIFF
--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -346,12 +346,13 @@ static struct resp *resp_queue;
 static CURLcode send_resp(curl_socket_t sock, struct resp *resp)
 {
   ssize_t rc;
-  int sockerr = 0;
+  int sockerr;
 
   do {
     rc = sendto(sock, (const void *)resp->body.data, (SENDTO3)resp->body.dlen,
                 0, &resp->addr, resp->addrlen);
-  } while((rc < 0) && ((sockerr = SOCKERRNO) == SOCKEINTR));
+    sockerr = SOCKERRNO;
+  } while((rc < 0) && (sockerr == SOCKEINTR));
   if(rc != (ssize_t)resp->body.dlen) {
     char errbuf[STRERROR_LEN];
     logmsg("failed sending %zu bytes, error: (%d) %s", resp->body.dlen,

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -351,7 +351,7 @@ static CURLcode send_resp(curl_socket_t sock, struct resp *resp)
   do {
     rc = sendto(sock, (const void *)resp->body.data, (SENDTO3)resp->body.dlen,
                 0, &resp->addr, resp->addrlen);
-  } while((rc < 0) && ((sockerr = SOCKERRNO) == SOCKEINTR))
+  } while((rc < 0) && ((sockerr = SOCKERRNO) == SOCKEINTR));
   if(rc != (ssize_t)resp->body.dlen) {
     logmsg("failed sending %d bytes, errno=%d\n",
            (int)resp->body.dlen, sockerr);

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -346,15 +346,15 @@ static struct resp *resp_queue;
 static CURLcode send_resp(curl_socket_t sock, struct resp *resp)
 {
   ssize_t rc;
+  int sockerr = 0;
 
-sending:
-  rc = sendto(sock, (const void *)resp->body.data, (SENDTO3)resp->body.dlen, 0,
-              &resp->addr, resp->addrlen);
-  if((rc < 0) && (SOCKERRNO == SOCKEINTR))
-    goto sending;
+  do {
+    rc = sendto(sock, (const void *)resp->body.data, (SENDTO3)resp->body.dlen,
+                0, &resp->addr, resp->addrlen);
+  } while((rc < 0) && ((sockerr = SOCKERRNO) == SOCKEINTR))
   if(rc != (ssize_t)resp->body.dlen) {
     logmsg("failed sending %d bytes, errno=%d\n",
-           (int)resp->body.dlen, SOCKERRNO);
+           (int)resp->body.dlen, sockerr);
     return CURLE_SEND_ERROR;
   }
   logmsg("[%d] sent response", resp->qid);

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -346,17 +346,20 @@ static struct resp *resp_queue;
 static CURLcode send_resp(curl_socket_t sock, struct resp *resp)
 {
   ssize_t rc;
-  int sockerr;
+  int sockerr = 0;
 
   do {
     rc = sendto(sock, (const void *)resp->body.data, (SENDTO3)resp->body.dlen,
                 0, &resp->addr, resp->addrlen);
-    sockerr = SOCKERRNO;
-  } while((rc < 0) && (sockerr == SOCKEINTR));
-  if(rc != (ssize_t)resp->body.dlen) {
+  } while((rc < 0) && ((sockerr = SOCKERRNO) == SOCKEINTR));
+  if(rc < 0) {
     char errbuf[STRERROR_LEN];
     logmsg("failed sending %zu bytes, error: (%d) %s", resp->body.dlen,
            sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
+    return CURLE_SEND_ERROR;
+  }
+  else if(rc != (ssize_t)resp->body.dlen) {
+    logmsg("failed sending %zu bytes, sent: %zd", resp->body.dlen, rc);
     return CURLE_SEND_ERROR;
   }
   logmsg("[%d] sent response", resp->qid);

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -347,13 +347,13 @@ static CURLcode send_resp(curl_socket_t sock, struct resp *resp)
 {
   ssize_t rc;
   int sockerr = 0;
-  char errbuf[STRERROR_LEN];
 
   do {
     rc = sendto(sock, (const void *)resp->body.data, (SENDTO3)resp->body.dlen,
                 0, &resp->addr, resp->addrlen);
   } while((rc < 0) && ((sockerr = SOCKERRNO) == SOCKEINTR));
   if(rc != (ssize_t)resp->body.dlen) {
+    char errbuf[STRERROR_LEN];
     logmsg("failed sending %zu bytes, error: (%d) %s", resp->body.dlen,
            sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     return CURLE_SEND_ERROR;

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -347,14 +347,15 @@ static CURLcode send_resp(curl_socket_t sock, struct resp *resp)
 {
   ssize_t rc;
   int sockerr = 0;
+  char errbuf[STRERROR_LEN];
 
   do {
     rc = sendto(sock, (const void *)resp->body.data, (SENDTO3)resp->body.dlen,
                 0, &resp->addr, resp->addrlen);
   } while((rc < 0) && ((sockerr = SOCKERRNO) == SOCKEINTR));
   if(rc != (ssize_t)resp->body.dlen) {
-    logmsg("failed sending %d bytes, errno=%d\n",
-           (int)resp->body.dlen, sockerr);
+    logmsg("failed sending %zu bytes, error: (%d) %s", resp->body.dlen,
+           sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     return CURLE_SEND_ERROR;
   }
   logmsg("[%d] sent response", resp->qid);

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2329,15 +2329,15 @@ static int test_sws(int argc, const char *argv[])
     if(got_exit_signal)
       goto sws_cleanup;
 
+    sockerr = 0;
     do {
       rc = select((int)maxfd + 1, &input, &output, NULL, &timeout);
-    } while(rc < 0 && SOCKERRNO == SOCKEINTR && !got_exit_signal);
+    } while(rc < 0 && ((sockerr = SOCKERRNO) == SOCKEINTR && !got_exit_signal);
 
     if(got_exit_signal)
       goto sws_cleanup;
 
     if(rc < 0) {
-      sockerr = SOCKERRNO;
       logmsg("select() failed with error (%d) %s",
              sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       goto sws_cleanup;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2332,7 +2332,8 @@ static int test_sws(int argc, const char *argv[])
     sockerr = 0;
     do {
       rc = select((int)maxfd + 1, &input, &output, NULL, &timeout);
-    } while(rc < 0 && ((sockerr = SOCKERRNO) == SOCKEINTR && !got_exit_signal);
+    } while(rc < 0 && ((sockerr = SOCKERRNO) == SOCKEINTR &&
+            !got_exit_signal));
 
     if(got_exit_signal)
       goto sws_cleanup;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1343,7 +1343,8 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
       FD_SET(serverfd, &output);
       while(1) {
         rc = select((int)serverfd + 1, NULL, &output, NULL, &timeout);
-        if(rc < 0 && SOCKERRNO != SOCKEINTR)
+        sockerr = SOCKERRNO;
+        if(rc < 0 && sockerr != SOCKEINTR)
           goto error;
         else if(rc > 0) {
           curl_socklen_t errSize = sizeof(sockerr);


### PR DESCRIPTION
- sws: fix socket error code in `select()` failure message.
  Spotted by Copilot
  Bug: https://github.com/curl/curl/pull/21998#discussion_r3409469444
- sws: do not call `SOCKERRNO` twice on error.
- dnsd: do not call `SOCKERRNO` twice on error. 
- dnsd: replace `goto` with `while()` to sync with rest of code.
- dnsd: `sendto()` fail message fixes:
  - replace `int` cast with `%zu` mask.
  - drop redundant newline.
  - show socket error string like rest of code.
  - report not-fully-sent error separately from socket errors.

---

Unrelated, but the way the return value is checked (nit) and whether
`got_exit_signal` is verified in these loops is a hit or miss. I'm guessing
it's not intentional.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
