### PR TITLE
doh: stricter HTTPS RR parsing

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -1088,10 +1088,14 @@ static CURLcode doh_decode_rdata_name(const unsigned char **buf,
   DEBUGASSERT(buf && remaining && dnsname);
   if(!buf || !remaining || !dnsname || !*remaining)
     return CURLE_OUT_OF_MEMORY;
-  curlx_dyn_init(&thename, CURL_MAXLEN_host_name);
+  curlx_dyn_init(&thename, CURL_MAXLEN_HOST_NAME);
   rem = *remaining;
   cp = *buf;
   clen = *cp++;
+  /* RFC 9460 says it must be uncompressed */
+  if((clen & 0xC0) == 0xC0)
+    return CURLE_WEIRD_SERVER_REPLY;
+
   if(clen == 0) {
     /* special case - return "." as name */
     if(curlx_dyn_addn(&thename, ".", 1))
@@ -1113,6 +1117,11 @@ static CURLcode doh_decode_rdata_name(const unsigned char **buf,
       return CURLE_OUT_OF_MEMORY;
     }
     clen = *cp++;
+    if(clen > 63) {
+      /* invalid format */
+      curlx_dyn_free(&thename);
+      return CURLE_WEIRD_SERVER_REPLY;
+    }
   }
   *buf = cp;
   *remaining = rem - 1;

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -1093,7 +1093,7 @@ static CURLcode doh_decode_rdata_name(const unsigned char **buf,
   cp = *buf;
   clen = *cp++;
   /* RFC 9460 says it must be uncompressed */
-  if((clen & 0xC0) == 0xC0)
+  if(clen > 63)
     return CURLE_WEIRD_SERVER_REPLY;
 
   if(clen == 0) {

--- a/lib/httpsrr.h
+++ b/lib/httpsrr.h
@@ -31,7 +31,7 @@
 
 #ifdef USE_HTTPSRR
 
-#define CURL_MAXLEN_host_name 253
+#define CURL_MAXLEN_HOST_NAME 253
 #define MAX_HTTPSRR_ALPNS     4
 
 struct Curl_easy;

--- a/tests/unit/unit1658.c
+++ b/tests/unit/unit1658.c
@@ -493,7 +493,26 @@ static CURLcode test_unit1658(const char *arg)
       "ech:fe80dabbc1ff7eb38a22123456789123|"
       "ipv6:fe80:dabb:c1ff:fea3:8a22:1234:5678:9123|"
       "ipv6:ee80:dabb:c1ff:fea3:8a22:1234:5678:9125|"
-    }
+    },
+    {
+      "rname too long label",
+      (const unsigned char *)"\x00\x00" /* 16-bit prio */
+      "\x40"
+      "0123456789012345678901234567890123456789012345678901234567890123"
+      "\x04some\x00", /* RNAME */
+      73,
+      "r:27|",
+    },
+    {
+      "rname long label",
+      (const unsigned char *)"\x00\x00" /* 16-bit prio */
+      "\x3f"
+      "012345678901234567890123456789012345678901234567890123456789012"
+      "\x04some\x00", /* RNAME */
+      72,
+      "r:0|p:0|"
+      "012345678901234567890123456789012345678901234567890123456789012.some.|",
+    },
   };
 
   CURLcode result = CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
If the target RDATA field tries to use compression, abort.

If any sublabel is longer than 63 octets, abort.

Reported-by: netspacer.research
