### PR TITLE
doh: cap the maximum TTL to 24 hours

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -726,8 +726,8 @@ UNITTEST void de_init(struct dohentry *de)
 }
 
 /* TTL value cap */
-#define MAX_DNS_TTL 86400U
-/* @unittest 1655 */
+#define MAX_DNS_TTL 86400U /* 24 hours */
+/* @unittest 1650 */
 UNITTEST DOHcode doh_resp_decode(const unsigned char *doh,
                                  size_t dohlen,
                                  DNStype dnstype,

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -726,8 +726,7 @@ UNITTEST void de_init(struct dohentry *de)
 }
 
 /* TTL value cap */
-#define MAX_DNS_TTL (24*3600)
-
+#define MAX_DNS_TTL 86400U
 /* @unittest 1655 */
 UNITTEST DOHcode doh_resp_decode(const unsigned char *doh,
                                  size_t dohlen,

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -725,6 +725,9 @@ UNITTEST void de_init(struct dohentry *de)
     curlx_dyn_init(&de->cname[i], DYN_DOH_CNAME);
 }
 
+/* TTL value cap */
+#define MAX_DNS_TTL (24*3600)
+
 /* @unittest 1655 */
 UNITTEST DOHcode doh_resp_decode(const unsigned char *doh,
                                  size_t dohlen,
@@ -795,6 +798,8 @@ UNITTEST DOHcode doh_resp_decode(const unsigned char *doh,
       return DOH_DNS_OUT_OF_RANGE;
 
     ttl = doh_get32bit(doh, index);
+    if(ttl > MAX_DNS_TTL)
+      ttl = MAX_DNS_TTL;
     if(ttl < d->ttl)
       d->ttl = ttl;
     index += 4;

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -102,16 +102,16 @@ static CURLcode test_unit1650(const char *arg)
    "\x6c\x04\x63\x75\x72\x6c\x00\x00\x05\x00\x01\xc0\x0c\x00\x05\x00"
    "\x01\x00\x00\x00\x37\x00\x11\x08\x61\x6e\x79\x77\x68\x65\x72\x65"
    "\x06\x72\x65\x61\x6c\x6c\x79\x00", 56,
-   CURL_DNS_TYPE_A, DOH_OK, "anywhere.really "},
+   CURL_DNS_TYPE_A, DOH_OK, "anywhere.really (55)"},
 
-  {DNS_FOO_EXAMPLE_COM, 49, CURL_DNS_TYPE_A, DOH_OK, "127.0.0.1 "},
+  {DNS_FOO_EXAMPLE_COM, 49, CURL_DNS_TYPE_A, DOH_OK, "127.0.0.1 (55)"},
 
   {"\x00\x00\x01\x00\x00\x01\x00\x01\x00\x00\x00\x00\x04\x61\x61\x61"
    "\x61\x07\x65\x78\x61\x6d\x70\x6c\x65\x03\x63\x6f\x6d\x00\x00\x1c"
-   "\x00\x01\xc0\x0c\x00\x1c\x00\x01\x00\x00\x00\x37\x00\x10\x20\x20"
+   "\x00\x01\xc0\x0c\x00\x1c\x00\x01\x00\x00\x01\x37\x00\x10\x20\x20"
    "\x20\x20\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x20\x20", 62,
    CURL_DNS_TYPE_AAAA, DOH_OK,
-   "2020:2020:0000:0000:0000:0000:0000:2020 " },
+   "2020:2020:0000:0000:0000:0000:0000:2020 (311)" },
 
   {"\x00\x00\x01\x00\x00\x01\x00\x01\x00\x00\x00\x00\x04\x63\x75\x72"
    "\x6c\x04\x63\x75\x72\x6c\x00\x00\x05\x00\x01\xc0\x0c\x00\x05\x00"
@@ -129,19 +129,19 @@ static CURLcode test_unit1650(const char *arg)
 
    62 + 30,
    CURL_DNS_TYPE_AAAA, DOH_OK,
-   "2020:2020:0000:0000:0000:0000:0000:2020 " },
+   "2020:2020:0000:0000:0000:0000:0000:2020 (55)" },
 
-  /* packet with ARCOUNT == 1 */
+  /* packet with ARCOUNT == 1, and a capped TTL */
   {"\x00\x00\x01\x00\x00\x01\x00\x01\x00\x00\x00\x01\x04\x61\x61\x61"
    "\x61\x07\x65\x78\x61\x6d\x70\x6c\x65\x03\x63\x6f\x6d\x00\x00\x1c"
-   "\x00\x01\xc0\x0c\x00\x1c\x00\x01\x00\x00\x00\x37\x00\x10\x20\x20"
+   "\x00\x01\xc0\x0c\x00\x1c\x00\x01\x00\xff\xff\x37\x00\x10\x20\x20"
    "\x20\x20\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x20\x20"
    LABEL_TEST LABEL_HOST LABEL_NAME DNSAAAA_EPILOGUE "\x00\x00\x00\x01"
    "\00\x04\x01\x01\x01\x01", /* RDDATA */
 
    62 + 30,
    CURL_DNS_TYPE_AAAA, DOH_OK,
-   "2020:2020:0000:0000:0000:0000:0000:2020 " },
+   "2020:2020:0000:0000:0000:0000:0000:2020 (86400)" },
 
   };
 
@@ -222,6 +222,7 @@ static CURLcode test_unit1650(const char *arg)
       len -= o;
       ptr += o;
     }
+    curl_msnprintf(ptr, len, "(%u)", d.ttl);
     de_cleanup(&d);
     if(resp[i].out && strcmp((const char *)buffer, resp[i].out)) {
       curl_mfprintf(stderr, "resp %zu: Expected %s got %s\n", i,


### PR DESCRIPTION
To avoid mistakes or abuse to cause problems. Many public DNS providers cap their cache times to this.
