### PR TITLE
autotools: remap root `test` target to `test`, add root `test-quiet` target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,7 @@ dist-hook:
 check: test examples check-docs
 
 if CROSSCOMPILING
+tests: tests
 test-quiet: test
 test-full: test
 test-nonflaky: test
@@ -102,6 +103,8 @@ test:
 	@echo "NOTICE: we cannot run the tests when cross-compiling!"
 
 else
+
+tests: tests
 
 test:
 	@(cd tests; $(MAKE) all test)

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,7 @@ dist-hook:
 check: test examples check-docs
 
 if CROSSCOMPILING
+tests: test
 test-full: test
 test-nonflaky: test
 test-torture: test
@@ -101,6 +102,9 @@ test:
 	@echo "NOTICE: we cannot run the tests when cross-compiling!"
 
 else
+
+tests:
+	@(cd tests; $(MAKE) all test)
 
 test:
 	@(cd tests; $(MAKE) all quiet-test)

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,7 @@ dist-hook:
 check: test examples check-docs
 
 if CROSSCOMPILING
-tests: test
+test-quiet: test
 test-full: test
 test-nonflaky: test
 test-torture: test
@@ -103,10 +103,10 @@ test:
 
 else
 
-tests:
+test:
 	@(cd tests; $(MAKE) all test)
 
-test:
+test-quiet:
 	@(cd tests; $(MAKE) all quiet-test)
 
 test-full:


### PR DESCRIPTION
Prior to this patch, root `test` target mapped to `quiet-test`, (which
enables certain runtests options by default, some with no override
option), while there was no root target mapping to the no-option `test`
target under the `tests` subdirectory.

To ease running a no-option test via a root target, and to untangle
mapping, remap root `test` to the same target within `tests`, and add
a new root `test-quiet` target that maps to the quiet target.

Also add a `tests` root target to match the same already present in
the tests subdirectory, and to match this target name added earlier to
CMake.

Reported-by: Zartaj Majeed
Ref: #22098
Follow-up to 51bc836c428ce7dbdf4deef41eeacee974ad7b3e #18145
Follow-up to ec3054e1f29cc2a40e2ce897c33e99c8a5c49595

---

- [ ] this breaks compatibility of the root `test` target, consider an
  alternative, if this breaks existing (automated?) uses too much.
  Automated are likely better served with the `test-ci` target.
- [ ] rebase onto #22154.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
