### PR TITLE
ratelimits: use minimal burst rate

### DIFF
--- a/lib/ratelimit.c
+++ b/lib/ratelimit.c
@@ -141,12 +141,14 @@ static void rlimit_tune_steps(struct Curl_rlimit *r,
         r->step_us = CURL_US_PER_SEC + ((timediff_t)mstep_inc * 1000);
         r->rate_per_step += rate_inc;
         r->tokens = r->rate_per_step;
+        if(r->burst_per_step) {
+          curl_off_t burst_inc = ((r->burst_per_step * mstep_inc) / 1000);
+          if(burst_inc)
+            r->burst_per_step += burst_inc;
+        }
       }
     }
   }
-
-  if(r->burst_per_step)
-    r->burst_per_step = r->rate_per_step;
 }
 
 void Curl_rlimit_init(struct Curl_rlimit *r,

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2768,7 +2768,9 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
     if(offt < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     s->max_send_speed = offt;
-    Curl_rlimit_init(&data->progress.ul.rlimit, offt, offt,
+    /* use minimal burst rate of 32k. some protocol batch IO */
+    Curl_rlimit_init(&data->progress.ul.rlimit, offt,
+                     CURLMAX(offt, (32 * 1024)),
                      Curl_pgrs_now(data));
     break;
   case CURLOPT_MAX_RECV_SPEED_LARGE:
@@ -2779,7 +2781,9 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
     if(offt < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     s->max_recv_speed = offt;
-    Curl_rlimit_init(&data->progress.dl.rlimit, offt, offt,
+    /* use minimal burst rate of 32k. some protocol batch IO */
+    Curl_rlimit_init(&data->progress.dl.rlimit, offt,
+                     CURLMAX(offt, (32 * 1024)),
                      Curl_pgrs_now(data));
     break;
   case CURLOPT_RESUME_FROM_LARGE:

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -190,6 +190,8 @@ static void cf_ngtcp2_upd_rx_win(struct Curl_cfilter *cf,
     return;
   }
   cur_win = stream->rx_offset_max - stream->rx_offset;
+  CURL_TRC_CF(data, cf, "rx_win: curent %" PRIu64 ", wanted %" PRIu64,
+              cur_win, wanted_win);
 
   if(wanted_win > cur_win) {
     uint64_t delta = wanted_win - cur_win;

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -190,8 +190,6 @@ static void cf_ngtcp2_upd_rx_win(struct Curl_cfilter *cf,
     return;
   }
   cur_win = stream->rx_offset_max - stream->rx_offset;
-  CURL_TRC_CF(data, cf, "rx_win: curent %" PRIu64 ", wanted %" PRIu64,
-              cur_win, wanted_win);
 
   if(wanted_win > cur_win) {
     uint64_t delta = wanted_win - cur_win;


### PR DESCRIPTION
Some protocols (and servers) prefer to batch IO and will not send data unless the window is of sufficient size. Set the burst rate for our rate limits to a minimum of 32KB to prevent stalling.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
