### PR TITLE
GHA/linux: allow more time for `apt.repos.intel.com` install

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -829,7 +829,7 @@ jobs:
 
       - name: 'install Intel compilers'
         if: ${{ contains(matrix.build.install_steps, 'intelc') }}
-        timeout-minutes: 2
+        timeout-minutes: 4
         run: |
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \


### PR DESCRIPTION
Whether the install is extreme slow and will fail anyway, or only slower
sometimes, and this fixes, we will see.

Example:
```
Need to get 1159 MB of archives.
After this operation, 4463 MB of additional disk space will be used.
Get:1 https://apt.repos.intel.com/oneapi all/main all intel-oneapi-common-licensing-2023.2.0 all 2023.2.0-49462 [30.4 kB]
Get:2 https://apt.repos.intel.com/oneapi all/main all intel-oneapi-common-licensing-2026.0 all 2026.0.0-235 [30.7 kB]
[...]
Get:21 https://apt.repos.intel.com/oneapi all/main amd64 intel-oneapi-dpcpp-debugger-2023.2.0 amd64 2023.2.0-49330 [201 MB]
Error: The action 'install Intel compilers' has timed out after 2 minutes.
```
Ref: https://github.com/curl/curl/actions/runs/27683923870/job/81877924590

Follow-up to 50ff4f2927e3e319d39ba86bbcac3f57e5c89984 #21414
