### PR TITLE
libssh2: fix to return error code on missing parameter

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -805,7 +805,7 @@ static CURLcode sftp_quote(struct Curl_easy *data,
   cp = strchr(cmd, ' ');
   if(!cp) {
     failf(data, "Syntax error command '%s', missing parameter", cmd);
-    return result;
+    return CURLE_QUOTE_ERROR;
   }
 
   /*


### PR DESCRIPTION
Reported by GitHub Code Quality

Follow-up to 0095f98464d85a3b2863d1c9ef7c5a71c9739450 #15250

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
