### PR TITLE
setopt: return error if received `curl_blob->data` is NULL

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -108,7 +108,7 @@ CURLcode Curl_setblobopt(struct curl_blob **blobp,
 
   if(blob) {
     struct curl_blob *nblob;
-    if(!blob->len || (blob->len > CURL_MAX_INPUT_LENGTH))
+    if(!blob->data || !blob->len || (blob->len > CURL_MAX_INPUT_LENGTH))
       return CURLE_BAD_FUNCTION_ARGUMENT;
     nblob = (struct curl_blob *)
       curlx_malloc(sizeof(struct curl_blob) +


### PR DESCRIPTION
To avoid dereferencing in the function if `CURL_BLOB_COPY` is set, or
outside of the function if unset.

Reported-by: netspacer.research

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
