### PR TITLE
src: sync nghttp2 versions checks with current requirements

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -264,8 +264,7 @@ static int proxy_h2_client_new(struct Curl_cfilter *cf,
     return rc;
   /* We handle window updates ourself to enforce buffer limits */
   nghttp2_option_set_no_auto_window_update(o, 1);
-#if NGHTTP2_VERSION_NUM >= 0x013200
-  /* with 1.50.0 */
+#if NGHTTP2_VERSION_NUM >= 0x013200 /* with 1.50.0 */
   /* turn off RFC 9113 leading and trailing white spaces validation against
      HTTP field value. */
   nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation(o, 1);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -47,14 +47,11 @@
 #include "curlx/dynbuf.h"
 #include "headers.h"
 
-#if NGHTTP2_VERSION_NUM < 0x010c00
-#error too old nghttp2 version, upgrade!
+#if NGHTTP2_VERSION_NUM < 0x010f00
+#error "nghttp2 1.15.0 or greater required"
 #endif
 
-#if NGHTTP2_VERSION_NUM >= 0x010c00
 #define NGHTTP2_HAS_SET_LOCAL_WINDOW_SIZE 1
-#endif
-
 
 /* buffer dimensioning:
  * use 16K as chunk size, as that fits H2 DATA frames well */
@@ -463,8 +460,7 @@ static int h2_client_new(struct Curl_cfilter *cf,
     return rc;
   /* We handle window updates ourself to enforce buffer limits */
   nghttp2_option_set_no_auto_window_update(o, 1);
-#if NGHTTP2_VERSION_NUM >= 0x013200
-  /* with 1.50.0 */
+#if NGHTTP2_VERSION_NUM >= 0x013200 /* with 1.50.0 */
   /* turn off RFC 9113 leading and trailing white spaces validation against
      HTTP field value. */
   nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation(o, 1);


### PR DESCRIPTION
Also:
- drop a redundant check.
- make the in-source error informative.

Follow-up to 2900c29218d2d24ab519853589da84caa850e8c7 #11473

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
