### PR TITLE
runtests: drop orphaned, no-op `-k` option

### DIFF
--- a/docs/runtests.md
+++ b/docs/runtests.md
@@ -164,11 +164,6 @@ CPU cores is a good figure to start with, or 1.3 times if Valgrind is in use,
 or 5 times for torture tests. Enabling parallel tests is not recommended in
 conjunction with the -g option.
 
-## `-k`
-
-Keep output and log files in log/ after a test run, even if no error was
-detected. Useful for debugging.
-
 ## `-L \<file\>`
 
 Load and execute the specified file which should contain perl code. This

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -182,7 +182,6 @@ my %runnersrunning;    # tests currently running by runner ID
 #
 my $short;
 my $no_debuginfod;
-my $keepoutfiles; # keep stdout and stderr files after tests
 my $postmortem;   # display detailed info about failed tests
 my $run_disabled; # run the specific tests even if listed in DISABLED
 my $scrambleorder;
@@ -2540,10 +2539,6 @@ while(@ARGV) {
             $jobs = $1;
         }
     }
-    elsif($ARGV[0] eq "-k") {
-        # keep stdout and stderr files after tests
-        $keepoutfiles = 1;
-    }
     elsif($ARGV[0] eq "-r") {
         # run time statistics needs Time::HiRes
         if($Time::HiRes::VERSION) {
@@ -2596,7 +2591,6 @@ Usage: runtests.pl [options] [test selection(s)]
   -gw      run the test case with gdb as a windowed application
   -h       this help text
   -j[N]    spawn this number of processes to run tests (default 0)
-  -k       keep stdout and stderr files present after tests
   -L path  require an additional perl library file to replace certain functions
   -l       list all test case names/descriptions
   -m=[seconds] set timeout for curl commands in tests


### PR DESCRIPTION
And the corresponding internal variable.

This option became the always-enabled default earlier, via #4035.

Reported-by: Zartaj Majeed
Ref: #22098
Follow-up to 6617db6a7ed322d28322896aa20bcabf3a479e7c #4035

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
