### PR TITLE
GHA/linux: give more time for `apt-get install`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -455,7 +455,7 @@ jobs:
     steps:
       - name: 'install prereqs'
         if: ${{ matrix.build.container == null && !contains(matrix.build.name, 'i686') }}
-        timeout-minutes: 2
+        timeout-minutes: 3
         env:
           INSTALL_PACKAGES_BREW: '${{ matrix.build.install_steps_brew }}'
           INSTALL_PACKAGES: >-


### PR DESCRIPTION
3 minutes (was: 2).

IIn the hope it fixes timeouts, assuming the Ubuntu mirrors are only
somewhat slower sometimes (and not completely stalled).

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
