### PR TITLE
openssl: do not mix OpenSSL int result with `CURLcode` variable

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3445,7 +3445,6 @@ static CURLcode ossl_init_ech(struct ossl_ctx *octx,
   size_t ech_config_len = 0;
   char *outername = data->set.str[STRING_ECH_PUBLIC];
   int trying_ech_now = 0;
-  CURLcode result = CURLE_OK;
 
   if(!CURLECH_ENABLED(data))
     return CURLE_OK;
@@ -3462,6 +3461,7 @@ static CURLcode ossl_init_ech(struct ossl_ctx *octx,
 #ifdef HAVE_BORINGSSL_LIKE
     /* have to do base64 decode here for BoringSSL */
     const char *b64 = data->set.str[STRING_ECH_CONFIG];
+    CURLcode result;
 
     if(!b64) {
       infof(data, "ECH: ECHConfig from command line empty");
@@ -3533,14 +3533,14 @@ static CURLcode ossl_init_ech(struct ossl_ctx *octx,
   }
 #else
   if(trying_ech_now && outername) {
+    int ret;
     infof(data, "ECH: inner: '%s', outer: '%s'",
           peer->origin->hostname ? peer->origin->hostname : "NULL", outername);
-    result = SSL_ech_set1_server_names(octx->ssl,
-                                       peer->origin->hostname, outername,
-                                       0 /* do send outer */);
-    if(result != 1) {
-      infof(data, "ECH: rv failed to set server name(s) %d [ERROR]",
-            (int)result);
+    ret = SSL_ech_set1_server_names(octx->ssl,
+                                    peer->origin->hostname, outername,
+                                    0 /* do send outer */);
+    if(ret != 1) {
+      infof(data, "ECH: rv failed to set server name(s) %d [ERROR]", ret);
       return CURLE_SSL_CONNECT_ERROR;
     }
   }


### PR DESCRIPTION
Seen with clang-22:
```
lib/vtls/openssl.c:3538:14: error: implicit conversion from 'int' to enumeration type 'CURLcode' is invalid in C++ [-Werror,-Wimplicit-int-enum-cast]
 3538 |     result = SSL_ech_set1_server_names(octx->ssl,
      |            ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 3539 |                                        peer->origin->hostname, outername,
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 3540 |                                        0 /* do send outer */);
      |                                        ~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
Ref: https://github.com/curl/curl/actions/runs/27769068896/job/82163712258#step:42:43

Cherry-picked from #22086
