### PR TITLE
gopher: reject CR and LF in the selector

### DIFF
--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -103,6 +103,16 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
     if(result)
       return result;
     buf = buf_alloc;
+
+    /* A decoded CR or LF would terminate the single-line gopher request and
+       let a crafted URL smuggle additional bytes onto the wire. REJECT_ZERO
+       only blocks NUL; reject CR and LF here too. A TAB is left alone as it
+       is the legitimate gopher type-7 selector/search separator. */
+    if(memchr(buf, '\r', buf_len) || memchr(buf, '\n', buf_len)) {
+      curlx_free(buf_alloc);
+      failf(data, "Bad gopher selector, CR or LF not allowed");
+      return CURLE_URL_MALFORMAT;
+    }
   }
 
   for(; buf_len;) {

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -211,7 +211,7 @@ test1573 test1574 test1575 test1576 test1577 test1578 test1579 test1580 \
 test1581 test1582 test1583 test1584 test1585 test1586 test1587 test1588 \
 test1589 test1590 test1591 test1592 test1593 test1594 test1595 test1596 \
 test1597 test1598 test1599 test1600 test1601 test1602 test1603 test1604 \
-test1605 test1606 test1607 test1608          test1610 test1611 test1612 \
+test1605 test1606 test1607 test1608 test1609 test1610 test1611 test1612 \
 test1613 test1614 test1615 test1616 test1617 test1618 test1619 test1620 \
 test1621 test1622 test1623 test1624 test1625 test1626 test1627 test1628 \
 test1629 test1630 test1631 test1632 test1633 test1634 test1635 test1636 \

--- a/tests/data/test1609
+++ b/tests/data/test1609
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+GOPHER
+CRLF-in-URL
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+gopher
+</server>
+<name>
+Gopher with URL-encoded CR LF in the selector
+</name>
+<command>
+gopher://%HOSTIP:%GOPHERPORT/1/sel%0d%0aINJECT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# 3 - CURLE_URL_MALFORMAT
+<errorcode>
+3
+</errorcode>
+# nothing must reach the server, the selector is rejected before any send
+<protocol>
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1609
+++ b/tests/data/test1609
@@ -31,7 +31,8 @@ gopher://%HOSTIP:%GOPHERPORT/1/sel%0d%0aINJECT/%TESTNUMBER
 3
 </errorcode>
 # nothing must reach the server, the selector is rejected before any send
-<protocol>
+<protocol nonewline="yes">
+
 </protocol>
 </verify>
 </testcase>


### PR DESCRIPTION
Repro: `gopher://host/1/sel%0d%0aINJECT` is sent on the wire as `sel\r\nINJECT\r\n`, so the `INJECT` line is smuggled as a second request line.
Cause: `gopher_do()` URL-decodes the selector with `REJECT_ZERO`, which only blocks a decoded `NUL`, leaving `CR`/`LF` to split the single-line gopher request.
Fix: reject a decoded `CR` or `LF` in `gopher_do()` after the decode and fail with `CURLE_URL_MALFORMAT`. A `TAB` stays allowed as the legitimate type-7 selector/search separator, so `test1202` keeps passing. `test1609` covers the rejection.