### PR TITLE
cmake/FindGSS: fix comment, adjust custom flavor property name

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -25,15 +25,15 @@
 #
 # Input variables:
 #
-# - `GSS_ROOT_DIR`:        Absolute path to the root installation of GSS. (also supported as environment)
+# - `GSS_ROOT_DIR`: Absolute path to the root installation of GSS. (also supported as environment)
 #
 # Defines:
 #
-# - `GSS_FOUND`:           System has a GSS library.
-# - `GSS_VERSION`:         This is set to version advertised by pkg-config or read from manifest.
-#                          In case the library is found but no version info available it is set to "unknown"
-# - `CURL::gss`:           GSS library target.
-#   - `CURL_GSS_FLAVOUR`:  Custom property. "GNU" or "MIT" if detected.
+# - `GSS_FOUND`:    System has a GSS library.
+# - `GSS_VERSION`:  This is set to version advertised by pkg-config or read from manifest.
+#                   In case the library is found but no version info available it is set to "unknown"
+# - `CURL::gss`:    GSS library target.
+#   - `INTERFACE_CURL_GSS_FLAVOUR`: Custom property. "GNU" or "MIT" if detected.
 
 set(_gnu_modname "gss")
 set(_mit_modname "mit-krb5-gssapi")

--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -33,7 +33,7 @@
 # - `GSS_VERSION`:  This is set to version advertised by pkg-config or read from manifest.
 #                   In case the library is found but no version info available it is set to "unknown"
 # - `CURL::gss`:    GSS library target.
-#   - `INTERFACE_CURL_GSS_FLAVOUR`: Custom property. "GNU" or "MIT" if detected.
+#   - `INTERFACE_CURL_GSS_FLAVOR`: Custom property. "GNU" or "MIT" if detected.
 
 set(_gnu_modname "gss")
 set(_mit_modname "mit-krb5-gssapi")
@@ -261,7 +261,7 @@ if(GSS_FOUND)
   if(NOT TARGET CURL::gss)
     add_library(CURL::gss INTERFACE IMPORTED)
     set_target_properties(CURL::gss PROPERTIES
-      INTERFACE_CURL_GSS_FLAVOUR "${_gss_flavour}"
+      INTERFACE_CURL_GSS_FLAVOR "${_gss_flavour}"
       INTERFACE_LIBCURL_PC_MODULES "${_gss_pc_requires}"
       INTERFACE_COMPILE_OPTIONS "${_gss_CFLAGS}"
       INTERFACE_INCLUDE_DIRECTORIES "${_gss_INCLUDE_DIRS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1350,7 +1350,7 @@ if(CURL_USE_GSSAPI)
   if(GSS_FOUND)
     list(APPEND CURL_LIBS CURL::gss)
 
-    get_target_property(_gss_flavour CURL::gss INTERFACE_CURL_GSS_FLAVOUR)
+    get_target_property(_gss_flavour CURL::gss INTERFACE_CURL_GSS_FLAVOR)
     if(_gss_flavour STREQUAL "GNU")
       set(HAVE_GSSGNU 1)
     elseif(GSS_VERSION)  # MIT


### PR DESCRIPTION
- fix property name in comment.
- rename `INTERFACE_CURL_GSS_FLAVOUR` ->
  `INTERFACE_CURL_GSS_FLAVOR` to match preferred usage.

Follow-up to 8aeefd0b353021053688e53fc3a4b0edef85dcc7 (subcommit)
Follow-up to 16f073ef49f94412000218c9f6ad04e3fd7e4d01 #16973

---

https://github.com/curl/curl/pull/22013/files?w=1

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
