### PR TITLE
perl: `open... || ` → `open... or` (cont.)

### DIFF
--- a/scripts/cd2cd
+++ b/scripts/cd2cd
@@ -89,7 +89,8 @@ sub single {
     my $salist = 0;
     my $copyright;
     my $spdx;
-    open(F, "<:crlf", $f) or return 1;
+    open(F, "<:crlf", $f) or
+        return 1;
     while(<F>) {
         $line++;
         $d = $_;

--- a/scripts/cd2cd
+++ b/scripts/cd2cd
@@ -89,8 +89,7 @@ sub single {
     my $salist = 0;
     my $copyright;
     my $spdx;
-    open(F, "<:crlf", $f) ||
-        return 1;
+    open(F, "<:crlf", $f) or return 1;
     while(<F>) {
         $line++;
         $d = $_;
@@ -212,7 +211,7 @@ HEAD
     close(F);
 
     if($inplace) {
-        open(O, ">$f") || return 1;
+        open(O, ">$f") or return 1;
         print O @desc;
         close(O);
     }

--- a/scripts/managen
+++ b/scripts/managen
@@ -562,7 +562,7 @@ sub maybespace {
 sub single {
     my ($dir, $manpage, $f, $standalone) = @_;
     my $fh;
-    open($fh, "<:crlf", "$dir/$f") ||
+    open($fh, "<:crlf", "$dir/$f") or
         die "could not find $dir/$f";
     my $short;
     my $long;
@@ -969,7 +969,7 @@ sub single {
 sub getshortlong {
     my ($dir, $f) = @_;
     $f =~ s/^.*\///;
-    open(F, "<:crlf", "$dir/$f") ||
+    open(F, "<:crlf", "$dir/$f") or
         die "could not find $dir/$f";
     my $short;
     my $long;
@@ -1037,8 +1037,7 @@ sub indexoptions {
 sub header {
     my ($dir, $manpage, $f) = @_;
     my $fh;
-    open($fh, "<:crlf", "$dir/$f") ||
-        die "could not find $dir/$f";
+    open($fh, "<:crlf", "$dir/$f") or die "could not find $dir/$f";
     my @d = render($manpage, $fh, $f, 1);
     close($fh);
     printdesc($manpage, 0, @d);
@@ -1047,8 +1046,7 @@ sub header {
 sub sourcecategories {
     my ($dir) = @_;
     my %cats;
-    open(H, "<$dir/../../src/tool_help.h") ||
-        die "cannot find the header file";
+    open(H, "<$dir/../../src/tool_help.h") or die "cannot find the header file";
     while(<H>) {
         if(/^\#define CURLHELP_([A-Z0-9]*)/) {
             $cats{lc($1)}++;
@@ -1177,7 +1175,7 @@ sub listglobals {
 
     # Find all global options and output them
     foreach my $f (sort @files) {
-        open(F, "<:crlf", "$dir/$f") ||
+        open(F, "<:crlf", "$dir/$f") or
             die "could not read $dir/$f";
         my $long;
         my $start = 0;
@@ -1222,7 +1220,7 @@ sub mainpage {
     # $manpage is 1 for nroff, 0 for ASCII
     my $ret;
     my $fh;
-    open($fh, "<:crlf", "$dir/mainpage.idx") ||
+    open($fh, "<:crlf", "$dir/mainpage.idx") or
         die "no $dir/mainpage.idx file";
 
     print <<HEADER

--- a/scripts/managen
+++ b/scripts/managen
@@ -1037,7 +1037,8 @@ sub indexoptions {
 sub header {
     my ($dir, $manpage, $f) = @_;
     my $fh;
-    open($fh, "<:crlf", "$dir/$f") or die "could not find $dir/$f";
+    open($fh, "<:crlf", "$dir/$f") or
+        die "could not find $dir/$f";
     my @d = render($manpage, $fh, $f, 1);
     close($fh);
     printdesc($manpage, 0, @d);
@@ -1046,7 +1047,8 @@ sub header {
 sub sourcecategories {
     my ($dir) = @_;
     my %cats;
-    open(H, "<$dir/../../src/tool_help.h") or die "cannot find the header file";
+    open(H, "<$dir/../../src/tool_help.h") or
+        die "cannot find the header file";
     while(<H>) {
         if(/^\#define CURLHELP_([A-Z0-9]*)/) {
             $cats{lc($1)}++;

--- a/scripts/mdlinkcheck
+++ b/scripts/mdlinkcheck
@@ -154,7 +154,7 @@ sub storelink {
 sub findlinks {
     my ($f) = @_;
     my $line = 1;
-    open(F, "<:crlf", $f) ||
+    open(F, "<:crlf", $f) or
         return;
 
     # is it a markdown extension?

--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -257,7 +257,7 @@ sub sha256 {
 
 sub oldhash {
     my $hash = "";
-    open(C, "<$_[0]") || return 0;
+    open(C, "<$_[0]") or return 0;
     while(<C>) {
         chomp;
         if($_ =~ /^\#\# SHA256: (.*)/) {

--- a/scripts/nroff2cd
+++ b/scripts/nroff2cd
@@ -43,7 +43,7 @@ my $nroff2cd = "0.1"; # to keep check
 
 sub single {
     my ($f) = @_;
-    open(F, "<:crlf", $f) ||
+    open(F, "<:crlf", $f) or
         return 1;
     my $line;
     my $title;
@@ -67,7 +67,7 @@ sub single {
                 # remove leading directory
                 $f =~ s/(.*?\/)//;
                 close(F);
-                open(F, "<:crlf", $f) || return 1;
+                open(F, "<:crlf", $f) or return 1;
             }
             if($d =~ /^\.TH ([^ ]*) (\d) \"(.*?)\" ([^ \n]*)/) {
                 # header, this needs to be the first thing after leading comments

--- a/tests/allversions.pm
+++ b/tests/allversions.pm
@@ -32,8 +32,7 @@ our %pastversion;
 
 sub allversions {
     my ($file) = @_;
-    open(A, "<$file") ||
-        die "cannot open the versions file $file\n";
+    open(A, "<$file") or die "cannot open the versions file $file\n";
     my $before = 1;
     my $relcount;
     while(<A>) {

--- a/tests/allversions.pm
+++ b/tests/allversions.pm
@@ -32,7 +32,8 @@ our %pastversion;
 
 sub allversions {
     my ($file) = @_;
-    open(A, "<$file") or die "cannot open the versions file $file\n";
+    open(A, "<$file") or
+        die "cannot open the versions file $file\n";
     my $before = 1;
     my $relcount;
     while(<A>) {

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -215,7 +215,7 @@ sub exit_signal_handler {
 
 sub ftpmsg {
   # append to the server.input file
-  open(my $input, ">>", "$logdir/server$idstr.input") ||
+  open(my $input, ">>", "$logdir/server$idstr.input") or
     logmsg "failed to open $logdir/server$idstr.input\n";
 
   print $input @_;
@@ -940,7 +940,7 @@ sub DATA_smtp {
 
         logmsg "Store test number $testno in $filename\n";
 
-        open(my $file, ">", $filename) ||
+        open(my $file, ">", $filename) or
             return 0; # failed to open output
 
         my $line;
@@ -1290,7 +1290,7 @@ sub APPEND_imap {
 
         logmsg "Store test number $testno in $filename\n";
 
-        open(my $file, ">", $filename) ||
+        open(my $file, ">", $filename) or
             return 0; # failed to open output
 
         my $received = 0;
@@ -2399,7 +2399,7 @@ sub STOR_ftp {
 
     sendcontrol "125 Gimme gimme gimme!\r\n";
 
-    open(my $file, ">", $filename) ||
+    open(my $file, ">", $filename) or
         return 0; # failed to open output
 
     my $line;
@@ -2826,7 +2826,7 @@ sub customize {
     %customcount = ();  #
     %delayreply = ();   #
 
-    open(my $custom, "<", "$logdir/$SERVERCMD") ||
+    open(my $custom, "<", "$logdir/$SERVERCMD") or
         return 1;
 
     logmsg "FTPD: Getting commands from $logdir/$SERVERCMD\n";

--- a/tests/libtest/test613.pl
+++ b/tests/libtest/test613.pl
@@ -41,16 +41,16 @@ sub errout {
 
 if($ARGV[0] eq "prepare") {
     my $dirname = $ARGV[1];
-    mkdir $dirname || errout "$!";
+    mkdir $dirname or errout "$!";
     chdir $dirname;
 
     # Create the files in alphabetical order, to increase the chances
     # of receiving a consistent set of directory contents regardless
     # of whether the server alphabetizes the results or not.
-    mkdir "asubdir" || errout "$!";
+    mkdir "asubdir" or errout "$!";
     chmod 0777, "asubdir";
 
-    open(FILE, ">plainfile.txt") || errout "$!";
+    open(FILE, ">plainfile.txt") or errout "$!";
     binmode FILE;
     print FILE "Test file to support curl test suite\n";
     close(FILE);
@@ -59,7 +59,7 @@ if($ARGV[0] eq "prepare") {
     utime time, timegm(0,0,12,1,0,100), "plainfile.txt";
     chmod 0666, "plainfile.txt";
 
-    open(FILE, ">emptyfile.txt") || errout "$!";
+    open(FILE, ">emptyfile.txt") or errout "$!";
     binmode FILE;
     close(FILE);
     # The mtime is specifically chosen to be an even number so that it can be
@@ -67,7 +67,7 @@ if($ARGV[0] eq "prepare") {
     utime time, timegm(0,0,12,1,0,100), "emptyfile.txt";
     chmod 0666, "emptyfile.txt";
 
-    open(FILE, ">rofile.txt") || errout "$!";
+    open(FILE, ">rofile.txt") or errout "$!";
     binmode FILE;
     print FILE "Read-only test file to support curl test suite\n";
     close(FILE);

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -998,8 +998,7 @@ sub singletest_run {
         logmsg "$CMDLINE\n";
     }
 
-    open(my $cmdlog, ">", "$LOGDIR/$CURLLOG") ||
-        die "Failure writing log file";
+    open(my $cmdlog, ">", "$LOGDIR/$CURLLOG") or die "Failure writing log file";
     print $cmdlog "$CMDLINE\n";
     close($cmdlog) or die "Failure writing log file";
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -356,8 +356,7 @@ sub cleardir {
     my $file;
 
     # Get all files
-    opendir(my $dh, $dir) ||
-        return 0; # cannot open dir
+    opendir(my $dh, $dir) or return 0; # cannot open dir
     while($file = readdir($dh)) {
         # Do not clear the $PIDDIR or $LOCKDIR since those need to live beyond
         # one test
@@ -2675,7 +2674,7 @@ if(!$randseed) {
     # seed of the month. December 2019 becomes 201912
     $randseed = ($year + 1900) * 100 + $mon + 1;
     print "Using curl: $CURL\n";
-    open(my $curlvh, "-|", exerunner() . shell_quote($CURL) . " --version 2>$dev_null") ||
+    open(my $curlvh, "-|", exerunner() . shell_quote($CURL) . " --version 2>$dev_null") or
         die "could not get curl version!";
     my @c = <$curlvh>;
     close($curlvh) or die "could not get curl version!";
@@ -2958,8 +2957,7 @@ sub displaylogcontent {
 sub displaylogs {
     my ($runnerid, $testnum) = @_;
     my $logdir = getrunnerlogdir($runnerid);
-    opendir(DIR, $logdir) ||
-        die "cannot open dir: $!";
+    opendir(DIR, $logdir) or die "cannot open dir: $!";
     my @logs = readdir(DIR);
     closedir(DIR);
 
@@ -3155,7 +3153,7 @@ while(1) {
                 $endwaitcnt = 0;
                 # This runner is ready to be serviced
                 my $testnum = $runnersrunning{$ridready};
-                defined $testnum ||  die "Internal error: test for runner $ridready unknown";
+                defined $testnum or die "Internal error: test for runner $ridready unknown";
                 delete $runnersrunning{$ridready};
                 my ($error, $again) = singletest($ridready, $testnum, $countforrunner{$ridready}, $totaltests);
                 if($again) {

--- a/tests/test1119.pl
+++ b/tests/test1119.pl
@@ -92,8 +92,7 @@ sub scanheader {
 
 sub scanallheaders {
     my $d = "$root/include/curl";
-    opendir(my $dh, $d) ||
-        die "Cannot opendir: $!";
+    opendir(my $dh, $d) or die "Cannot opendir: $!";
     my @headers = grep { /.h\z/ } readdir($dh);
     closedir $dh;
     foreach my $h (@headers) {
@@ -130,8 +129,7 @@ sub checkmanpage {
 
 sub scanman_md_dir {
     my ($d) = @_;
-    opendir(my $dh, $d) ||
-        die "Cannot opendir: $!";
+    opendir(my $dh, $d) or die "Cannot opendir: $!";
     my @mans = grep { /.md\z/ } readdir($dh);
     closedir $dh;
     for my $m (@mans) {

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -227,7 +227,8 @@ close($r);
 # parse the curl.1 man page, extract all documented command line options
 # The man page may or may not be rebuilt, so check both possible locations
 open($r, "<", "$buildroot/docs/cmdline-opts/curl.1") or
-open($r, "<", "$root/docs/cmdline-opts/curl.1") or die "failed getting curl.1";
+    open($r, "<", "$root/docs/cmdline-opts/curl.1") or
+    die "failed getting curl.1";
 my @manpage; # store all parsed parameters
 while(<$r>) {
     chomp;

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -67,8 +67,7 @@ my %alias = (
 sub scanmdpage {
     my ($file, @words) = @_;
 
-    open(my $mh, "<", $file) ||
-        die "could not open $file";
+    open(my $mh, "<", $file) or die "could not open $file";
     my @m;
     while(<$mh>) {
         if($_ =~ /^## (.*)/) {
@@ -101,8 +100,7 @@ sub scanmdpage {
 my $r;
 
 # check for define aliases
-open($r, "<", $curlh) ||
-    die "no curl.h";
+open($r, "<", $curlh) or die "no curl.h";
 while(<$r>) {
     if(/^\#define (CURL(OPT|INFO|MOPT)_\w+) (.*)/) {
         $alias{$1} = $3;
@@ -113,8 +111,7 @@ close($r);
 my @curlopt;
 my @curlinfo;
 my @curlmopt;
-open($r, "<", $syms) ||
-    die "no input file";
+open($r, "<", $syms) or die "no input file";
 while(<$r>) {
     chomp;
     my $l= $_;
@@ -187,8 +184,7 @@ my %opts = (
 
 #########################################################################
 # parse the curl code that parses the command line arguments!
-open($r, "<", "$root/src/tool_getparam.c") ||
-    die "no input file";
+open($r, "<", "$root/src/tool_getparam.c") or die "no input file";
 my $list;
 my @getparam; # store all parsed parameters
 
@@ -230,8 +226,8 @@ close($r);
 #########################################################################
 # parse the curl.1 man page, extract all documented command line options
 # The man page may or may not be rebuilt, so check both possible locations
-open($r, "<", "$buildroot/docs/cmdline-opts/curl.1") || open($r, "<", "$root/docs/cmdline-opts/curl.1") ||
-    die "failed getting curl.1";
+open($r, "<", "$buildroot/docs/cmdline-opts/curl.1") or
+open($r, "<", "$root/docs/cmdline-opts/curl.1") or die "failed getting curl.1";
 my @manpage; # store all parsed parameters
 while(<$r>) {
     chomp;
@@ -258,8 +254,7 @@ close($r);
 
 #########################################################################
 # parse the curl code that outputs the curl -h list
-open($r, "<", "$root/src/tool_listhelp.c") ||
-    die "no input file";
+open($r, "<", "$root/src/tool_listhelp.c") or die "no input file";
 my @toolhelp; # store all parsed parameters
 while(<$r>) {
     chomp;

--- a/tests/test1140.pl
+++ b/tests/test1140.pl
@@ -58,8 +58,7 @@ sub manpresent {
 
 sub file {
     my ($f) = @_;
-    open(my $fh, "<", $f) ||
-        die "test1140.pl could not open $f";
+    open(my $fh, "<", $f) or die "test1140.pl could not open $f";
     my $line = 1;
     while(<$fh>) {
         chomp;

--- a/tests/test1167.pl
+++ b/tests/test1167.pl
@@ -72,7 +72,7 @@ sub scanenums {
     my ($file) = @_;
     my $skipit = 0;
 
-    open H_IN, "-|", "$Cpreprocessor -DCURL_DISABLE_DEPRECATION $i$file" ||
+    open(H_IN, "-|", "$Cpreprocessor -DCURL_DISABLE_DEPRECATION $i$file") or
         die "Cannot preprocess $file";
     while(<H_IN>) {
         my ($line, $linenum) = ($_, $.);

--- a/tests/test1173.pl
+++ b/tests/test1173.pl
@@ -79,8 +79,7 @@ my %deprecated = (
     CURLOPT_RANDOM_FILE => 1,
     );
 sub allsymbols {
-    open(my $f, "<", $symbolsinversions) ||
-        die "$symbolsinversions: $|";
+    open(my $f, "<", $symbolsinversions) or die "$symbolsinversions: $|";
     while(<$f>) {
         if($_ =~ /^([^ ]*) +(.*)/) {
             my ($name, $info) = ($1, $2);
@@ -144,8 +143,7 @@ sub scanmanpage {
     my @separators;
     my @sepline;
 
-    open(my $m, "<", $file) ||
-        die "test1173.pl could not open $file";
+    open(my $m, "<", $file) or die "test1173.pl could not open $file";
     if($file =~ /[\/\\](CURL|curl_)([^\/\\]*).3/) {
         # This is a man page for libcurl. It requires an example unless it is
         # considered deprecated.

--- a/tests/test1222.pl
+++ b/tests/test1222.pl
@@ -238,7 +238,8 @@ sub scan_man_page {
 }
 
 # Read symbols-in-versions.
-open(my $fh, "<", "$root/docs/libcurl/symbols-in-versions") or die "$root/docs/libcurl/symbols-in-versions";
+open(my $fh, "<", "$root/docs/libcurl/symbols-in-versions") or
+    die "$root/docs/libcurl/symbols-in-versions";
 while(<$fh>) {
     if($_ =~ /^((?:CURL|LIBCURL)\S+)\s+\S+\s*(\S*)\s*(\S*)$/) {
         if($3 eq "") {

--- a/tests/test1222.pl
+++ b/tests/test1222.pl
@@ -238,8 +238,7 @@ sub scan_man_page {
 }
 
 # Read symbols-in-versions.
-open(my $fh, "<", "$root/docs/libcurl/symbols-in-versions") ||
-    die "$root/docs/libcurl/symbols-in-versions";
+open(my $fh, "<", "$root/docs/libcurl/symbols-in-versions") or die "$root/docs/libcurl/symbols-in-versions";
 while(<$fh>) {
     if($_ =~ /^((?:CURL|LIBCURL)\S+)\s+\S+\s*(\S*)\s*(\S*)$/) {
         if($3 eq "") {

--- a/tests/test1488.pl
+++ b/tests/test1488.pl
@@ -97,8 +97,7 @@ sub checkmanpage {
 
 sub scanman_md_dir {
     my ($d) = @_;
-    opendir(my $dh, $d) ||
-        die "Cannot opendir: $!";
+    opendir(my $dh, $d) or die "Cannot opendir: $!";
     my @mans = grep { /.md\z/ } readdir($dh);
     closedir $dh;
     for my $m (@mans) {

--- a/tests/valgrind.pm
+++ b/tests/valgrind.pm
@@ -40,8 +40,7 @@ use File::Basename;
 sub valgrindparse {
     my ($file) = @_;
     my @o;
-    open(my $val, "<", $file) ||
-        return;
+    open(my $val, "<", $file) or return;
     @o = <$val>;
     close($val);
     return @o;


### PR DESCRIPTION
Also: unfold a few lines, fix a space, add a missing parentheses.

Follow-up to 678e63934cc4bd1941b20c5111d37a6e530d2a5d #22036

---

(After finding more combinations, the `||` was the winner earlier at 60%/40%,
continuing with changing to `or`.)

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
