### PR TITLE
multi wakeup socket and waitfds/fdset

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -566,6 +566,11 @@ CURLcode Curl_async_thrdd_multi_set_props(struct Curl_multi *multi,
                               min_threads, max_threads, idle_time_ms);
 }
 
+bool Curl_async_thrdd_multi_is_waiting(struct Curl_multi *multi)
+{
+  return Curl_thrdq_is_busy(multi->resolv_thrdq);
+}
+
 static CURLcode async_thrdd_query(struct Curl_easy *data,
                                   struct Curl_resolv_async *async,
                                   uint8_t dns_queries)

--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -164,6 +164,8 @@ CURLcode Curl_async_thrdd_multi_set_props(struct Curl_multi *multi,
                                           uint32_t max_threads,
                                           uint32_t idle_time_ms);
 
+bool Curl_async_thrdd_multi_is_waiting(struct Curl_multi *multi);
+
 #endif /* USE_RESOLV_THREADED */
 
 #ifndef CURL_DISABLE_DOH

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1147,14 +1147,15 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
 
   Curl_pollset_reset(ps);
-#ifdef ENABLE_WAKEUP
-  /* The admin handle always listens on the wakeup socket when there
-   * are transfers alive. */
+#if defined(ENABLE_WAKEUP) && defined(USE_RESOLV_THREADED)
+  /* If we are waiting on threaded resolves, we need to poll the
+   * wakeup socket. */
   if(data->multi && (data == data->multi->admin) &&
-     data->multi->xfers_alive) {
+     Curl_async_thrdd_multi_is_waiting(data->multi)) {
     result = Curl_pollset_add_in(data, ps, data->multi->wakeup_pair[0]);
   }
-#endif
+#endif /* ENABLE_WAKEUP && USE_RESOLV_THREADED */
+
   /* If the transfer has no connection, this is fine. Happens when
      called via curl_multi_remove_handle() => Curl_multi_ev_assess() =>
      Curl_multi_pollset(). */
@@ -1305,6 +1306,16 @@ CURLMcode curl_multi_fdset(CURLM *m,
   Curl_cshutdn_setfds(&multi->cshutdn, multi->admin,
                       read_fd_set, write_fd_set, &this_max_fd);
 
+#ifdef ENABLE_WAKEUP
+  /* If the the set is not empty and does not contain the wakeup
+   * socket already, add it so a poll can be interrupted. */
+  if((this_max_fd >= 0) && !FD_ISSET(multi->wakeup_pair[0], read_fd_set)) {
+    FD_SET(multi->wakeup_pair[0], read_fd_set);
+    if((int)multi->wakeup_pair[0] > this_max_fd)
+      this_max_fd = (int)multi->wakeup_pair[0];
+  }
+#endif
+
   *max_fd = this_max_fd;
   Curl_pollset_cleanup(&ps);
 
@@ -1349,6 +1360,14 @@ CURLMcode curl_multi_waitfds(CURLM *m,
   }
 
   need += Curl_cshutdn_add_waitfds(&multi->cshutdn, multi->admin, &cwfds);
+
+#ifdef ENABLE_WAKEUP
+  /* If the the set is not empty, add the wakeup socket. */
+  if(need) {
+    need += Curl_waitfds_add_sock(&cwfds, multi->wakeup_pair[0],
+                                  CURL_WAIT_POLLIN);
+  }
+#endif
 
   if(need != cwfds.n && ufds)
     mresult = CURLM_OUT_OF_MEMORY;

--- a/lib/select.c
+++ b/lib/select.c
@@ -439,7 +439,7 @@ void Curl_waitfds_init(struct Curl_waitfds *cwfds,
   cwfds->count = static_count;
 }
 
-static unsigned int cwfds_add_sock(struct Curl_waitfds *cwfds,
+unsigned int Curl_waitfds_add_sock(struct Curl_waitfds *cwfds,
                                    curl_socket_t sock, short events)
 {
   int i;
@@ -479,7 +479,7 @@ unsigned int Curl_waitfds_add_ps(struct Curl_waitfds *cwfds,
     if(ps->actions[i] & CURL_POLL_OUT)
       events |= CURL_WAIT_POLLOUT;
     if(events)
-      need += cwfds_add_sock(cwfds, ps->sockets[i], events);
+      need += Curl_waitfds_add_sock(cwfds, ps->sockets[i], events);
   }
   return need;
 }

--- a/lib/select.h
+++ b/lib/select.h
@@ -226,6 +226,8 @@ void Curl_waitfds_init(struct Curl_waitfds *cwfds,
                        struct curl_waitfd *static_wfds,
                        unsigned int static_count);
 
+unsigned int Curl_waitfds_add_sock(struct Curl_waitfds *cwfds,
+                                   curl_socket_t sock, short events);
 unsigned int Curl_waitfds_add_ps(struct Curl_waitfds *cwfds,
                                  struct easy_pollset *ps);
 

--- a/lib/thrdpool.c
+++ b/lib/thrdpool.c
@@ -384,6 +384,15 @@ static bool thrdpool_all_idle(struct curl_thrdpool *tpool)
   return TRUE;
 }
 
+bool Curl_thrdpool_is_busy(struct curl_thrdpool *tpool)
+{
+   bool busy = FALSE;
+  Curl_mutex_acquire(&tpool->lock);
+  busy = !thrdpool_all_idle(tpool);
+  Curl_mutex_release(&tpool->lock);
+  return busy;
+}
+
 CURLcode Curl_thrdpool_await_idle(struct curl_thrdpool *tpool,
                                   uint32_t timeout_ms)
 {

--- a/lib/thrdpool.h
+++ b/lib/thrdpool.h
@@ -87,6 +87,8 @@ void Curl_thrdpool_destroy(struct curl_thrdpool *tpool, bool join);
  */
 CURLcode Curl_thrdpool_signal(struct curl_thrdpool *tpool, uint32_t nthreads);
 
+bool Curl_thrdpool_is_busy(struct curl_thrdpool *tpool);
+
 CURLcode Curl_thrdpool_await_idle(struct curl_thrdpool *tpool,
                                   uint32_t timeout_ms);
 

--- a/lib/thrdqueue.c
+++ b/lib/thrdqueue.c
@@ -383,6 +383,21 @@ CURLcode Curl_thrdq_set_props(struct curl_thrdq *tqueue,
   return result;
 }
 
+bool Curl_thrdq_is_busy(struct curl_thrdq *tqueue)
+{
+  bool aborted = FALSE, busy = FALSE;
+  Curl_mutex_acquire(&tqueue->lock);
+  if(!tqueue->aborted) {
+    busy = Curl_llist_head(&tqueue->recvq) || Curl_llist_head(&tqueue->sendq);
+  }
+  else
+    aborted = TRUE;
+  Curl_mutex_release(&tqueue->lock);
+  if(!aborted && !busy)
+    busy = Curl_thrdpool_is_busy(tqueue->tpool);
+  return busy;
+}
+
 #ifdef CURLVERBOSE
 void Curl_thrdq_trace(struct curl_thrdq *tqueue,
                       struct Curl_easy *data)

--- a/lib/thrdqueue.h
+++ b/lib/thrdqueue.h
@@ -100,14 +100,13 @@ void Curl_thrdq_clear(struct curl_thrdq *tqueue,
                       Curl_thrdq_item_match_cb *fn_match,
                       void *match_data);
 
-CURLcode Curl_thrdq_await_done(struct curl_thrdq *tqueue,
-                               uint32_t timeout_ms);
-
 CURLcode Curl_thrdq_set_props(struct curl_thrdq *tqueue,
                               uint32_t max_len, /* 0 for unlimited */
                               uint32_t min_threads,
                               uint32_t max_threads,
                               uint32_t idle_time_ms);
+
+bool Curl_thrdq_is_busy(struct curl_thrdq *tqueue);
 
 #ifdef CURLVERBOSE
 void Curl_thrdq_trace(struct curl_thrdq *tqueue,


### PR DESCRIPTION
Only add the wakeup socket when:

1. the waitfds/fdset would not be empty otherwise
2. an async resolve with a thread queue is ongoing

refs #22050

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
