### PR TITLE
_URL.md: remove the zone-id mention

### DIFF
--- a/docs/cmdline-opts/_URL.md
+++ b/docs/cmdline-opts/_URL.md
@@ -20,9 +20,5 @@ handshakes. This improves speed. Connection reuse can only be done for URLs
 specified for a single command line invocation and cannot be performed between
 separate curl runs.
 
-Provide an IPv6 zone id in the URL with an escaped percentage sign. Like in
-
-    http://[fe80::3%25eth0]/
-
 Everything provided on the command line that is not a command line option or
 its argument, curl assumes is a URL and treats it as such.


### PR DESCRIPTION
While correct, it felt random and misplaced there.
