### PR TITLE
verify-release: verify more thoroughly with git

### DIFF
--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -36,9 +36,23 @@ script that generates a new curl release from source code and then compares
 this newly generated release tarball with the tarball file you downloaded from
 curl.se.
 
+For full verification, invoke the script inside an up-to-date curl source code
+git repository. Without a git repository present, it does a lighter check by
+rebuilding the release using the files in the tarball.
+
+Note: full verification mode checks out the release tag in your repository.
+Run it in a clean working tree (no local changes) or a dedicated clone.
+
 Invoke it like this:
 
+    git clone https://github.com/curl/curl
+    cd curl
+    mv [download-dir]/curl-8.19.0.tar.xz .
     ./scripts/verify-release curl-8.19.0.tar.xz
+
+A successful check ends up with a final output similar to:
+
+    curl-8.19.0.tar.xz: OK
 
 By verifying the release tarballs, you verify that Daniel does not infect the
 release on purpose or involuntarily because of anything malicious running in

--- a/scripts/verify-release
+++ b/scripts/verify-release
@@ -27,8 +27,11 @@
 # This script remakes a provided curl release and verifies that the newly
 # built version is identical to the original file.
 #
-# It is designed to be invoked in a clean directory with the path to the
-# release tarball as an argument.
+# Invoke in a clean directory with the path to the release tarball as an
+# argument for basic verification.
+#
+# For maximum verification: run the script in an up-to-date curl git
+# repository.
 #
 
 set -eu
@@ -47,6 +50,16 @@ if test "$i" -gt 1; then
     exit
 fi
 
+# check if this is in a git clone directory
+
+if git log -1 include/curl/curl.h 2>/dev/null >/dev/null; then
+    echo "*** Detected a git checkout, do full verification"
+    withgit=1
+else
+    echo "*** Lacking a full git checkout, do the lesser verification"
+    withgit=0
+fi
+
 mkdir -p _tarballs
 rm -rf _tarballs/*
 
@@ -62,13 +75,33 @@ echo "version $curlver"
 
 timestamp=$(grep -Eo 'SOURCE_DATE_EPOCH=[0-9]*' curl-"$curlver"/docs/RELEASE-TOOLS.md | cut -d= -f2)
 
-pwd=$(pwd)
-cd "curl-$curlver"
-./configure --without-ssl --without-libpsl
-./scripts/dmaketgz "$curlver" "$timestamp"
+if test "$withgit" = 0; then
+    # without git
 
-mv curl-"$curlver"* ../_tarballs/
-cd "$pwd"
+    pwd=$(pwd)
+    cd "curl-$curlver"
+    ./configure --without-ssl --without-libpsl
+    ./scripts/dmaketgz "$curlver" "$timestamp"
+
+    for f in "curl-$curlver.tar.gz" "curl-$curlver.tar.bz2" "curl-$curlver.tar.xz" "curl-$curlver.zip"; do
+        mv "$f" ../_tarballs/
+    done
+    cd "$pwd"
+else
+    tag=$(grep -Eo 'tag/commit: curl-[0-9_]*' curl-"$curlver"/docs/RELEASE-TOOLS.md | head -n 1 | sed 's/^tag\/commit: //')
+    echo "*** Use git tag $tag"
+    prevtag=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
+    git checkout -f "$tag"
+
+    ./scripts/dmaketgz "$curlver" "$timestamp"
+
+    # switch back to where it was
+    git checkout -f "$prevtag"
+
+    for f in "curl-$curlver.tar.gz" "curl-$curlver.tar.bz2" "curl-$curlver.tar.xz" "curl-$curlver.zip"; do
+        mv "$f" _tarballs/
+    done
+fi
 cd "_tarballs"
 
 # compare the new tarball against the original

--- a/scripts/verify-release
+++ b/scripts/verify-release
@@ -39,25 +39,25 @@ set -eu
 tarball="${1:-}"
 
 if [ -z "$tarball" ]; then
-    echo "Provide a curl release tarball name as argument"
-    exit
+  echo "Provide a curl release tarball name as argument"
+  exit
 fi
 
 i="$(find . -maxdepth 1 -type d -name 'curl-*' | wc -l)"
 
 if test "$i" -gt 1; then
-    echo "multiple curl-* entries found, disambiguate please"
-    exit
+  echo "multiple curl-* entries found, disambiguate please"
+  exit
 fi
 
 # check if this is in a git clone directory
 
 if git log -1 include/curl/curl.h 2>/dev/null >/dev/null; then
-    echo "*** Detected a git checkout, do full verification"
-    withgit=1
+  echo "*** Detected a git checkout, do full verification"
+  withgit=1
 else
-    echo "*** Lacking a full git checkout, do the lesser verification"
-    withgit=0
+  echo "*** Lacking a full git checkout, do the lesser verification"
+  withgit=0
 fi
 
 mkdir -p _tarballs
@@ -76,31 +76,31 @@ echo "version $curlver"
 timestamp=$(grep -Eo 'SOURCE_DATE_EPOCH=[0-9]*' curl-"$curlver"/docs/RELEASE-TOOLS.md | cut -d= -f2)
 
 if test "$withgit" = 0; then
-    # without git
+  # without git
 
-    pwd=$(pwd)
-    cd "curl-$curlver"
-    ./configure --without-ssl --without-libpsl
-    ./scripts/dmaketgz "$curlver" "$timestamp"
+  pwd=$(pwd)
+  cd "curl-$curlver"
+  ./configure --without-ssl --without-libpsl
+  ./scripts/dmaketgz "$curlver" "$timestamp"
 
-    for f in "curl-$curlver.tar.gz" "curl-$curlver.tar.bz2" "curl-$curlver.tar.xz" "curl-$curlver.zip"; do
-        mv "$f" ../_tarballs/
-    done
-    cd "$pwd"
+  for f in "curl-$curlver.tar.gz" "curl-$curlver.tar.bz2" "curl-$curlver.tar.xz" "curl-$curlver.zip"; do
+    mv "$f" ../_tarballs/
+  done
+  cd "$pwd"
 else
-    tag=$(grep -Eo 'tag/commit: curl-[0-9_]*' curl-"$curlver"/docs/RELEASE-TOOLS.md | head -n 1 | sed 's/^tag\/commit: //')
-    echo "*** Use git tag $tag"
-    prevtag=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
-    git checkout -f "$tag"
+  tag=$(grep -Eo 'tag/commit: curl-[0-9_]*' curl-"$curlver"/docs/RELEASE-TOOLS.md | head -n 1 | sed 's/^tag\/commit: //')
+  echo "*** Use git tag $tag"
+  prevtag=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
+  git checkout -f "$tag"
 
-    ./scripts/dmaketgz "$curlver" "$timestamp"
+  ./scripts/dmaketgz "$curlver" "$timestamp"
 
-    # switch back to where it was
-    git checkout -f "$prevtag"
+  # switch back to where it was
+  git checkout -f "$prevtag"
 
-    for f in "curl-$curlver.tar.gz" "curl-$curlver.tar.bz2" "curl-$curlver.tar.xz" "curl-$curlver.zip"; do
-        mv "$f" _tarballs/
-    done
+  for f in "curl-$curlver.tar.gz" "curl-$curlver.tar.bz2" "curl-$curlver.tar.xz" "curl-$curlver.zip"; do
+    mv "$f" _tarballs/
+  done
 fi
 cd "_tarballs"
 


### PR DESCRIPTION
If the script is invoked in a git repository it verifies the tarball better.
