### PR TITLE
lib668: do not assume null-terminator in test input data

### DIFF
--- a/tests/libtest/lib668.c
+++ b/tests/libtest/lib668.c
@@ -31,7 +31,7 @@ struct t668_WriteThis {
 static size_t t668_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct t668_WriteThis *pooh = (struct t668_WriteThis *)userp;
-  size_t len = strlen(pooh->readptr);
+  size_t len = (size_t)pooh->sizeleft;
 
   (void)size; /* Always 1 */
 
@@ -40,6 +40,7 @@ static size_t t668_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
   if(len) {
     memcpy(ptr, pooh->readptr, len);
     pooh->readptr += len;
+    pooh->sizeleft -= (curl_off_t)len;
   }
   return len;
 }

--- a/tests/libtest/lib668.c
+++ b/tests/libtest/lib668.c
@@ -25,13 +25,13 @@
 
 struct t668_WriteThis {
   const char *readptr;
-  curl_off_t sizeleft;
+  size_t sizeleft;
 };
 
 static size_t t668_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct t668_WriteThis *pooh = (struct t668_WriteThis *)userp;
-  size_t len = (size_t)pooh->sizeleft;
+  size_t len = pooh->sizeleft;
 
   (void)size; /* Always 1 */
 
@@ -40,7 +40,7 @@ static size_t t668_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
   if(len) {
     memcpy(ptr, pooh->readptr, len);
     pooh->readptr += len;
-    pooh->sizeleft -= (curl_off_t)len;
+    pooh->sizeleft -= len;
   }
   return len;
 }
@@ -77,7 +77,7 @@ static CURLcode test_lib668(const char *URL)
 
   /* Prepare the callback structures. */
   pooh1.readptr = testdata;
-  pooh1.sizeleft = (curl_off_t)(sizeof(testdata) - 1);
+  pooh1.sizeleft = sizeof(testdata) - 1;
   pooh2 = pooh1;
 
   /* Build the mime tree. */
@@ -85,7 +85,7 @@ static CURLcode test_lib668(const char *URL)
   part = curl_mime_addpart(mime);
   curl_mime_name(part, "field1");
   /* Early end of data detection can be done because the data size is known. */
-  curl_mime_data_cb(part, (curl_off_t)(sizeof(testdata) - 1),
+  curl_mime_data_cb(part, (curl_off_t)pooh1.sizeleft,
                     t668_read_cb, NULL, NULL, &pooh1);
   part = curl_mime_addpart(mime);
   curl_mime_name(part, "field2");


### PR DESCRIPTION
For correctness. Did not cause an issue, because the null-terminator is
present.

Also:
- change a size type to avoid casts.
- reuse input length value.

Spotted by GitHub Code Quality

Follow-up to 1e4cb333ef632bf081045bb7b36f0736bec52708 #4826

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
