### PR TITLE
GHA: separate pytype from other checkers and pips

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -4,6 +4,5 @@
 
 cmakelang==0.6.13
 codespell==2.4.2
-pytype==2024.10.11
 reuse==6.2.0
 ruff==0.15.16

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -88,15 +88,31 @@ jobs:
         run: |
           scripts/perlcheck.sh
 
-      - name: 'pytype'
-        run: |
-          source ~/venv/bin/activate
-          find . -name '*.py' -exec pytype -j auto -k -- {} +
-
       - name: 'ruff'
         run: |
           source ~/venv/bin/activate
           scripts/pythonlint.sh
+
+  pytype:
+    name: 'pytype'
+    runs-on: ubuntu-24.04-arm  # pytype is discontinued and requires python 3.8-3.12
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: 'install prereqs'
+        run: |
+          python3 -m venv ~/venv
+          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary pytype==2024.10.11 \
+            -r .github/scripts/requirements.txt \
+            -r tests/http/requirements.txt \
+            -r tests/requirements.txt
+
+      - name: 'check'
+        run: |
+          source ~/venv/bin/activate
+          find . -name '*.py' -exec pytype -j auto -k -- {} +
 
   complexity:
     name: 'complexity and function sizes'


### PR DESCRIPTION
pytype is discontinued, does not receive further updates, and it
requires older python, offered by Ubuntu 24.04 or older.

Move it to its own GHA job to allow bumping the rest of checkers to
newer runner images. Also move it out from the shared `requirements.txt`
and install directly from its separate GHA job, to avoid installing it
unnecessarily from others. Since it does not receive updates, it's fine 
to move out from Dependabot's view.

Ref: https://pypi.org/project/pytype/
Cherry-picked from #22092
