### PR TITLE
smb: constify `strchr()` result variable

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -467,7 +467,7 @@ static CURLcode smb_connect(struct Curl_easy *data, bool *done)
 {
   struct connectdata *conn = data->conn;
   struct smb_conn *smbc = Curl_conn_meta_get(conn, CURL_META_SMB_CONN);
-  char *slash;
+  const char *slash;
   const char *user = Curl_creds_user(conn->creds);
 
   (void)done;


### PR DESCRIPTION
Fixing (as seen with gcc-15 on Ubuntu 26.04):
```
lib/smb.c: In function 'smb_connect':
lib/smb.c:491:9: error: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  491 |   slash = strchr(user, '/');
      |         ^
lib/smb.c:493:11: error: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  493 |     slash = strchr(user, '\\');
      |           ^
```
Ref: https://github.com/curl/curl/actions/runs/27778098314/job/82195462418?pr=22092

Follow-up to 4e5908306ad5febee88f7eae8ea3b0c41a6b7d84 #20428
Follow-up to 7dc60bdb90c710c2e36b2d05aa3686ff491a9bbe #20425
Follow-up to 0e2507a3c65376d6bda860ff20bd94ada9bbb9fd #20421

Cherry-picked from #22092

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
