### PR TITLE
servers: fix off-by-3 OOB write for large `loghex()` inputs

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -42,7 +42,7 @@ void loghex(const unsigned char *buffer, ssize_t len)
   ssize_t width = 0;
   int left = sizeof(data);
 
-  for(i = 0; i < len && (left >= 0); i++) {
+  for(i = 0; i < len && (left > 2); i++) {
     snprintf(optr, left, "%02x", ptr[i]);
     width += 2;
     optr += 2;


### PR DESCRIPTION
Spotted by GitHub Code Quality

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
