### PR TITLE
mqtt: reject control bytes in the topic

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -438,7 +438,7 @@ static CURLcode mqtt_get_topic(struct Curl_easy *data,
   const char *path = data->state.up.path;
   CURLcode result = CURLE_URL_MALFORMAT;
   if(strlen(path) > 1) {
-    result = Curl_urldecode(path + 1, 0, topic, topiclen, REJECT_NADA);
+    result = Curl_urldecode(path + 1, 0, topic, topiclen, REJECT_CTRL);
     if(!result && (*topiclen > 0xffff)) {
       failf(data, "Too long MQTT topic");
       result = CURLE_URL_MALFORMAT;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -254,7 +254,7 @@ test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
-test2108 \
+test2108 test2109 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 test2208 \

--- a/tests/data/test2109
+++ b/tests/data/test2109
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+MQTT
+MQTT SUBSCRIBE
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+hello
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+mqtt
+</features>
+<server>
+mqtt
+</server>
+<name>
+MQTT rejects a control byte in the topic
+</name>
+<command option="binary-trace">
+mqtt://%HOSTIP:%MQTTPORT/aa%00bb
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# These are hexadecimal protocol dumps from the client
+# Strip out the random part of the client id from the CONNECT message
+# before comparison
+<strippart>
+s/^(.* 00044d5154540402003c000c6375726c).*/$1/
+</strippart>
+# the topic is decoded and the embedded nul rejected before SUBSCRIBE is sent
+<protocol>
+client CONNECT 18 00044d5154540402003c000c6375726c
+server CONNACK 2 20020000
+</protocol>
+<errorcode>
+3
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Repro: `mqtt://host/aa%00bb` (any percent-encoded control byte in the topic, including a `nul`).

Cause: `mqtt_get_topic` URL-decodes the topic with `REJECT_NADA`, so the byte is copied verbatim into the length-prefixed `SUBSCRIBE`/`PUBLISH` packet and goes out on the wire (observed `820a0001` `0005` `6161`**`00`**`6262` `00`, topic `aa\0bb`). A `nul` in a topic name is forbidden by MQTT 3.1.1 `[MQTT-1.5.4-2]`, so a conformant broker treats it as a protocol error.

Fix: decode with `REJECT_CTRL`, matching every other URL scheme that turns a path component into a command argument (`ftp`, `imap`, `pop3`, `smtp`, `smb`, `dict` all use it). `test2109` covers it.