### PR TITLE
xfers_really_alive

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -531,6 +531,8 @@ CURLMcode curl_multi_add_handle(CURLM *m, CURL *curl)
 
   /* set the easy handle */
   multistate(data, MSTATE_INIT);
+  /* not yet passed INIT state */
+  data->state.really_alive = FALSE;
 
 #ifdef USE_LIBPSL
   /* Do the same for PSL. */
@@ -851,6 +853,10 @@ CURLMcode curl_multi_remove_handle(CURLM *m, CURL *curl)
   /* If in `msgsent`, it was deducted from `multi->xfers_alive` already. */
   if(!Curl_uint32_bset_contains(&multi->msgsent, data->mid))
     --multi->xfers_alive;
+  if(data->state.really_alive) {
+    data->state.really_alive = FALSE;
+    --multi->xfers_really_alive;
+  }
 
   Curl_wildcard_dtor(&data->wildcard);
 
@@ -1151,7 +1157,9 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
   /* The admin handle always listens on the wakeup socket when there
    * are transfers alive. */
   if(data->multi && (data == data->multi->admin) &&
-     data->multi->xfers_alive) {
+     data->multi->xfers_really_alive) {
+    CURL_TRC_M(data, "adding wakeup, %u xfers really alive",
+               data->multi->xfers_really_alive);
     result = Curl_pollset_add_in(data, ps, data->multi->wakeup_pair[0]);
   }
 #endif
@@ -2459,6 +2467,10 @@ static void handle_completed(struct Curl_multi *multi,
   Curl_uint32_bset_remove(&multi->dirty, data->mid);
   Curl_uint32_bset_remove(&multi->pending, data->mid);
   Curl_uint32_bset_add(&multi->msgsent, data->mid);
+  if(data->state.really_alive) {
+    data->state.really_alive = FALSE;
+    --multi->xfers_really_alive;
+  }
   --multi->xfers_alive;
   if(!multi->xfers_alive)
     multi_assess_wakeup(multi);
@@ -2466,6 +2478,11 @@ static void handle_completed(struct Curl_multi *multi,
 
 static CURLMcode multistate_init(struct Curl_easy *data, CURLcode *result)
 {
+  if(!data->state.really_alive) {
+    data->state.really_alive = TRUE;
+    ++data->multi->xfers_really_alive;
+  }
+
   *result = Curl_pretransfer(data);
   if(*result)
     return CURLM_OK;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -572,12 +572,6 @@ CURLMcode curl_multi_add_handle(CURLM *m, CURL *curl)
     data->set.server_response_timeout;
   multi->admin->set.no_signal = data->set.no_signal;
 
-  mresult = multi_assess_wakeup(multi);
-  if(mresult) {
-    failf(data, "error enabling wakeup listening: %d", mresult);
-    return mresult;
-  }
-
   CURL_TRC_M(data, "added to multi, mid=%u, running=%u, total=%u",
              data->mid, Curl_multi_xfers_running(multi),
              Curl_uint32_tbl_count(&multi->xfers));
@@ -856,6 +850,13 @@ CURLMcode curl_multi_remove_handle(CURLM *m, CURL *curl)
   if(data->state.really_alive) {
     data->state.really_alive = FALSE;
     --multi->xfers_really_alive;
+    if(!multi->xfers_really_alive) {
+      mresult = multi_assess_wakeup(multi);
+      if(mresult) {
+        failf(data, "error disable wakeup listening: %d", mresult);
+        return mresult;
+      }
+    }
   }
 
   Curl_wildcard_dtor(&data->wildcard);
@@ -2470,6 +2471,8 @@ static void handle_completed(struct Curl_multi *multi,
   if(data->state.really_alive) {
     data->state.really_alive = FALSE;
     --multi->xfers_really_alive;
+    if(!multi->xfers_really_alive)
+      (void)multi_assess_wakeup(multi);
   }
   --multi->xfers_alive;
   if(!multi->xfers_alive)
@@ -2481,6 +2484,13 @@ static CURLMcode multistate_init(struct Curl_easy *data, CURLcode *result)
   if(!data->state.really_alive) {
     data->state.really_alive = TRUE;
     ++data->multi->xfers_really_alive;
+    if(data->multi->xfers_really_alive == 1) {
+      CURLMcode mresult = multi_assess_wakeup(data->multi);
+      if(mresult) {
+        failf(data, "error enabling wakeup listening: %d", mresult);
+        return mresult;
+      }
+    }
   }
 
   *result = Curl_pretransfer(data);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -850,13 +850,8 @@ CURLMcode curl_multi_remove_handle(CURLM *m, CURL *curl)
   if(data->state.really_alive) {
     data->state.really_alive = FALSE;
     --multi->xfers_really_alive;
-    if(!multi->xfers_really_alive) {
-      mresult = multi_assess_wakeup(multi);
-      if(mresult) {
-        failf(data, "error disable wakeup listening: %d", mresult);
-        return mresult;
-      }
-    }
+    if(!multi->xfers_really_alive)
+      (void)multi_assess_wakeup(multi);
   }
 
   Curl_wildcard_dtor(&data->wildcard);

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -85,6 +85,8 @@ struct Curl_multi {
 
   unsigned int xfers_alive; /* amount of added transfers that have
                                not yet reached COMPLETE state */
+  unsigned int xfers_really_alive; /* amount of added transfers that have
+                               passed INIT state but COMPLETE yet */
   curl_off_t xfers_total_ever; /* total of added transfers, ever. */
   struct uint32_tbl xfers; /* transfers added to this multi */
   /* Each transfer's mid may be present in at most one of these */

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -86,7 +86,7 @@ struct Curl_multi {
   unsigned int xfers_alive; /* amount of added transfers that have
                                not yet reached COMPLETE state */
   unsigned int xfers_really_alive; /* amount of added transfers that have
-                               passed INIT state but COMPLETE yet */
+                               passed INIT state but are not COMPLETE yet */
   curl_off_t xfers_total_ever; /* total of added transfers, ever. */
   struct uint32_tbl xfers; /* transfers added to this multi */
   /* Each transfer's mid may be present in at most one of these */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -704,11 +704,7 @@ struct UrlState {
   uint8_t httpreq; /* Curl_HttpReq; what kind of HTTP request (if any)
                             is this */
 
-  /* when curl_easy_perform() is called, the multi handle is "owned" by
-     the easy handle so curl_easy_cleanup() on such an easy handle will
-     also close the multi handle! */
-  BIT(multi_owned_by_easy);
-
+  BIT(really_alive); /* transfer is really alive in multi, passed INIT */
   BIT(this_is_a_follow); /* this is a followed Location: request */
   BIT(refused_stream); /* this was refused, try again */
   BIT(errorbuf); /* Set to TRUE if the error buffer is already filled in.

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -262,7 +262,7 @@ test2300 test2301 test2302 test2303 test2304 test2306 test2307 test2308 \
 test2309 test2310 test2311 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 test2407 \
-test2408 test2409 test2410 test2411 \
+test2408 test2409 test2410 test2411 test2412 \
 \
 test2500 test2501 test2502 test2503 test2504 test2505 test2506 \
 \

--- a/tests/data/test2412
+++ b/tests/data/test2412
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+multi
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6007
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+%repeat[1000 x foobar]%
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+wakeup
+</features>
+<server>
+http
+</server>
+<tool>
+lib%TESTNUMBER
+</tool>
+<name>
+checking curl_multi_waitfds on nothing to do
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/data/test2412
+++ b/tests/data/test2412
@@ -37,7 +37,7 @@ http
 lib%TESTNUMBER
 </tool>
 <name>
-checking curl_multi_waitfds on nothing to do
+checking curl_multi_fdset on nothing to do
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -115,6 +115,7 @@ TESTS_C = \
   lib2023.c lib2032.c lib2082.c \
   lib2301.c lib2302.c lib2304.c           lib2306.c lib2308.c lib2309.c \
   lib2402.c           lib2404.c lib2405.c \
+  lib2412.c \
   lib2502.c lib2504.c lib2505.c lib2506.c \
   lib2700.c \
   lib3010.c lib3025.c lib3026.c lib3027.c lib3033.c lib3034.c \

--- a/tests/libtest/lib2412.c
+++ b/tests/libtest/lib2412.c
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Dmitry Karpov <dkarpov1970@gmail.com>
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "first.h"
+
+
+static CURLcode test_lib2412(const char *URL)
+{
+  CURLcode result = CURLE_OK;
+  CURLM *multi = NULL;
+  CURL *easy = NULL;
+  CURLMcode rc;
+  fd_set readFdSet, writeFdSet, exceptFdSet;
+  int maxFd;
+
+  (void)URL;
+  global_init(CURL_GLOBAL_ALL);
+
+  easy = curl_easy_init();
+  if(!easy) {
+    curl_mfprintf(stderr, "curl_easy_init() failed\n");
+    result = TEST_ERR_MAJOR_BAD;
+    goto test_cleanup;
+  }
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
+  easy_setopt(easy, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(easy, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
+  easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+
+  multi = curl_multi_init();
+  if(!multi) {
+    curl_mfprintf(stderr, "curl_multi_init() failed\n");
+    result = TEST_ERR_MAJOR_BAD;
+    goto test_cleanup;
+  }
+
+  rc = curl_multi_add_handle(multi, easy);
+  if(rc) {
+    curl_mfprintf(stderr, "curl_multi_add_handle() failed: %d\n", rc);
+    result = TEST_ERR_MAJOR_BAD;
+    goto test_cleanup;
+  }
+
+  rc = curl_multi_fdset(multi, &readFdSet, &writeFdSet, &exceptFdSet,
+                        &maxFd);
+  if(rc) {
+    curl_mfprintf(stderr, "curl_multi_fdset() failed: %d\n", rc);
+    result = TEST_ERR_MAJOR_BAD;
+    goto test_cleanup;
+  }
+
+  if(maxFd == -1)
+    curl_mfprintf(stderr, "There are no file descriptors to wait for\n");
+  else {
+    curl_mfprintf(stderr, "libcurl supplied a file descriptor to "
+           "wait for (maxFd=%d).  Waiting now ...\n", maxFd);
+    result = TEST_ERR_FAILURE;
+  }
+
+test_cleanup:
+  if(multi)
+    curl_multi_cleanup(multi);
+  if(easy)
+    curl_easy_cleanup(easy);
+  curl_global_cleanup();
+  return result;
+}

--- a/tests/libtest/lib2412.c
+++ b/tests/libtest/lib2412.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include "first.h"
+#include "testtrace.h"
 
 static CURLcode test_lib2412(const char *URL)
 {

--- a/tests/libtest/lib2412.c
+++ b/tests/libtest/lib2412.c
@@ -24,7 +24,6 @@
 
 #include "first.h"
 
-
 static CURLcode test_lib2412(const char *URL)
 {
   CURLcode result = CURLE_OK;

--- a/tests/libtest/lib2412.c
+++ b/tests/libtest/lib2412.c
@@ -37,6 +37,13 @@ static CURLcode test_lib2412(const char *URL)
   (void)URL;
   global_init(CURL_GLOBAL_ALL);
 
+  multi = curl_multi_init();
+  if(!multi) {
+    curl_mfprintf(stderr, "curl_multi_init() failed\n");
+    result = TEST_ERR_MAJOR_BAD;
+    goto test_cleanup;
+  }
+
   easy = curl_easy_init();
   if(!easy) {
     curl_mfprintf(stderr, "curl_easy_init() failed\n");
@@ -49,13 +56,6 @@ static CURLcode test_lib2412(const char *URL)
   easy_setopt(easy, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(easy, CURLOPT_VERBOSE, 1L);
 
-  multi = curl_multi_init();
-  if(!multi) {
-    curl_mfprintf(stderr, "curl_multi_init() failed\n");
-    result = TEST_ERR_MAJOR_BAD;
-    goto test_cleanup;
-  }
-
   rc = curl_multi_add_handle(multi, easy);
   if(rc) {
     curl_mfprintf(stderr, "curl_multi_add_handle() failed: %d\n", rc);
@@ -63,6 +63,10 @@ static CURLcode test_lib2412(const char *URL)
     goto test_cleanup;
   }
 
+  FD_ZERO(&readFdSet);
+  FD_ZERO(&writeFdSet);
+  FD_ZERO(&exceptFdSet);
+  maxFd = -1;
   rc = curl_multi_fdset(multi, &readFdSet, &writeFdSet, &exceptFdSet,
                         &maxFd);
   if(rc) {
@@ -80,10 +84,12 @@ static CURLcode test_lib2412(const char *URL)
   }
 
 test_cleanup:
+  if(easy) {
+    curl_multi_remove_handle(multi, easy);
+    curl_easy_cleanup(easy);
+  }
   if(multi)
     curl_multi_cleanup(multi);
-  if(easy)
-    curl_easy_cleanup(easy);
   curl_global_cleanup();
   return result;
 }

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -29,6 +29,7 @@
  */
 
 #include "first.h"
+#include "testtrace.h"
 
 static struct t530_ctx {
   int socket_calls;
@@ -279,7 +280,6 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
   CURLM *multi = NULL;
   struct t530_ReadWriteSockets sockets = { { NULL, 0, 0 }, { NULL, 0, 0 } };
   int success = 0;
-  int iterations = 0;
   struct curltime timeout = { 0 };
   timeout.tv_sec = (time_t)-1;
 
@@ -301,6 +301,8 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
   easy_setopt(curl, CURLOPT_URL, URL);
 
   /* go verbose */
+  easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
+  easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   multi_init(multi);
@@ -324,7 +326,6 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
     struct timeval tv = { 0 };
     tv.tv_sec = 10;
 
-    ++iterations;
     FD_ZERO(&readSet);
     FD_ZERO(&writeSet);
     t530_updateFdSet(&sockets.read, &readSet, &maxFd);
@@ -340,8 +341,7 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
       tv.tv_usec = 100000;
     }
 
-    if(iterations > 1)
-      assert(maxFd);
+    assert(maxFd);
     select_test((int)maxFd, &readSet, &writeSet, NULL, &tv);
 
     /* Check the sockets for reading / writing */

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -279,6 +279,7 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
   CURLM *multi = NULL;
   struct t530_ReadWriteSockets sockets = { { NULL, 0, 0 }, { NULL, 0, 0 } };
   int success = 0;
+  int iterations = 0;
   struct curltime timeout = { 0 };
   timeout.tv_sec = (time_t)-1;
 
@@ -323,6 +324,7 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
     struct timeval tv = { 0 };
     tv.tv_sec = 10;
 
+    ++iterations;
     FD_ZERO(&readSet);
     FD_ZERO(&writeSet);
     t530_updateFdSet(&sockets.read, &readSet, &maxFd);
@@ -338,7 +340,8 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
       tv.tv_usec = 100000;
     }
 
-    assert(maxFd);
+    if(iterations > 1)
+      assert(maxFd);
     select_test((int)maxFd, &readSet, &writeSet, NULL, &tv);
 
     /* Check the sockets for reading / writing */


### PR DESCRIPTION
Yes, we were counting the "live" transfers before, but were they *really* alive?

When determining to add the wakeup socket to fdset/waitfds etc, we should only do that when the multi handle is actually processing transfers. Other wise, the application could wait on the wakeup socket forever.

For this, we counted `multi->xfers_alive` (e.g. the "running" number returned by `curl_multi_perform()`). This was almost correct.

The problem is that added easy handles are counted as "alive" right away on the addition. But the processing has not started yet. They did not trigger any DNS resolves or opened any sockets yet.

Add two fields in multi and easy handle:

* `multi->xfers_really_alive`: counts the "alive" transfers that have passed `MSTATE_INIT` (at least once)
* `data->state.really_alive`: to track if the transfer has been counted

Add test2412 to check that adding transfers without perform will not trigger the wakeup socket to be added.

refs #22050
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
