### PR TITLE
GHA/windows: do `apt-get update` in clang-tidy cross-build job again

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -789,6 +789,7 @@ jobs:
           MATRIX_INSTALL_PACKAGES: '${{ matrix.install_packages }}'
         run: |
           sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+          sudo apt-get -o Dpkg::Use-Pty=0 update
           sudo apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32 ${MATRIX_INSTALL_PACKAGES}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Syncing with most similar uses in other workflows.

Fixing, e.g.:
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/l/
  llvm-toolchain-20/llvm-20-linker-tools_20.1.2-0ubuntu1%7e24.04.2_amd64.deb
  404  Not Found [IP: 172.66.152.176 443]
```
Ref: https://github.com/curl/curl/actions/runs/27682974841/job/81877061033?pr=22061

Follow-up to 1b8449674adb57ee0f60e761d654c69b20ee8fcf #14992

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
