### PR TITLE
doh: drop redundant `curlx_dyn_free()` call in `doh_probe_done()`

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -259,7 +259,6 @@ static void doh_probe_done(struct Curl_easy *data,
     result = curlx_dyn_addn(&dohp->probe_resp[i].body,
                             curlx_dyn_ptr(&doh_req->resp_body),
                             curlx_dyn_len(&doh_req->resp_body));
-    curlx_dyn_free(&doh_req->resp_body);
   }
   Curl_meta_remove(doh, CURL_EZM_DOH_PROBE);
 


### PR DESCRIPTION
The buffer is freed on the next instruction via `Curl_meta_remove()`'s
destructor.

Reported-by: netspacer.research

Follow-up to 1ebd92d0fdbb1693c926f7190442dff00226fbf3 #16384

---

AFAICS this cannot cause a double free due to using `curlx_safefree()`
which resets the pointer to NULL after free. It may have called free with
NULL on the second call, which should be a no-op.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
