### PR TITLE
servers: fix error message if unix socket path is not a socket

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -706,7 +706,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     }
 #ifdef S_IFSOCK
     if((statbuf.st_mode & S_IFSOCK) != S_IFSOCK) {
-      logmsg("Error binding socket, failed to stat %s", unix_socket);
+      logmsg("Error binding socket, not a socket %s", unix_socket);
       return -1;
     }
 #endif

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -706,7 +706,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     }
 #ifdef S_IFSOCK
     if((statbuf.st_mode & S_IFSOCK) != S_IFSOCK) {
-      logmsg("Error binding socket, not a socket %s", unix_socket);
+      logmsg("Error binding socket, %s is not a socket", unix_socket);
       return -1;
     }
 #endif


### PR DESCRIPTION
Follow-up to 99fb36797a3f0b64ad20fcb8b83026875640f8e0
Cherry-picked from #22010

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
