### PR TITLE
setopt: make CURLOPT_KEYPASSWD work for SSH-only builds

### DIFF
--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
@@ -9,6 +9,8 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+  - SFTP
+  - SCP
 TLS-backend:
   - OpenSSL
   - mbedTLS

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2023,9 +2023,9 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
     return setopt_ech(data, ptr);
 #endif
   default:
-    break;
+    return CURLE_UNKNOWN_OPTION;
   }
-  return CURLE_UNKNOWN_OPTION;
+  return result;
 }
 #endif
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2026,7 +2026,6 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
     break;
   }
   return CURLE_UNKNOWN_OPTION;
-
 }
 #endif
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1889,9 +1889,7 @@ static CURLcode setopt_ech(struct Curl_easy *data, const char *ptr)
 static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
                                 char *ptr)
 {
-#ifdef USE_SSL
   CURLcode result = CURLE_OK;
-#endif
   struct UserDefined *s = &data->set;
 
   switch(option) {

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1893,7 +1893,7 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
   struct UserDefined *s = &data->set;
 
   switch(option) {
-#ifdef USE_SSH
+#if defined(USE_SSL) || defined(USE_SSH)
   case CURLOPT_KEYPASSWD:
     /*
      * String that holds the SSL or SSH private key password.

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1889,7 +1889,7 @@ static CURLcode setopt_ech(struct Curl_easy *data, const char *ptr)
 static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
                                 char *ptr)
 {
-  CURLcode result = CURLE_OK;
+  CURLcode result;
   struct UserDefined *s = &data->set;
 
   switch(option) {
@@ -2021,9 +2021,10 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
     return setopt_ech(data, ptr);
 #endif
   default:
-    return CURLE_UNKNOWN_OPTION;
+    break;
   }
-  return result;
+  return CURLE_UNKNOWN_OPTION;
+
 }
 #endif
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1884,7 +1884,8 @@ static CURLcode setopt_ech(struct Curl_easy *data, const char *ptr)
 #define setopt_ech(x,y) CURLE_NOT_BUILT_IN
 #endif
 
-#ifdef USE_SSL
+#if defined(USE_SSL) || defined(USE_SSH)
+/* One of the options is used for both TLS and SSH */
 static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
                                 char *ptr)
 {
@@ -1892,6 +1893,14 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
   struct UserDefined *s = &data->set;
 
   switch(option) {
+#ifdef USE_SSH
+  case CURLOPT_KEYPASSWD:
+    /*
+     * String that holds the SSL or SSH private key password.
+     */
+    return Curl_setstropt(&s->str[STRING_KEY_PASSWD], ptr);
+#endif
+#ifdef USE_SSL
   case CURLOPT_CAINFO:
     /*
      * Set CA info for SSL connection. Specify filename of the CA certificate
@@ -1965,11 +1974,6 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
      * String that holds file type of the SSL key to use
      */
     return Curl_setstropt(&s->str[STRING_KEY_TYPE], ptr);
-  case CURLOPT_KEYPASSWD:
-    /*
-     * String that holds the SSL or SSH private key password.
-     */
-    return Curl_setstropt(&s->str[STRING_KEY_PASSWD], ptr);
   case CURLOPT_SSLENGINE:
     /*
      * String that holds the SSL crypto engine.
@@ -2015,6 +2019,7 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
     return CURLE_NOT_BUILT_IN;
   case CURLOPT_ECH:
     return setopt_ech(data, ptr);
+#endif
   default:
     return CURLE_UNKNOWN_OPTION;
   }
@@ -2501,7 +2506,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #ifndef CURL_DISABLE_PROXY
     setopt_cptr_proxy,
 #endif
-#ifdef USE_SSL
+#if defined(USE_SSL) || defined(USE_SSH)
     setopt_cptr_ssl,
 #endif
 #ifdef USE_SSH

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1890,7 +1890,7 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
                                 char *ptr)
 {
 #ifdef USE_SSL
-  CURLcode result;
+  CURLcode result = CURLE_OK;
 #endif
   struct UserDefined *s = &data->set;
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1893,14 +1893,12 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
   struct UserDefined *s = &data->set;
 
   switch(option) {
-#if defined(USE_SSL) || defined(USE_SSH)
   case CURLOPT_KEYPASSWD:
     /*
      * String that holds the SSL or SSH private key password.
      */
     result = Curl_setstropt(&s->str[STRING_KEY_PASSWD], ptr);
     break;
-#endif
 #ifdef USE_SSL
   case CURLOPT_CAINFO:
     /*

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1900,7 +1900,8 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
     /*
      * String that holds the SSL or SSH private key password.
      */
-    return Curl_setstropt(&s->str[STRING_KEY_PASSWD], ptr);
+    result = Curl_setstropt(&s->str[STRING_KEY_PASSWD], ptr);
+    break;
 #endif
 #ifdef USE_SSL
   case CURLOPT_CAINFO:

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1889,7 +1889,9 @@ static CURLcode setopt_ech(struct Curl_easy *data, const char *ptr)
 static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
                                 char *ptr)
 {
+#ifdef USE_SSL
   CURLcode result;
+#endif
   struct UserDefined *s = &data->set;
 
   switch(option) {


### PR DESCRIPTION
This option is used for both TLS and SSH so it needs to be handled even in TLS-disabled builds

Mention this in the man page as well.

Follow-up to 52fa8d9
Pointed out by Codex Security