### PR TITLE
proxy: fix automatic tunnel mode with "connect to host"

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2100,7 +2100,7 @@ static CURLcode url_create_needle(struct Curl_easy *data,
                  Curl_hash_str, curlx_str_key_compare, conn_meta_freeentry);
 
   /*************************************************************
-   * Determine `conn->origin` and propulate `data->state.up` and
+   * Determine `conn->origin` and populate `data->state.up` and
    * other URL related properties.
    *************************************************************/
   result = url_set_conn_origin_etc(data, needle);
@@ -2135,6 +2135,15 @@ static CURLcode url_create_needle(struct Curl_easy *data,
       goto out;
   }
 
+  /*************************************************************
+   * Check whether the host and the "connect to host" are equal.
+   * Do this after the hostnames have been IDN-converted and
+   * before initializing the proxy.
+   *************************************************************/
+  if(Curl_peer_equal(needle->origin, needle->via_peer)) {
+    Curl_peer_unlink(&needle->via_peer);
+  }
+
 #ifndef CURL_DISABLE_PROXY
   /* Going via a unix socket ignores any proxy settings */
   if(network_scheme &&
@@ -2148,14 +2157,6 @@ static CURLcode url_create_needle(struct Curl_easy *data,
   result = url_set_conn_login(data, needle); /* default credentials */
   if(result)
     goto out;
-
-  /*************************************************************
-   * Check whether the host and the "connect to host" are equal.
-   * Do this after the hostnames have been IDN-converted.
-   *************************************************************/
-  if(Curl_peer_equal(needle->origin, needle->via_peer)) {
-    Curl_peer_unlink(&needle->via_peer);
-  }
 
   /*************************************************************
    * Setup internals depending on protocol. Needs to be done after

--- a/tests/data/test2050
+++ b/tests/data/test2050
@@ -50,7 +50,8 @@ http-proxy
 </name>
 
 <command>
-http://www.example.com.%TESTNUMBER/%TESTNUMBER --connect-to ::connect.example.com.%TESTNUMBER:%HTTPPORT -x %HOSTIP:%PROXYPORT
+http://www.example.com.%TESTNUMBER/%TESTNUMBER --connect-to ::connect.example.com.%TESTNUMBER:%HTTPPORT -x %HOSTIP:%PROXYPORT --next
+http://www.example.com.%TESTNUMBER:%HTTPPORT/%TESTNUMBER --connect-to ::www.example.com.%TESTNUMBER:%HTTPPORT -x %HOSTIP:%PROXYPORT
 </command>
 <features>
 proxy
@@ -59,10 +60,16 @@ proxy
 
 # Verify data after the test has been "shot"
 <verify>
-<proxy crlf="headers">
+<proxy crlf="yes">
 CONNECT connect.example.com.%TESTNUMBER:%HTTPPORT HTTP/1.1
 Host: connect.example.com.%TESTNUMBER:%HTTPPORT
 User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+GET http://www.example.com.%TESTNUMBER:%HTTPPORT/%TESTNUMBER HTTP/1.1
+Host: www.example.com.%TESTNUMBER:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
 Proxy-Connection: Keep-Alive
 
 </proxy>

--- a/tests/data/test2055
+++ b/tests/data/test2055
@@ -54,16 +54,23 @@ socks5
 proxy
 </features>
 <command>
-http://www.example.com.%TESTNUMBER/%TESTNUMBER --connect-to ::connect.example.com.%TESTNUMBER:%HTTPPORT -x %HOSTIP:%PROXYPORT --preproxy socks5://%HOSTIP:%SOCKSPORT
+http://www.example.com.%TESTNUMBER/%TESTNUMBER --connect-to ::connect.example.com.%TESTNUMBER:%HTTPPORT -x %HOSTIP:%PROXYPORT --preproxy socks5://%HOSTIP:%SOCKSPORT --next
+http://www.example.com.%TESTNUMBER:%HTTPPORT/%TESTNUMBER --connect-to ::www.example.com.%TESTNUMBER:%HTTPPORT -x %HOSTIP:%PROXYPORT --preproxy socks5://%HOSTIP:%SOCKSPORT
 </command>
 </client>
 
 # Verify data after the test has been "shot"
 <verify>
-<proxy crlf="headers">
+<proxy crlf="yes">
 CONNECT connect.example.com.%TESTNUMBER:%HTTPPORT HTTP/1.1
 Host: connect.example.com.%TESTNUMBER:%HTTPPORT
 User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+GET http://www.example.com.%TESTNUMBER:%HTTPPORT/%TESTNUMBER HTTP/1.1
+Host: www.example.com.%TESTNUMBER:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
 Proxy-Connection: Keep-Alive
 
 </proxy>


### PR DESCRIPTION
Fix a regression in curl 8.21.0-rc3: Check whether the host and the "connect to host" are equal before initializing the proxy. If they are equal, switching to tunnel mode is not necessary.

Follow-up to 73daec6