### PR TITLE
GHA/linux: drop arm runner home attribute workaround (fixed upstream)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -475,12 +475,6 @@ jobs:
           if [ -n "${INSTALL_PACKAGES_BREW}" ]; then
             /home/linuxbrew/.linuxbrew/bin/brew install ${INSTALL_PACKAGES_BREW}
           fi
-          # Workaround for ubuntu-24.04-arm images having 0777 for /home/runner,
-          # which breaks the test sshd server used in pytest.
-          #if [[ "$(uname -m)" = *'aarch64'* ]]; then
-            ls -l /home
-          #  chmod 0755 /home/runner
-          #fi
 
       - name: 'install prereqs (i686)'
         if: ${{ contains(matrix.build.name, 'i686') }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -477,10 +477,10 @@ jobs:
           fi
           # Workaround for ubuntu-24.04-arm images having 0777 for /home/runner,
           # which breaks the test sshd server used in pytest.
-          if [[ "$(uname -m)" = *'aarch64'* ]]; then
+          #if [[ "$(uname -m)" = *'aarch64'* ]]; then
             ls -l /home
-            chmod 0755 /home/runner
-          fi
+          #  chmod 0755 /home/runner
+          #fi
 
       - name: 'install prereqs (i686)'
         if: ${{ contains(matrix.build.name, 'i686') }}


### PR DESCRIPTION
Issue had been fixed in the ubuntu-24.04-arm runner image upstream.

now:
```
$ ls -l /home  # on arm
drwxr-x---  11 runner runner 4096 Jun 18 08:19 runner

$ ls -l /home  # on intel
drwxr-x---  11 runner runner 4096 Jun 18 08:19 runner
```

Follow-up to 2b0d8dcc16c531d3154ab54347a3eaabf9bd2c7d #20231
