### PR TITLE
GHA/linux: use default GCC compiler, drop `CC`/`CXX` envs

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -35,8 +35,6 @@ env:
   MAKEFLAGS: -j 5
   CURL_CI: github
   CURL_TEST_MIN: 1850
-  CC: gcc-12
-  CXX: g++-12
   DO_NOT_TRACK: '1'
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   AWSLC_VERSION: 5.0.0


### PR DESCRIPTION
At the time of the original commit, the runner was ubuntu-22.04 with
a default GCC 11. It made sense to bump to 12 manually. Since 2025,
the default is ubuntu-24.04 with GCC 13, when this became a downgrade.

Drop manual envs and bump to GCC 13 with it. Other options available are
14, 15 and 16.

Refs:
https://packages.ubuntu.com/jammy/gcc (ubuntu-22.04)
https://packages.ubuntu.com/noble/gcc (ubuntu-24.04)

Follow-up to 6079ff314b059c48f560065cdbe6da8334961e2b #22075
Follow-up to a8174176b5425c5692b55b78e40aef3a2331155f #13841
