### PR TITLE
configure: tidy up `OPT_APPLE_SECTRUST` initialization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,7 +306,7 @@ AS_HELP_STRING([--with-rustls=PATH],[where to look for Rustls, PATH points to th
   fi
 ])
 
-OPT_APPLE_SECTRUST=$curl_cv_apple
+OPT_APPLE_SECTRUST=no
 AC_ARG_WITH(apple-sectrust,
 AS_HELP_STRING([--with-apple-sectrust],[enable Apple OS native certificate verification]),[
   OPT_APPLE_SECTRUST=$withval

--- a/configure.ac
+++ b/configure.ac
@@ -552,6 +552,14 @@ AC_SUBST(AR_FLAGS, [cr])
 dnl This defines _ALL_SOURCE for AIX
 CURL_CHECK_AIX_ALL_SOURCE
 
+dnl Set operating system detection variables
+curl_cv_android='no'
+curl_cv_apple='no'
+case $host in
+  *-*-android*) curl_cv_android='yes';;
+  *-apple-*) curl_cv_apple='yes';;
+esac
+
 dnl Our configure and build reentrant settings
 CURL_CONFIGURE_THREAD_SAFE
 CURL_CONFIGURE_REENTRANT
@@ -733,13 +741,6 @@ dnl Compilation based checks should not be done before this point.
 dnl **********************************************************************
 
 CURL_CHECK_WIN32_CRYPTO
-
-curl_cv_android='no'
-curl_cv_apple='no'
-case $host in
-  *-*-android*) curl_cv_android='yes';;
-  *-apple-*) curl_cv_apple='yes';;
-esac
 
 if test "$curl_cv_apple" = "yes"; then
   CURL_DARWIN_CFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -552,14 +552,6 @@ AC_SUBST(AR_FLAGS, [cr])
 dnl This defines _ALL_SOURCE for AIX
 CURL_CHECK_AIX_ALL_SOURCE
 
-dnl Set operating system detection variables
-curl_cv_android='no'
-curl_cv_apple='no'
-case $host in
-  *-*-android*) curl_cv_android='yes';;
-  *-apple-*) curl_cv_apple='yes';;
-esac
-
 dnl Our configure and build reentrant settings
 CURL_CONFIGURE_THREAD_SAFE
 CURL_CONFIGURE_REENTRANT
@@ -741,6 +733,13 @@ dnl Compilation based checks should not be done before this point.
 dnl **********************************************************************
 
 CURL_CHECK_WIN32_CRYPTO
+
+curl_cv_android='no'
+curl_cv_apple='no'
+case $host in
+  *-*-android*) curl_cv_android='yes';;
+  *-apple-*) curl_cv_apple='yes';;
+esac
 
 if test "$curl_cv_apple" = "yes"; then
   CURL_DARWIN_CFLAGS


### PR DESCRIPTION
The OS detection variable is not initialized at the time of assigning
its value to `OPT_APPLE_SECTRUST`. Replace the current empty value with
`no`. This keeps existing, desired, behavior.
