### PR TITLE
lib650: fix to pass `long` `CURLFORM_CONTENTSLENGTH` via `struct curl_forms`

### DIFF
--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -86,7 +86,7 @@ static CURLcode test_lib650(const char *URL)
   formarray[0].option = CURLFORM_PTRCONTENTS;
   formarray[0].value = testdata;
   formarray[1].option = CURLFORM_CONTENTSLENGTH;
-  formarray[1].value = (char *)(strlen(testdata) - 1);
+  formarray[1].value = (char *)(long)(strlen(testdata) - 1);
   formarray[2].option = CURLFORM_END;
   formarray[2].value = NULL;
   formrc = curl_formadd(&formpost,


### PR DESCRIPTION
It's a guess. I'm not sure which is the correct type here.

Ref: adb606eae752eaeea9a5fcea77fc46498e2ecf05 #22017 Follow-up to 3620e569b312476f1e63b298106f942079b5afe8

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
