### PR TITLE
servers: mask to `S_IFMT` in unix socket path attribute check

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -701,7 +701,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
                errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
         return -1;
       }
-      if((statbuf.st_mode & S_IFSOCK) != S_IFSOCK) {
+      if((statbuf.st_mode & S_IFMT) != S_IFSOCK) {
         logmsg("Error binding socket, %s is not a socket", unix_socket);
         return -1;
       }


### PR DESCRIPTION
Instead of `S_IFSOCK` before this patch. For correctness; it is probably
not an issue in most environments.

Spotted by Copilot
Bug: https://github.com/curl/curl/pull/22021#discussion_r3413049506
Follow-up to 99fb36797a3f0b64ad20fcb8b83026875640f8e0

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
