### PR TITLE
servers: drop CRT and curlx calls from `main_window_loop()` (Windows)

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -471,7 +471,7 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
       static const char msg[] = "main_window_proc(): WM_CLOSE -> SIGTERM\n";
       DWORD dwWritten;
       WriteFile(GetStdHandle(STD_ERROR_HANDLE), msg, CURL_CSTRLEN(msg),
-                             &dwWritten, NULL);
+                &dwWritten, NULL);
       exit_msg = msg;
       initiate_exit(SIGTERM);
       break;
@@ -522,7 +522,7 @@ static DWORD WINAPI main_window_loop(void *lpParameter)
     if(ret == -1) {
       static const char str[] = "GetMessage() failed\n";
       WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
-                             &dwWritten, NULL);
+                &dwWritten, NULL);
       return (DWORD)-1;
     }
     else if(ret) {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -409,6 +409,8 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
 
 #else /* _WIN32 */
 
+/* #define DEBUG_WIN32_CALLBACKS */
+
 /* CTRL event handler for Windows Console applications to handle exit events.
  *
  * Background information from MSDN:
@@ -490,17 +492,27 @@ static DWORD WINAPI main_window_loop(void *lpParameter)
   WNDCLASS wc;
   BOOL ret;
   MSG msg;
+#ifdef DEBUG_WIN32_CALLBACKS
   DWORD err;
   char buffer[WINAPI_ERROR_LEN];
+#else
+  DWORD dwWritten;
+#endif
 
   ZeroMemory(&wc, sizeof(wc));
   wc.lpfnWndProc = (WNDPROC)main_window_proc;
   wc.hInstance = (HINSTANCE)lpParameter;
   wc.lpszClassName = TEXT("MainWClass");
   if(!RegisterClass(&wc)) {
+#ifdef DEBUG_WIN32_CALLBACKS
     err = GetLastError();
     curlx_winapi_strerror(err, buffer, sizeof(buffer));
     fprintf(stderr, "RegisterClass failed: %s\n", buffer);
+#else
+    static const char str[] = "RegisterClass() failed\n";
+    WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
+              &dwWritten, NULL);
+#endif
     return (DWORD)-1;
   }
 
@@ -512,18 +524,30 @@ static DWORD WINAPI main_window_loop(void *lpParameter)
                                       (HWND)NULL, (HMENU)NULL,
                                       wc.hInstance, NULL);
   if(!hidden_main_window) {
+#ifdef DEBUG_WIN32_CALLBACKS
     err = GetLastError();
     curlx_winapi_strerror(err, buffer, sizeof(buffer));
     fprintf(stderr, "CreateWindowEx failed: (0x%08lx) - %s\n", err, buffer);
+#else
+    static const char str[] = "CreateWindowEx() failed\n";
+    WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
+              &dwWritten, NULL);
+#endif
     return (DWORD)-1;
   }
 
   do {
     ret = GetMessage(&msg, NULL, 0, 0);
     if(ret == -1) {
+#ifdef DEBUG_WIN32_CALLBACKS
       err = GetLastError();
       curlx_winapi_strerror(err, buffer, sizeof(buffer));
       fprintf(stderr, "GetMessage failed: (0x%08lx) - %s\n", err, buffer);
+#else
+      static const char str[] = "GetMessage() failed\n";
+      WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
+                             &dwWritten, NULL);
+#endif
       return (DWORD)-1;
     }
     else if(ret) {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -409,8 +409,6 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
 
 #else /* _WIN32 */
 
-/* #define DEBUG_WIN32_CALLBACKS */
-
 /* CTRL event handler for Windows Console applications to handle exit events.
  *
  * Background information from MSDN:
@@ -492,27 +490,16 @@ static DWORD WINAPI main_window_loop(void *lpParameter)
   WNDCLASS wc;
   BOOL ret;
   MSG msg;
-#ifdef DEBUG_WIN32_CALLBACKS
-  DWORD err;
-  char buffer[WINAPI_ERROR_LEN];
-#else
   DWORD dwWritten;
-#endif
 
   ZeroMemory(&wc, sizeof(wc));
   wc.lpfnWndProc = (WNDPROC)main_window_proc;
   wc.hInstance = (HINSTANCE)lpParameter;
   wc.lpszClassName = TEXT("MainWClass");
   if(!RegisterClass(&wc)) {
-#ifdef DEBUG_WIN32_CALLBACKS
-    err = GetLastError();
-    curlx_winapi_strerror(err, buffer, sizeof(buffer));
-    fprintf(stderr, "RegisterClass failed: %s\n", buffer);
-#else
     static const char str[] = "RegisterClass() failed\n";
     WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
               &dwWritten, NULL);
-#endif
     return (DWORD)-1;
   }
 
@@ -524,30 +511,18 @@ static DWORD WINAPI main_window_loop(void *lpParameter)
                                       (HWND)NULL, (HMENU)NULL,
                                       wc.hInstance, NULL);
   if(!hidden_main_window) {
-#ifdef DEBUG_WIN32_CALLBACKS
-    err = GetLastError();
-    curlx_winapi_strerror(err, buffer, sizeof(buffer));
-    fprintf(stderr, "CreateWindowEx failed: (0x%08lx) - %s\n", err, buffer);
-#else
     static const char str[] = "CreateWindowEx() failed\n";
     WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
               &dwWritten, NULL);
-#endif
     return (DWORD)-1;
   }
 
   do {
     ret = GetMessage(&msg, NULL, 0, 0);
     if(ret == -1) {
-#ifdef DEBUG_WIN32_CALLBACKS
-      err = GetLastError();
-      curlx_winapi_strerror(err, buffer, sizeof(buffer));
-      fprintf(stderr, "GetMessage failed: (0x%08lx) - %s\n", err, buffer);
-#else
       static const char str[] = "GetMessage() failed\n";
       WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
                              &dwWritten, NULL);
-#endif
       return (DWORD)-1;
     }
     else if(ret) {


### PR DESCRIPTION
To simplify and to avoid the chance of potential interference or
thread-safety issues. If one these 3 Win32 API calls fail, there is
likely a serious problem, out of the code's control. Knowing
`GetLastError()` is unlikely to help.

Refs:
https://learn.microsoft.com/windows/win32/api/winuser/nc-winuser-wndproc
https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms686736(v=vs.85)
https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-getmessage
https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-createwindowexa
https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-registerclassa

Ref: 9ea48811fed455d4a869eb100b2216f039f8677a #22487
Ref: 1c49f2f26d0f200bb9de61f795f06a1bc56845e9 #18451
Follow-up to ac1e206278b98fbe762f4b554803c64e8b562156

---

- [x] perhaps limit this to the ctrl event handler. → merged separately via #22487
