### PR TITLE
MANUAL.md: update `apt-key` example

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -188,13 +188,13 @@ transfers, and curl's `-v` option to see exactly what curl is sending.
 
 ## Piping
 
-Get a key file and add it with `apt-key` (when on a system that uses `apt` for
-package management):
+Get a key file and install it as a trusted one (when on a system that uses
+`apt` for package management):
 
-    curl -L https://apt.example.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    curl -L https://apt.example.org/llvm-snapshot.gpg.key | sudo tee
+      /etc/apt/trusted.gpg.d/llvm-snapshot.asc >/dev/null
 
-The '|' pipes the output to STDIN. `-` tells `apt-key` that the key file
-should be read from STDIN.
+The '|' pipes the output to stdin. `tee` reads from stdin.
 
 ## Ranges
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -192,7 +192,7 @@ Get a key file and install it as a trusted one (when on a system that uses
 `apt` for package management):
 
     curl -L https://apt.example.org/llvm-snapshot.gpg.key | sudo tee
-      /etc/apt/keyrings/llvm-snapshot.asc >/dev/null
+      /etc/apt/trusted.gpg.d/llvm-snapshot.asc >/dev/null
 
 The '|' pipes the output to stdin. `tee` reads from stdin.
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -192,7 +192,7 @@ Get a key file and install it as a trusted one (when on a system that uses
 `apt` for package management):
 
     curl -L https://apt.example.org/llvm-snapshot.gpg.key | sudo tee
-      /etc/apt/trusted.gpg.d/llvm-snapshot.asc >/dev/null
+      /etc/apt/keyrings/llvm-snapshot.asc >/dev/null
 
 The '|' pipes the output to stdin. `tee` reads from stdin.
 


### PR DESCRIPTION
To use `tee` instead, due to `apt-key` being deprecated, and missing
from recent distros.

Also lowercase `stdin` to match rest of the file.

Ref: https://documentation.ubuntu.com/release-notes/26.04/summary-for-lts-users/#package-management-apt-3

Ref: #22091
Follow-up to b13e9066b3dfd65ba8aadc336232ae7832ac687a #16127
Follow-up to 54130a6cad4e044a199f40e857c300a139818b9b #10170

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
