### PR TITLE
Disable valgrind for test1399

### DIFF
--- a/tests/data/test1399
+++ b/tests/data/test1399
@@ -16,4 +16,9 @@ unittest
 Curl_pgrsTime unit tests
 </name>
 </client>
+<verify>
+<valgrind>
+disable
+</valgrind>
+</verify>
 </testcase>


### PR DESCRIPTION
It slows down the test enough on my machine that it starts failing:
```
is 2638556 us same as 2 seconds? Yes
is 2638888 us same as 2 seconds? Yes
is 2638959 us same as 2 seconds? Yes
is 2639035 us same as 2 seconds? Yes
is 2639109 us same as 2 seconds? Yes
is 4281507 us same as 3 seconds? No
unit1399.c:78 Assertion 'usec_matches_seconds(data->progress.t_nslookup, seconds)' FAILED: about 3 seconds should have passed
is 4281876 us same as 3 seconds? No
unit1399.c:79 Assertion 'usec_matches_seconds(data->progress.t_connect, seconds)' FAILED: about 3 seconds should have passed
is 4281980 us same as 3 seconds? No
unit1399.c:80 Assertion 'usec_matches_seconds(data->progress.t_appconnect, seconds)' FAILED: about 3 seconds should have passed
is 4282087 us same as 3 seconds? No
unit1399.c:81 Assertion 'usec_matches_seconds(data->progress.t_pretransfer, seconds)' FAILED: about 3 seconds should have passed
is 4282192 us same as 3 seconds? No
unit1399.c:83 Assertion 'usec_matches_seconds(data->progress.t_starttransfer, seconds)' FAILED: about 3 seconds should have passed
Test ended with result 5
```
