### PR TITLE
GHA/windows: settle on windows-2025 image name

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1032,7 +1032,7 @@ jobs:
               # VS2022). Since it integrates badly with CI steps and shell scripts,
               # reproduce the necessary build configuration manually, without envs.
               MSVC_EDITION='2022/Enterprise/vc/tools/msvc'
-              [[ "${MATRIX_IMAGE}" = *'vs2026'* ]] && MSVC_EDITION='18/Enterprise/vc/tools/msvc'
+              [[ "${MATRIX_IMAGE}" = *'windows-2025'* ]] && MSVC_EDITION='18/Enterprise/vc/tools/msvc'
               [[ "$(uname -s)" = *'ARM64'* ]] && MSVC_HOST='arm64' || MSVC_HOST='x64'  # x86
               MSVC_ROOTD="$(cygpath --mixed --short-name "$PROGRAMFILES/Microsoft Visual Studio")"  # to avoid spaces in directory names
               MSVC_ROOTU="$(/usr/bin/find "$(cygpath --unix "$MSVC_ROOTD/$MSVC_EDITION")" -mindepth 1 -maxdepth 1 -type d -name '*.*' | sort | tail -n 1)"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -311,7 +311,7 @@ jobs:
           #   build: 'autotools', sys: 'ucrt64'    , env: 'ucrt-x86_64'  , tflags: 'skiprun'   ,
           #   config: '--without-debug --with-schannel --disable-static',
           #   install: 'mingw-w64-ucrt-x86_64-libssh2' }
-          - { name: 'schannel dev debug', type: 'Debug', cppflags: '-DCURL_SCHANNEL_DEV_DEBUG', image: 'windows-2025-vs2026',
+          - { name: 'schannel dev debug', type: 'Debug', cppflags: '-DCURL_SCHANNEL_DEV_DEBUG', image: 'windows-2025',
               build: 'cmake'    , sys: 'mingw64'   , env: 'x86_64'       , tflags: 'skiprun'   ,
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCMAKE_VERBOSE_MAKEFILE=ON',
               install: 'mingw-w64-x86_64-libssh2' }
@@ -902,7 +902,7 @@ jobs:
             env: 'ucrt-x86_64'
             plat: 'uwp'
             type: 'Debug'
-            image: 'windows-2025-vs2026'
+            image: 'windows-2025'
             tflags: 'skiprun'
             config: >-
               -DENABLE_DEBUG=ON
@@ -924,7 +924,7 @@ jobs:
             env: 'ucrt-x86_64'
             plat: 'windows'
             type: 'Debug'
-            image: 'windows-2025-vs2026'
+            image: 'windows-2025'
             chkprefill: '_chkprefill'
             tflags: '--min=1850'
             config: >-


### PR DESCRIPTION
It's the final/stable image name and it's shipping with VS2026 now.

Ref: https://github.com/actions/runner-images/issues/14017
Follow-up to b0239417b34238121165dee465afb944cbad17ec #21713

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
