### PR TITLE
cmake/FindGSS: drop CMake <3.16 compatibility logic

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -192,12 +192,10 @@ if(NOT _gss_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     message(FATAL_ERROR "GNU or MIT GSS is required")
   endif()
 else()
-  # _gss_MODULE_NAME set since CMake 3.16.
-  # _pkg_check_modules_pkg_name is undocumented and used as a fallback for CMake <3.16 versions.
-  if(_gss_MODULE_NAME STREQUAL _gnu_modname OR _pkg_check_modules_pkg_name STREQUAL _gnu_modname)
+  if(_gss_MODULE_NAME STREQUAL _gnu_modname)
     set(_gss_flavor "GNU")
     set(_gss_pc_requires ${_gnu_modname})
-  elseif(_gss_MODULE_NAME STREQUAL _mit_modname OR _pkg_check_modules_pkg_name STREQUAL _mit_modname)
+  elseif(_gss_MODULE_NAME STREQUAL _mit_modname)
     set(_gss_flavor "MIT")
     set(_gss_pc_requires ${_mit_modname})
   else()


### PR DESCRIPTION
Redundant since bumping minimum to 3.18.

Follow-up to 89043ba90689418a115e967633e261139b48ce23 #20407
Follow-up to 1f112242323848d0ebfc88ae97b139d18e7987f6 #18950

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
