### PR TITLE
servers: accept `unlink()` failing due to the file missing

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -708,7 +708,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
     }
 #endif
     /* dead socket, cleanup and retry bind */
-    if(unlink(unix_socket)) {
+    if(unlink(unix_socket) && errno != ENOENT) {
       logmsg("Error binding socket, failed to unlink %s: %d (%s)", unix_socket,
              errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
       return -1;


### PR DESCRIPTION
In `bind_unix_socket()`, before retrying `bind()`.

This patch uses `ENOENT`. This was last time in source between 
d25b0503795f1fbf557632ce870298f52f2a78c1 (2018) and
dffd996e3b54a0c9314b1c93c7f837a5b2b1fc3d (2023), and also earlier. Also
defined by supported Windows envs. Seems safe to use.

Reported-by CodeQL
Follow-up to 99fb36797a3f0b64ad20fcb8b83026875640f8e0
Cherry-picked from #22010

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
