### PR TITLE
cookie: check __Secure- and __Host- case sensitively when read from file

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -759,10 +759,12 @@ static CURLcode parse_netscape(struct Cookie *co,
       if(!co->name)
         return CURLE_OUT_OF_MEMORY;
       else {
-        /* For Netscape file format cookies we check prefix on the name */
-        if(curl_strnequal("__Secure-", co->name, 9))
+        /* For Netscape file format cookies we check prefix on the name.
+           These prefixes are matched case sensitively, same as on the
+           header path and as the 6265bis document specifies. */
+        if(!strncmp("__Secure-", co->name, 9))
           co->prefix_secure = TRUE;
-        else if(curl_strnequal("__Host-", co->name, 7))
+        else if(!strncmp("__Host-", co->name, 7))
           co->prefix_host = TRUE;
       }
       break;

--- a/tests/data/test2311
+++ b/tests/data/test2311
@@ -26,7 +26,7 @@ This server says moo
 http
 </server>
 <name>
-Cookie from file with control octet in value is rejected
+Cookie from file: control octet rejected, prefixes matched case sensitively
 </name>
 <command>
 http://example.fake/%TESTNUMBER -b %LOGDIR/injar%TESTNUMBER -x %HOSTIP:%HTTPPORT
@@ -34,6 +34,8 @@ http://example.fake/%TESTNUMBER -b %LOGDIR/injar%TESTNUMBER -x %HOSTIP:%HTTPPORT
 <file name="%LOGDIR/injar%TESTNUMBER">
 example.fake	FALSE	/	FALSE	0	clean	good
 example.fake	FALSE	/	FALSE	0	bad	%hex[ba%07d]hex%
+example.fake	FALSE	/	FALSE	0	__secure-x	yes
+example.fake	FALSE	/	FALSE	0	__Secure-y	no
 </file>
 <features>
 cookies
@@ -49,7 +51,7 @@ Host: example.fake
 User-Agent: curl/%VERSION
 Accept: */*
 Proxy-Connection: Keep-Alive
-Cookie: clean=good
+Cookie: __secure-x=yes; clean=good
 
 </protocol>
 </verify>


### PR DESCRIPTION
Repro: load a cookie file holding `__secure-x` (lower case, no `Secure`) and the name is dropped, while the identical `__secure-x` received over a `Set-Cookie` header is kept as an ordinary cookie. `test2311` covers it.

Cause: `parse_netscape()` detected the `__Secure-`/`__Host-` name prefixes with case-insensitive `curl_strnequal()`, but the header path uses case-sensitive `strncmp()` and the 6265bis document specifies a case-sensitive match (the reason 5af0165562 switched the header path). So on the file path a differently cased name was wrongly put through the prefix integrity checks.

Fix: use `strncmp()` on the file path too, so both paths match the prefixes case sensitively and agree with the spec. A correctly cased `__Secure-`/`__Host-` is still enforced.

Earlier I had this the other way round (making the header path case insensitive); that was wrong, the spec wants case-sensitive. Folded the coverage into test 2311 instead of a new file.