### PR TITLE
https-rr: add resolves for all relevant peers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,7 +295,6 @@ if(CURL_GCC_ANALYZER AND CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER
   list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-infinite-loop")
   list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-malloc-leak")
   list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-out-of-bounds")
-  list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-deref-before-check")
 endif()
 
 option(CURL_CODE_COVERAGE "Enable code coverage build options" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ if(CURL_GCC_ANALYZER AND CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER
   list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-infinite-loop")
   list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-malloc-leak")
   list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-out-of-bounds")
+  list(APPEND CURL_ANALYZER_CFLAGS "-Wno-analyzer-deref-before-check")
 endif()
 
 option(CURL_CODE_COVERAGE "Enable code coverage build options" OFF)

--- a/lib/asyn-base.c
+++ b/lib/asyn-base.c
@@ -256,9 +256,10 @@ CURLcode Curl_async_failed(struct Curl_easy *data,
   }
 #endif
 
-  failf(data, "Could not resolve %s: %s%s%s%s",
-        host_or_proxy, async->hostname,
-        detail ? " (" : "", detail ? detail : "", detail ? ")" : "");
+  if(async->dns_queries & (CURL_DNSQ_A|CURL_DNSQ_AAAA))
+    failf(data, "Could not resolve %s: %s%s%s%s",
+          host_or_proxy, async->hostname,
+          detail ? " (" : "", detail ? detail : "", detail ? ")" : "");
   return result;
 }
 

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -638,6 +638,9 @@ CURLcode Curl_async_getaddrinfo(struct Curl_easy *data,
 #endif
 
 out:
+  if(!async->queries_ongoing)
+    async->done = TRUE;
+
   if(result)
     CURL_TRC_DNS(data, "error queueing query %s:%d -> %d",
                  async->hostname, async->port, (int)result);

--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -730,22 +730,32 @@ CURLcode Curl_async_take_result(struct Curl_easy *data,
       result = CURLE_OUT_OF_MEMORY;
       goto out;
     }
+  }
 
 #ifdef USE_HTTPSRR_ARES
-    if(thrdd->rr.channel) {
-      struct Curl_https_rrinfo *lhrr = NULL;
-      if(thrdd->rr.hinfo.complete) {
-        lhrr = Curl_httpsrr_dup_move(&thrdd->rr.hinfo);
-        if(!lhrr) {
-          result = CURLE_OUT_OF_MEMORY;
-          goto out;
-        }
+  if(thrdd->rr.channel) {
+    struct Curl_https_rrinfo *lhrr = NULL;
+    if(thrdd->rr.hinfo.complete) {
+      lhrr = Curl_httpsrr_dup_move(&thrdd->rr.hinfo);
+      if(!lhrr) {
+        result = CURLE_OUT_OF_MEMORY;
+        goto out;
       }
-      Curl_httpsrr_trace(data, lhrr);
-      Curl_dns_entry_set_https_rr(dns, lhrr);
     }
-#endif
+    Curl_httpsrr_trace(data, lhrr);
+    if(!dns && lhrr) {
+      dns = Curl_dnscache_mk_entry2(
+        data, async->dns_queries, NULL, NULL,
+        async->hostname, async->port);
+      if(!dns) {
+        result = CURLE_OUT_OF_MEMORY;
+        goto out;
+      }
+    }
+    if(dns)
+      Curl_dns_entry_set_https_rr(dns, lhrr);
   }
+#endif
 
   if(dns) {
     *pdns = dns;

--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -201,7 +201,8 @@ static CURLcode cf_dns_start(struct Curl_cfilter *cf,
   }
   else {
     DEBUGASSERT(result);
-    failf(data, "Could not resolve: %s", ctx->peer->hostname);
+    if(ctx->dns_queries & (CURL_DNSQ_A|CURL_DNSQ_AAAA))
+      failf(data, "Could not resolve: %s", ctx->peer->hostname);
     return result;
   }
 }
@@ -246,6 +247,7 @@ static CURLcode cf_dns_connect(struct Curl_cfilter *cf,
                                bool *done)
 {
   struct cf_dns_ctx *ctx = cf->ctx;
+  bool ip_query = (ctx->dns_queries & (CURL_DNSQ_A|CURL_DNSQ_AAAA));
 
   if(cf->connected) {
     *done = TRUE;
@@ -263,12 +265,13 @@ static CURLcode cf_dns_connect(struct Curl_cfilter *cf,
       Curl_resolv_take_result(data, ctx->resolv_id, &ctx->dns);
   }
 
-  if(ctx->resolv_result) {
+  if(ctx->resolv_result && ip_query) {
+    /* failing A|AAAA resolves is a hard failure. */
     CURL_TRC_CF(data, cf, "error resolving: %d", (int)ctx->resolv_result);
     return ctx->resolv_result;
   }
 
-  if(ctx->dns && !ctx->announced) {
+  if(ctx->dns && ip_query && !ctx->announced) {
     ctx->announced = TRUE;
     if(cf->sockindex == FIRSTSOCKET) {
       cf->conn->bits.dns_resolved = TRUE;
@@ -397,12 +400,12 @@ out:
 
 /* Adds a "resolv" filter at the top of the connection's filter chain.
  * The filter will resolve the peer on the first connect attempt. */
-CURLcode Curl_cf_dns_add(struct Curl_easy *data,
-                         struct connectdata *conn,
-                         int sockindex,
-                         struct Curl_peer *peer,
-                         uint8_t dns_queries,
-                         uint8_t transport)
+static CURLcode cf_dns_add(struct Curl_easy *data,
+                           struct connectdata *conn,
+                           int sockindex,
+                           struct Curl_peer *peer,
+                           uint8_t dns_queries,
+                           uint8_t transport)
 {
   struct Curl_cfilter *cf = NULL;
   bool for_proxy = FALSE;
@@ -432,8 +435,8 @@ out:
  */
 CURLcode Curl_cf_dns_insert_after(struct Curl_cfilter *cf_at,
                                   struct Curl_easy *data,
-                                  uint8_t dns_queries,
                                   struct Curl_peer *peer,
+                                  uint8_t dns_queries,
                                   uint8_t transport,
                                   bool complete_resolve)
 {
@@ -591,6 +594,57 @@ bool Curl_conn_dns_resolved_https(struct Curl_easy *data,
     }
   }
   return TRUE;
+}
+
+CURLcode Curl_conn_dns_add_resolve(struct Curl_easy *data,
+                                   struct connectdata *conn,
+                                   int sockindex,
+                                   struct Curl_peer *peer,
+                                   uint8_t dns_queries,
+                                   uint8_t transport)
+{
+  struct Curl_cfilter *cf = data->conn->cfilter[sockindex];
+  struct Curl_cfilter *cf_dns = NULL;
+
+  CURL_TRC_DNS(data, "add resolve for %s:%u, queries=%x",
+               peer->hostname, peer->port, dns_queries);
+  if((dns_queries & CURL_DNSQ_HTTPS) &&
+     Curl_is_ipaddr(peer->hostname)) {
+    CURL_TRC_DNS(data, "ignoring HTTPS query for IP");
+    dns_queries &= (uint8_t)~CURL_DNSQ_HTTPS;
+  }
+
+  for(; cf && dns_queries; cf = cf->next) {
+    if(cf->cft == &Curl_cft_dns) {
+      struct cf_dns_ctx *ctx = cf->ctx;
+      cf_dns = cf;
+      if(Curl_peer_same_destination(ctx->peer, peer)) {
+        /* substract queries already being scheduled/ongoing */
+        dns_queries = (uint8_t)(~ctx->dns_queries & dns_queries);
+        if(!dns_queries) { /* already there */
+          return CURLE_OK;
+        }
+        else if(!ctx->started) { /* not yet started, we can add */
+          ctx->dns_queries |= dns_queries;
+          return CURLE_OK;
+        }
+      }
+    }
+  }
+
+  if(dns_queries) {
+    /* No existing filter is handling these, add a new DNS filter
+     * (after the last one if there was one already. First come
+     * first should start respolving). */
+    if(cf_dns) {
+      return Curl_cf_dns_insert_after(cf_dns, data, peer,
+                                      dns_queries, transport, FALSE);
+    }
+    else
+      return cf_dns_add(data, conn, sockindex, peer,
+                        dns_queries, transport);
+  }
+  return CURLE_OK;
 }
 
 #endif /* USE_HTTPSRR */

--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -475,7 +475,7 @@ CURLcode Curl_conn_dns_add_resolve(struct Curl_easy *data,
       struct cf_dns_ctx *ctx = cf->ctx;
       cf_dns = cf;
       if(Curl_peer_same_destination(ctx->peer, peer)) {
-        /* substract queries already being scheduled/ongoing */
+        /* subtract queries already being scheduled/ongoing */
         dns_queries = (uint8_t)(~ctx->dns_queries & dns_queries);
         if(!dns_queries) { /* already there */
           return CURLE_OK;

--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -467,7 +467,7 @@ CURLcode Curl_conn_dns_add_resolve(struct Curl_easy *data,
   if((dns_queries & CURL_DNSQ_HTTPS) &&
      Curl_is_ipaddr(peer->hostname)) {
     CURL_TRC_DNS(data, "ignoring HTTPS query for IP");
-    dns_queries &= (uint8_t)~CURL_DNSQ_HTTPS;
+    dns_queries = (uint8_t)(dns_queries & ~CURL_DNSQ_HTTPS);
   }
 
   for(; cf && dns_queries; cf = cf->next) {

--- a/lib/cf-dns.c
+++ b/lib/cf-dns.c
@@ -452,6 +452,57 @@ CURLcode Curl_cf_dns_insert_after(struct Curl_cfilter *cf_at,
   return CURLE_OK;
 }
 
+CURLcode Curl_conn_dns_add_resolve(struct Curl_easy *data,
+                                   struct connectdata *conn,
+                                   int sockindex,
+                                   struct Curl_peer *peer,
+                                   uint8_t dns_queries,
+                                   uint8_t transport)
+{
+  struct Curl_cfilter *cf = data->conn->cfilter[sockindex];
+  struct Curl_cfilter *cf_dns = NULL;
+
+  CURL_TRC_DNS(data, "add resolve for %s:%u, queries=%x",
+               peer->hostname, peer->port, dns_queries);
+  if((dns_queries & CURL_DNSQ_HTTPS) &&
+     Curl_is_ipaddr(peer->hostname)) {
+    CURL_TRC_DNS(data, "ignoring HTTPS query for IP");
+    dns_queries &= (uint8_t)~CURL_DNSQ_HTTPS;
+  }
+
+  for(; cf && dns_queries; cf = cf->next) {
+    if(cf->cft == &Curl_cft_dns) {
+      struct cf_dns_ctx *ctx = cf->ctx;
+      cf_dns = cf;
+      if(Curl_peer_same_destination(ctx->peer, peer)) {
+        /* substract queries already being scheduled/ongoing */
+        dns_queries = (uint8_t)(~ctx->dns_queries & dns_queries);
+        if(!dns_queries) { /* already there */
+          return CURLE_OK;
+        }
+        else if(!ctx->started) { /* not yet started, we can add */
+          ctx->dns_queries |= dns_queries;
+          return CURLE_OK;
+        }
+      }
+    }
+  }
+
+  if(dns_queries) {
+    /* No existing filter is handling these, add a new DNS filter
+     * (after the last one if there was one already. First come
+     * first should start respolving). */
+    if(cf_dns) {
+      return Curl_cf_dns_insert_after(cf_dns, data, peer,
+                                      dns_queries, transport, FALSE);
+    }
+    else
+      return cf_dns_add(data, conn, sockindex, peer,
+                        dns_queries, transport);
+  }
+  return CURLE_OK;
+}
+
 /* Return the resolv result from the first "resolv" filter, starting
  * the given filter `cf` downwards.
  */
@@ -594,57 +645,6 @@ bool Curl_conn_dns_resolved_https(struct Curl_easy *data,
     }
   }
   return TRUE;
-}
-
-CURLcode Curl_conn_dns_add_resolve(struct Curl_easy *data,
-                                   struct connectdata *conn,
-                                   int sockindex,
-                                   struct Curl_peer *peer,
-                                   uint8_t dns_queries,
-                                   uint8_t transport)
-{
-  struct Curl_cfilter *cf = data->conn->cfilter[sockindex];
-  struct Curl_cfilter *cf_dns = NULL;
-
-  CURL_TRC_DNS(data, "add resolve for %s:%u, queries=%x",
-               peer->hostname, peer->port, dns_queries);
-  if((dns_queries & CURL_DNSQ_HTTPS) &&
-     Curl_is_ipaddr(peer->hostname)) {
-    CURL_TRC_DNS(data, "ignoring HTTPS query for IP");
-    dns_queries &= (uint8_t)~CURL_DNSQ_HTTPS;
-  }
-
-  for(; cf && dns_queries; cf = cf->next) {
-    if(cf->cft == &Curl_cft_dns) {
-      struct cf_dns_ctx *ctx = cf->ctx;
-      cf_dns = cf;
-      if(Curl_peer_same_destination(ctx->peer, peer)) {
-        /* substract queries already being scheduled/ongoing */
-        dns_queries = (uint8_t)(~ctx->dns_queries & dns_queries);
-        if(!dns_queries) { /* already there */
-          return CURLE_OK;
-        }
-        else if(!ctx->started) { /* not yet started, we can add */
-          ctx->dns_queries |= dns_queries;
-          return CURLE_OK;
-        }
-      }
-    }
-  }
-
-  if(dns_queries) {
-    /* No existing filter is handling these, add a new DNS filter
-     * (after the last one if there was one already. First come
-     * first should start respolving). */
-    if(cf_dns) {
-      return Curl_cf_dns_insert_after(cf_dns, data, peer,
-                                      dns_queries, transport, FALSE);
-    }
-    else
-      return cf_dns_add(data, conn, sockindex, peer,
-                        dns_queries, transport);
-  }
-  return CURLE_OK;
 }
 
 #endif /* USE_HTTPSRR */

--- a/lib/cf-dns.h
+++ b/lib/cf-dns.h
@@ -31,17 +31,17 @@ struct Curl_dns_entry;
 struct Curl_addrinfo;
 struct Curl_peer;
 
-CURLcode Curl_cf_dns_add(struct Curl_easy *data,
-                         struct connectdata *conn,
-                         int sockindex,
-                         struct Curl_peer *peer,
-                         uint8_t dns_queries,
-                         uint8_t transport);
+CURLcode Curl_conn_dns_add_resolve(struct Curl_easy *data,
+                                   struct connectdata *conn,
+                                   int sockindex,
+                                   struct Curl_peer *peer,
+                                   uint8_t dns_queries,
+                                   uint8_t transport);
 
 CURLcode Curl_cf_dns_insert_after(struct Curl_cfilter *cf_at,
                                   struct Curl_easy *data,
-                                  uint8_t dns_queries,
                                   struct Curl_peer *peer,
+                                  uint8_t dns_queries,
                                   uint8_t transport,
                                   bool complete_resolve);
 

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -110,6 +110,7 @@ static CURLcode cf_hc_baller_cntrl(struct cf_hc_baller *b,
 
 struct cf_hc_ctx {
   cf_hc_state state;
+  struct Curl_peer *destination; /* who we ultimately want to talk to */
   struct curltime started;  /* when connect started */
   CURLcode result;          /* overall result */
   CURLcode check_h3_result;
@@ -123,21 +124,14 @@ struct cf_hc_ctx {
   BIT(ballers_complete);
 };
 
-static void cf_hc_ctx_close(struct Curl_easy *data,
-                            struct cf_hc_ctx *ctx)
+static void cf_hc_ctx_destroy(struct Curl_easy *data,
+                              struct cf_hc_ctx *ctx)
 {
   if(ctx) {
     size_t i;
     for(i = 0; i < ctx->baller_count; ++i)
       cf_hc_baller_discard(&ctx->ballers[i], data);
-  }
-}
-
-static void cf_hc_ctx_destroy(struct Curl_easy *data,
-                              struct cf_hc_ctx *ctx)
-{
-  if(ctx) {
-    cf_hc_ctx_close(data, ctx);
+    Curl_peer_unlink(&ctx->destination);
     curlx_free(ctx);
   }
 }
@@ -222,7 +216,6 @@ static CURLcode baller_connected(struct Curl_cfilter *cf,
   ctx->state = CF_HC_SUCCESS;
   cf->connected = TRUE;
 
-  cf_hc_ctx_close(data, ctx);
   /* ballers may have failf()'d, the winner resets it, so our
    * errorbuf is clean again. */
   Curl_reset_fail(data);
@@ -296,6 +289,7 @@ static enum alpnid cf_hc_get_httpsrr_alpn(struct Curl_cfilter *cf,
                                           enum alpnid not_this_one)
 {
 #ifdef USE_HTTPSRR
+  struct cf_hc_ctx *ctx = cf->ctx;
   /* Is there an HTTPSRR use its ALPNs here.
    * We are here after having selected a connection to a host+port and
    * can no longer change that. Any HTTPSRR advice for other hosts and ports
@@ -304,8 +298,7 @@ static enum alpnid cf_hc_get_httpsrr_alpn(struct Curl_cfilter *cf,
   size_t i;
 
   /* Do we have HTTPS-RR information? */
-  rr = Curl_conn_dns_get_https(
-    data, cf->sockindex, Curl_conn_get_destination(cf->conn, cf->sockindex));
+  rr = Curl_conn_dns_get_https(data, cf->sockindex, ctx->destination);
 
   /* We do not support `rr->no_def_alpn`. */
   if(Curl_httpsrr_applicable(data, rr) && !rr->no_def_alpn) {
@@ -495,7 +488,7 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
 
   if(!ctx->httpsrr_resolved) {
     ctx->httpsrr_resolved = Curl_conn_dns_resolved_https(
-      data, cf->sockindex, Curl_conn_get_destination(cf->conn, cf->sockindex));
+      data, cf->sockindex, ctx->destination);
 #ifdef DEBUGBUILD
     if(!ctx->httpsrr_resolved && getenv("CURL_DBG_AWAIT_HTTPSRR")) {
       CURL_TRC_CF(data, cf, "awaiting HTTPS-RR");
@@ -761,6 +754,7 @@ struct Curl_cftype Curl_cft_http_connect = {
 
 static CURLcode cf_hc_create(struct Curl_cfilter **pcf,
                              struct Curl_easy *data,
+                             struct Curl_peer *destination,
                              uint8_t def_transport)
 {
   struct Curl_cfilter *cf = NULL;
@@ -772,6 +766,7 @@ static CURLcode cf_hc_create(struct Curl_cfilter **pcf,
     result = CURLE_OUT_OF_MEMORY;
     goto out;
   }
+  Curl_peer_link(&ctx->destination, destination);
   ctx->def_transport = def_transport;
   ctx->hard_eyeballs_timeout_ms = data->set.happy_eyeballs_timeout;
   ctx->soft_eyeballs_timeout_ms = data->set.happy_eyeballs_timeout / 2;
@@ -788,6 +783,7 @@ out:
 }
 
 static CURLcode cf_hc_add(struct Curl_easy *data,
+                          struct Curl_peer *destination,
                           struct connectdata *conn,
                           int sockindex,
                           uint8_t def_transport)
@@ -796,7 +792,7 @@ static CURLcode cf_hc_add(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
 
   DEBUGASSERT(data);
-  result = cf_hc_create(&cf, data, def_transport);
+  result = cf_hc_create(&cf, data, destination, def_transport);
   if(result)
     goto out;
   Curl_conn_cf_add(data, conn, sockindex, cf);
@@ -805,6 +801,7 @@ out:
 }
 
 CURLcode Curl_cf_https_setup(struct Curl_easy *data,
+                             struct Curl_peer *destination,
                              struct connectdata *conn,
                              int sockindex)
 {
@@ -821,7 +818,8 @@ CURLcode Curl_cf_https_setup(struct Curl_easy *data,
      !conn->bits.tls_enable_alpn)
     goto out;
 
-  result = cf_hc_add(data, conn, sockindex, conn->transport_wanted);
+  result = cf_hc_add(data, destination, conn, sockindex,
+                     conn->transport_wanted);
 
 out:
   return result;

--- a/lib/cf-https-connect.h
+++ b/lib/cf-https-connect.h
@@ -31,10 +31,12 @@ struct Curl_cfilter;
 struct Curl_easy;
 struct connectdata;
 struct Curl_cftype;
+struct Curl_peer;
 
 extern struct Curl_cftype Curl_cft_http_connect;
 
 CURLcode Curl_cf_https_setup(struct Curl_easy *data,
+                             struct Curl_peer *destination,
                              struct connectdata *conn,
                              int sockindex);
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -246,22 +246,23 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
                          int sockindex,
                          int ssl_mode)
 {
+  struct Curl_peer *first_peer = Curl_conn_get_first_peer(conn, sockindex);
+  struct Curl_peer *destination = Curl_conn_get_destination(conn, sockindex);
   CURLcode result = CURLE_OK;
-  struct Curl_peer *peer = Curl_conn_get_first_peer(conn, sockindex);
   uint8_t dns_queries;
 
   DEBUGASSERT(data);
   DEBUGASSERT(conn->scheme);
   DEBUGASSERT(!conn->cfilter[sockindex]);
 
-  if(!peer)
+  if(!first_peer)
     return CURLE_FAILED_INIT;
 
 #ifndef CURL_DISABLE_HTTP
   if(!conn->cfilter[sockindex] &&
      conn->scheme->protocol == CURLPROTO_HTTPS) {
     DEBUGASSERT(ssl_mode != CURL_CF_SSL_DISABLE);
-    result = Curl_cf_https_setup(data, conn, sockindex);
+    result = Curl_cf_https_setup(data, destination, conn, sockindex);
     if(result)
       goto out;
   }
@@ -275,13 +276,53 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
       goto out;
   }
 
+  /* What do we need to resolve for this connection?
+   * Add resolves in order of importance. First added, first started.
+   * DNS filter will aggregate queries for the same peer. */
+
+  /* first_peer: always for A+AAAA (whatever applies) */
   dns_queries = Curl_resolv_dns_queries(data, conn->ip_version);
+  result = Curl_conn_dns_add_resolve(data, conn, sockindex,
+                                     first_peer, dns_queries,
+                                     conn->transport_wanted);
+  if(result)
+    goto out;
+
 #ifdef USE_HTTPSRR
-  if(sockindex == FIRSTSOCKET)
-    dns_queries |= CURL_DNSQ_HTTPS;
-#endif
-  result = Curl_cf_dns_add(data, conn, sockindex, peer, dns_queries,
-                           conn->transport_wanted);
+  /* With HTTPS-RR, we also want that for first_peer. */
+  result = Curl_conn_dns_add_resolve(data, conn, sockindex,
+                                     first_peer, CURL_DNSQ_HTTPS,
+                                     conn->transport_wanted);
+  if(result)
+    goto out;
+
+#ifndef CURL_DISABLE_PROXY
+  /* And HTTPS-RR for http proxy, when using SSL */
+  if(conn->http_proxy.peer &&
+     CURL_PROXY_IS_HTTPS(conn->http_proxy.proxytype)) {
+    result = Curl_conn_dns_add_resolve(
+      data, conn, sockindex, conn->http_proxy.peer,
+      CURL_DNSQ_HTTPS, conn->transport_wanted);
+    if(result)
+      goto out;
+  }
+#endif /* CURL_DISABLE_PROXY */
+
+  /* And HTTPS-RR for origin + destination, when using SSL */
+  if(conn->scheme->flags & PROTOPT_SSL) {
+    result = Curl_conn_dns_add_resolve(
+      data, conn, sockindex, Curl_conn_get_origin(conn, sockindex),
+      CURL_DNSQ_HTTPS, conn->transport_wanted);
+    if(result)
+      goto out;
+    result = Curl_conn_dns_add_resolve(
+      data, conn, sockindex, Curl_conn_get_destination(conn, sockindex),
+      CURL_DNSQ_HTTPS, conn->transport_wanted);
+    if(result)
+      goto out;
+  }
+#endif /* USE_HTTPSRR */
+
   DEBUGASSERT(conn->cfilter[sockindex]);
 out:
   return result;

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -247,7 +247,6 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
                          int ssl_mode)
 {
   struct Curl_peer *first_peer = Curl_conn_get_first_peer(conn, sockindex);
-  struct Curl_peer *destination = Curl_conn_get_destination(conn, sockindex);
   CURLcode result = CURLE_OK;
   uint8_t dns_queries;
 
@@ -262,7 +261,8 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
   if(!conn->cfilter[sockindex] &&
      conn->scheme->protocol == CURLPROTO_HTTPS) {
     DEBUGASSERT(ssl_mode != CURL_CF_SSL_DISABLE);
-    result = Curl_cf_https_setup(data, destination, conn, sockindex);
+    result = Curl_cf_https_setup(
+      data, Curl_conn_get_destination(conn, sockindex), conn, sockindex);
     if(result)
       goto out;
   }

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -731,7 +731,8 @@ out:
     if(IS_RESOLV_FAIL(result)) {
       if(cache_dns)
         Curl_dnscache_add_negative(data, dns_queries, hostname, port);
-      failf(data, "Could not resolve: %s:%u", hostname, port);
+      if(dns_queries & (CURL_DNSQ_A|CURL_DNSQ_AAAA))
+        failf(data, "Could not resolve: %s:%u", hostname, port);
     }
     else {
       failf(data, "Error %d resolving %s:%u", (int)result, hostname, port);
@@ -1069,7 +1070,8 @@ CURLcode Curl_resolv_take_result(struct Curl_easy *data, uint32_t resolv_id,
   else if(IS_RESOLV_FAIL(result)) {
     Curl_dnscache_add_negative(data, async->dns_queries,
                                async->hostname, async->port);
-    failf(data, "Could not resolve: %s:%u", async->hostname, async->port);
+    if(async->dns_queries & (CURL_DNSQ_A|CURL_DNSQ_AAAA))
+      failf(data, "Could not resolve: %s:%u", async->hostname, async->port);
   }
   else if(result) {
     failf(data, "Error %d resolving %s:%u",

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -325,8 +325,8 @@ static CURLproxycode socks4_resolving(struct socks_ctx *sx,
     /* need to resolve hostname to add destination address */
     sx->start_resolving = FALSE;
     result = Curl_cf_dns_insert_after(
-      cf, data, Curl_resolv_dns_queries(data, sx->ip_version),
-      sx->dest, TRNSPRT_TCP, TRUE);
+      cf, data, sx->dest, Curl_resolv_dns_queries(data, sx->ip_version),
+      TRNSPRT_TCP, TRUE);
     if(result) {
       failf(data, "unable to create DNS filter for socks");
       return CURLPX_UNKNOWN_FAIL;
@@ -842,8 +842,8 @@ static CURLproxycode socks5_resolving(struct socks_ctx *sx,
     /* need to resolve hostname to add destination address */
     sx->start_resolving = FALSE;
     result = Curl_cf_dns_insert_after(
-      cf, data, Curl_resolv_dns_queries(data, sx->ip_version),
-      sx->dest, TRNSPRT_TCP, TRUE);
+      cf, data, sx->dest, Curl_resolv_dns_queries(data, sx->ip_version),
+      TRNSPRT_TCP, TRUE);
     if(result) {
       failf(data, "unable to create DNS filter for socks");
       return CURLPX_UNKNOWN_FAIL;


### PR DESCRIPTION
A connection can involve several peers for which resolving the HTTPS DNS records might be interesting. Add the resolves at connection setup.

Also: explicitly ingore HTTPS-RR on hostname that are an IP address.

asyn-thrdd: fix result handling when only HTTPS is queried.

WIP

refs #22043

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
