### PR TITLE
libtest: unify on easy_setopt macro

### DIFF
--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -184,16 +184,15 @@ void ws_close(CURL *curl);  /* close the connection */
 
 /* ---------------------------------------------------------------- */
 
-#define exe_easy_setopt(A, B, C, Y, Z)                      \
-  do {                                                      \
-    CURLcode ec = curl_easy_setopt(A, B, C);                \
-    if(ec != CURLE_OK) {                                    \
-      curl_mfprintf(stderr,                                 \
-                    "%s:%d curl_easy_setopt() failed, "     \
-                    "with code %d (%s)\n",                  \
-                    Y, Z, (int)ec, curl_easy_strerror(ec)); \
-      result = ec;                                          \
-    }                                                       \
+#define exe_easy_setopt(A, B, C, Y, Z)                          \
+  do {                                                          \
+    result = curl_easy_setopt(A, B, C);                         \
+    if(result)                                                  \
+      curl_mfprintf(stderr,                                     \
+                    "%s:%d curl_easy_setopt() failed, "         \
+                    "with code %d (%s)\n",                      \
+                    Y, Z, (int)result,                          \
+                    curl_easy_strerror(result));                \
   } while(0)
 
 #define res_easy_setopt(A, B, C) \
@@ -512,14 +511,13 @@ void ws_close(CURL *curl);  /* close the connection */
 
 #define exe_global_init(A, Y, Z)                            \
   do {                                                      \
-    CURLcode ec = curl_global_init(A);                      \
-    if(ec != CURLE_OK) {                                    \
+    result = curl_global_init(A);                           \
+    if(result)                                              \
       curl_mfprintf(stderr,                                 \
                     "%s:%d curl_global_init() failed, "     \
                     "with code %d (%s)\n",                  \
-                    Y, Z, (int)ec, curl_easy_strerror(ec)); \
-      result = ec;                                          \
-    }                                                       \
+                    Y, Z, (int)result,                      \
+                    curl_easy_strerror(result));            \
   } while(0)
 
 #define chk_global_init(A, Y, Z) \

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -59,24 +59,6 @@ extern int unitfail; /* for unittests */
 #include <sys/select.h>
 #endif
 
-#ifndef UNITTESTS
-#define test_setopt(A, B, C)            \
-  do {                                  \
-    result = curl_easy_setopt(A, B, C); \
-    if(result != CURLE_OK)              \
-      goto test_cleanup;                \
-  } while(0)
-#endif /* !UNITTESTS */
-
-#if 0
-#define test_multi_setopt(A, B, C)       \
-  do {                                   \
-    result = curl_multi_setopt(A, B, C); \
-    if(result != CURLE_OK)               \
-      goto test_cleanup;                 \
-  } while(0)
-#endif
-
 extern const char *libtest_arg2; /* set by first.c to the argv[2] or NULL */
 extern const char *libtest_arg3; /* set by first.c to the argv[3] or NULL */
 extern const char *libtest_arg4; /* set by first.c to the argv[4] or NULL */
@@ -241,11 +223,6 @@ void ws_close(CURL *curl);  /* close the connection */
     }                                                    \
   } while(0)
 
-#if 0
-#define res_multi_setopt(A, B, C) \
-  exe_multi_setopt(A, B, C, __FILE__, __LINE__)
-#endif
-
 #define chk_multi_setopt(A, B, C, Y, Z) \
   do {                                  \
     exe_multi_setopt(A, B, C, Y, Z);    \
@@ -296,11 +273,6 @@ void ws_close(CURL *curl);  /* close the connection */
       result = TEST_ERR_MULTI;                                  \
     }                                                           \
   } while(0)
-
-#if 0
-#define res_multi_remove_handle(A, B) \
-  exe_multi_remove_handle(A, B, __FILE__, __LINE__)
-#endif
 
 #define chk_multi_remove_handle(A, B, Y, Z) \
   do {                                      \
@@ -435,11 +407,6 @@ void ws_close(CURL *curl);  /* close the connection */
     }                                                           \
   } while(0)
 
-#if 0
-#define res_multi_poll(A, B, C, D, E) \
-  exe_multi_poll(A, B, C, D, E, __FILE__, __LINE__)
-#endif
-
 #define chk_multi_poll(A, B, C, D, E, Y, Z) \
   do {                                      \
     exe_multi_poll(A, B, C, D, E, Y, Z);    \
@@ -466,18 +433,6 @@ void ws_close(CURL *curl);  /* close the connection */
 
 #define res_multi_wakeup(A) \
   exe_multi_wakeup(A, __FILE__, __LINE__)
-
-#if 0
-#define chk_multi_wakeup(A, Y, Z) \
-  do {                            \
-    exe_multi_wakeup(A, Y, Z);    \
-    if(result)                    \
-      goto test_cleanup;          \
-  } while(0)
-
-#define multi_wakeup(A) \
-  chk_multi_wakeup(A, __FILE__, __LINE__)
-#endif
 
 /* ---------------------------------------------------------------- */
 
@@ -530,11 +485,6 @@ void ws_close(CURL *curl);  /* close the connection */
 
 #define res_test_timedout() \
   exe_test_timedout(TEST_HANG_TIMEOUT, __FILE__, __LINE__)
-
-#if 0
-#define res_test_timedout_custom(T) \
-  exe_test_timedout(T, __FILE__, __LINE__)
-#endif
 
 #define chk_test_timedout(T, Y, Z) \
   do {                             \

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -92,12 +92,12 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
   if(p->flags & F_HTTP416)
     replyselector += 2;
   curl_msnprintf(urlbuf, sizeof(urlbuf), "%s%04u", url, replyselector);
-  test_setopt(curl, CURLOPT_URL, urlbuf);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME) ? 3L : 0L);
-  test_setopt(curl, CURLOPT_RANGE, !(p->flags & F_RESUME) ?
+  easy_setopt(curl, CURLOPT_URL, urlbuf);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME) ? 3L : 0L);
+  easy_setopt(curl, CURLOPT_RANGE, !(p->flags & F_RESUME) ?
                                    "3-1000000" : (char *)NULL);
-  test_setopt(curl, CURLOPT_FAILONERROR, (p->flags & F_FAIL) ? 1L : 0L);
+  easy_setopt(curl, CURLOPT_FAILONERROR, (p->flags & F_FAIL) ? 1L : 0L);
   hasbody = 0;
   result = curl_easy_perform(curl);
   if(result != p->result) {
@@ -149,7 +149,7 @@ static CURLcode test_lib1156(const char *URL)
       return TEST_ERR_MAJOR_BAD;
     }
 
-    test_setopt(curl, CURLOPT_WRITEFUNCTION, writedata);
+    easy_setopt(curl, CURLOPT_WRITEFUNCTION, writedata);
 
 #ifdef SINGLETEST
     if(SINGLETEST == i)

--- a/tests/libtest/lib1517.c
+++ b/tests/libtest/lib1517.c
@@ -75,29 +75,29 @@ static CURLcode test_lib1517(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now specify we want to POST data */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* Set the expected POST size */
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)pooh.sizeleft);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)pooh.sizeleft);
 
   /* we want to use our own read function */
-  test_setopt(curl, CURLOPT_READFUNCTION, t1517_read_cb);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1517_read_cb);
 
   /* pointer to pass to our read function */
-  test_setopt(curl, CURLOPT_READDATA, &pooh);
+  easy_setopt(curl, CURLOPT_READDATA, &pooh);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
 #if 0
   /* detect HTTP error codes >= 400 */
-  test_setopt(curl, CURLOPT_FAILONERROR, 1L);
+  easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
 #endif
 
   /* Perform the request, result gets the return code */

--- a/tests/libtest/lib1518.c
+++ b/tests/libtest/lib1518.c
@@ -49,13 +49,13 @@ static CURLcode test_lib1518(const char *URL)
     if(!urlu || rc) {
       goto test_cleanup;
     }
-    test_setopt(curl, CURLOPT_CURLU, urlu);
-    test_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    easy_setopt(curl, CURLOPT_CURLU, urlu);
+    easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   }
   else {
-    test_setopt(curl, CURLOPT_URL, URL);
+    easy_setopt(curl, CURLOPT_URL, URL);
     /* to make it explicit and visible in this test: */
-    test_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+    easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
   }
 
   /* Perform the request, result gets the return code */
@@ -67,7 +67,7 @@ static CURLcode test_lib1518(const char *URL)
   curl_easy_getinfo(curl, CURLINFO_REDIRECT_COUNT, &curlRedirectCount);
   curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &effectiveUrl);
   curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirectUrl);
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   curl_mprintf("result %d\n"
                "status %ld\n"

--- a/tests/libtest/lib1520.c
+++ b/tests/libtest/lib1520.c
@@ -87,13 +87,13 @@ static CURLcode test_lib1520(const char *URL)
   /* more addresses can be added here */
   rcpt_list = curl_slist_append(rcpt_list, "<others@example.com>");
 #endif
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1520_read_cb);
-  test_setopt(curl, CURLOPT_READDATA, &upload_ctx);
-  test_setopt(curl, CURLOPT_MAIL_FROM, "<sender@example.com>");
-  test_setopt(curl, CURLOPT_MAIL_RCPT, rcpt_list);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1520_read_cb);
+  easy_setopt(curl, CURLOPT_READDATA, &upload_ctx);
+  easy_setopt(curl, CURLOPT_MAIL_FROM, "<sender@example.com>");
+  easy_setopt(curl, CURLOPT_MAIL_RCPT, rcpt_list);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -61,9 +61,9 @@ static CURLcode test_lib1522(const char *URL)
 
   debug_config.nohex = TRUE;
   debug_config.tracetime = TRUE;
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
-  test_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* Remove "Expect: 100-continue" */
   pHeaderList = curl_slist_append(pHeaderList, "Expect:");

--- a/tests/libtest/lib1525.c
+++ b/tests/libtest/lib1525.c
@@ -69,20 +69,20 @@ static CURLcode test_lib1525(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
-  test_setopt(curl, CURLOPT_PROXYHEADER, hhl);
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
-  test_setopt(curl, CURLOPT_POST, 0L);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1525_read_cb);
-  test_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE, (long)t1525_datalen);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, hhl);
+  easy_setopt(curl, CURLOPT_PROXYHEADER, hhl);
+  easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
+  easy_setopt(curl, CURLOPT_POST, 0L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1525_read_cb);
+  easy_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE, (long)t1525_datalen);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1526.c
+++ b/tests/libtest/lib1526.c
@@ -73,20 +73,20 @@ static CURLcode test_lib1526(const char *URL)
   }
   phl = tmp;
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
-  test_setopt(curl, CURLOPT_PROXYHEADER, phl);
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
-  test_setopt(curl, CURLOPT_POST, 0L);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1526_read_cb);
-  test_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE, (long)t1526_datalen);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, hhl);
+  easy_setopt(curl, CURLOPT_PROXYHEADER, phl);
+  easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
+  easy_setopt(curl, CURLOPT_POST, 0L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1526_read_cb);
+  easy_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE, (long)t1526_datalen);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1527.c
+++ b/tests/libtest/lib1527.c
@@ -72,19 +72,19 @@ static CURLcode test_lib1527(const char *URL)
   }
   hhl = tmp;
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
-  test_setopt(curl, CURLOPT_POST, 0L);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1527_read_cb);
-  test_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE, (long)t1527_datalen);
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, hhl);
+  easy_setopt(curl, CURLOPT_POST, 0L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1527_read_cb);
+  easy_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE, (long)t1527_datalen);
+  easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1528.c
+++ b/tests/libtest/lib1528.c
@@ -50,14 +50,14 @@ static CURLcode test_lib1528(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
-  test_setopt(curl, CURLOPT_PROXYHEADER, phl);
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, hhl);
+  easy_setopt(curl, CURLOPT_PROXYHEADER, phl);
+  easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1529.c
+++ b/tests/libtest/lib1529.c
@@ -43,11 +43,11 @@ static CURLcode test_lib1529(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, bURL);
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, bURL);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1530.c
+++ b/tests/libtest/lib1530.c
@@ -52,9 +52,9 @@ static CURLcode test_lib1530(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, "http://99.99.99.99:9999");
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket);
+  easy_setopt(curl, CURLOPT_URL, "http://99.99.99.99:9999");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1533.c
+++ b/tests/libtest/lib1533.c
@@ -139,15 +139,15 @@ static CURLcode test_lib1533(const char *URL)
 
   reset_data(&data, curl);
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_POST, 1L);
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
               (curl_off_t)data.remaining_bytes);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1533_read_cb);
-  test_setopt(curl, CURLOPT_READDATA, &data);
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, t1533_write_cb);
-  test_setopt(curl, CURLOPT_WRITEDATA, &data);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1533_read_cb);
+  easy_setopt(curl, CURLOPT_READDATA, &data);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, t1533_write_cb);
+  easy_setopt(curl, CURLOPT_WRITEDATA, &data);
 
   result =
     perform_and_check_connections(curl,
@@ -165,7 +165,7 @@ static CURLcode test_lib1533(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_KEEP_SENDING_ON_ERROR, 1L);
+  easy_setopt(curl, CURLOPT_KEEP_SENDING_ON_ERROR, 1L);
 
   reset_data(&data, curl);
 

--- a/tests/libtest/lib1540.c
+++ b/tests/libtest/lib1540.c
@@ -107,7 +107,7 @@ static CURLcode test_lib1540(const char *URL)
 
   debug_config.nohex = TRUE;
   debug_config.tracetime = TRUE;
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 

--- a/tests/libtest/lib1549.c
+++ b/tests/libtest/lib1549.c
@@ -42,9 +42,9 @@ static CURLcode test_lib1549(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_COOKIEFILE, "");
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_COOKIEFILE, "");
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1553.c
+++ b/tests/libtest/lib1553.c
@@ -72,7 +72,7 @@ static CURLcode test_lib1553(const char *URL)
 
   debug_config.nohex = TRUE;
   debug_config.tracetime = TRUE;
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 

--- a/tests/libtest/lib1571.c
+++ b/tests/libtest/lib1571.c
@@ -40,23 +40,23 @@ static CURLcode test_lib1571(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if((testnum == 1571) || (testnum == 1572) ||
      (testnum == 1575) || (testnum == 1581)) {
-    test_setopt(curl, CURLOPT_POSTFIELDS, "moo");
+    easy_setopt(curl, CURLOPT_POSTFIELDS, "moo");
   }
   if(testnum == 1581) {
-    test_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_301);
+    easy_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_301);
   }
 
-  test_setopt(curl, CURLOPT_CUSTOMREQUEST, "IGLOO");
+  easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "IGLOO");
   if((testnum == 1574) || (testnum == 1575)) {
-    test_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_FIRSTONLY);
+    easy_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_FIRSTONLY);
   }
   else {
-    test_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_OBEYCODE);
+    easy_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_OBEYCODE);
   }
 
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib1576.c
+++ b/tests/libtest/lib1576.c
@@ -64,20 +64,20 @@ static CURLcode test_lib1576(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1576_read_cb);
-  test_setopt(curl, CURLOPT_SEEKFUNCTION, t1576_seek_callback);
-  test_setopt(curl, CURLOPT_INFILESIZE, (long)t1576_datalen);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1576_read_cb);
+  easy_setopt(curl, CURLOPT_SEEKFUNCTION, t1576_seek_callback);
+  easy_setopt(curl, CURLOPT_INFILESIZE, (long)t1576_datalen);
 
-  test_setopt(curl, CURLOPT_CUSTOMREQUEST, "CURL");
+  easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "CURL");
   if(testnum == 1578 || testnum == 1580) {
-    test_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_FIRSTONLY);
+    easy_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_FIRSTONLY);
   }
   else {
-    test_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_OBEYCODE);
+    easy_setopt(curl, CURLOPT_FOLLOWLOCATION, CURLFOLLOW_OBEYCODE);
   }
   /* Remove "Expect: 100-continue" */
   pHeaderList = curl_slist_append(pHeaderList, "Expect:");

--- a/tests/libtest/lib1582.c
+++ b/tests/libtest/lib1582.c
@@ -40,13 +40,13 @@ static CURLcode test_lib1582(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_NEGOTIATE);
-  test_setopt(curl, CURLOPT_USERPWD, ":");
-  test_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-  test_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_NEGOTIATE);
+  easy_setopt(curl, CURLOPT_USERPWD, ":");
+  easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+  easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1591.c
+++ b/tests/libtest/lib1591.c
@@ -98,12 +98,12 @@ static CURLcode test_lib1591(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1591_read_cb);
-  test_setopt(curl, CURLOPT_TRAILERFUNCTION, t1591_trailers_callback);
-  test_setopt(curl, CURLOPT_TRAILERDATA, NULL);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, hhl);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1591_read_cb);
+  easy_setopt(curl, CURLOPT_TRAILERFUNCTION, t1591_trailers_callback);
+  easy_setopt(curl, CURLOPT_TRAILERDATA, NULL);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1598.c
+++ b/tests/libtest/lib1598.c
@@ -82,13 +82,13 @@ static CURLcode test_lib1598(const char *URL)
     hhl = list;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(post_data));
-  test_setopt(curl, CURLOPT_POSTFIELDS, post_data);
-  test_setopt(curl, CURLOPT_TRAILERFUNCTION, t1598_trailers_callback);
-  test_setopt(curl, CURLOPT_TRAILERDATA, NULL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, hhl);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(post_data));
+  easy_setopt(curl, CURLOPT_POSTFIELDS, post_data);
+  easy_setopt(curl, CURLOPT_TRAILERFUNCTION, t1598_trailers_callback);
+  easy_setopt(curl, CURLOPT_TRAILERDATA, NULL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1686.c
+++ b/tests/libtest/lib1686.c
@@ -72,9 +72,13 @@ static CURLcode test_lib1686(const char *hostip)
 
     easy_setopt(curl, CURLOPT_URL, firsturl);
     result = curl_easy_perform(curl);
+    if(result)
+      goto test_cleanup;
 
     easy_setopt(curl, CURLOPT_URL, secondurl);
     result = curl_easy_perform(curl);
+    if(result)
+      goto test_cleanup;
 
     easy_setopt(curl, CURLOPT_USERPWD, "bob:secret");
     easy_setopt(curl, CURLOPT_URL, secondurl);

--- a/tests/libtest/lib1906.c
+++ b/tests/libtest/lib1906.c
@@ -50,7 +50,6 @@ static CURLcode test_lib1906(const char *URL)
       result = TEST_ERR_MAJOR_BAD;  /* force an error return */
     goto test_cleanup;
   }
-  result = CURLE_OK;  /* reset for next use */
 
   /* print the used URL */
   curl_url_get(curlu, CURLUPART_URL, &url_after, 0);

--- a/tests/libtest/lib1933.c
+++ b/tests/libtest/lib1933.c
@@ -42,16 +42,16 @@ static CURLcode test_lib1933(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   list = curl_slist_append(list, "Content-Type: application/json");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1934.c
+++ b/tests/libtest/lib1934.c
@@ -42,17 +42,17 @@ static CURLcode test_lib1934(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx:yyy");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx:yyy");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   list = curl_slist_append(list, "Content-Type: application/json");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1935.c
+++ b/tests/libtest/lib1935.c
@@ -42,17 +42,17 @@ static CURLcode test_lib1935(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx:yyy:rrr");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx:yyy:rrr");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   list = curl_slist_append(list, "Content-Type: application/json");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1936.c
+++ b/tests/libtest/lib1936.c
@@ -42,17 +42,17 @@ static CURLcode test_lib1936(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx:yyy:rrr:sss");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx:yyy:rrr:sss");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   list = curl_slist_append(list, "Content-Type: application/json");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1937.c
+++ b/tests/libtest/lib1937.c
@@ -42,19 +42,19 @@ static CURLcode test_lib1937(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_POST, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "provider1:provider2:region:service");
-  test_setopt(curl, CURLOPT_USERPWD, "keyId:SecretKey");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "provider1:provider2:region:service");
+  easy_setopt(curl, CURLOPT_USERPWD, "keyId:SecretKey");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   list = curl_slist_append(list, "Content-Type: application/json");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
-  test_setopt(curl, CURLOPT_POSTFIELDS, "postData");
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, "postData");
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1938.c
+++ b/tests/libtest/lib1938.c
@@ -43,20 +43,20 @@ static CURLcode test_lib1938(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_POST, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "provider1:provider2:region:service");
-  test_setopt(curl, CURLOPT_USERPWD, "keyId:SecretKey");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "provider1:provider2:region:service");
+  easy_setopt(curl, CURLOPT_USERPWD, "keyId:SecretKey");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   list = curl_slist_append(list, "Content-Type: application/json");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
-  test_setopt(curl, CURLOPT_POSTFIELDS, data);
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(data));
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(data));
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1955.c
+++ b/tests/libtest/lib1955.c
@@ -42,18 +42,18 @@ static CURLcode test_lib1955(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "test3: 1234");
   if(!list)
     goto test_cleanup;
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   curl_slist_append(list, "Content-Type: application/json");
 
   /* 'name;' user headers with no value are used to send an empty header in the
@@ -73,7 +73,7 @@ static CURLcode test_lib1955(const char *URL)
 
   curl_slist_append(list, "test_space: t\ts  m\t   end    ");
   curl_slist_append(list, "tesMixCase: MixCase");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1956.c
+++ b/tests/libtest/lib1956.c
@@ -42,21 +42,21 @@ static CURLcode test_lib1956(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   curl_slist_append(list, "X-Xxx-Content-Sha256: "
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1957.c
+++ b/tests/libtest/lib1957.c
@@ -42,20 +42,20 @@ static CURLcode test_lib1957(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   curl_slist_append(list, "X-Xxx-Content-Sha256: arbitrary");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1958.c
+++ b/tests/libtest/lib1958.c
@@ -42,20 +42,20 @@ static CURLcode test_lib1958(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   curl_slist_append(list, "X-Xxx-Content-Sha256: \tarbitrary ");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1959.c
+++ b/tests/libtest/lib1959.c
@@ -42,22 +42,22 @@ static CURLcode test_lib1959(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "xxx");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
   curl_slist_append(list, "X-Xxx-Content-Sha256: "
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -122,16 +122,16 @@ static CURLcode test_lib1960(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, socket_cb);
-  test_setopt(curl, CURLOPT_OPENSOCKETDATA, &client_fd);
-  test_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_cb);
-  test_setopt(curl, CURLOPT_SOCKOPTDATA, NULL);
-  test_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket_cb);
-  test_setopt(curl, CURLOPT_CLOSESOCKETDATA, NULL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, socket_cb);
+  easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &client_fd);
+  easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_cb);
+  easy_setopt(curl, CURLOPT_SOCKOPTDATA, NULL);
+  easy_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket_cb);
+  easy_setopt(curl, CURLOPT_CLOSESOCKETDATA, NULL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1970.c
+++ b/tests/libtest/lib1970.c
@@ -42,21 +42,21 @@ static CURLcode test_lib1970(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE, 0L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE, 0L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1971.c
+++ b/tests/libtest/lib1971.c
@@ -51,21 +51,21 @@ static CURLcode test_lib1971(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1971_read_cb);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1971_read_cb);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1972.c
+++ b/tests/libtest/lib1972.c
@@ -53,20 +53,20 @@ static CURLcode test_lib1972(const char *URL)
   curl_mime_name(part, "foo");
   curl_mime_data(part, "bar", CURL_ZERO_TERMINATED);
 
-  test_setopt(curl, CURLOPT_MIMEPOST, mime);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1973.c
+++ b/tests/libtest/lib1973.c
@@ -42,20 +42,20 @@ static CURLcode test_lib1973(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_POSTFIELDS, "post fields\n");
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, "post fields\n");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1974.c
+++ b/tests/libtest/lib1974.c
@@ -41,15 +41,15 @@ static CURLcode test_lib1974(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1975.c
+++ b/tests/libtest/lib1975.c
@@ -51,23 +51,23 @@ static CURLcode test_lib1975(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1975_read_cb);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
-  test_setopt(curl, CURLOPT_USERPWD, "xxx");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t1975_read_cb);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
   list = curl_slist_append(list, "Content-Type: application/json");
   if(!list)
     goto test_cleanup;
   curl_slist_append(list, "X-Amz-Content-Sha256: "
     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1978.c
+++ b/tests/libtest/lib1978.c
@@ -42,12 +42,12 @@ static CURLcode test_lib1978(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE, 0L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
-  test_setopt(curl, CURLOPT_HEADER, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE, 0L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, "aws:amz:us-east-1:s3");
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* We want to test a couple assumptions here.
      1. the merging works with non-adjacent headers
@@ -83,11 +83,11 @@ static CURLcode test_lib1978(const char *URL)
   curl_slist_append(list, "header-some-no-value;");
   curl_slist_append(list, "header-some-no-value: value");
 
-  test_setopt(curl, CURLOPT_HTTPHEADER, list);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, list);
   if(libtest_arg2) {
     connect_to = curl_slist_append(connect_to, libtest_arg2);
   }
-  test_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
+  easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib2023.c
+++ b/tests/libtest/lib2023.c
@@ -42,12 +42,12 @@ static CURLcode send_request(CURL *curl, const char *url, int seq,
   curl_msnprintf(full_url, len, "%s%04d", url, seq);
   curl_mfprintf(stderr, "Sending new request %d to %s with credential %s "
                 "(auth %ld)\n", seq, full_url, userpwd, auth_scheme);
-  test_setopt(curl, CURLOPT_URL, full_url);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_HTTPGET, 1L);
-  test_setopt(curl, CURLOPT_USERPWD, userpwd);
-  test_setopt(curl, CURLOPT_HTTPAUTH, auth_scheme);
+  easy_setopt(curl, CURLOPT_URL, full_url);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+  easy_setopt(curl, CURLOPT_USERPWD, userpwd);
+  easy_setopt(curl, CURLOPT_HTTPAUTH, auth_scheme);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib2502.c
+++ b/tests/libtest/lib2502.c
@@ -74,7 +74,7 @@ static CURLcode test_lib2502(const char *URL)
     /* go verbose */
     debug_config.nohex = TRUE;
     debug_config.tracetime = FALSE;
-    test_setopt(curl[i], CURLOPT_DEBUGDATA, &debug_config);
+    easy_setopt(curl[i], CURLOPT_DEBUGDATA, &debug_config);
     easy_setopt(curl[i], CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
     easy_setopt(curl[i], CURLOPT_VERBOSE, 1L);
     /* include headers */

--- a/tests/libtest/lib2504.c
+++ b/tests/libtest/lib2504.c
@@ -61,17 +61,17 @@ static CURLcode test_lib2504(const char *URL)
 
   hdrs = curl_slist_append(hdrs, "Host: victim.internal");
   if(hdrs) {
-    test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
-    test_setopt(curl, CURLOPT_COOKIEFILE, "");
-    test_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
-    test_setopt(curl, CURLOPT_URL, URL);
+    easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
+    easy_setopt(curl, CURLOPT_COOKIEFILE, "");
+    easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+    easy_setopt(curl, CURLOPT_URL, URL);
 
     result = curl_easy_perform(curl);
     curl_mprintf("req1=%d\n", (int)result);
     dump_cookies2504(curl, "after request 1");
 
-    test_setopt(curl, CURLOPT_HTTPHEADER, NULL);
-    test_setopt(curl, CURLOPT_URL, URL);
+    easy_setopt(curl, CURLOPT_HTTPHEADER, NULL);
+    easy_setopt(curl, CURLOPT_URL, URL);
 
     result = curl_easy_perform(curl);
     curl_mprintf("req2=%d\n", (int)result);

--- a/tests/libtest/lib2505.c
+++ b/tests/libtest/lib2505.c
@@ -42,16 +42,16 @@ static CURLcode test_lib2505(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
-  test_setopt(curl, CURLOPT_AUTOREFERER, 1L);
-  test_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
+  easy_setopt(curl, CURLOPT_AUTOREFERER, 1L);
+  easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   result = curl_easy_perform(curl);
   curl_mprintf("req1=%d\n", (int)result);
 
-  test_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   result = curl_easy_perform(curl);
   curl_mprintf("req2=%d\n", (int)result);

--- a/tests/libtest/lib2506.c
+++ b/tests/libtest/lib2506.c
@@ -42,17 +42,17 @@ static CURLcode test_lib2506(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
-  test_setopt(curl, CURLOPT_PROXY, URL);
-  test_setopt(curl, CURLOPT_URL, libtest_arg2);
-  test_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
-  test_setopt(curl, CURLOPT_NETRC_FILE, libtest_arg3);
-  test_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
+  easy_setopt(curl, CURLOPT_PROXY, URL);
+  easy_setopt(curl, CURLOPT_URL, libtest_arg2);
+  easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+  easy_setopt(curl, CURLOPT_NETRC_FILE, libtest_arg3);
+  easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* CURLOPT_UNRESTRICTED_AUTH should not make a difference because the
      credentials come from netrc */
-  test_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
+  easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib3025.c
+++ b/tests/libtest/lib3025.c
@@ -42,10 +42,10 @@ static CURLcode test_lib3025(const char *URL)
   }
 
   icy = curl_slist_append(icy, "ICY 200 OK");
-  test_setopt(curl, CURLOPT_HTTP200ALIASES, icy);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HTTP200ALIASES, icy);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib3034.c
+++ b/tests/libtest/lib3034.c
@@ -46,12 +46,12 @@ static CURLcode test_lib3034(const char *URL)
    * set the CURLOPT_READFUNCTION but not the CURLOPT_SEEKFUNCTION to force a
    * rewind failure (CURLE_SEND_FAIL_REWIND).
    */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE, 5L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t3034_read_cb);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE, 5L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t3034_read_cb);
 
   result = curl_easy_perform(curl);
   if(result != CURLE_SEND_FAIL_REWIND) {
@@ -65,8 +65,8 @@ static CURLcode test_lib3034(const char *URL)
   curl_easy_reset(curl);
 
   /* Perform a second request, which should succeed. */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib3100.c
+++ b/tests/libtest/lib3100.c
@@ -40,17 +40,17 @@ static CURLcode test_lib3100(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
-  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, URL);
 
-  test_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
-  test_setopt(curl, CURLOPT_USERNAME, "user");
-  test_setopt(curl, CURLOPT_PASSWORD, "password");
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
+  easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  easy_setopt(curl, CURLOPT_USERNAME, "user");
+  easy_setopt(curl, CURLOPT_PASSWORD, "password");
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
 
   result = curl_easy_perform(curl);
   if(result != CURLE_OK) {

--- a/tests/libtest/lib3101.c
+++ b/tests/libtest/lib3101.c
@@ -40,14 +40,14 @@ static CURLcode test_lib3101(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
-  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
-  test_setopt(curl, CURLOPT_USERNAME, "user");
-  test_setopt(curl, CURLOPT_PASSWORD, "password");
-  test_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+  easy_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  easy_setopt(curl, CURLOPT_USERNAME, "user");
+  easy_setopt(curl, CURLOPT_PASSWORD, "password");
+  easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
 
   result = curl_easy_perform(curl);
   if(result != CURLE_OK) {

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -98,17 +98,17 @@ static CURLcode test_lib3102(const char *URL)
   }
 
   /* Set the HTTPS URL to retrieve. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Capture certificate information */
-  test_setopt(curl, CURLOPT_CERTINFO, 1L);
+  easy_setopt(curl, CURLOPT_CERTINFO, 1L);
 
   /* Ignore output */
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
 
   /* No peer verify */
-  test_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-  test_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+  easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+  easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib3103.c
+++ b/tests/libtest/lib3103.c
@@ -35,17 +35,17 @@ static CURLcode test_lib3103(const char *URL)
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
 
   curl = curl_easy_init();
-  test_setopt(curl, CURLOPT_SHARE, share);
+  easy_setopt(curl, CURLOPT_SHARE, share);
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_PROXY, URL);
-  test_setopt(curl, CURLOPT_URL, "http://localhost/");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_PROXY, URL);
+  easy_setopt(curl, CURLOPT_URL, "http://localhost/");
 
-  test_setopt(curl, CURLOPT_COOKIEFILE, "");
+  easy_setopt(curl, CURLOPT_COOKIEFILE, "");
 
   /* Set a cookie without Max-age or Expires */
-  test_setopt(curl, CURLOPT_COOKIELIST, "Set-Cookie: c1=v1; domain=localhost");
+  easy_setopt(curl, CURLOPT_COOKIELIST, "Set-Cookie: c1=v1; domain=localhost");
 
   result = curl_easy_perform(curl);
   if(result) {

--- a/tests/libtest/lib3104.c
+++ b/tests/libtest/lib3104.c
@@ -35,16 +35,16 @@ static CURLcode test_lib3104(const char *URL)
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
 
   curl = curl_easy_init();
-  test_setopt(curl, CURLOPT_SHARE, share);
+  easy_setopt(curl, CURLOPT_SHARE, share);
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_PROXY, URL);
-  test_setopt(curl, CURLOPT_URL, "http://example.com/");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_PROXY, URL);
+  easy_setopt(curl, CURLOPT_URL, "http://example.com/");
 
-  test_setopt(curl, CURLOPT_COOKIEFILE, "");
+  easy_setopt(curl, CURLOPT_COOKIEFILE, "");
 
-  test_setopt(curl, CURLOPT_COOKIELIST,
+  easy_setopt(curl, CURLOPT_COOKIELIST,
               "example.com\tFALSE\t/\tFALSE\t0\tname\tvalue");
 
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib500.c
+++ b/tests/libtest/lib500.c
@@ -69,17 +69,17 @@ static CURLcode test_lib500(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   debug_config.nohex = TRUE;
   debug_config.tracetime = TRUE;
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
-  test_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   if(libtest_arg3 && !strcmp(libtest_arg3, "activeftp"))
-    test_setopt(curl, CURLOPT_FTPPORT, "-");
+    easy_setopt(curl, CURLOPT_FTPPORT, "-");
 
   if(testnum == 585 || testnum == 586 || testnum == 595 || testnum == 596)
     setupcallbacks(curl);

--- a/tests/libtest/lib501.c
+++ b/tests/libtest/lib501.c
@@ -42,10 +42,10 @@ static CURLcode test_lib501(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* verify that setting this to -1 is fine */
-  test_setopt(curl, CURLOPT_MAXREDIRS, -1L);
+  easy_setopt(curl, CURLOPT_MAXREDIRS, -1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib505.c
+++ b/tests/libtest/lib505.c
@@ -111,22 +111,22 @@ static CURLcode test_lib505(const char *URL)
   headerlist = temp;
 
   /* enable uploading */
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
   /* enable verbose */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* specify target */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* pass in that last of FTP commands to run after the transfer */
-  test_setopt(curl, CURLOPT_POSTQUOTE, headerlist);
+  easy_setopt(curl, CURLOPT_POSTQUOTE, headerlist);
 
   /* now specify which file to upload */
-  test_setopt(curl, CURLOPT_READDATA, hd_src);
+  easy_setopt(curl, CURLOPT_READDATA, hd_src);
 
   /* and give the size of the upload (optional) */
-  test_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);
+  easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);
 
   /* Now run off and do what you have been told! */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -239,21 +239,21 @@ static CURLcode test_lib506(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
   curl_mprintf("CURLOPT_SHARE\n");
-  test_setopt(curl, CURLOPT_SHARE, share);
+  easy_setopt(curl, CURLOPT_SHARE, share);
   curl_mprintf("CURLOPT_COOKIELIST injected_and_clobbered\n");
-  test_setopt(curl, CURLOPT_COOKIELIST,
+  easy_setopt(curl, CURLOPT_COOKIELIST,
               "Set-Cookie: injected_and_clobbered=yes; "
               "domain=host.foo.com; expires=Sat Feb 2 11:56:27 GMT 2030");
   curl_mprintf("CURLOPT_COOKIELIST ALL\n");
-  test_setopt(curl, CURLOPT_COOKIELIST, "ALL");
+  easy_setopt(curl, CURLOPT_COOKIELIST, "ALL");
   curl_mprintf("CURLOPT_COOKIELIST session\n");
-  test_setopt(curl, CURLOPT_COOKIELIST, "Set-Cookie: session=elephants");
+  easy_setopt(curl, CURLOPT_COOKIELIST, "Set-Cookie: session=elephants");
   curl_mprintf("CURLOPT_COOKIELIST injected\n");
-  test_setopt(curl, CURLOPT_COOKIELIST,
+  easy_setopt(curl, CURLOPT_COOKIELIST,
               "Set-Cookie: injected=yes; domain=host.foo.com; "
               "expires=Sat Feb 2 11:56:27 GMT 2030");
   curl_mprintf("CURLOPT_COOKIELIST SESS\n");
-  test_setopt(curl, CURLOPT_COOKIELIST, "SESS");
+  easy_setopt(curl, CURLOPT_COOKIELIST, "SESS");
   curl_mprintf("CLEANUP\n");
   curl_easy_cleanup(curl);
 
@@ -283,14 +283,14 @@ static CURLcode test_lib506(const char *URL)
 
   url = tutil_suburl(URL, i);
   headers = sethost(NULL);
-  test_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  test_setopt(curl, CURLOPT_URL, url);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  easy_setopt(curl, CURLOPT_URL, url);
   curl_mprintf("CURLOPT_SHARE\n");
-  test_setopt(curl, CURLOPT_SHARE, share);
+  easy_setopt(curl, CURLOPT_SHARE, share);
   curl_mprintf("CURLOPT_COOKIEJAR\n");
-  test_setopt(curl, CURLOPT_COOKIEJAR, jar);
+  easy_setopt(curl, CURLOPT_COOKIEJAR, jar);
   curl_mprintf("CURLOPT_COOKIELIST FLUSH\n");
-  test_setopt(curl, CURLOPT_COOKIELIST, "FLUSH");
+  easy_setopt(curl, CURLOPT_COOKIELIST, "FLUSH");
 
   curl_mprintf("PERFORM\n");
   curl_easy_perform(curl);
@@ -310,16 +310,16 @@ static CURLcode test_lib506(const char *URL)
   }
   url = tutil_suburl(URL, i);
   headers = sethost(NULL);
-  test_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  test_setopt(curl, CURLOPT_URL, url);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  easy_setopt(curl, CURLOPT_URL, url);
   curl_mprintf("CURLOPT_SHARE\n");
-  test_setopt(curl, CURLOPT_SHARE, share);
+  easy_setopt(curl, CURLOPT_SHARE, share);
   curl_mprintf("CURLOPT_COOKIELIST ALL\n");
-  test_setopt(curl, CURLOPT_COOKIELIST, "ALL");
+  easy_setopt(curl, CURLOPT_COOKIELIST, "ALL");
   curl_mprintf("CURLOPT_COOKIEJAR\n");
-  test_setopt(curl, CURLOPT_COOKIEFILE, jar);
+  easy_setopt(curl, CURLOPT_COOKIEFILE, jar);
   curl_mprintf("CURLOPT_COOKIELIST RELOAD\n");
-  test_setopt(curl, CURLOPT_COOKIELIST, "RELOAD");
+  easy_setopt(curl, CURLOPT_COOKIELIST, "RELOAD");
 
   result = CURLE_OK;
 

--- a/tests/libtest/lib508.c
+++ b/tests/libtest/lib508.c
@@ -71,25 +71,25 @@ static CURLcode test_lib508(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now specify we want to POST data */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* Set the expected POST size */
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)pooh.sizeleft);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)pooh.sizeleft);
 
   /* we want to use our own read function */
-  test_setopt(curl, CURLOPT_READFUNCTION, t508_read_cb);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t508_read_cb);
 
   /* pointer to pass to our read function */
-  test_setopt(curl, CURLOPT_READDATA, &pooh);
+  easy_setopt(curl, CURLOPT_READDATA, &pooh);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib509.c
+++ b/tests/libtest/lib509.c
@@ -99,7 +99,7 @@ static CURLcode test_lib509(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_USERAGENT, "test509"); /* uses curlx_strdup() */
+  easy_setopt(curl, CURLOPT_USERAGENT, "test509"); /* uses curlx_strdup() */
 
   asize = (int)sizeof(a);
   /* uses curlx_realloc() */

--- a/tests/libtest/lib510.c
+++ b/tests/libtest/lib510.c
@@ -87,29 +87,29 @@ static CURLcode test_lib510(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now specify we want to POST data */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* we want to use our own read function */
-  test_setopt(curl, CURLOPT_READFUNCTION, t510_read_cb);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t510_read_cb);
 
   /* pointer to pass to our read function */
-  test_setopt(curl, CURLOPT_READDATA, &pooh);
+  easy_setopt(curl, CURLOPT_READDATA, &pooh);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* enforce chunked transfer by setting the header */
-  test_setopt(curl, CURLOPT_HTTPHEADER, slist);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
 
   if(testnum == 565) {
-    test_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
-    test_setopt(curl, CURLOPT_USERPWD, "foo:bar");
+    easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+    easy_setopt(curl, CURLOPT_USERPWD, "foo:bar");
   }
 
   /* Perform the request, result gets the return code */

--- a/tests/libtest/lib511.c
+++ b/tests/libtest/lib511.c
@@ -40,10 +40,10 @@ static CURLcode test_lib511(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_FILETIME, 1L);
-  test_setopt(curl, CURLOPT_NOBODY, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_FILETIME, 1L);
+  easy_setopt(curl, CURLOPT_NOBODY, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib513.c
+++ b/tests/libtest/lib513.c
@@ -50,25 +50,25 @@ static CURLcode test_lib513(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now specify we want to POST data */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* Set the expected POST size */
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, 1L);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 1L);
 
   /* we want to use our own read function */
-  test_setopt(curl, CURLOPT_READFUNCTION, t513_read_cb);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t513_read_cb);
 
   /* pointer to pass to our read function */
-  test_setopt(curl, CURLOPT_READDATA, NULL);
+  easy_setopt(curl, CURLOPT_READDATA, NULL);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib514.c
+++ b/tests/libtest/lib514.c
@@ -41,7 +41,7 @@ static CURLcode test_lib514(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Based on a bug report by Niels van Tongeren on June 29, 2004:
 
@@ -52,17 +52,17 @@ static CURLcode test_lib514(const char *URL)
 
   */
 
-  test_setopt(curl, CURLOPT_POSTFIELDS, "moo");
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, 3L);
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, "moo");
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 3L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* this is where transfer 1 would take place, but skip that and change
      options right away instead */
 
-  test_setopt(curl, CURLOPT_NOBODY, 1L);
+  easy_setopt(curl, CURLOPT_NOBODY, 1L);
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
-  test_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
+  easy_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
 
   /* Now, we should be making a fine HEAD request */
 

--- a/tests/libtest/lib515.c
+++ b/tests/libtest/lib515.c
@@ -41,11 +41,11 @@ static CURLcode test_lib515(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_POSTFIELDS, NULL);
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, 0L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
-  test_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, NULL);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
+  easy_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
 
   /* Now, we should be making a zero byte POST request */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib516.c
+++ b/tests/libtest/lib516.c
@@ -41,10 +41,10 @@ static CURLcode test_lib516(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HTTPPOST, NULL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
-  test_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HTTPPOST, NULL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
+  easy_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
 
   /* Now, we should be making a zero byte POST request */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -447,8 +447,8 @@ static CURLcode test_lib518(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib519.c
+++ b/tests/libtest/lib519.c
@@ -40,17 +40,17 @@ static CURLcode test_lib519(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_USERPWD, "monster:underbed");
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_USERPWD, "monster:underbed");
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* get first page */
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
 
-  test_setopt(curl, CURLOPT_USERPWD, "anothermonster:inwardrobe");
+  easy_setopt(curl, CURLOPT_USERPWD, "anothermonster:inwardrobe");
 
   /* get second page */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib520.c
+++ b/tests/libtest/lib520.c
@@ -40,9 +40,9 @@ static CURLcode test_lib520(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_FILETIME, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_FILETIME, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib521.c
+++ b/tests/libtest/lib521.c
@@ -44,10 +44,10 @@ static CURLcode test_lib521(const char *URL)
     return result;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_PORT, (long)port);
-  test_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_PORT, (long)port);
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib523.c
+++ b/tests/libtest/lib523.c
@@ -40,11 +40,11 @@ static CURLcode test_lib523(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_PORT, 19999L);
-  test_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_PORT, 19999L);
+  easy_setopt(curl, CURLOPT_USERPWD, "xxx:yyy");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib524.c
+++ b/tests/libtest/lib524.c
@@ -40,9 +40,9 @@ static CURLcode test_lib524(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib536.c
+++ b/tests/libtest/lib536.c
@@ -56,16 +56,16 @@ static CURLcode test_lib536(const char *URL)
   if(!host)
     goto test_cleanup;
 
-  test_setopt(curl, CURLOPT_RESOLVE, host);
-  test_setopt(curl, CURLOPT_PROXY, URL);
-  test_setopt(curl, CURLOPT_URL, url_with_proxy);
-  test_setopt(curl, CURLOPT_NOPROXY, "goingdirect.test");
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_RESOLVE, host);
+  easy_setopt(curl, CURLOPT_PROXY, URL);
+  easy_setopt(curl, CURLOPT_URL, url_with_proxy);
+  easy_setopt(curl, CURLOPT_NOPROXY, "goingdirect.test");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
   if(!result) {
     proxystat(curl);
-    test_setopt(curl, CURLOPT_URL, url_without_proxy);
+    easy_setopt(curl, CURLOPT_URL, url_without_proxy);
     result = curl_easy_perform(curl);
     if(!result)
       proxystat(curl);

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -463,8 +463,8 @@ static CURLcode test_lib537(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib539.c
+++ b/tests/libtest/lib539.c
@@ -45,9 +45,9 @@ static CURLcode test_lib539(const char *URL)
   /*
    * Begin with curl set to use a single CWD to the URL's directory.
    */
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
 
   result = curl_easy_perform(curl);
   if(result == CURLE_OK) {
@@ -67,9 +67,9 @@ static CURLcode test_lib539(const char *URL)
       return TEST_ERR_MAJOR_BAD;
     }
 
-    test_setopt(curl, CURLOPT_URL, libtest_arg2);
-    test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
-    test_setopt(curl, CURLOPT_QUOTE, slist);
+    easy_setopt(curl, CURLOPT_URL, libtest_arg2);
+    easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
+    easy_setopt(curl, CURLOPT_QUOTE, slist);
 
     result = curl_easy_perform(curl);
   }

--- a/tests/libtest/lib541.c
+++ b/tests/libtest/lib541.c
@@ -82,16 +82,16 @@ static CURLcode test_lib541(const char *URL)
   }
 
   /* enable uploading */
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
   /* enable verbose */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* specify target */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* now specify which file to upload */
-  test_setopt(curl, CURLOPT_READDATA, hd_src);
+  easy_setopt(curl, CURLOPT_READDATA, hd_src);
 
   /* Now run off and do what you have been told! */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib542.c
+++ b/tests/libtest/lib542.c
@@ -46,16 +46,16 @@ static CURLcode test_lib542(const char *URL)
   }
 
   /* enable verbose */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* enable NOBODY */
-  test_setopt(curl, CURLOPT_NOBODY, 1L);
+  easy_setopt(curl, CURLOPT_NOBODY, 1L);
 
   /* disable HEADER */
-  test_setopt(curl, CURLOPT_HEADER, 0L);
+  easy_setopt(curl, CURLOPT_HEADER, 0L);
 
   /* specify target */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now run off and do what you have been told! */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib544.c
+++ b/tests/libtest/lib544.c
@@ -52,15 +52,15 @@ static CURLcode test_lib544(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   if(testnum == 545)
-    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(teststring));
+    easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(teststring));
 
-  test_setopt(curl, CURLOPT_COPYPOSTFIELDS, teststring);
+  easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, teststring);
 
-  test_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
-  test_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
+  easy_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
 
   /* Update the original data to detect non-copy. */
   curlx_strcopy(teststring, sizeof(teststring), "FAIL", strlen("FAIL"));

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -80,28 +80,28 @@ static CURLcode test_lib547(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
   if(testnum == 548) {
     /* set the data to POST with a mere pointer to a null-terminated string */
-    test_setopt(curl, CURLOPT_POSTFIELDS, t547_uploadthis);
+    easy_setopt(curl, CURLOPT_POSTFIELDS, t547_uploadthis);
   }
   else {
     /* 547 style, which means reading the POST data from a callback */
-    test_setopt(curl, CURLOPT_IOCTLFUNCTION, t547_ioctl_callback);
-    test_setopt(curl, CURLOPT_IOCTLDATA, &counter);
+    easy_setopt(curl, CURLOPT_IOCTLFUNCTION, t547_ioctl_callback);
+    easy_setopt(curl, CURLOPT_IOCTLDATA, &counter);
 
-    test_setopt(curl, CURLOPT_READFUNCTION, t547_read_cb);
-    test_setopt(curl, CURLOPT_READDATA, &counter);
+    easy_setopt(curl, CURLOPT_READFUNCTION, t547_read_cb);
+    easy_setopt(curl, CURLOPT_READDATA, &counter);
     /* We CANNOT do the POST fine without setting the size (or choose
        chunked)! */
-    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)t547_datalen);
+    easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)t547_datalen);
   }
-  test_setopt(curl, CURLOPT_POST, 1L);
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_PROXYUSERPWD, libtest_arg3);
-  test_setopt(curl, CURLOPT_PROXYAUTH,
+  easy_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_PROXYUSERPWD, libtest_arg3);
+  easy_setopt(curl, CURLOPT_PROXYAUTH,
               CURLAUTH_BASIC | CURLAUTH_DIGEST | CURLAUTH_NTLM);
 
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib549.c
+++ b/tests/libtest/lib549.c
@@ -45,13 +45,13 @@ static CURLcode test_lib549(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_PROXY_TRANSFER_MODE, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_PROXY_TRANSFER_MODE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   if(libtest_arg3) {
     /* enable ASCII/text mode */
-    test_setopt(curl, CURLOPT_TRANSFERTEXT, 1L);
+    easy_setopt(curl, CURLOPT_TRANSFERTEXT, 1L);
   }
 
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -79,35 +79,35 @@ static CURLcode test_lib552(const char *URL)
   global_init(CURL_GLOBAL_ALL);
   easy_init(curl);
 
-  test_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
   /* the DEBUGFUNCTION has no effect until we enable VERBOSE */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* setup repeated data string */
   for(i = 0; i < sizeof(databuf); ++i)
     databuf[i] = fill[i % sizeof(fill)];
 
   /* Post */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* Setup read callback */
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(databuf));
-  test_setopt(curl, CURLOPT_READFUNCTION, t552_read_cb);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(databuf));
+  easy_setopt(curl, CURLOPT_READFUNCTION, t552_read_cb);
 
   /* Write callback */
-  test_setopt(curl, CURLOPT_WRITEFUNCTION, t552_write_cb);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, t552_write_cb);
 
   /* Ioctl function */
-  test_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctl_callback);
+  easy_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctl_callback);
 
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);
 
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Accept any auth. But for this bug configure proxy with DIGEST, basic
      might work too, not NTLM */
-  test_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+  easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib553.c
+++ b/tests/libtest/lib553.c
@@ -89,13 +89,13 @@ static CURLcode test_lib553(const char *URL)
     goto test_cleanup;
   headerlist = hl;
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  test_setopt(curl, CURLOPT_POST, 1L);
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)POSTLEN);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, myreadfunc);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
+  easy_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)POSTLEN);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, myreadfunc);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib554.c
+++ b/tests/libtest/lib554.c
@@ -151,30 +151,30 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now specify we want to POST data */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* Set the expected POST size */
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)pooh.sizeleft);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)pooh.sizeleft);
 
   /* we want to use our own read function */
   if(testnum == 587) {
-    test_setopt(curl, CURLOPT_READFUNCTION, t587_read_cb);
+    easy_setopt(curl, CURLOPT_READFUNCTION, t587_read_cb);
   }
   else {
-    test_setopt(curl, CURLOPT_READFUNCTION, t554_read_cb);
+    easy_setopt(curl, CURLOPT_READFUNCTION, t554_read_cb);
   }
 
   /* send a multi-part formpost */
-  test_setopt(curl, CURLOPT_HTTPPOST, formpost);
+  easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib556.c
+++ b/tests/libtest/lib556.c
@@ -41,9 +41,9 @@ static CURLcode test_lib556(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
 again:
 

--- a/tests/libtest/lib559.c
+++ b/tests/libtest/lib559.c
@@ -40,9 +40,9 @@ static CURLcode test_lib559(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_BUFFERSIZE, 1L); /* the smallest! */
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_BUFFERSIZE, 1L); /* the smallest! */
 
   result = curl_easy_perform(curl);
 test_cleanup:

--- a/tests/libtest/lib562.c
+++ b/tests/libtest/lib562.c
@@ -53,13 +53,13 @@ static CURLcode test_lib562(const char *URL)
   }
 
   /* enable verbose */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* set port number */
-  test_setopt(curl, CURLOPT_PORT, (long)port);
+  easy_setopt(curl, CURLOPT_PORT, (long)port);
 
   /* specify target */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now run off and do what you have been told! */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib566.c
+++ b/tests/libtest/lib566.c
@@ -42,8 +42,8 @@ static CURLcode test_lib566(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib567.c
+++ b/tests/libtest/lib567.c
@@ -45,17 +45,17 @@ static CURLcode test_lib567(const char *URL)
   }
 
   /* Dump data to stdout for protocol verification */
-  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
-  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, URL);
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
-  test_setopt(curl, CURLOPT_USERAGENT, "test567");
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, URL);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
+  easy_setopt(curl, CURLOPT_USERAGENT, "test567");
 
   custom_headers = curl_slist_append(custom_headers, "Test-Number: 567");
-  test_setopt(curl, CURLOPT_RTSPHEADER, custom_headers);
+  easy_setopt(curl, CURLOPT_RTSPHEADER, custom_headers);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib568.c
+++ b/tests/libtest/lib568.c
@@ -50,17 +50,17 @@ static CURLcode test_lib568(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
-  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  easy_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
 
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   stream_uri = tutil_suburl(URL, request++);
   if(!stream_uri) {
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
@@ -83,19 +83,19 @@ static CURLcode test_lib568(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_ANNOUNCE);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_ANNOUNCE);
 
-  test_setopt(curl, CURLOPT_READDATA, sdpf);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_READDATA, sdpf);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* Do the ANNOUNCE */
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
 
-  test_setopt(curl, CURLOPT_UPLOAD, 0L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 0L);
   curlx_fclose(sdpf);
   sdpf = NULL;
 
@@ -105,11 +105,11 @@ static CURLcode test_lib568(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
@@ -121,7 +121,7 @@ static CURLcode test_lib568(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
@@ -131,17 +131,17 @@ static CURLcode test_lib568(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSPHEADER, custom_headers);
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_ANNOUNCE);
-  test_setopt(curl, CURLOPT_POSTFIELDS,
+  easy_setopt(curl, CURLOPT_RTSPHEADER, custom_headers);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_ANNOUNCE);
+  easy_setopt(curl, CURLOPT_POSTFIELDS,
               "postyfield=postystuff&project=curl\n");
 
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
 
-  test_setopt(curl, CURLOPT_POSTFIELDS, NULL);
-  test_setopt(curl, CURLOPT_RTSPHEADER, NULL);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, NULL);
+  easy_setopt(curl, CURLOPT_RTSPHEADER, NULL);
   curl_slist_free_all(custom_headers);
   custom_headers = NULL;
 
@@ -151,11 +151,11 @@ static CURLcode test_lib568(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
   result = curl_easy_perform(curl);
 
 test_cleanup:

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -54,13 +54,13 @@ static CURLcode test_lib569(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
-  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
   result = curl_easy_perform(curl);
   if(result != CURLE_BAD_FUNCTION_ARGUMENT) {
     curl_mfprintf(stderr, "This should have failed. "
@@ -77,12 +77,12 @@ static CURLcode test_lib569(const char *URL)
       result = TEST_ERR_MAJOR_BAD;
       goto test_cleanup;
     }
-    test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+    easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
     curl_free(stream_uri);
     stream_uri = NULL;
 
-    test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
-    test_setopt(curl, CURLOPT_RTSP_TRANSPORT,
+    easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
+    easy_setopt(curl, CURLOPT_RTSP_TRANSPORT,
                 "Fake/NotReal/JustATest;foo=baz");
     result = curl_easy_perform(curl);
     if(result)
@@ -97,17 +97,17 @@ static CURLcode test_lib569(const char *URL)
       result = TEST_ERR_MAJOR_BAD;
       goto test_cleanup;
     }
-    test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+    easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
     curl_free(stream_uri);
     stream_uri = NULL;
 
-    test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_TEARDOWN);
+    easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_TEARDOWN);
     result = curl_easy_perform(curl);
     if(result)
       goto test_cleanup;
 
     /* Clear for the next go-round */
-    test_setopt(curl, CURLOPT_RTSP_SESSION_ID, NULL);
+    easy_setopt(curl, CURLOPT_RTSP_SESSION_ID, NULL);
   }
 
 test_cleanup:

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -42,20 +42,20 @@ static CURLcode test_lib570(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
-  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
 
   stream_uri = tutil_suburl(URL, request++);
   if(!stream_uri) {
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
@@ -66,17 +66,17 @@ static CURLcode test_lib570(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_RTSP_CLIENT_CSEQ, 999L);
-  test_setopt(curl, CURLOPT_RTSP_TRANSPORT,
+  easy_setopt(curl, CURLOPT_RTSP_CLIENT_CSEQ, 999L);
+  easy_setopt(curl, CURLOPT_RTSP_TRANSPORT,
               "RAW/RAW/UDP;unicast;client_port=3056-3057");
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
 
   stream_uri = tutil_suburl(URL, request++);
   if(!stream_uri) {
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
@@ -84,14 +84,14 @@ static CURLcode test_lib570(const char *URL)
   if(result)
     goto test_cleanup;
 
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
 
   stream_uri = tutil_suburl(URL, request++);
   if(!stream_uri) {
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -115,24 +115,24 @@ static CURLcode test_lib571(const char *URL)
     curl_global_cleanup();
     return TEST_ERR_MAJOR_BAD;
   }
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   stream_uri = tutil_suburl(URL, request++);
   if(!stream_uri) {
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
-  test_setopt(curl, CURLOPT_INTERLEAVEFUNCTION, rtp_write);
-  test_setopt(curl, CURLOPT_TIMEOUT, 30L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_WRITEDATA, protofile);
+  easy_setopt(curl, CURLOPT_INTERLEAVEFUNCTION, rtp_write);
+  easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_WRITEDATA, protofile);
 
-  test_setopt(curl, CURLOPT_RTSP_TRANSPORT, "RTP/AVP/TCP;interleaved=0-1");
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
+  easy_setopt(curl, CURLOPT_RTSP_TRANSPORT, "RTP/AVP/TCP;interleaved=0-1");
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
 
   result = curl_easy_perform(curl);
   if(result)
@@ -144,10 +144,10 @@ static CURLcode test_lib571(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
 
   result = curl_easy_perform(curl);
   if(result)
@@ -159,10 +159,10 @@ static CURLcode test_lib571(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
 
   result = curl_easy_perform(curl);
   if(result)
@@ -173,10 +173,10 @@ static CURLcode test_lib571(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_PLAY);
 
   result = curl_easy_perform(curl);
   if(result)
@@ -187,7 +187,7 @@ static CURLcode test_lib571(const char *URL)
   /* Use Receive to get the rest of the data */
   while(!result && rtp_packet_count < 19) {
     curl_mfprintf(stderr, "LOOPY LOOP!\n");
-    test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_RECEIVE);
+    easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_RECEIVE);
     result = curl_easy_perform(curl);
   }
 

--- a/tests/libtest/lib572.c
+++ b/tests/libtest/lib572.c
@@ -50,11 +50,11 @@ static CURLcode test_lib572(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_HEADERDATA, stdout);
-  test_setopt(curl, CURLOPT_WRITEDATA, stdout);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HEADERDATA, stdout);
+  easy_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* SETUP */
   stream_uri = tutil_suburl(URL, request++);
@@ -62,12 +62,12 @@ static CURLcode test_lib572(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
-  test_setopt(curl, CURLOPT_RTSP_TRANSPORT, "Planes/Trains/Automobiles");
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
+  easy_setopt(curl, CURLOPT_RTSP_TRANSPORT, "Planes/Trains/Automobiles");
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
@@ -77,7 +77,7 @@ static CURLcode test_lib572(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
@@ -101,17 +101,17 @@ static CURLcode test_lib572(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_GET_PARAMETER);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_GET_PARAMETER);
 
-  test_setopt(curl, CURLOPT_READDATA, paramsf);
-  test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);
+  easy_setopt(curl, CURLOPT_READDATA, paramsf);
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)file_info.st_size);
 
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
 
-  test_setopt(curl, CURLOPT_UPLOAD, 0L);
+  easy_setopt(curl, CURLOPT_UPLOAD, 0L);
   curlx_fclose(paramsf);
   paramsf = NULL;
 
@@ -121,7 +121,7 @@ static CURLcode test_lib572(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
@@ -136,18 +136,18 @@ static CURLcode test_lib572(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_GET_PARAMETER);
-  test_setopt(curl, CURLOPT_POSTFIELDS, "packets_received\njitter\n");
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_GET_PARAMETER);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, "packets_received\njitter\n");
 
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
 
-  test_setopt(curl, CURLOPT_POSTFIELDS, NULL);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, NULL);
 
   /* Make sure we can do a normal request now */
   stream_uri = tutil_suburl(URL, request++);
@@ -155,11 +155,11 @@ static CURLcode test_lib572(const char *URL)
     result = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
-  test_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
+  easy_setopt(curl, CURLOPT_RTSP_STREAM_URI, stream_uri);
   curl_free(stream_uri);
   stream_uri = NULL;
 
-  test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
+  easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
   result = curl_easy_perform(curl);
 
 test_cleanup:

--- a/tests/libtest/lib574.c
+++ b/tests/libtest/lib574.c
@@ -48,10 +48,10 @@ static CURLcode test_lib574(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
-  test_setopt(curl, CURLOPT_FNMATCH_FUNCTION, new_fnmatch);
-  test_setopt(curl, CURLOPT_TIMEOUT_MS, (long)TEST_HANG_TIMEOUT);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
+  easy_setopt(curl, CURLOPT_FNMATCH_FUNCTION, new_fnmatch);
+  easy_setopt(curl, CURLOPT_TIMEOUT_MS, (long)TEST_HANG_TIMEOUT);
 
   result = curl_easy_perform(curl);
   if(result) {

--- a/tests/libtest/lib576.c
+++ b/tests/libtest/lib576.c
@@ -106,11 +106,11 @@ static CURLcode test_lib576(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
-  test_setopt(curl, CURLOPT_CHUNK_BGN_FUNCTION, chunk_bgn);
-  test_setopt(curl, CURLOPT_CHUNK_END_FUNCTION, chunk_end);
-  test_setopt(curl, CURLOPT_CHUNK_DATA, &chunk_data);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
+  easy_setopt(curl, CURLOPT_CHUNK_BGN_FUNCTION, chunk_bgn);
+  easy_setopt(curl, CURLOPT_CHUNK_END_FUNCTION, chunk_end);
+  easy_setopt(curl, CURLOPT_CHUNK_DATA, &chunk_data);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib578.c
+++ b/tests/libtest/lib578.c
@@ -66,24 +66,24 @@ static CURLcode test_lib578(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now specify we want to POST data */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* Set the expected POST size */
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)data_size);
-  test_setopt(curl, CURLOPT_POSTFIELDS, t578_testdata);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)data_size);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, t578_testdata);
 
   /* we want to use our own progress function */
-  test_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-  test_setopt(curl, CURLOPT_PROGRESSFUNCTION, t578_progress_callback);
+  easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+  easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, t578_progress_callback);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib579.c
+++ b/tests/libtest/lib579.c
@@ -127,32 +127,32 @@ static CURLcode test_lib579(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Now specify we want to POST data */
-  test_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POST, 1L);
 
   /* we want to use our own read function */
-  test_setopt(curl, CURLOPT_READFUNCTION, t579_read_cb);
+  easy_setopt(curl, CURLOPT_READFUNCTION, t579_read_cb);
 
   /* pointer to pass to our read function */
-  test_setopt(curl, CURLOPT_READDATA, &pooh);
+  easy_setopt(curl, CURLOPT_READDATA, &pooh);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* enforce chunked transfer by setting the header */
-  test_setopt(curl, CURLOPT_HTTPHEADER, slist);
+  easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
 
-  test_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
-  test_setopt(curl, CURLOPT_USERPWD, "foo:bar");
+  easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+  easy_setopt(curl, CURLOPT_USERPWD, "foo:bar");
 
   /* we want to use our own progress function */
-  test_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-  test_setopt(curl, CURLOPT_PROGRESSFUNCTION, t579_progress_callback);
+  easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+  easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, t579_progress_callback);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -203,9 +203,9 @@ static CURLcode test_lib586(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
   curl_mprintf("CURLOPT_SHARE\n");
-  test_setopt(curl, CURLOPT_SHARE, share);
+  easy_setopt(curl, CURLOPT_SHARE, share);
 
   curl_mprintf("PERFORM\n");
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib589.c
+++ b/tests/libtest/lib589.c
@@ -43,9 +43,9 @@ static CURLcode test_lib589(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
-  test_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
+  easy_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
 
   if(testnum == 584) {
     mime = curl_mime_init(curl);
@@ -53,14 +53,14 @@ static CURLcode test_lib589(const char *URL)
     if(mime && part) {
       curl_mime_name(part, "fake");
       curl_mime_data(part, "party", 5);
-      test_setopt(curl, CURLOPT_MIMEPOST, mime);
+      easy_setopt(curl, CURLOPT_MIMEPOST, mime);
       result = curl_easy_perform(curl);
     }
     if(result)
       goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_MIMEPOST, NULL);
+  easy_setopt(curl, CURLOPT_MIMEPOST, NULL);
 
   /* Now, we should be making a zero byte POST request */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib590.c
+++ b/tests/libtest/lib590.c
@@ -55,16 +55,16 @@ static CURLcode test_lib590(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_PROXYAUTH,
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_PROXYAUTH,
               CURLAUTH_BASIC | CURLAUTH_DIGEST | CURLAUTH_NTLM);
-  test_setopt(curl, CURLOPT_PROXY, libtest_arg2); /* set in first.c */
+  easy_setopt(curl, CURLOPT_PROXY, libtest_arg2); /* set in first.c */
 
   /* set the name + password twice to test that the API is fine with it */
-  test_setopt(curl, CURLOPT_PROXYUSERNAME, "me");
-  test_setopt(curl, CURLOPT_PROXYPASSWORD, "password");
-  test_setopt(curl, CURLOPT_PROXYUSERPWD, "me:password");
+  easy_setopt(curl, CURLOPT_PROXYUSERNAME, "me");
+  easy_setopt(curl, CURLOPT_PROXYPASSWORD, "password");
+  easy_setopt(curl, CURLOPT_PROXYUSERPWD, "me:password");
 
   result = curl_easy_perform(curl);
   if(result)

--- a/tests/libtest/lib598.c
+++ b/tests/libtest/lib598.c
@@ -40,12 +40,12 @@ static CURLcode test_lib598(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_REFERER, "http://example.com/the-moo");
-  test_setopt(curl, CURLOPT_USERAGENT, "the-moo agent next generation");
-  test_setopt(curl, CURLOPT_COOKIE, "name=moo");
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_REFERER, "http://example.com/the-moo");
+  easy_setopt(curl, CURLOPT_USERAGENT, "the-moo agent next generation");
+  easy_setopt(curl, CURLOPT_COOKIE, "name=moo");
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
   if(result) {
@@ -55,9 +55,9 @@ static CURLcode test_lib598(const char *URL)
 
   curl_easy_reset(curl);
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
   if(result)

--- a/tests/libtest/lib599.c
+++ b/tests/libtest/lib599.c
@@ -58,20 +58,20 @@ static CURLcode test_lib599(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* we want to use our own progress function */
-  test_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-  test_setopt(curl, CURLOPT_PROGRESSFUNCTION, t599_progress_callback);
+  easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+  easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, t599_progress_callback);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* follow redirects */
-  test_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib643.c
+++ b/tests/libtest/lib643.c
@@ -194,16 +194,16 @@ static CURLcode t643_test_once(const char *URL, bool oldstyle)
     curl_mprintf("curl_mime_xxx(5) = %s\n", curl_easy_strerror(result));
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* send a multi-part mimepost */
-  test_setopt(curl, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -172,19 +172,19 @@ static CURLcode test_lib650(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* send a multi-part formpost */
-  test_setopt(curl, CURLOPT_HTTPPOST, formpost);
+  easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  test_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_301);
+  easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  easy_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_301);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib651.c
+++ b/tests/libtest/lib651.c
@@ -64,16 +64,16 @@ static CURLcode test_lib651(const char *URL)
   }
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* send a multi-part formpost */
-  test_setopt(curl, CURLOPT_HTTPPOST, formpost);
+  easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib652.c
+++ b/tests/libtest/lib652.c
@@ -94,22 +94,22 @@ static CURLcode test_lib652(const char *URL)
   }
 
   /* First set the URL that is about to receive our mime mail. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Set sender. */
-  test_setopt(curl, CURLOPT_MAIL_FROM, "somebody@example.com");
+  easy_setopt(curl, CURLOPT_MAIL_FROM, "somebody@example.com");
 
   /* Set recipients. */
-  test_setopt(curl, CURLOPT_MAIL_RCPT, recipients);
+  easy_setopt(curl, CURLOPT_MAIL_RCPT, recipients);
 
   /* send a multi-part mail */
-  test_setopt(curl, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* Shorten upload buffer. */
-  test_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, 16411L);
+  easy_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, 16411L);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib654.c
+++ b/tests/libtest/lib654.c
@@ -82,13 +82,13 @@ static CURLcode test_lib654(const char *URL)
   curl = curl_easy_init();
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Prepare the callback structure. */
   pooh.readptr = testdata;
@@ -111,7 +111,7 @@ static CURLcode test_lib654(const char *URL)
                     free_callback, &pooh);
 
   /* Bind mime data to its easy handle. */
-  test_setopt(curl, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* Duplicate the handle. */
   curl2 = curl_easy_duphandle(curl);

--- a/tests/libtest/lib655.c
+++ b/tests/libtest/lib655.c
@@ -78,13 +78,13 @@ static CURLcode test_lib655(const char *URL)
   }
 
   /* Set the URL that is about to receive our first request. */
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
-  test_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_RESOLVER_START_DATA, TEST_DATA_STRING);
-  test_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, resolver_alloc_cb_fail);
+  easy_setopt(curl, CURLOPT_RESOLVER_START_DATA, TEST_DATA_STRING);
+  easy_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, resolver_alloc_cb_fail);
 
   /* this should fail */
   result = curl_easy_perform(curl);
@@ -98,12 +98,12 @@ static CURLcode test_lib655(const char *URL)
   }
 
   /* Set the URL that receives our second request. */
-  test_setopt(curl, CURLOPT_URL, libtest_arg2);
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
-  test_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, libtest_arg2);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  test_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, resolver_alloc_cb_pass);
+  easy_setopt(curl, CURLOPT_RESOLVER_START_FUNCTION, resolver_alloc_cb_pass);
 
   /* this should succeed */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib661.c
+++ b/tests/libtest/lib661.c
@@ -45,17 +45,17 @@ static CURLcode test_lib661(const char *URL)
   /* test: CURLFTPMETHOD_SINGLECWD with absolute path should
            skip CWD to entry path */
   newURL = curl_maprintf("%s/folderA/661", URL);
-  test_setopt(curl, CURLOPT_URL, newURL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
+  easy_setopt(curl, CURLOPT_URL, newURL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
   result = curl_easy_perform(curl);
   if(result != CURLE_REMOTE_FILE_NOT_FOUND)
     goto test_cleanup;
 
   curl_free(newURL);
   newURL = curl_maprintf("%s/folderB/661", URL);
-  test_setopt(curl, CURLOPT_URL, newURL);
+  easy_setopt(curl, CURLOPT_URL, newURL);
   result = curl_easy_perform(curl);
   if(result != CURLE_REMOTE_FILE_NOT_FOUND)
     goto test_cleanup;
@@ -72,10 +72,10 @@ static CURLcode test_lib661(const char *URL)
 
   curl_free(newURL);
   newURL = curl_maprintf("%s/folderA/661", URL);
-  test_setopt(curl, CURLOPT_URL, newURL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
+  easy_setopt(curl, CURLOPT_URL, newURL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_IGNORE_CONTENT_LENGTH, 1L);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
   result = curl_easy_perform(curl);
   if(result != CURLE_REMOTE_FILE_NOT_FOUND)
     goto test_cleanup;
@@ -83,16 +83,16 @@ static CURLcode test_lib661(const char *URL)
   /* curve ball: CWD /folderB before reusing connection with _NOCWD */
   curl_free(newURL);
   newURL = curl_maprintf("%s/folderB/661", URL);
-  test_setopt(curl, CURLOPT_URL, newURL);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
+  easy_setopt(curl, CURLOPT_URL, newURL);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
   result = curl_easy_perform(curl);
   if(result != CURLE_REMOTE_FILE_NOT_FOUND)
     goto test_cleanup;
 
   curl_free(newURL);
   newURL = curl_maprintf("%s/folderA/661", URL);
-  test_setopt(curl, CURLOPT_URL, newURL);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
+  easy_setopt(curl, CURLOPT_URL, newURL);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
   result = curl_easy_perform(curl);
   if(result != CURLE_REMOTE_FILE_NOT_FOUND)
     goto test_cleanup;
@@ -114,11 +114,11 @@ static CURLcode test_lib661(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_NOBODY, 1L);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
-  test_setopt(curl, CURLOPT_QUOTE, slist);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_NOBODY, 1L);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
+  easy_setopt(curl, CURLOPT_QUOTE, slist);
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
@@ -133,11 +133,11 @@ static CURLcode test_lib661(const char *URL)
     goto test_cleanup;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_NOBODY, 1L);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
-  test_setopt(curl, CURLOPT_QUOTE, slist);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_NOBODY, 1L);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
+  easy_setopt(curl, CURLOPT_QUOTE, slist);
   result = curl_easy_perform(curl);
   if(result)
     goto test_cleanup;
@@ -146,11 +146,11 @@ static CURLcode test_lib661(const char *URL)
      not emit CWD for second FTP access when not needed +
      bonus: see if path buffering survives curl_easy_reset() */
   curl_easy_reset(curl);
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_NOBODY, 1L);
-  test_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
-  test_setopt(curl, CURLOPT_QUOTE, slist);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_NOBODY, 1L);
+  easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
+  easy_setopt(curl, CURLOPT_QUOTE, slist);
   result = curl_easy_perform(curl);
 
 test_cleanup:

--- a/tests/libtest/lib666.c
+++ b/tests/libtest/lib666.c
@@ -89,19 +89,19 @@ static CURLcode test_lib666(const char *URL)
   }
 
   /* First set the URL that is about to receive our mime mail. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* Post form */
-  test_setopt(curl, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* Shorten upload buffer. */
-  test_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, 16411L);
+  easy_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, 16411L);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Perform the request, result gets the return code */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib667.c
+++ b/tests/libtest/lib667.c
@@ -72,13 +72,13 @@ static CURLcode test_lib667(const char *URL)
   curl = curl_easy_init();
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Prepare the callback structure. */
   pooh.readptr = testdata;
@@ -93,7 +93,7 @@ static CURLcode test_lib667(const char *URL)
   curl_mime_data_cb(part, (curl_off_t)-1, t667_read_cb, NULL, NULL, &pooh);
 
   /* Bind mime data to its easy handle. */
-  test_setopt(curl, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* Send data. */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib668.c
+++ b/tests/libtest/lib668.c
@@ -67,13 +67,13 @@ static CURLcode test_lib668(const char *URL)
   curl = curl_easy_init();
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* Prepare the callback structures. */
   pooh1.readptr = testdata;
@@ -99,7 +99,7 @@ static CURLcode test_lib668(const char *URL)
   curl_mime_filedata(part, libtest_arg2);
 
   /* Bind mime data to its easy handle. */
-  test_setopt(curl, CURLOPT_MIMEPOST, mime);
+  easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* Send data. */
   result = curl_easy_perform(curl);

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -105,13 +105,13 @@ static CURLcode test_lib670(const char *URL)
   pooh.curl = curl_easy_init();
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(pooh.curl, CURLOPT_URL, URL);
+  easy_setopt(pooh.curl, CURLOPT_URL, URL);
 
   /* get verbose debug output please */
-  test_setopt(pooh.curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(pooh.curl, CURLOPT_VERBOSE, 1L);
 
   /* include headers in the output */
-  test_setopt(pooh.curl, CURLOPT_HEADER, 1L);
+  easy_setopt(pooh.curl, CURLOPT_HEADER, 1L);
 
   if(testnum == 670 || testnum == 671) {
     curl_mimepart *part;
@@ -131,7 +131,7 @@ static CURLcode test_lib670(const char *URL)
 
     /* Bind mime data to its easy handle. */
     if(result == CURLE_OK)
-      test_setopt(pooh.curl, CURLOPT_MIMEPOST, mime);
+      easy_setopt(pooh.curl, CURLOPT_MIMEPOST, mime);
   }
   else {
     struct curl_httppost *lastptr = NULL;
@@ -148,10 +148,10 @@ static CURLcode test_lib670(const char *URL)
     }
 
     /* We want to use our own read function. */
-    test_setopt(pooh.curl, CURLOPT_READFUNCTION, t670_read_cb);
+    easy_setopt(pooh.curl, CURLOPT_READFUNCTION, t670_read_cb);
 
     /* Send a multi-part formpost. */
-    test_setopt(pooh.curl, CURLOPT_HTTPPOST, formpost);
+    easy_setopt(pooh.curl, CURLOPT_HTTPPOST, formpost);
   }
 
   if(testnum == 670 || testnum == 672) {
@@ -223,9 +223,9 @@ static CURLcode test_lib670(const char *URL)
   }
   else {
     /* Use the easy interface. */
-    test_setopt(pooh.curl, CURLOPT_XFERINFODATA, &pooh);
-    test_setopt(pooh.curl, CURLOPT_XFERINFOFUNCTION, t670_xferinfo);
-    test_setopt(pooh.curl, CURLOPT_NOPROGRESS, 0L);
+    easy_setopt(pooh.curl, CURLOPT_XFERINFODATA, &pooh);
+    easy_setopt(pooh.curl, CURLOPT_XFERINFOFUNCTION, t670_xferinfo);
+    easy_setopt(pooh.curl, CURLOPT_NOPROGRESS, 0L);
     result = curl_easy_perform(pooh.curl);
   }
 

--- a/tests/libtest/lib676.c
+++ b/tests/libtest/lib676.c
@@ -40,11 +40,11 @@ static CURLcode test_lib676(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_USERAGENT, "the-moo agent next generation");
-  test_setopt(curl, CURLOPT_COOKIEFILE, libtest_arg2);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_USERAGENT, "the-moo agent next generation");
+  easy_setopt(curl, CURLOPT_COOKIEFILE, libtest_arg2);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   result = curl_easy_perform(curl);
   if(result) {
@@ -53,7 +53,7 @@ static CURLcode test_lib676(const char *URL)
   }
 
   /* now clear the cookies */
-  test_setopt(curl, CURLOPT_COOKIEFILE, NULL);
+  easy_setopt(curl, CURLOPT_COOKIEFILE, NULL);
 
   result = curl_easy_perform(curl);
   if(result)

--- a/tests/libtest/lib694.c
+++ b/tests/libtest/lib694.c
@@ -42,12 +42,12 @@ static CURLcode test_lib694(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HEADER, 1L);
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_HTTPAUTH,
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_HTTPAUTH,
               CURLAUTH_BASIC | CURLAUTH_DIGEST | CURLAUTH_NTLM);
-  test_setopt(curl, CURLOPT_USERPWD, "me:password");
+  easy_setopt(curl, CURLOPT_USERPWD, "me:password");
 
   do {
 
@@ -63,7 +63,7 @@ static CURLcode test_lib694(const char *URL)
     }
 
     /* set a new URL for the second, so that we do not restart NTLM */
-    test_setopt(curl, CURLOPT_URL, libtest_arg2);
+    easy_setopt(curl, CURLOPT_URL, libtest_arg2);
   } while(!result && ++count < 2);
 
 test_cleanup:

--- a/tests/libtest/lib695.c
+++ b/tests/libtest/lib695.c
@@ -43,10 +43,10 @@ static CURLcode test_lib695(const char *URL)
   curl = curl_easy_init();
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* Do not write anything. */
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);

--- a/tests/libtest/lib757.c
+++ b/tests/libtest/lib757.c
@@ -64,10 +64,10 @@ static CURLcode test_lib757(const char *URL)
   curl = curl_easy_init();
 
   /* First set the URL that is about to receive our POST. */
-  test_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_URL, URL);
 
   /* get verbose debug output please */
-  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   /* Do not write anything. */
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);

--- a/tests/libtest/lib758.c
+++ b/tests/libtest/lib758.c
@@ -352,7 +352,7 @@ static CURLcode t758_one(const char *URL, int timer_fail_at,
   easy_init(curl);
   debug_config.nohex = TRUE;
   debug_config.tracetime = TRUE;
-  test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 


### PR DESCRIPTION
- drop the old test_setopt() which did the same thing
- remove #if 0'ed macros from first.h
