### PR TITLE
vquic: fix `-Wunused-parameter` with proxies disabled

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -877,6 +877,8 @@ CURLcode Curl_conn_may_http3(struct Curl_easy *data,
     failf(data, "HTTP/3 is not supported over a SOCKS proxy");
     return CURLE_URL_MALFORMAT;
   }
+#else
+  (void)conn;
 #endif
 
   return CURLE_OK;


### PR DESCRIPTION
Fixing:
```
lib/vquic/vquic.c:864:56: error: unused parameter 'conn' [-Werror,-Wunused-parameter]
  864 |                              const struct connectdata *conn,
      |                                                        ^
```

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
