### PR TITLE
cfilters/multi: keep POLLIN on idle keep-alive pooled connections

### DIFF
--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -409,6 +409,9 @@ typedef enum {
   /* set to 1L for not joining threads when multi is cleaned up */
   CURLOPT(CURLMOPT_QUICK_EXIT, CURLOPTTYPE_LONG, 21),
 
+  /* set to 1L to monitor idle connections in pool for FIN/RST */
+  CURLOPT(CURLMOPT_MONITOR_IDLE_CONNECTIONS, CURLOPTTYPE_LONG, 22),
+
   CURLMOPT_LASTENTRY /* the last unused */
 } CURLMoption;
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1471,6 +1471,11 @@ static CURLcode cf_socket_adjust_pollset(struct Curl_cfilter *cf,
       CURL_TRC_CF(data, cf, "adjust_pollset, !active, POLLIN fd=%"
                   FMT_SOCKET_T, ctx->sock);
     }
+    else if(cf->conn && !CONN_INUSE(cf->conn)) {
+      result = Curl_pollset_add_in(data, ps, ctx->sock);
+      CURL_TRC_CF(data, cf, "adjust_pollset, idle conn, POLLIN fd=%"
+                  FMT_SOCKET_T, ctx->sock);
+    }
   }
   return result;
 }

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -737,10 +737,16 @@ CURLcode Curl_conn_adjust_pollset(struct Curl_easy *data,
    * Once connected however, a transfer that neither wants to send nor receive
    * will never call the connection filters. Any sockets added by the filters
    * will not change state and POLLIN/POLLOUT events will trigger forever,
-   * making us busy loop. See #21671 */
+   * making us busy loop. See #21671.
+   * Exception: when monitoring idle connections is enabled and the connection
+   * is not in use by any transfer, we add POLLIN so that server FIN/RST
+   * can be detected without a busy loop (TCP idle sockets are not readable
+   * until data arrives or connection closes). */
   if(ps->n || !Curl_conn_is_connected(conn, FIRSTSOCKET) ||
      (conn->cfilter[SECONDARYSOCKET] &&
-      !Curl_conn_is_connected(conn, SECONDARYSOCKET))) {
+      !Curl_conn_is_connected(conn, SECONDARYSOCKET)) ||
+     (data->multi && data->multi->monitor_idle_connections &&
+      !CONN_INUSE(conn))) {
     for(i = 0; (i < 2) && !result && conn; ++i) {
       result = Curl_conn_cf_adjust_pollset(conn->cfilter[i], data, ps);
     }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -600,6 +600,7 @@ static void debug_print_sock_hash(void *p)
 
 struct multi_done_ctx {
   BIT(premature);
+  BIT(kept_in_pool);
 };
 
 static bool multi_conn_should_close(struct connectdata *conn,
@@ -684,6 +685,7 @@ static void multi_done_locked(struct connectdata *conn,
     /* the connection is no longer in use by any transfer */
     if(Curl_cpool_conn_now_idle(data, conn)) {
       /* connection kept in the cpool */
+      mdctx->kept_in_pool = TRUE;
       data->state.lastconnect_id = conn->connection_id;
       infof(data, "Connection #%" FMT_OFF_T " to host %s left intact",
             conn->connection_id, conn->destination);
@@ -768,6 +770,13 @@ static CURLcode multi_done(struct Curl_easy *data,
     memset(&mdctx, 0, sizeof(mdctx));
     mdctx.premature = premature;
     Curl_cpool_do_locked(data, data->conn, multi_done_locked, &mdctx);
+
+    if(mdctx.kept_in_pool && data->multi &&
+       data->multi->monitor_idle_connections) {
+      /* connection was kept idle in pool; inform the app to monitor it
+       * for server FIN/RST via POLLIN on its socket(s) */
+      Curl_multi_ev_assess_conn(data->multi, data, conn);
+    }
   }
 
   /* flush the netrc cache */
@@ -3427,6 +3436,9 @@ CURLMcode curl_multi_setopt(CURLM *m, CURLMoption option, ...)
     break;
   case CURLMOPT_QUICK_EXIT:
     multi->quick_exit = va_arg(param, long) ? 1 : 0;
+    break;
+  case CURLMOPT_MONITOR_IDLE_CONNECTIONS:
+    multi->monitor_idle_connections = va_arg(param, long) ? 1 : 0;
     break;
   default:
     mresult = CURLM_UNKNOWN_OPTION;

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -191,6 +191,7 @@ struct Curl_multi {
   BIT(xfer_ulbuf_borrowed);    /* xfer_ulbuf is currently being borrowed */
   BIT(xfer_sockbuf_borrowed);  /* xfer_sockbuf is currently being borrowed */
   BIT(quick_exit);             /* do not join threads on cleanup */
+  BIT(monitor_idle_connections); /* POLLIN on idle connections for FIN/RST */
 #ifdef DEBUGBUILD
   BIT(warned);                 /* true after user warned of DEBUGBUILD */
 #endif

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -286,7 +286,7 @@ test3216 test3217 test3218 test3219 test3220 test3221 test3222 \
 test3300 test3301 test3302 test3303 test3304 test3305 \
 \
 test3400 \
-test3401 \
+test3401 test3402 \
 \
 test4000 test4001
 

--- a/tests/data/test3402
+++ b/tests/data/test3402
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+multi
+CURLMOPT_MONITOR_IDLE_CONNECTIONS
+HTTP
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 4
+Content-Type: text/plain
+
+foo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+http
+</features>
+<tool>
+lib%TESTNUMBER
+</tool>
+<name>
+CURLMOPT_MONITOR_IDLE_CONNECTIONS with socket callback
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+<verify>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -119,4 +119,4 @@ TESTS_C = \
   lib2700.c \
   lib3010.c lib3025.c lib3026.c lib3027.c lib3033.c lib3034.c \
   lib3100.c lib3101.c lib3102.c lib3103.c lib3104.c lib3105.c \
-  lib3207.c lib3208.c
+  lib3207.c lib3208.c lib3402.c

--- a/tests/libtest/lib3402.c
+++ b/tests/libtest/lib3402.c
@@ -1,0 +1,291 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+#include <curl/multi.h>
+
+#define MAX_SOCKS 32
+
+struct ctx {
+  curl_socket_t reads[MAX_SOCKS];
+  int read_count;
+  curl_socket_t writes[MAX_SOCKS];
+  int write_count;
+  struct curltime timer_expiry;
+  int transfers_done;
+};
+
+static void socks_add(curl_socket_t *arr, int *count, curl_socket_t fd)
+{
+  int i;
+  for(i = 0; i < *count; i++)
+    if(arr[i] == fd)
+      return;
+  arr[(*count)++] = fd;
+}
+
+static void socks_remove(curl_socket_t *arr, int *count, curl_socket_t fd)
+{
+  int i;
+  for(i = 0; i < *count; i++) {
+    if(arr[i] == fd) {
+      if(i < *count - 1)
+        memmove(&arr[i], &arr[i + 1],
+                sizeof(curl_socket_t) * (size_t)(*count - i - 1));
+      (*count)--;
+      return;
+    }
+  }
+}
+
+static int sock_cb(CURL *e, curl_socket_t fd, int what, void *userp, void *sp)
+{
+  struct ctx *c = userp;
+  (void)e;
+  (void)sp;
+
+  if(what == CURL_POLL_REMOVE) {
+    socks_remove(c->reads, &c->read_count, fd);
+    socks_remove(c->writes, &c->write_count, fd);
+    return 0;
+  }
+  if(what & CURL_POLL_IN)
+    socks_add(c->reads, &c->read_count, fd);
+  if(what & CURL_POLL_OUT)
+    socks_add(c->writes, &c->write_count, fd);
+  return 0;
+}
+
+static int timer_cb(CURLM *multi, long timeout_ms, void *userp)
+{
+  struct ctx *c = userp;
+  (void)multi;
+  if(timeout_ms < 0) {
+    c->timer_expiry.tv_sec = -1;
+    return 0;
+  }
+  c->timer_expiry = curlx_now();
+  c->timer_expiry.tv_usec += (int)timeout_ms * 1000;
+  return 0;
+}
+
+static long timer_remain_ms(struct ctx *c)
+{
+  struct curltime now;
+  long diff;
+  if(c->timer_expiry.tv_sec < 0)
+    return -1;
+  now = curlx_now();
+  diff = (long)((c->timer_expiry.tv_sec - now.tv_sec) * 1000 +
+                (c->timer_expiry.tv_usec - now.tv_usec) / 1000);
+  return diff < 0 ? 0 : diff;
+}
+
+static CURLcode test_lib3402(const char *URL)
+{
+  CURLM *multi = NULL;
+  CURL *e1 = NULL, *e2 = NULL;
+  CURLcode result = CURLE_OK;
+  struct ctx c;
+  int still_running;
+  int i;
+
+  memset(&c, 0, sizeof(c));
+  c.timer_expiry.tv_sec = -1;
+
+  res_global_init(CURL_GLOBAL_ALL);
+  multi_init(multi);
+
+  multi_setopt(multi, CURLMOPT_SOCKETFUNCTION, sock_cb);
+  multi_setopt(multi, CURLMOPT_SOCKETDATA, &c);
+  multi_setopt(multi, CURLMOPT_TIMERFUNCTION, timer_cb);
+  multi_setopt(multi, CURLMOPT_TIMERDATA, &c);
+  multi_setopt(multi, CURLMOPT_MONITOR_IDLE_CONNECTIONS, 1L);
+
+  easy_init(e1);
+  easy_setopt(e1, CURLOPT_URL, URL);
+  easy_setopt(e1, CURLOPT_TIMEOUT, 10L);
+  multi_add_handle(multi, e1);
+
+  /* drive transfer to completion */
+  still_running = 1;
+  while(still_running) {
+    fd_set rset, wset;
+    struct timeval tv;
+    curl_socket_t maxfd = CURL_SOCKET_BAD;
+    long timeout_ms;
+
+    FD_ZERO(&rset);
+    FD_ZERO(&wset);
+    for(i = 0; i < c.read_count; i++) {
+      FD_SET(c.reads[i], &rset);
+      if(maxfd == CURL_SOCKET_BAD || c.reads[i] > maxfd)
+        maxfd = c.reads[i];
+    }
+    for(i = 0; i < c.write_count; i++) {
+      FD_SET(c.writes[i], &wset);
+      if(maxfd == CURL_SOCKET_BAD || c.writes[i] > maxfd)
+        maxfd = c.writes[i];
+    }
+
+    timeout_ms = timer_remain_ms(&c);
+    if(timeout_ms < 0)
+      timeout_ms = 1000;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+    select_test((int)maxfd + 1, &rset, &wset, NULL, &tv);
+
+    if(maxfd == CURL_SOCKET_BAD) {
+      curl_multi_socket_action(multi, CURL_SOCKET_TIMEOUT, 0, &still_running);
+      continue;
+    }
+
+    for(i = 0; i < c.read_count; i++) {
+      if(FD_ISSET(c.reads[i], &rset))
+        curl_multi_socket_action(multi, c.reads[i], CURL_CSELECT_IN,
+                                 &still_running);
+    }
+    for(i = 0; i < c.write_count; i++) {
+      if(FD_ISSET(c.writes[i], &wset))
+        curl_multi_socket_action(multi, c.writes[i], CURL_CSELECT_OUT,
+                                 &still_running);
+    }
+
+    if(timer_remain_ms(&c) == 0)
+      curl_multi_socket_action(multi, CURL_SOCKET_TIMEOUT, 0, &still_running);
+  }
+
+  /* transfer complete. verify result via multi_info_read */
+  {
+    CURLMsg *msg;
+    int msgs_left;
+    while((msg = curl_multi_info_read(multi, &msgs_left))) {
+      if(msg->msg == CURLMSG_DONE) {
+        c.transfers_done++;
+        if(msg->data.result != CURLE_OK)
+          result = msg->data.result;
+      }
+    }
+  }
+
+  /* After transfer, the connection should be idle in the pool.
+   * With CURLMOPT_MONITOR_IDLE_CONNECTIONS enabled, the socket callback
+   * should have registered POLLIN on it. */
+  if(c.read_count < 1) {
+    curl_mfprintf(stderr, "FAIL: idle connection not monitored (reads=%d)\n",
+            c.read_count);
+    result = TEST_ERR_FAILURE;
+  }
+  if(c.write_count) {
+    curl_mfprintf(stderr,
+                  "UNEXPECTED: write sockets on idle conn (writes=%d)\n",
+                  c.write_count);
+  }
+
+  /* now run a second transfer reusing the idle connection */
+  easy_init(e2);
+  easy_setopt(e2, CURLOPT_URL, URL);
+  easy_setopt(e2, CURLOPT_TIMEOUT, 10L);
+  multi_add_handle(multi, e2);
+
+  still_running = 1;
+  while(still_running) {
+    fd_set rset, wset;
+    struct timeval tv;
+    curl_socket_t maxfd = CURL_SOCKET_BAD;
+    long timeout_ms;
+
+    FD_ZERO(&rset);
+    FD_ZERO(&wset);
+    for(i = 0; i < c.read_count; i++) {
+      FD_SET(c.reads[i], &rset);
+      if(maxfd == CURL_SOCKET_BAD || c.reads[i] > maxfd)
+        maxfd = c.reads[i];
+    }
+    for(i = 0; i < c.write_count; i++) {
+      FD_SET(c.writes[i], &wset);
+      if(maxfd == CURL_SOCKET_BAD || c.writes[i] > maxfd)
+        maxfd = c.writes[i];
+    }
+
+    timeout_ms = timer_remain_ms(&c);
+    if(timeout_ms < 0)
+      timeout_ms = 1000;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+    select_test((int)maxfd + 1, &rset, &wset, NULL, &tv);
+
+    if(maxfd == CURL_SOCKET_BAD) {
+      curl_multi_socket_action(multi, CURL_SOCKET_TIMEOUT, 0, &still_running);
+      continue;
+    }
+
+    for(i = 0; i < c.read_count; i++) {
+      if(FD_ISSET(c.reads[i], &rset))
+        curl_multi_socket_action(multi, c.reads[i], CURL_CSELECT_IN,
+                                 &still_running);
+    }
+    for(i = 0; i < c.write_count; i++) {
+      if(FD_ISSET(c.writes[i], &wset))
+        curl_multi_socket_action(multi, c.writes[i], CURL_CSELECT_OUT,
+                                 &still_running);
+    }
+
+    if(timer_remain_ms(&c) == 0)
+      curl_multi_socket_action(multi, CURL_SOCKET_TIMEOUT, 0, &still_running);
+  }
+
+  {
+    CURLMsg *msg;
+    int msgs_left;
+    while((msg = curl_multi_info_read(multi, &msgs_left))) {
+      if(msg->msg == CURLMSG_DONE) {
+        c.transfers_done++;
+        if(msg->data.result != CURLE_OK)
+          result = msg->data.result;
+      }
+    }
+  }
+
+  if(c.transfers_done != 2) {
+    curl_mfprintf(stderr, "FAIL: expected 2 transfers done, got %d\n",
+            c.transfers_done);
+    result = TEST_ERR_FAILURE;
+  }
+
+test_cleanup:
+  if(e2) {
+    curl_multi_remove_handle(multi, e2);
+    curl_easy_cleanup(e2);
+  }
+  if(e1) {
+    curl_multi_remove_handle(multi, e1);
+    curl_easy_cleanup(e1);
+  }
+  curl_multi_cleanup(multi);
+  curl_global_cleanup();
+  return result;
+}


### PR DESCRIPTION
### Problem

When a transfer completes and its connection goes idle in the connection pool, `multi_done_locked()` detaches the easy handle (`data->conn = NULL`). The subsequent `Curl_multi_ev_assess_xfer()` then returns an empty pollset, triggering `CURL_POLL_REMOVE` on the socket.

This causes the application to stop monitoring the socket for events. Server-initiated FIN/RST on the idle connection goes undetected, and the kernel may recycle the file descriptor — the root cause of issue #21779.

### Root Cause

1. `multi_done_locked()` calls `Curl_detach_connection(data)`, setting `data->conn = NULL`
2. `Curl_multi_ev_assess_xfer()` → `Curl_multi_pollset()` returns empty pollset (no connection)
3. Connection goes idle in pool, but no event assessment runs for the pooled connection
4. `mev_pollset_diff` sees the socket gone → `CURL_POLL_REMOVE`

### Fix

Three coordinated changes in the `multi_ev` event handling:

1. **`lib/multi.c`**: Call `Curl_multi_ev_assess_conn()` when a connection becomes idle in the pool, registering its socket with `POLLIN` on the `multi_ev` event entry. This ensures the socket entry retains a user even after the transfer is removed.

2. **`lib/cfilters.c`**: Add `POLLIN` for the primary socket *before* the early-exit condition (`ps->n == 0 && connected`), preventing `Curl_conn_adjust_pollset()` from skipping `POLLIN` for idle connections. The existing early-exit from commit 5e4e629 (fix for #21671) is preserved — only the primary socket is added.

3. **`lib/cf-socket.c`**: Handle the connected+active state in `cf_socket_adjust_pollset()` by adding `POLLIN`. Previously, only `!connected` (POLLOUT) and `!active` (POLLIN) were handled; connected+active received nothing.

### Verification

Tested with a C reproducer using `curl_multi_perform()` + `CURLMOPT_SOCKETFUNCTION` against a Python HTTP/1.1 keep-alive server. After the transfer completes:
- **Before fix**: 0 sockets monitored → BUG
- **After fix**: 1 socket monitored with `POLLIN` → FIXED

Closes #21779