### PR TITLE
cmake/FindGSS: drop "MIT Unknown" version value, related tidy ups

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -25,14 +25,13 @@
 #
 # Input variables:
 #
-# - `GSS_ROOT_DIR`: Absolute path to the root installation of GSS. (also supported as environment)
+# - `GSS_ROOT_DIR`:  Absolute path to the root installation of GSS. (also supported as environment)
 #
 # Defines:
 #
-# - `GSS_FOUND`:    System has a GSS library.
-# - `GSS_VERSION`:  This is set to version advertised by pkg-config or read from manifest.
-#                   In case the library is found but no version info available it is set to "unknown"
-# - `CURL::gss`:    GSS library target.
+# - `GSS_FOUND`:     System has GSS.
+# - `GSS_VERSION`:   Version of GSS.
+# - `CURL::gss`:     GSS library target.
 #   - `INTERFACE_CURL_GSS_FLAVOR`: Custom property. "GNU" or "MIT" if detected.
 
 set(_gnu_modname "gss")
@@ -210,7 +209,7 @@ endif()
 set(GSS_VERSION ${_gss_version})
 
 if(NOT GSS_VERSION)
-  if(_gss_flavor STREQUAL "MIT")
+  if(_gss_flavor STREQUAL "MIT" AND WIN32)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
       cmake_host_system_information(RESULT _mit_version QUERY WINDOWS_REGISTRY
         "HKLM/SOFTWARE/MIT/Kerberos/SDK/CurrentVersion" VALUE "VersionString")
@@ -218,12 +217,8 @@ if(NOT GSS_VERSION)
       get_filename_component(_mit_version
         "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MIT\\Kerberos\\SDK\\CurrentVersion;VersionString]" NAME CACHE)
     endif()
-    if(WIN32 AND _mit_version)
-      set(GSS_VERSION "${_mit_version}")
-    else()
-      set(GSS_VERSION "MIT Unknown")
-    endif()
-  else()  # GNU
+    set(GSS_VERSION "${_mit_version}")
+  elseif(_gss_flavor STREQUAL "GNU")
     if(_gss_INCLUDE_DIRS AND EXISTS "${_gss_INCLUDE_DIRS}/gss.h")
       set(_version_regex "#[\t ]*define[\t ]+GSS_VERSION[\t ]+\"([^\"]*)\"")
       file(STRINGS "${_gss_INCLUDE_DIRS}/gss.h" _version_str REGEX "${_version_regex}")


### PR DESCRIPTION
After this patch the `GSS_VERSION` value is left empty in all cases when
there is known version number (potentially on Windows).

Also:
- sync `GSS_FOUND` comment with other Find modules.
- sync `GSS_VERSION` comment with other Find modules, drop the promise
  of returning "unknown", which was not true and also not done by other
  Find modules.
- tidy up Windows-registry-based MIT `GSS_VERSION` detection, by
  guarding the whole block for `WIN32`.
- drop fallback version value `MIT Unknown` used for MIT.
- fix vertical alignment in comment block.

Changing CMake log output like so (in affected config):
```
-- Found GSS: MIT (found version "MIT Unknown")
```
→
```
-- Found GSS: MIT
```

Spotted by Copilot
Bug: https://github.com/curl/curl/pull/22052#discussion_r3429273238
Follow-up to 558814e16d84aa202c5ccc0c8108a9d728e77a58
