### PR TITLE
servers: accept `lstat()` failing due to the file missing

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -321,32 +321,35 @@ static HWND hidden_main_window = NULL;
  * Hence, do not call 'logmsg()', and instead use 'open/write/close' to
  * log errors.
  */
+static size_t useless; /* to silence variable 'rc' set but not used */
 static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
+  size_t rc = 0;
   if(!serverlogfile) {
     static const char msg[] = "exit_signal_handler: serverlogfile not set\n";
-    write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    rc = write(STDERR_FILENO, msg, sizeof(msg) - 1);
   }
   else {
     int fd = -1;
 #ifdef _WIN32
     if(!_sopen_s(&fd, serverlogfile, _O_WRONLY | _O_CREAT | _O_APPEND,
-                 _SH_DENYNO, _S_IREAD | _S_IWRITE) && fd != -1) {
+                 _SH_DENYNO, _S_IREAD | _S_IWRITE) &&
+       fd != -1) {
 #else
     /* !checksrc! disable BANNEDFUNC 1 */
     fd = open(serverlogfile, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
     if(fd != -1) {
 #endif
       static const char msg[] = "exit_signal_handler: called\n";
-      write(fd, msg, sizeof(msg) - 1);
+      rc = write(fd, msg, sizeof(msg) - 1);
       curlx_close(fd);
     }
     else {
       static const char msg[] = "exit_signal_handler: failed opening ";
-      write(STDERR_FILENO, msg, sizeof(msg) - 1);
-      write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
-      write(STDERR_FILENO, "\n", 1);
+      rc = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+      rc += write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
+      rc += write(STDERR_FILENO, "\n", 1);
     }
   }
   if(got_exit_signal == 0) {
@@ -357,6 +360,7 @@ static void exit_signal_handler(int signum)
       (void)SetEvent(exit_event);
 #endif
   }
+  useless = rc;
   (void)signal(signum, exit_signal_handler);
   errno = old_errno;
 }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -321,35 +321,32 @@ static HWND hidden_main_window = NULL;
  * Hence, do not call 'logmsg()', and instead use 'open/write/close' to
  * log errors.
  */
-static size_t useless; /* to silence variable 'rc' set but not used */
 static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
-  size_t rc = 0;
   if(!serverlogfile) {
     static const char msg[] = "exit_signal_handler: serverlogfile not set\n";
-    rc = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    write(STDERR_FILENO, msg, sizeof(msg) - 1);
   }
   else {
     int fd = -1;
 #ifdef _WIN32
     if(!_sopen_s(&fd, serverlogfile, _O_WRONLY | _O_CREAT | _O_APPEND,
-                 _SH_DENYNO, _S_IREAD | _S_IWRITE) &&
-       fd != -1) {
+                 _SH_DENYNO, _S_IREAD | _S_IWRITE) && fd != -1) {
 #else
     /* !checksrc! disable BANNEDFUNC 1 */
     fd = open(serverlogfile, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
     if(fd != -1) {
 #endif
       static const char msg[] = "exit_signal_handler: called\n";
-      rc = write(fd, msg, sizeof(msg) - 1);
+      write(fd, msg, sizeof(msg) - 1);
       curlx_close(fd);
     }
     else {
       static const char msg[] = "exit_signal_handler: failed opening ";
-      rc = write(STDERR_FILENO, msg, sizeof(msg) - 1);
-      rc += write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
-      rc += write(STDERR_FILENO, "\n", 1);
+      write(STDERR_FILENO, msg, sizeof(msg) - 1);
+      write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
+      write(STDERR_FILENO, "\n", 1);
     }
   }
   if(got_exit_signal == 0) {
@@ -360,7 +357,6 @@ static void exit_signal_handler(int signum)
       (void)SetEvent(exit_event);
 #endif
   }
-  useless = rc;
   (void)signal(signum, exit_signal_handler);
   errno = old_errno;
 }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -695,7 +695,22 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
              sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       return rc;
     }
-    /* dead socket path, cleanup and retry bind */
+#if !defined(_WIN32) && defined(S_IFSOCK) /* No lstat(), S_IFSOCK on Windows */
+    /* socket server is not alive, now check if it was actually a socket. */
+    {
+      curlx_struct_stat statbuf;
+      if(lstat(unix_socket, &statbuf)) {
+        logmsg("Error binding socket, failed to stat %s (%d) %s", unix_socket,
+               errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
+        return -1;
+      }
+      if((statbuf.st_mode & S_IFMT) != S_IFSOCK) {
+        logmsg("Error binding socket, %s is not a socket", unix_socket);
+        return -1;
+      }
+    }
+#endif
+    /* dead socket, cleanup and retry bind */
     if(unlink(unix_socket) && errno != ENOENT) {
       logmsg("Error binding socket, failed to unlink %s: %d (%s)", unix_socket,
              errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -699,12 +699,13 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     /* socket server is not alive, now check if it was actually a socket. */
     {
       curlx_struct_stat statbuf;
-      if(lstat(unix_socket, &statbuf)) {
+      rc = lstat(unix_socket, &statbuf);
+      if(rc && errno != ENOENT) {
         logmsg("Error binding socket, failed to stat %s (%d) %s", unix_socket,
                errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
         return -1;
       }
-      if((statbuf.st_mode & S_IFMT) != S_IFSOCK) {
+      if(!rc && (statbuf.st_mode & S_IFMT) != S_IFSOCK) {
         logmsg("Error binding socket, %s is not a socket", unix_socket);
         return -1;
       }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -695,22 +695,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
              sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
       return rc;
     }
-#if !defined(_WIN32) && defined(S_IFSOCK) /* No lstat(), S_IFSOCK on Windows */
-    /* socket server is not alive, now check if it was actually a socket. */
-    {
-      curlx_struct_stat statbuf;
-      if(lstat(unix_socket, &statbuf)) {
-        logmsg("Error binding socket, failed to stat %s (%d) %s", unix_socket,
-               errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
-        return -1;
-      }
-      if((statbuf.st_mode & S_IFMT) != S_IFSOCK) {
-        logmsg("Error binding socket, %s is not a socket", unix_socket);
-        return -1;
-      }
-    }
-#endif
-    /* dead socket, cleanup and retry bind */
+    /* dead socket path, cleanup and retry bind */
     if(unlink(unix_socket) && errno != ENOENT) {
       logmsg("Error binding socket, failed to unlink %s: %d (%s)", unix_socket,
              errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));


### PR DESCRIPTION
In `bind_unix_socket()`, before retrying `bind()`.

Before this patch the code wanted to check if the to-be-deleted unix
socket path was indeed a socket, before deleting it and retrying to
bind. If `lstat()` failed for any reason, it skipped retry. Fix to retry
if `lstat()` failed because of the file missing.

Ref: https://pubs.opengroup.org/onlinepubs/9799919799/functions/lstat.html

Follow-up to 0882e3951d910b923f3463fa98604df9fcb13a0c #22026
Follow-up to 03bc93bd327e06e86af0b0c14a888f7482affedc #22021
Follow-up to e70f8ebd34edade24df442152f52b361abaf4309 #22020
Follow-up to 30e491e5c921aecca5a16083d8185840dc64eccd #7034
Follow-up to 99fb36797a3f0b64ad20fcb8b83026875640f8e0

---

- [x] guard for envs without `ENOENT` (non-UCRT Windows) (but test first) [defined by all CI-test envs) (also used previously for other platforms)
- [x] consider dropping stat stuff before unlink. Seems unnecessary. [DONE]
- [x] check if S_IFSOCK exist on Windows, if not stat is unnecessary there. [IT DOESN'T] [dropped that code too]
- [x] moved fixes to separate PRs: #22021 #22020 #22028

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
