### PR TITLE
GHA: fix Linux triplet passed to `CMAKE_C_COMPILER_TARGET`

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -789,7 +789,7 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             [[ "${MATRIX_GENERATE}" = *'boringssl'* ]] && options=" -DBORINGSSL_VERSION=${BORINGSSL_VERSION}"
             cmake -B bld -G Ninja \
-              -DCMAKE_C_COMPILER_TARGET="$(uname -m)-pc-linux-gnu" -DBUILD_STATIC_LIBS=ON \
+              -DCMAKE_C_COMPILER_TARGET="$(uname -m)-linux-gnu" -DBUILD_STATIC_LIBS=ON \
               -DCURL_WERROR=ON -DENABLE_DEBUG=ON \
               -DCURL_USE_LIBUV=ON -DCURL_ENABLE_NTLM=ON \
               -DTEST_NGHTTPX=/home/runner/nghttp2/build/bin/nghttpx \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -866,7 +866,7 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake -B bld -G Ninja \
               -DCMAKE_INSTALL_PREFIX="$HOME"/curl-install \
-              -DCMAKE_C_COMPILER_TARGET="$(uname -m)-pc-linux-gnu" -DBUILD_STATIC_LIBS=ON \
+              -DCMAKE_C_COMPILER_TARGET="$(uname -m)-linux-gnu" -DBUILD_STATIC_LIBS=ON \
               -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON \
               ${MATRIX_GENERATE}
           else


### PR DESCRIPTION
Before this patch it broke clang 20/21 cmake builds on ubuntu-26.04-arm
runner, failing at the beginning of the configure stage while probing
the compiler.

Seen in the 'CM openssl clang krb5 LTO' job:
```
: && /usr/bin/clang --target=aarch64-pc-linux-gnu   CMakeFiles/cmTC_3d9ae.dir/testCCompiler.c.o -o cmTC_3d9ae   && :
    /usr/bin/aarch64-linux-gnu-ld.bfd: cannot find crtbeginS.o: No such file or directory
    /usr/bin/aarch64-linux-gnu-ld.bfd: cannot find -lgcc: No such file or directory
    /usr/bin/aarch64-linux-gnu-ld.bfd: cannot find -lgcc_s: No such file or directory
```
Ref: https://github.com/curl/curl/actions/runs/27778098314/job/82195462687#step:38:66

Follow-up to 36bd8074758a0b3a784403eb3d2cc31d240de896 #15242
Follow-up to 232302f88a152a1d1722da9f69c383a766528918 #14382
Cherry-picked from #22092
