### PR TITLE
creds: create with empty user+pass

### DIFF
--- a/lib/creds.c
+++ b/lib/creds.c
@@ -51,7 +51,7 @@ CURLcode Curl_creds_create(const char *user,
   Curl_creds_unlink(pcreds);
 
   /* Everything empty/NULL, this is the NULL credential */
-  if(!ulen && !plen && !olen && !salen && !sslen)
+  if(!user && !passwd && !olen && !salen && !sslen)
     goto out;
 
   if((ulen > CURL_MAX_INPUT_LENGTH) ||
@@ -108,15 +108,18 @@ CURLcode Curl_creds_merge(const char *user,
   struct Curl_creds *creds_out = NULL;
   CURLcode result;
 
-  if(!user || !user[0])
-    user = Curl_creds_user(creds_in);
-  if(!passwd || !passwd[0])
-    passwd = Curl_creds_passwd(creds_in);
-  result = Curl_creds_create(user, passwd,
-                             Curl_creds_oauth_bearer(creds_in),
-                             Curl_creds_sasl_authzid(creds_in),
-                             Curl_creds_sasl_service(creds_in),
-                             source, &creds_out);
+  if(!creds_in) {
+    result = Curl_creds_create(user, passwd, NULL, NULL, NULL,
+                               source, &creds_out);
+  }
+  else {
+    result = Curl_creds_create(user ? user : Curl_creds_user(creds_in),
+                               passwd ? passwd : Curl_creds_passwd(creds_in),
+                               Curl_creds_oauth_bearer(creds_in),
+                               Curl_creds_sasl_authzid(creds_in),
+                               Curl_creds_sasl_service(creds_in),
+                               source, &creds_out);
+  }
   Curl_creds_link(pcreds_out, creds_out);
   Curl_creds_unlink(&creds_out);
   return result;


### PR DESCRIPTION
Allow creation of a `Curl_creds` instance with empty username and password (not NULL username/password). There are authentication schemes like <insert greek mythology'> that do not use the actual values of username/password but trigger on the mere existance.

We have no test cases for this, so this is a shot in the dark here.

refs #21943

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
