### PR TITLE
servers: silence `-Wunused-result` with pragma

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -313,22 +313,25 @@ static HWND hidden_main_window = NULL;
  * should finish its execution in a controlled manner as soon as possible.
  * The first time this is called it sets got_exit_signal to 1 and
  * stores in exit_signal the signal that triggered its execution.
- */
-/*
+ *
  * Only call signal-safe functions from the signal handler, as required by
  * the POSIX specification:
  *   https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html
  * Hence, do not call 'logmsg()', and instead use 'open/write/close' to
  * log errors.
  */
-static size_t useless; /* to silence variable 'rc' set but not used */
+/* suppress warnings seen in configurations where 'write()' has the attribute
+   'warn_unused_result' and '(void)' does not silence them. */
+#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+#endif
 static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
-  size_t rc = 0;
   if(!serverlogfile) {
     static const char msg[] = "exit_signal_handler: serverlogfile not set\n";
-    rc = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    (void)write(STDERR_FILENO, msg, sizeof(msg) - 1);
   }
   else {
     int fd = -1;
@@ -342,14 +345,14 @@ static void exit_signal_handler(int signum)
     if(fd != -1) {
 #endif
       static const char msg[] = "exit_signal_handler: called\n";
-      rc = write(fd, msg, sizeof(msg) - 1);
+      (void)write(fd, msg, sizeof(msg) - 1);
       curlx_close(fd);
     }
     else {
       static const char msg[] = "exit_signal_handler: failed opening ";
-      rc = write(STDERR_FILENO, msg, sizeof(msg) - 1);
-      rc += write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
-      rc += write(STDERR_FILENO, "\n", 1);
+      (void)write(STDERR_FILENO, msg, sizeof(msg) - 1);
+      (void)write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
+      (void)write(STDERR_FILENO, "\n", 1);
     }
   }
   if(got_exit_signal == 0) {
@@ -360,10 +363,12 @@ static void exit_signal_handler(int signum)
       (void)SetEvent(exit_event);
 #endif
   }
-  useless = rc;
   (void)signal(signum, exit_signal_handler);
   errno = old_errno;
 }
+#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef _WIN32
 /* CTRL event handler for Windows Console applications to simulate

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -321,10 +321,10 @@ static HWND hidden_main_window = NULL;
  * log errors.
  */
 /* suppress warnings seen in configurations where 'write()' has the attribute
-   'warn_unused_result' and '(void)' does not silence them. */
+   'warn_unused_result', which is not silenced by casting to '(void)'. */
 #if defined(CURL_HAVE_DIAG) && !defined(__clang__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
+#pragma GCC diagnostic ignored "-Wunused-result" /* GCC 4.5+ */
 #endif
 static void exit_signal_handler(int signum)
 {


### PR DESCRIPTION
In some configurations the `write()` functions gets the 
`warn_unused_result` attribute, that makes casting to `(void)`
ineffective to silence this warning. Seen with glibc, in 5 CI jobs.
The warning option appeared in GCC 4.5 and comes enabled by default.

```
tests/server/util.c:329:5: error: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
  329 |     write(STDERR_FILENO, msg, sizeof(msg) - 1);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/27548333990/job/81427544632

Refs:
https://github.com/curl/curl/pull/22023#issuecomment-4708455631
https://gcc.gnu.org/onlinedocs/gcc-16.1.0/gcc/Warning-Options.html#index-Wunused-result
https://gcc.gnu.org/onlinedocs/gcc-16.1.0/gcc/Common-Attributes.html#index-warn_005funused_005fresult
https://stackoverflow.com/questions/40576003/ignoring-warning-wunused-result

Follow-up to c8d8f081fd62c68c588f8963a8e441c730a23b5b #22023
Follow-up to e95f509c66abdd88ae02e3243cdc217f19c4a330 #16852

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
