### PR TITLE
cf-https-connect: do not engage on proxy origin

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -813,7 +813,10 @@ CURLcode Curl_cf_https_setup(struct Curl_easy *data,
   /* This filter is intended for HTTPS using ALPN and does
    * not support HTTPS Eyeballing to a proxy. */
   if((conn->scheme->protocol != CURLPROTO_HTTPS) ||
-     !conn->bits.tls_enable_alpn || conn->bits.origin_is_proxy)
+#ifndef CURL_DISABLE_PROXY
+     conn->bits.origin_is_proxy ||
+#endif
+     !conn->bits.tls_enable_alpn)
     goto out;
 
   result = cf_hc_add(data, conn, sockindex, conn->transport_wanted);

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -810,8 +810,10 @@ CURLcode Curl_cf_https_setup(struct Curl_easy *data,
 
   DEBUGASSERT(conn->scheme->protocol == CURLPROTO_HTTPS);
 
+  /* This filter is intended for HTTPS using ALPN and does
+   * not support HTTPS Eyeballing to a proxy. */
   if((conn->scheme->protocol != CURLPROTO_HTTPS) ||
-     !conn->bits.tls_enable_alpn)
+     !conn->bits.tls_enable_alpn || conn->bits.origin_is_proxy)
     goto out;
 
   result = cf_hc_add(data, conn, sockindex, conn->transport_wanted);

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -84,15 +84,16 @@ class TestProxy:
     # upload via https: with proto (no tunnel)
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
     @pytest.mark.parametrize("proto", Env.http_h1_h2_protos())
-    @pytest.mark.parametrize("fname, fcount", [
-        ['data.json', 5],
-        ['data-100k', 5],
-        ['data-1m', 2]
+    @pytest.mark.parametrize("fname, fcount, with_alpn", [
+        ['data.json', 5, False],
+        ['data.json', 5, True],
+        ['data-100k', 5, True],
+        ['data-1m', 2, True]
     ])
     @pytest.mark.skipif(condition=not Env.have_nghttpx(),
                         reason="no nghttpx available")
     def test_10_02_proxys_up(self, env: Env, httpd, nghttpx, proto,
-                             fname, fcount):
+                             fname, fcount, with_alpn):
         if proto == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         count = fcount
@@ -100,6 +101,8 @@ class TestProxy:
         curl = CurlClient(env=env)
         url = f'http://localhost:{env.http_port}/curltest/echo?id=[0-{count-1}]'
         xargs = curl.get_proxy_args(proto=proto)
+        if not with_alpn:
+            xargs.append('--no-alpn')
         r = curl.http_upload(urls=[url], data=f'@{srcfile}', alpn_proto=proto,
                              extra_args=xargs)
         r.check_response(count=count, http_status=200,


### PR DESCRIPTION
When talking to a forwarding proxy, do not start HTTPS Eyeballing. We might support this in the future, but for now, the --httpx.x arguments to do not apply to such a setup.

Add a test case for forward proxying without use of ALPN.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
