### PR TITLE
Several small improvements

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -687,6 +687,7 @@ void Curl_conn_terminate(struct Curl_easy *data,
 struct cpool_reaper_ctx {
   size_t checked;
   size_t reaped;
+  struct curltime now;
 };
 
 static int cpool_reap_dead_cb(struct Curl_easy *data,
@@ -697,7 +698,7 @@ static int cpool_reap_dead_cb(struct Curl_easy *data,
 
   if(!terminate) {
     reaper->checked++;
-    terminate = Curl_conn_seems_dead(conn, data);
+    terminate = Curl_conn_seems_dead(conn, data, &reaper->now);
   }
   if(terminate) {
     /* stop the iteration here, pass back the connection that was pruned */
@@ -718,17 +719,19 @@ static int cpool_reap_dead_cb(struct Curl_easy *data,
 void Curl_cpool_prune_dead(struct Curl_easy *data)
 {
   struct cpool *cpool = cpool_get_instance(data);
-  struct cpool_reaper_ctx reaper;
   timediff_t elapsed;
 
   if(!cpool)
     return;
 
-  memset(&reaper, 0, sizeof(reaper));
   CPOOL_LOCK(cpool, data);
   elapsed = curlx_ptimediff_ms(Curl_pgrs_now(data), &cpool->last_cleanup);
 
   if(elapsed >= 1000L) {
+    struct cpool_reaper_ctx reaper;
+
+    memset(&reaper, 0, sizeof(reaper));
+    reaper.now = *Curl_pgrs_now(data);
     while(cpool_foreach(data, cpool, &reaper, cpool_reap_dead_cb))
       ;
     cpool->last_cleanup = *Curl_pgrs_now(data);

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -636,7 +636,9 @@ CURLcode Curl_hsts_loadfiles(struct Curl_easy *data)
 
 bool Curl_hsts_applies(struct hsts *h, const struct Curl_peer *dest)
 {
-  return !!hsts_check(h, dest->hostname, strlen(dest->hostname), TRUE);
+  if(Curl_llist_count(&h->list))
+    return !!hsts_check(h, dest->hostname, strlen(dest->hostname), TRUE);
+  return FALSE;
 }
 
 #if defined(DEBUGBUILD) || defined(UNITTESTS)

--- a/lib/http.c
+++ b/lib/http.c
@@ -2115,7 +2115,7 @@ static CURLcode http_target(struct Curl_easy *data,
       return CURLE_OUT_OF_MEMORY;
     }
 
-    if(curl_strequal("http", data->state.up.scheme)) {
+    if(data->state.origin->scheme == &Curl_scheme_http) {
       /* when getting HTTP, we do not want the userinfo the URL */
       uc = curl_url_set(h, CURLUPART_USER, NULL, 0);
       if(uc) {
@@ -2157,7 +2157,7 @@ static CURLcode http_target(struct Curl_easy *data,
     if(result)
       return result;
 
-    if(curl_strequal("ftp", data->state.up.scheme) &&
+    if((data->state.origin->scheme == &Curl_scheme_ftp) &&
        data->set.proxy_transfer_mode) {
       /* when doing ftp, append ;type=<a|i> if not present */
       size_t len = strlen(path);

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -449,10 +449,10 @@ CURLcode Curl_http_proxy_create_tunnel_request(
     return result;
 
   if(udp_tunnel)
-    infof(data, "Establishing %s proxy UDP tunnel to %s:%s",
+    infof(data, "Establishing %s proxy UDP tunnel to %s:%u",
           (ver == PROXY_HTTP_V2) ? "HTTP/2" :
           (ver == PROXY_HTTP_V3) ? "HTTP/3" : "HTTP",
-          data->state.up.hostname, data->state.up.port);
+          dest->hostname, dest->port);
   else
     infof(data, "Establishing %s proxy tunnel to %s",
           (ver == PROXY_HTTP_V2) ? "HTTP/2" :

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -452,7 +452,7 @@ CURLcode Curl_http_proxy_create_tunnel_request(
     infof(data, "Establishing %s proxy UDP tunnel to %s:%u",
           (ver == PROXY_HTTP_V2) ? "HTTP/2" :
           (ver == PROXY_HTTP_V3) ? "HTTP/3" : "HTTP",
-          dest->hostname, dest->port);
+          dest->user_hostname, dest->port);
   else
     infof(data, "Establishing %s proxy tunnel to %s",
           (ver == PROXY_HTTP_V2) ? "HTTP/2" :

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -718,7 +718,8 @@ static curl_ldap_num_t ldap_url_parse2_low(struct Curl_easy *data,
   if(!data ||
      !data->state.up.path ||
      data->state.up.path[0] != '/' ||
-     !curl_strnequal("LDAP", data->state.up.scheme, 4))
+     ((data->state.origin->scheme != &Curl_scheme_ldap) &&
+      (data->state.origin->scheme != &Curl_scheme_ldaps)))
     return LDAP_INVALID_SYNTAX;
 
   ludp->lud_scope = LDAP_SCOPE_BASE;

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -164,7 +164,7 @@ static CURLcode oldap_map_error(int rc, CURLcode result)
 static CURLcode oldap_url_parse(struct Curl_easy *data, LDAPURLDesc **ludp)
 {
   CURLcode result = CURLE_OK;
-  int rc = LDAP_URL_ERR_BADURL;
+  int rc;
   static const char * const url_errs[] = {
     "success",
     "out of memory",
@@ -180,9 +180,16 @@ static CURLcode oldap_url_parse(struct Curl_easy *data, LDAPURLDesc **ludp)
   };
 
   *ludp = NULL;
-  if(!Curl_creds_has_user_or_pass(data->state.creds) &&
-     !data->state.up.options)
+  /* `ldap_url_parse() seems to be terrible with urls
+   * that have user/pass/options in it. So when we have options or
+   * creds from the url, fail without calling the function.
+   * Yes, this is super-weird code and I do not like it. */
+  if((data->state.creds && (data->state.creds->source == CREDS_URL)) ||
+     data->state.up.options)
+    rc = LDAP_URL_ERR_BADURL;
+  else
     rc = ldap_url_parse(Curl_bufref_ptr(&data->state.url), ludp);
+
   if(rc != LDAP_URL_SUCCESS) {
     const char *msg = "url parsing problem";
 

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -614,11 +614,11 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   if(result)
     goto out;
 
-  hosturl = curl_maprintf("%s://%s%s%s:%u",
+  hosturl = curl_maprintf("%s://%s:%u",
                           conn->scheme->name,
-                          conn->origin->ipv6 ? "[" : "",
+                          conn->origin->ipv6 ?
+                          conn->origin->user_hostname :
                           conn->origin->hostname,
-                          conn->origin->ipv6 ? "]" : "",
                           conn->origin->port);
   if(!hosturl) {
     result = CURLE_OUT_OF_MEMORY;

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -180,7 +180,7 @@ static CURLcode oldap_url_parse(struct Curl_easy *data, LDAPURLDesc **ludp)
   };
 
   *ludp = NULL;
-  if(!data->state.up.user && !data->state.up.password &&
+  if(!Curl_creds_has_user_or_pass(data->state.creds) &&
      !data->state.up.options)
     rc = ldap_url_parse(Curl_bufref_ptr(&data->state.url), ludp);
   if(rc != LDAP_URL_SUCCESS) {
@@ -605,7 +605,7 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   if(result)
     goto out;
 
-  li->proto = ldap_pvt_url_scheme2proto(data->state.up.scheme);
+  li->proto = ldap_pvt_url_scheme2proto(data->state.origin->scheme->name);
 
   /* Initialize the SASL storage */
   Curl_sasl_init(&li->sasl, data, &saslldap);
@@ -614,10 +614,11 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   if(result)
     goto out;
 
-  hosturl = curl_maprintf("%s://%s:%d",
+  hosturl = curl_maprintf("%s://%s%s%s:%u",
                           conn->scheme->name,
-                          (data->state.up.hostname[0] == '[') ?
-                          data->state.up.hostname : conn->origin->hostname,
+                          conn->origin->ipv6 ? "[" : "",
+                          conn->origin->hostname,
+                          conn->origin->ipv6 ? "]" : "",
                           conn->origin->port);
   if(!hosturl) {
     result = CURLE_OUT_OF_MEMORY;

--- a/lib/peer.c
+++ b/lib/peer.c
@@ -74,6 +74,7 @@
 #include "peer.h"
 #include "urldata.h"
 #include "url.h"
+#include "urlapi-int.h"
 #include "vtls/vtls.h"
 
 struct peer_parse {
@@ -354,27 +355,26 @@ CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,
                             struct Curl_peer **ppeer)
 {
   struct peer_parse pp;
-  char *zoneid = NULL;
+  char *zoneid = NULL, *scheme = NULL, *hostname = NULL;
   CURLUcode uc;
   CURLcode result;
 
+  (void)up;
   Curl_peer_unlink(ppeer);
   memset(&pp, 0, sizeof(pp));
 
-  curlx_safefree(up->scheme);
-  uc = curl_url_get(uh, CURLUPART_SCHEME, &up->scheme, 0);
+  uc = curl_url_get(uh, CURLUPART_SCHEME, &scheme, 0);
   if(uc)
     return Curl_uc_to_curlcode(uc);
-  pp.scheme = Curl_get_scheme(up->scheme);
+  pp.scheme = Curl_get_scheme(scheme);
   if(!pp.scheme) {
-    failf(data, "Protocol \"%s\" not supported%s", up->scheme,
+    failf(data, "Protocol \"%s\" not supported%s", scheme,
           data->state.this_is_a_follow ? " (in redirect)" : "");
     result = CURLE_UNSUPPORTED_PROTOCOL;
     goto out;
   }
 
-  curlx_safefree(up->hostname);
-  uc = curl_url_get(uh, CURLUPART_HOST, &up->hostname, 0);
+  uc = curl_url_get(uh, CURLUPART_HOST, &hostname, 0);
   if(uc) {
     if((uc == CURLUE_NO_HOST) && (pp.scheme->flags & PROTOPT_NONETWORK))
       ; /* acceptable */
@@ -383,13 +383,13 @@ CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,
       goto out;
     }
   }
-  else if(strlen(up->hostname) > MAX_URL_LEN) {
+  else if(strlen(hostname) > MAX_URL_LEN) {
     failf(data, "Too long hostname (maximum is %d)", MAX_URL_LEN);
     result = CURLE_URL_MALFORMAT;
     goto out;
   }
 
-  pp.host_user.str = up->hostname ? up->hostname : "";
+  pp.host_user.str = hostname ? hostname : "";
   pp.host_user.len = strlen(pp.host_user.str);
   if(pp.host_user.len) {
     result = peer_parse_host(data, &pp, FALSE);
@@ -399,7 +399,6 @@ CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,
   else
     pp.host = pp.host_user;
 
-  curlx_safefree(up->port);
   if(port_override) {
     /* if set, we use this instead of the port possibly given in the URL */
     char portbuf[16];
@@ -413,7 +412,7 @@ CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,
       pp.port = port_override;
   }
   else {
-    uc = curl_url_get(uh, CURLUPART_PORT, &up->port, CURLU_DEFAULT_PORT);
+    uc = Curl_url_get_port(uh, &pp.port);
     if(uc) {
       if(uc == CURLUE_OUT_OF_MEMORY) {
         result = CURLE_OUT_OF_MEMORY;
@@ -424,13 +423,6 @@ CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,
         goto out;
       }
       /* no port ok when not a network scheme */
-    }
-    else {
-      const char *p = up->port;
-      curl_off_t offt;
-      if(curlx_str_number(&p, &offt, 0xffff))
-        return CURLE_URL_MALFORMAT;
-      pp.port = (uint16_t)offt;
     }
   }
 
@@ -456,6 +448,8 @@ CURLcode Curl_peer_from_url(CURLU *uh, struct Curl_easy *data,
 
 out:
   peer_parse_clear(&pp);
+  curlx_free(scheme);
+  curlx_free(hostname);
   curlx_free(zoneid);
   return result;
 }

--- a/lib/proxy.c
+++ b/lib/proxy.c
@@ -282,8 +282,6 @@ UNITTEST bool proxy_check_noproxy(const char *name, const char *no_proxy)
 static char *proxy_detect_proxy(struct Curl_easy *data,
                                 const struct Curl_scheme *scheme)
 {
-  char *proxy = NULL;
-
   /* If proxy was not specified, we check for default proxy environment
    * variables, to enable i.e Lynx compliance:
    *
@@ -301,58 +299,61 @@ static char *proxy_detect_proxy(struct Curl_easy *data,
    * For compatibility, the all-uppercase versions of these variables are
    * checked if the lowercase versions do not exist.
    */
-  char proxy_env[20];
-  const char *envp;
-  VERBOSE(envp = proxy_env);
+  const char *env_name = NULL;
+  char *proxy = NULL;
+  char name_buf[20];
 
-  curl_msnprintf(proxy_env, sizeof(proxy_env), "%s_proxy", scheme->name);
+  /* Optimize for common use */
+  if((scheme != &Curl_scheme_https) && (scheme != &Curl_scheme_http)) {
+    curl_msnprintf(name_buf, sizeof(name_buf), "%s_proxy", scheme->name);
+    env_name = name_buf;
+    /* read the protocol proxy: */
+    proxy = curl_getenv(env_name);
+    if(!proxy) {
+      /* There was no lowercase variable, try the uppercase version: */
+      Curl_strntoupper(name_buf, name_buf, sizeof(name_buf));
+      proxy = curl_getenv(env_name);
+    }
+  }
 
-  /* read the protocol proxy: */
-  proxy = curl_getenv(proxy_env);
-
-  /*
-   * We do not try the uppercase version of HTTP_PROXY because of
-   * security reasons:
-   *
-   * When curl is used in a webserver application
-   * environment (cgi or php), this environment variable can
-   * be controlled by the web server user by setting the
-   * http header 'Proxy:' to some value.
-   *
-   * This can cause 'internal' http/ftp requests to be
-   * arbitrarily redirected by any external attacker.
-   */
-  if(!proxy && !curl_strequal("http_proxy", proxy_env)) {
-    /* There was no lowercase variable, try the uppercase version: */
-    Curl_strntoupper(proxy_env, proxy_env, sizeof(proxy_env));
-    proxy = curl_getenv(proxy_env);
+  if(!proxy &&
+     ((scheme == &Curl_scheme_https) || (scheme == &Curl_scheme_wss))) {
+    env_name = "https_proxy";
+    proxy = curl_getenv(env_name);
+    if(!proxy) {
+      env_name = "HTTPS_PROXY";
+      proxy = curl_getenv(env_name);
+    }
+  }
+  else if(!proxy &&
+          ((scheme == &Curl_scheme_http) || (scheme == &Curl_scheme_ws))) {
+    /*
+     * We do not try the uppercase version of HTTP_PROXY because of
+     * security reasons:
+     *
+     * When curl is used in a webserver application
+     * environment (cgi or php), this environment variable can
+     * be controlled by the web server user by setting the
+     * http header 'Proxy:' to some value.
+     *
+     * This can cause 'internal' http/ftp requests to be
+     * arbitrarily redirected by any external attacker.
+     */
+    env_name = "http_proxy";
+    proxy = curl_getenv(env_name);
   }
 
   if(!proxy) {
-#ifndef CURL_DISABLE_WEBSOCKETS
-    /* websocket proxy fallbacks */
-    if(curl_strequal("ws_proxy", proxy_env)) {
-      proxy = curl_getenv("http_proxy");
-    }
-    else if(curl_strequal("wss_proxy", proxy_env)) {
-      proxy = curl_getenv("https_proxy");
-      if(!proxy)
-        proxy = curl_getenv("HTTPS_PROXY");
-    }
+    env_name = "all_proxy";
+    proxy = curl_getenv(env_name); /* default proxy to use */
     if(!proxy) {
-#endif
-      envp = "all_proxy";
-      proxy = curl_getenv(envp); /* default proxy to use */
-      if(!proxy) {
-        envp = "ALL_PROXY";
-        proxy = curl_getenv(envp);
-      }
-#ifndef CURL_DISABLE_WEBSOCKETS
+      env_name = "ALL_PROXY";
+      proxy = curl_getenv(env_name);
     }
-#endif
   }
+
   if(proxy)
-    infof(data, "Uses proxy env variable %s == '%s'", envp, proxy);
+    infof(data, "Uses proxy env variable %s == '%s'", env_name, proxy);
 
   return proxy;
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -178,11 +178,6 @@ void Curl_freeset(struct Curl_easy *data)
 static void up_free(struct Curl_easy *data)
 {
   struct urlpieces *up = &data->state.up;
-  curlx_safefree(up->scheme);
-  curlx_safefree(up->hostname);
-  curlx_safefree(up->port);
-  curlx_safefree(up->user);
-  curlx_safefree(up->password);
   curlx_safefree(up->options);
   curlx_safefree(up->path);
   curlx_safefree(up->query);
@@ -606,7 +601,8 @@ static bool conn_maxage(struct Curl_easy *data,
  * Return TRUE iff the given connection is considered dead.
  */
 bool Curl_conn_seems_dead(struct connectdata *conn,
-                          struct Curl_easy *data)
+                          struct Curl_easy *data,
+                          const struct curltime *pnow)
 {
   DEBUGASSERT(!data->conn);
   if(!CONN_INUSE(conn)) {
@@ -614,10 +610,12 @@ bool Curl_conn_seems_dead(struct connectdata *conn,
        use */
     bool dead;
 
-    if(conn_maxage(data, conn, *Curl_pgrs_now(data))) {
+    if(conn_maxage(data, conn, *pnow)) {
       /* avoid check if already too old */
       dead = TRUE;
     }
+    else if(curlx_ptimediff_ms(pnow, &conn->lastchecked) < 1000)
+      dead = FALSE;
     else if(conn->scheme->run->connection_is_dead) {
       /* The protocol has a special method for checking the state of the
          connection. Use it to check if the connection is dead. */
@@ -625,6 +623,7 @@ bool Curl_conn_seems_dead(struct connectdata *conn,
       Curl_attach_connection(data, conn);
       dead = conn->scheme->run->connection_is_dead(data, conn);
       Curl_detach_connection(data);
+      conn->lastchecked = *pnow;
     }
     else {
       bool input_pending = FALSE;
@@ -644,6 +643,7 @@ bool Curl_conn_seems_dead(struct connectdata *conn,
         dead = TRUE;
       }
       Curl_detach_connection(data);
+      conn->lastchecked = *pnow;
     }
 
     if(dead) {
@@ -690,6 +690,7 @@ struct url_conn_match {
   struct connectdata *found;
   struct Curl_easy *data;
   struct connectdata *needle;
+  struct curltime now;
   BIT(may_multiplex);
   BIT(want_ntlm_http);
   BIT(want_proxy_ntlm_http);
@@ -1172,7 +1173,7 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
   if(!url_match_multiplex_limits(conn, m))
     return FALSE;
 
-  if(!CONN_INUSE(conn) && Curl_conn_seems_dead(conn, m->data)) {
+  if(!CONN_INUSE(conn) && Curl_conn_seems_dead(conn, m->data, &m->now)) {
     /* remove and disconnect. */
     Curl_conn_terminate(m->data, conn, FALSE);
     return FALSE;
@@ -1227,6 +1228,7 @@ static bool url_attach_existing(struct Curl_easy *data,
   memset(&match, 0, sizeof(match));
   match.data = data;
   match.needle = needle;
+  match.now = *Curl_pgrs_now(data);
   match.may_multiplex = xfer_may_multiplex(data, needle);
 
 #ifdef USE_NTLM
@@ -1374,7 +1376,6 @@ static CURLcode hsts_upgrade(struct Curl_easy *data,
     CURLUcode uc;
     CURLcode result;
 
-    curlx_safefree(data->state.up.scheme);
     uc = curl_url_set(uh, CURLUPART_SCHEME, "https", 0);
     if(uc)
       return Curl_uc_to_curlcode(uc);
@@ -1542,26 +1543,28 @@ static CURLcode url_set_data_creds(struct Curl_easy *data, CURLU *uh)
   /* Extract credentials from the URL only if there are none OR
    * if no CURLOPT_USER was set. */
   if(!newcreds || !Curl_creds_has_user(newcreds)) {
+    char *user = NULL;
+    char *passwd = NULL;
     char *udecoded = NULL;
     char *pdecoded = NULL;
     CURLUcode uc;
 
-    uc = curl_url_get(uh, CURLUPART_USER, &data->state.up.user, 0);
+    uc = curl_url_get(uh, CURLUPART_USER, &user, 0);
     if(uc && (uc != CURLUE_NO_USER))
       result = Curl_uc_to_curlcode(uc);
     if(!result) {
-      uc = curl_url_get(uh, CURLUPART_PASSWORD, &data->state.up.password, 0);
+      uc = curl_url_get(uh, CURLUPART_PASSWORD, &passwd, 0);
       if(uc && (uc != CURLUE_NO_PASSWORD))
         result = Curl_uc_to_curlcode(uc);
     }
-    if(!result && data->state.up.user) {
-      result = Curl_urldecode(data->state.up.user, 0, &udecoded, NULL,
+    if(!result && user) {
+      result = Curl_urldecode(user, 0, &udecoded, NULL,
                               (data->state.origin->scheme->flags &
                                PROTOPT_USERPWDCTRL) ?
                               REJECT_ZERO : REJECT_CTRL);
     }
-    if(!result && data->state.up.password) {
-      result = Curl_urldecode(data->state.up.password, 0, &pdecoded, NULL,
+    if(!result && passwd) {
+      result = Curl_urldecode(passwd, 0, &pdecoded, NULL,
                               (data->state.origin->scheme->flags &
                                PROTOPT_USERPWDCTRL) ?
                               REJECT_ZERO : REJECT_CTRL);
@@ -1572,6 +1575,8 @@ static CURLcode url_set_data_creds(struct Curl_easy *data, CURLU *uh)
 
     curlx_free(udecoded);
     curlx_free(pdecoded);
+    curlx_free(passwd);
+    curlx_free(user);
     if(result) {
       failf(data, "error extracting credentials from URL");
       goto out;

--- a/lib/url.h
+++ b/lib/url.h
@@ -75,7 +75,8 @@ void *Curl_conn_meta_get(struct connectdata *conn, const char *key);
  * Return TRUE iff the given connection is considered dead.
  */
 bool Curl_conn_seems_dead(struct connectdata *conn,
-                          struct Curl_easy *data);
+                          struct Curl_easy *data,
+                          const struct curltime *pnow);
 
 /**
  * Perform upkeep operations on the connection.

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -65,4 +65,6 @@ CURLUcode Curl_junkscan(const char *url, size_t *urllen, bool allowspace);
 
 bool Curl_url_same_origin(CURLU *base, CURLU *href);
 
+CURLUcode Curl_url_get_port(CURLU *u, uint16_t *pport);
+
 #endif /* HEADER_CURL_URLAPI_INT_H */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -2100,3 +2100,20 @@ bool Curl_url_same_origin(CURLU *base, CURLU *href)
     return FALSE;
   return TRUE;
 }
+
+CURLUcode Curl_url_get_port(CURLU *u, uint16_t *pport)
+{
+  if(u->port) {
+    *pport = u->portnum;
+    return CURLUE_OK;
+  }
+  else if(u->scheme) {
+    const struct Curl_scheme *s = Curl_get_scheme(u->scheme);
+    if(s && s->defport) {
+      *pport = s->defport;
+      return CURLUE_OK;
+    }
+  }
+  *pport = 0;
+  return CURLUE_NO_PORT;
+}

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -305,6 +305,7 @@ struct connectdata {
   char *options; /* options string, allocated */
   struct curltime created; /* creation time */
   struct curltime lastused; /* when returned to the connection pool as idle */
+  struct curltime lastchecked; /* last checked for being alive */
 
   /* A connection can have one or two sockets and connection filters.
    * The protocol using the 2nd one is FTP for CONTROL+DATA sockets */
@@ -559,11 +560,6 @@ struct time_node {
 
 /* individual pieces of the URL */
 struct urlpieces {
-  char *scheme;
-  char *hostname;
-  char *port;
-  char *user;
-  char *password;
   char *options;
   char *path;
   char *query;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2616,8 +2616,8 @@ static CURLcode myssh_connect(struct Curl_easy *data, bool *done)
   }
 
   rc = ssh_options_set(sshc->ssh_session, SSH_OPTIONS_HOST,
-                       (data->state.up.hostname[0] == '[') ?
-                       data->state.up.hostname : conn->origin->hostname);
+                       conn->origin->ipv6 ?
+                       conn->origin->user_hostname : conn->origin->hostname);
 
   if(rc != SSH_OK) {
     failf(data, "Could not set remote host");

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -671,7 +671,7 @@ static CURLcode post_output_handling(struct per_transfer *per,
       return CURLE_WRITE_ERROR;
   }
 
-  if(!outs->regular_file && outs->stream) {
+  if(!outs->regular_file && outs->stream && !outs->out_null) {
     /* Dump standard stream buffered data */
     rc = fflush(outs->stream);
     if(!result && rc) {


### PR DESCRIPTION
- check alive status of a connection not more than once every second
- do not string compare scheme names, use protocol.h constants
- struct urlpieces: remove scheme, hostname, port, user, password. Use values from peer/creds
- add urlapi internal function `Curl_url_get_port()` to avoid port number conversions back and forth
- proxy setup: use getenv with string constants for common schemes
- tool: do not flush output when --out-null is in effect

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
