### PR TITLE
libtests: prefer `sizeof()` over `strlen()`, fix potential OOB read in 1591

### DIFF
--- a/tests/libtest/lib1517.c
+++ b/tests/libtest/lib1517.c
@@ -60,7 +60,7 @@ static CURLcode test_lib1517(const char *URL)
   struct t1517_WriteThis pooh;
 
   pooh.readptr = testdata;
-  pooh.sizeleft = strlen(testdata);
+  pooh.sizeleft = sizeof(testdata) - 1;
 
   if(curl_global_init(CURL_GLOBAL_ALL)) {
     curl_mfprintf(stderr, "curl_global_init() failed\n");

--- a/tests/libtest/lib1591.c
+++ b/tests/libtest/lib1591.c
@@ -34,15 +34,16 @@ static size_t consumed = 0;
 static size_t t1591_read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   static const char testdata[] = "Hello Cloud!\r\n";
+  static size_t const datalen = sizeof(testdata) - 1;
 
   size_t amount = nmemb * size; /* Total bytes curl wants */
 
-  if(consumed == strlen(testdata)) {
+  if(consumed == datalen) {
     return 0;
   }
 
-  if(amount > strlen(testdata) - consumed) {
-    amount = strlen(testdata);
+  if(amount > datalen - consumed) {
+    amount = datalen - consumed;
   }
 
   consumed += amount;

--- a/tests/libtest/lib1948.c
+++ b/tests/libtest/lib1948.c
@@ -55,9 +55,9 @@ static CURLcode test_lib1948(const char *URL)
   easy_setopt(curl, CURLOPT_HEADER, 1L);
   easy_setopt(curl, CURLOPT_READFUNCTION, put_callback);
   pbuf.buf = testput;
-  pbuf.len = strlen(testput);
+  pbuf.len = sizeof(testput) - 1;
   easy_setopt(curl, CURLOPT_READDATA, &pbuf);
-  easy_setopt(curl, CURLOPT_INFILESIZE, (long)strlen(testput));
+  easy_setopt(curl, CURLOPT_INFILESIZE, (long)(sizeof(testput) - 1));
   easy_setopt(curl, CURLOPT_URL, URL);
   result = curl_easy_perform(curl);
   if(result)
@@ -66,7 +66,7 @@ static CURLcode test_lib1948(const char *URL)
   /* POST */
   easy_setopt(curl, CURLOPT_POST, 1L);
   easy_setopt(curl, CURLOPT_POSTFIELDS, testput);
-  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(testput));
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)(sizeof(testput) - 1));
   result = curl_easy_perform(curl);
 
 test_cleanup:

--- a/tests/libtest/lib1948.c
+++ b/tests/libtest/lib1948.c
@@ -43,7 +43,7 @@ static CURLcode test_lib1948(const char *URL)
 {
   CURL *curl;
   CURLcode result = CURLE_OK;
-  static const char *testput = "This is test PUT data\n";
+  static const char testput[] = "This is test PUT data\n";
   struct put_buffer pbuf;
 
   curl_global_init(CURL_GLOBAL_DEFAULT);

--- a/tests/libtest/lib508.c
+++ b/tests/libtest/lib508.c
@@ -56,7 +56,7 @@ static CURLcode test_lib508(const char *URL)
   struct t508_WriteThis pooh;
 
   pooh.readptr = testdata;
-  pooh.sizeleft = strlen(testdata);
+  pooh.sizeleft = sizeof(testdata) - 1;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     curl_mfprintf(stderr, "curl_global_init() failed\n");

--- a/tests/libtest/lib554.c
+++ b/tests/libtest/lib554.c
@@ -69,7 +69,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
   struct t554_WriteThis pooh2;
 
   pooh.readptr = testdata;
-  pooh.sizeleft = strlen(testdata);
+  pooh.sizeleft = sizeof(testdata) - 1;
 
   /* Fill in the file upload field */
   if(oldstyle) {
@@ -99,7 +99,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
      a file upload but still using the callback */
 
   pooh2.readptr = testdata;
-  pooh2.sizeleft = strlen(testdata);
+  pooh2.sizeleft = sizeof(testdata) - 1;
 
   /* Fill in the file upload field */
   formrc = curl_formadd(&formpost,

--- a/tests/libtest/lib643.c
+++ b/tests/libtest/lib643.c
@@ -69,7 +69,7 @@ static CURLcode t643_test_once(const char *URL, bool oldstyle)
 
   pooh.readptr = testdata;
   if(testnum == 643)
-    datasize = (curl_off_t)strlen(testdata);
+    datasize = (curl_off_t)(sizeof(testdata) - 1);
   pooh.sizeleft = datasize;
 
   curl = curl_easy_init();
@@ -123,7 +123,7 @@ static CURLcode t643_test_once(const char *URL, bool oldstyle)
 
   pooh2.readptr = testdata;
   if(testnum == 643)
-    datasize = (curl_off_t)strlen(testdata);
+    datasize = (curl_off_t)(sizeof(testdata) - 1);
   pooh2.sizeleft = datasize;
 
   part = curl_mime_addpart(mime);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -83,7 +83,7 @@ static CURLcode test_lib650(const char *URL)
     goto test_cleanup;
   }
 
-  contentlength = (long)(strlen(testdata) - 1);
+  contentlength = (long)(sizeof(testdata) - 1);
 
   /* Use a form array for the non-copy test. */
   formarray[0].option = CURLFORM_PTRCONTENTS;
@@ -95,7 +95,7 @@ static CURLcode test_lib650(const char *URL)
   formrc = curl_formadd(&formpost,
                         &lastptr,
                         CURLFORM_PTRNAME, testname,
-                        CURLFORM_NAMELENGTH, strlen(testname) - 1,
+                        CURLFORM_NAMELENGTH, sizeof(testname) - 1,
                         CURLFORM_ARRAY, formarray,
                         CURLFORM_FILENAME, "remotefile.txt",
                         CURLFORM_END);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -83,7 +83,7 @@ static CURLcode test_lib650(const char *URL)
     goto test_cleanup;
   }
 
-  contentlength = (long)(sizeof(testdata) - 1);
+  contentlength = (long)(sizeof(testdata) - 2);
 
   /* Use a form array for the non-copy test. */
   formarray[0].option = CURLFORM_PTRCONTENTS;
@@ -95,7 +95,7 @@ static CURLcode test_lib650(const char *URL)
   formrc = curl_formadd(&formpost,
                         &lastptr,
                         CURLFORM_PTRNAME, testname,
-                        CURLFORM_NAMELENGTH, sizeof(testname) - 1,
+                        CURLFORM_NAMELENGTH, sizeof(testname) - 2,
                         CURLFORM_ARRAY, formarray,
                         CURLFORM_FILENAME, "remotefile.txt",
                         CURLFORM_END);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -95,7 +95,7 @@ static CURLcode test_lib650(const char *URL)
   formrc = curl_formadd(&formpost,
                         &lastptr,
                         CURLFORM_PTRNAME, testname,
-                        CURLFORM_NAMELENGTH, strlen(testname) - 1,
+                        CURLFORM_NAMELENGTH, sizeof(testname) - 2,
                         CURLFORM_ARRAY, formarray,
                         CURLFORM_FILENAME, "remotefile.txt",
                         CURLFORM_END);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -83,7 +83,7 @@ static CURLcode test_lib650(const char *URL)
     goto test_cleanup;
   }
 
-  contentlength = (long)(sizeof(testdata) - 2);
+  contentlength = (long)(strlen(testdata) - 1);
 
   /* Use a form array for the non-copy test. */
   formarray[0].option = CURLFORM_PTRCONTENTS;
@@ -95,7 +95,7 @@ static CURLcode test_lib650(const char *URL)
   formrc = curl_formadd(&formpost,
                         &lastptr,
                         CURLFORM_PTRNAME, testname,
-                        CURLFORM_NAMELENGTH, sizeof(testname) - 2,
+                        CURLFORM_NAMELENGTH, strlen(testname) - 1,
                         CURLFORM_ARRAY, formarray,
                         CURLFORM_FILENAME, "remotefile.txt",
                         CURLFORM_END);

--- a/tests/libtest/lib654.c
+++ b/tests/libtest/lib654.c
@@ -92,7 +92,7 @@ static CURLcode test_lib654(const char *URL)
 
   /* Prepare the callback structure. */
   pooh.readptr = testdata;
-  pooh.sizeleft = (curl_off_t)strlen(testdata);
+  pooh.sizeleft = (curl_off_t)(sizeof(testdata) - 1);
   pooh.freecount = 0;
 
   /* Build the mime tree. */

--- a/tests/libtest/lib667.c
+++ b/tests/libtest/lib667.c
@@ -82,7 +82,7 @@ static CURLcode test_lib667(const char *URL)
 
   /* Prepare the callback structure. */
   pooh.readptr = testdata;
-  pooh.sizeleft = (curl_off_t)strlen(testdata);
+  pooh.sizeleft = (curl_off_t)(sizeof(testdata) - 1);
 
   /* Build the mime tree. */
   mime = curl_mime_init(curl);

--- a/tests/libtest/lib668.c
+++ b/tests/libtest/lib668.c
@@ -76,7 +76,7 @@ static CURLcode test_lib668(const char *URL)
 
   /* Prepare the callback structures. */
   pooh1.readptr = testdata;
-  pooh1.sizeleft = (curl_off_t)strlen(testdata);
+  pooh1.sizeleft = (curl_off_t)(sizeof(testdata) - 1);
   pooh2 = pooh1;
 
   /* Build the mime tree. */
@@ -84,7 +84,7 @@ static CURLcode test_lib668(const char *URL)
   part = curl_mime_addpart(mime);
   curl_mime_name(part, "field1");
   /* Early end of data detection can be done because the data size is known. */
-  curl_mime_data_cb(part, (curl_off_t)strlen(testdata),
+  curl_mime_data_cb(part, (curl_off_t)(sizeof(testdata) - 1),
                     t668_read_cb, NULL, NULL, &pooh1);
   part = curl_mime_addpart(mime);
   curl_mime_name(part, "field2");


### PR DESCRIPTION
- test1591: fix potential OOB read.
  Spotted by GitHub Code Quality
  Follow-up to f464535bfdd9a83140d8a13c3fe3d937239d1c2a #3350

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
