### PR TITLE
libssh2: drop stray double-negative from `strncmp()` result

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1207,7 +1207,7 @@ static CURLcode sftp_quote_stat(struct Curl_easy *data,
     sshc->acceptfail = TRUE;
   }
 
-  if(!!strncmp(cmd, "chmod", 5)) {
+  if(strncmp(cmd, "chmod", 5)) {
     /* Since chown and chgrp only set owner OR group but libssh2 wants to set
      * them both at once, we need to obtain the current ownership first. This
      * takes an extra protocol round trip.


### PR DESCRIPTION
Just a tidy-up. Logic remains identical.

Spotted by GitHub Code Quality

Follow-up to a867314f4fba0f05201226093335d75f3dbd0f3f #16382

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
