### PR TITLE
smtp: reject CR and LF in the envelope address

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -250,16 +250,26 @@ static CURLcode smtp_parse_custom_request(struct Curl_easy *data,
  * calling function deems it to be) then the input will be returned in
  * the address part with the hostname being NULL.
  */
-static CURLcode smtp_parse_address(const char *fqma, char **address,
-                                   struct hostname *host, const char **suffix)
+static CURLcode smtp_parse_address(struct Curl_easy *data, const char *fqma,
+                                   char **address, struct hostname *host,
+                                   const char **suffix)
 {
   CURLcode result = CURLE_OK;
   size_t length;
   char *addressend;
+  char *dup;
+
+  /* A CR or LF in the address ends up verbatim in the MAIL FROM/RCPT TO
+     command line, so a crafted address could smuggle further SMTP commands
+     onto the wire. Reject it before the command is built. */
+  if(strpbrk(fqma, "\r\n")) {
+    failf(data, "Refusing to send email address with a CR or LF");
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  }
 
   /* Duplicate the fully qualified email address so we can manipulate it,
      ensuring it does not contain the delimiters if specified */
-  char *dup = curlx_strdup(fqma[0] == '<' ? fqma + 1 : fqma);
+  dup = curlx_strdup(fqma[0] == '<' ? fqma + 1 : fqma);
   if(!dup)
     return CURLE_OUT_OF_MEMORY;
 
@@ -842,7 +852,7 @@ static CURLcode smtp_perform_command(struct Curl_easy *data,
 
       /* Parse the mailbox to verify into the local address and hostname
          parts, converting the hostname to an IDN A-label if necessary */
-      result = smtp_parse_address(smtp->rcpt->data,
+      result = smtp_parse_address(data, smtp->rcpt->data,
                                   &address, &host, &suffix);
       if(result)
         return result;
@@ -918,7 +928,7 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data,
 
     /* Parse the FROM mailbox into the local address and hostname parts,
        converting the hostname to an IDN A-label if necessary */
-    result = smtp_parse_address(data->set.str[STRING_MAIL_FROM],
+    result = smtp_parse_address(data, data->set.str[STRING_MAIL_FROM],
                                 &address, &host, &suffix);
     if(result)
       goto out;
@@ -960,7 +970,7 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data,
 
       /* Parse the AUTH mailbox into the local address and hostname parts,
          converting the hostname to an IDN A-label if necessary */
-      result = smtp_parse_address(data->set.str[STRING_MAIL_AUTH],
+      result = smtp_parse_address(data, data->set.str[STRING_MAIL_AUTH],
                                   &address, &host, &suffix);
       if(result)
         goto out;
@@ -1097,7 +1107,7 @@ static CURLcode smtp_perform_rcpt_to(struct Curl_easy *data,
 
   /* Parse the recipient mailbox into the local address and hostname parts,
      converting the hostname to an IDN A-label if necessary */
-  result = smtp_parse_address(smtp->rcpt->data,
+  result = smtp_parse_address(data, smtp->rcpt->data,
                               &address, &host, &suffix);
   if(result)
     return result;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -254,7 +254,7 @@ test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
-test2108 test2109 test2113 \
+test2108 test2109 test2110 test2113 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 test2208 \

--- a/tests/data/test2110
+++ b/tests/data/test2110
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+SMTP
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+smtp
+</server>
+<name>
+SMTP --mail-from with embedded CRLF is rejected
+</name>
+<file1 name="%LOGDIR/test%TESTNUMBER.eml" crlf="yes">
+From: different
+To: another
+
+body
+</file1>
+# read the sender from a config file so the raw CR LF reaches curl intact
+# regardless of how the platform passes command line arguments
+<file2 name="%LOGDIR/test%TESTNUMBER.config">
+mail-from = "sender@example.com\r\nDATA"
+</file2>
+<command>
+smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt recipient@example.com -K %LOGDIR/test%TESTNUMBER.config -T %LOGDIR/test%TESTNUMBER.eml
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+# 43 - CURLE_BAD_FUNCTION_ARGUMENT
+<errorcode>
+43
+</errorcode>
+# the injected DATA command must never reach the server
+<protocol crlf="yes">
+EHLO %TESTNUMBER
+QUIT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Repro: point `--mail-from` (or `--mail-rcpt`) at an address holding a real CR/LF, e.g. `sender@example.com` followed by `%0d%0a` then `DATA`. The server receives the smuggled `DATA` as its own command line.

Cause: `smtp_parse_address()` copies the address straight into the `MAIL FROM:`/`RCPT TO:` line through `Curl_pp_sendf()` with no control-byte check. Each SMTP command is one CRLF-terminated line, so an embedded CR or LF in the address splits the line and injects further commands.

Fix: reject a CR or LF in `smtp_parse_address()`, the shared parser behind `MAIL FROM`, `RCPT TO`, `AUTH` and `VRFY`/`EXPN`, before the command is built. Other curl protocol fields built from a single value already refuse control octets; the SMTP envelope addresses did not.

`test2110` covers it: before the change the injected line reaches the server, after it `curl` fails with `CURLE_BAD_FUNCTION_ARGUMENT` and only `EHLO`/`QUIT` go out.