### PR TITLE
KNOWN_BUGS.md: drop outdated CMake issues

### DIFF
--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -492,32 +492,6 @@ then subsequently fails anyway if that was actually in use.
 
 [curl issue 8112](https://github.com/curl/curl/issues/8112)
 
-# CMake
-
-## cmake outputs: no version information available
-
-Something in the SONAME generation seems to be wrong in the cmake build.
-
-[curl issue 11158](https://github.com/curl/curl/issues/11158)
-
-## generated `.pc` file contains strange entries
-
-The `Libs.private` field of the generated `.pc` file contains `-lgcc -lgcc_s
--lc -lgcc -lgcc_s`.
-
-See [curl issue 6167](https://github.com/curl/curl/issues/6167)
-
-## CMake build with MIT Kerberos does not work
-
-Minimum CMake version was bumped in curl 7.71.0 (#5358) Since CMake 3.2
-try_compile started respecting the `CMAKE_EXE_FLAGS`. The code dealing with
-MIT Kerberos detection sets few variables to potentially weird mix of space,
-and ;-separated flags. It had to blow up at some point. All the CMake checks
-that involve compilation are doomed from that point, the configured tree
-cannot be built.
-
-[curl issue 6904](https://github.com/curl/curl/issues/6904)
-
 # HTTP/2
 
 ## HTTP/2 prior knowledge over proxy


### PR DESCRIPTION
- "cmake outputs: no version information available"
  Ref: #11158

  Seems to be about missing support for autotools `--enable-versioned-symbols`.
  This was implemented for CMake in:
  14d4712db7e34fda25a11fd5f23f0f57a6aea67f #17039
  7100c5bc9b8c9c49a44c47d64b42e98b4de2465b #14818
  7b1444979094a365c82c665cce0e2ebc6b69467b #14378

- "generated `.pc` file contains strange entries"
  Ref: #6167

  Fixed in:
  9f56bb608ecfbb8978c6cb72a04d9e8b23162d82 #14681

- "CMake build with MIT Kerberos does not work"
  Ref: #6904

  The FindGSS module responsible for MIT Kerberos detection has seen 50
  updates since this report. In the last years I made many local tests
  with it, and it's also extensively CI-tested since (including Windows
  for a 1-year period), with no known issues.

If you see problems remaining, let us know in a new issue.
