### PR TITLE
cookie: reject control octets in cookies loaded from a file

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -786,6 +786,14 @@ static CURLcode parse_netscape(struct Cookie *co,
     /* we did not find the sufficient number of fields */
     return CURLE_OK;
 
+  /* Reject control octets in the name or value, matching the filtering done
+     for cookies set over HTTP. A cookie loaded from a file is later sent in
+     request headers, so the same bytes that make a server reject a request
+     must not slip in through the file. */
+  if(invalid_octets(co->name, strlen(co->name)) ||
+     invalid_octets(co->value, strlen(co->value)))
+    return CURLE_OK;
+
   *okay = TRUE;
   return CURLE_OK;
 }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -259,7 +259,7 @@ test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 test2208 \
 \
 test2300 test2301 test2302 test2303 test2304 test2306 test2307 test2308 \
-test2309 test2310 \
+test2309 test2310 test2311 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 test2407 \
 test2408 test2409 test2410 test2411 \

--- a/tests/data/test2311
+++ b/tests/data/test2311
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP proxy
+cookies
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+Server: test-server/fake
+Content-Length: 21
+
+This server says moo
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Cookie from file with control octet in value is rejected
+</name>
+<command>
+http://example.fake/%TESTNUMBER -b %LOGDIR/injar%TESTNUMBER -x %HOSTIP:%HTTPPORT
+</command>
+<file name="%LOGDIR/injar%TESTNUMBER">
+example.fake	FALSE	/	FALSE	0	clean	good
+example.fake	FALSE	/	FALSE	0	bad	%hex[ba%07d]hex%
+</file>
+<features>
+cookies
+proxy
+</features>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://example.fake/%TESTNUMBER HTTP/1.1
+Host: example.fake
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+Cookie: clean=good
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
`parse_netscape()` in `lib/cookie.c` copies the cookie name and value straight out of the file without the `invalid_octets()` filtering that a `Set-Cookie` header goes through. A cookie file whose value holds a control byte (anything `0x01`-`0x1f` or `0x7f`) is loaded and then written verbatim into the outgoing `Cookie` request header, the very bytes that make some servers reject the request and that the HTTP path already drops.

Apply the same `invalid_octets()` check on the file path, dropping the cookie when its name or value carries a control octet. Putting it in the loader keeps both ingestion paths agreeing on what a valid cookie looks like instead of leaning on the send path to cope. `test2311` loads a jar with a `0x07` byte in one value and verifies only the clean cookie reaches the wire.