### PR TITLE
curl_formdata: fix to pass long where missing, document `CURLFORM_NAMELENGTH`

### DIFF
--- a/docs/libcurl/curl_formadd.md
+++ b/docs/libcurl/curl_formadd.md
@@ -114,8 +114,8 @@ you must make sure strlen() on the data pointer returns zero.
 
 ## CURLFORM_NAMELENGTH
 
-followed by a long giving the length of the contents. Pass this option to set
-the length of *CURLFORM_COPYNAME* and *CURLFORM_PTRNAME* buffers, if they are
+followed by a long giving the length of the name. Pass this option to set
+the length of *CURLFORM_COPYNAME* and *CURLFORM_PTRNAME* strings, if they are
 not null-terminated.
 
 ## CURLFORM_FILECONTENT

--- a/docs/libcurl/curl_formadd.md
+++ b/docs/libcurl/curl_formadd.md
@@ -112,6 +112,12 @@ If you pass a 0 (zero) for this option, libcurl calls strlen() on the contents
 to figure out the size. If you really want to send a zero byte content then
 you must make sure strlen() on the data pointer returns zero.
 
+## CURLFORM_NAMELENGTH
+
+followed by a long giving the length of the contents. Pass this option to set
+the length of *CURLFORM_COPYNAME* and *CURLFORM_PTRNAME* buffers, if they are
+not null-terminated.
+
 ## CURLFORM_FILECONTENT
 
 followed by a filename, causes that file to be read and its contents used

--- a/docs/libcurl/curl_formadd.md
+++ b/docs/libcurl/curl_formadd.md
@@ -284,7 +284,7 @@ int main(void)
                  CURLFORM_COPYNAME, "name",
                  CURLFORM_BUFFER, "data",
                  CURLFORM_BUFFERPTR, record,
-                 CURLFORM_BUFFERLENGTH, sizeof(record),
+                 CURLFORM_BUFFERLENGTH, (long)sizeof(record),
                  CURLFORM_END);
 
     /* no option needed for the end marker */

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -184,7 +184,7 @@ static void free_formlist(struct FormInfo *ptr)
  *
  * name/value pair where only the content pointer is remembered:
  * curl_formadd(&post, &last, CURLFORM_COPYNAME, "name",
- *              CURLFORM_PTRCONTENTS, ptr, CURLFORM_CONTENTSLENGTH, 10,
+ *              CURLFORM_PTRCONTENTS, ptr, CURLFORM_CONTENTSLENGTH, 10L,
  *              CURLFORM_END);
  * (if CURLFORM_CONTENTSLENGTH is missing strlen () is used)
  *

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -95,7 +95,7 @@ static CURLcode test_lib650(const char *URL)
   formrc = curl_formadd(&formpost,
                         &lastptr,
                         CURLFORM_PTRNAME, testname,
-                        CURLFORM_NAMELENGTH, sizeof(testname) - 2,
+                        CURLFORM_NAMELENGTH, (long)(sizeof(testname) - 2),
                         CURLFORM_ARRAY, formarray,
                         CURLFORM_FILENAME, "remotefile.txt",
                         CURLFORM_END);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -86,7 +86,7 @@ static CURLcode test_lib650(const char *URL)
   formarray[0].option = CURLFORM_PTRCONTENTS;
   formarray[0].value = testdata;
   formarray[1].option = CURLFORM_CONTENTSLENGTH;
-  formarray[1].value = (char *)(size_t)(long)(strlen(testdata) - 1);
+  formarray[1].value = (char *)(strlen(testdata) - 1);
   formarray[2].option = CURLFORM_END;
   formarray[2].value = NULL;
   formrc = curl_formadd(&formpost,

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -48,7 +48,6 @@ static CURLcode test_lib650(const char *URL)
   struct curl_forms formarray[3];
   size_t formlength = 0;
   char flbuf[32];
-  long contentlength = 0;
 
   static const char testname[] = "fieldname";
   static char testdata[] = "this is what we post to the silly web server";
@@ -83,13 +82,11 @@ static CURLcode test_lib650(const char *URL)
     goto test_cleanup;
   }
 
-  contentlength = (long)(strlen(testdata) - 1);
-
   /* Use a form array for the non-copy test. */
   formarray[0].option = CURLFORM_PTRCONTENTS;
   formarray[0].value = testdata;
   formarray[1].option = CURLFORM_CONTENTSLENGTH;
-  formarray[1].value = (char *)(size_t)contentlength;
+  formarray[1].value = (char *)(size_t)(long)(strlen(testdata) - 1);
   formarray[2].option = CURLFORM_END;
   formarray[2].value = NULL;
   formrc = curl_formadd(&formpost,


### PR DESCRIPTION
- lib650: pass `long` to `CURLFORM_NAMELENGTH` in test.
  Spotted by Copilot.
  https://github.com/curl/curl/pull/22011#discussion_r3412407235
  Follow-up to 3620e569b312476f1e63b298106f942079b5afe8

- lib650: drop an interim variable, and interim casts.
  Follow-up to 60776a0515c2a8f572902ad5bcc9f63eeaeafa84 #2747

- curl_formdata.md: document `CURLFORM_NAMELENGTH` on man page.

- curl_formdata.md: pass `long` to `CURLFORM_BUFFERLENGTH` on man page.

- formdata: pass `long` to `CURLFORM_CONTENTSLENGTH` in comment.

---

https://github.com/curl/curl/pull/22017/files?w=1

There is also this in lib650, I couldn't trace back in source
if `size_t` is correct or should be `long` (I'd guess it's the
latter):
```c
  formarray[1].option = CURLFORM_CONTENTSLENGTH;
  formarray[1].value = (char *)(size_t)contentlength;
```

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
