### PR TITLE
peer: fix ipv6 detection

### DIFF
--- a/lib/peer.c
+++ b/lib/peer.c
@@ -222,7 +222,14 @@ static CURLcode peer_parse_host(struct Curl_easy *data,
     if(scan_for_ipv6 &&
        Curl_looks_like_ipv6(pp->host_user.str, pp->host_user.len, TRUE,
                             &pp->host, &pp->zoneid)) {
-      pp->ipv6 = TRUE;
+      if(pp->host_user.len < MAX_IPADR_LEN) {
+        char tmp[MAX_IPADR_LEN];
+        memcpy(tmp, pp->host_user.str, pp->host_user.len);
+        tmp[pp->host_user.len] = 0;
+        pp->ipv6 = !Curl_is_ipv4addr(tmp);
+      }
+      else
+        pp->ipv6 = TRUE;
     }
     else
       pp->host = pp->host_user;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -263,7 +263,7 @@ test2300 test2301 test2302 test2303 test2304 test2306 test2307 test2308 \
 test2309 test2310 test2311 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 test2407 \
-test2408 test2409 test2410 test2411 test2412 \
+test2408 test2409 test2410 test2411 test2412 test2413 \
 \
 test2500 test2501 test2502 test2503 test2504 test2505 test2506 \
 \

--- a/tests/data/test2413
+++ b/tests/data/test2413
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+Curl_peer
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+unittest
+</features>
+<name>
+Curl_peer unit tests
+</name>
+</client>
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -44,6 +44,7 @@ TESTS_C = \
              unit1666.c unit1667.c unit1668.c unit1669.c \
   unit1674.c unit1675.c unit1676.c \
   unit1979.c unit1980.c \
+  unit2413.c \
   unit2600.c unit2601.c unit2602.c unit2603.c unit2604.c unit2605.c \
   unit3200.c                                             unit3205.c \
   unit3211.c unit3212.c unit3213.c unit3214.c            unit3216.c unit3219.c \

--- a/tests/unit/unit2413.c
+++ b/tests/unit/unit2413.c
@@ -57,7 +57,7 @@ static CURLcode test_create2413(const char *name,
   else if(peer->port != port)
     curl_mfprintf(stderr, "%s: port=%u, expected %u", name,
                   peer->port, port);
-  else if(peer->ipv6 != exp_ipv6)
+  else if((bool)peer->ipv6 != exp_ipv6)
     curl_mfprintf(stderr, "%s: ipv6=%d, expected %d", name,
                   peer->ipv6, exp_ipv6);
   else if(exp_zoneid &&

--- a/tests/unit/unit2413.c
+++ b/tests/unit/unit2413.c
@@ -101,6 +101,8 @@ static CURLcode test_unit2413(const char *arg)
                             "test.curl.se.", FALSE, NULL);
   test_create2413("peer5", curl, &Curl_scheme_https, "[::1%tada]", 1234,
                             "::1", TRUE, "tada");
+  test_create2413("peer6", curl, &Curl_scheme_https, "::1%tada", 1234,
+                            "::1", TRUE, "tada");
 
   curl_easy_cleanup(curl);
   Curl_peer_unlink(&peer);

--- a/tests/unit/unit2413.c
+++ b/tests/unit/unit2413.c
@@ -1,0 +1,110 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+#include "urldata.h"
+
+static CURLcode test_create2413(const char *name,
+                                CURL *curl,
+                                const struct Curl_scheme *scheme,
+                                const char *hostname,
+                                uint16_t port,
+                                const char *exp_hostname,
+                                bool exp_ipv6,
+                                const char *exp_zoneid)
+{
+  struct Curl_peer *peer = NULL;
+  CURLcode result;
+
+  result = Curl_peer_create((struct Curl_easy *)curl,
+                            scheme, hostname, port, &peer);
+  if(result) {
+    curl_mfprintf(stderr, "%s: create failed %d", name, (int)result);
+    goto out;
+  }
+
+  result = CURLE_FAILED_INIT;
+  if(peer->scheme != scheme) {
+    curl_mfprintf(stderr, "%s: has wrong scheme", name);
+  }
+  else if(!curl_strequal(peer->user_hostname, hostname)) {
+    curl_mfprintf(stderr, "%s: user_hostname=%s, expected %s", name,
+                  peer->user_hostname, exp_hostname);
+  }
+  else if(exp_hostname && !curl_strequal(peer->hostname, exp_hostname))
+    curl_mfprintf(stderr, "%s: hostname=%s, expected %s", name,
+                  peer->hostname, exp_hostname);
+  else if(peer->port != port)
+    curl_mfprintf(stderr, "%s: port=%u, expected %u", name,
+                  peer->port, port);
+  else if(peer->ipv6 != exp_ipv6)
+    curl_mfprintf(stderr, "%s: ipv6=%d, expected %d", name,
+                  peer->ipv6, exp_ipv6);
+  else if(exp_zoneid &&
+          (!peer->zoneid || !curl_strequal(exp_zoneid, peer->zoneid)))
+    curl_mfprintf(stderr, "%s: zoneid=%s, expected %s", name,
+                  peer->zoneid, exp_zoneid);
+  else if(!exp_zoneid && peer->zoneid)
+    curl_mfprintf(stderr, "%s: zoneid=%s, expected nothing", name,
+                  peer->zoneid);
+  else
+    result = CURLE_OK;
+
+out:
+  Curl_peer_unlink(&peer);
+  fail_unless(!result, "check failed");
+  return result;
+}
+
+static CURLcode test_unit2413(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+  CURL *curl;
+  struct Curl_peer *peer = NULL;
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  curl = curl_easy_init();
+  if(!curl) {
+    curl_global_cleanup();
+    goto unit_test_abort;
+  }
+
+  test_create2413("peer1", curl, &Curl_scheme_https, "test.curl.se", 1234,
+                            "test.curl.se", FALSE, NULL);
+  test_create2413("peer2", curl, &Curl_scheme_https, "127.0.0.1", 1234,
+                            "127.0.0.1", FALSE, NULL);
+  test_create2413("peer3", curl, &Curl_scheme_https, "::1", 1234,
+                            "::1", TRUE, NULL);
+  test_create2413("peer3", curl, &Curl_scheme_https, "[::1]", 1234,
+                            "::1", TRUE, NULL);
+  test_create2413("peer4", curl, &Curl_scheme_https, "test.curl.se.", 1234,
+                            "test.curl.se.", FALSE, NULL);
+  test_create2413("peer5", curl, &Curl_scheme_https, "[::1%tada]", 1234,
+                            "::1", TRUE, "tada");
+
+  curl_easy_cleanup(curl);
+  Curl_peer_unlink(&peer);
+  curl_global_cleanup();
+
+  UNITTEST_END_SIMPLE
+}


### PR DESCRIPTION
When trying to detect ipv6 addresses, ipv4 addresses were also flagged as ipv6.

Add test2413 to check.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
