### PR TITLE
GHA/non-native: BSD overhaul, test more autotools, bump versions

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -144,6 +144,7 @@ jobs:
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             sudo pkg_add brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
+            sudo pkg_delete curl
           fi
 
       - name: 'autoreconf'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -101,7 +101,7 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools="${tools} stunnel py311-impacket"
+            [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} stunnel py311-impacket"
             sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
@@ -121,7 +121,7 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools="${tools} py311-impacket"
+            [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py311-impacket"
             sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
@@ -131,7 +131,7 @@ jobs:
             else
               tools='autoconf-- automake-- libtool'
             fi
-            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools="${tools} py3-six py3-impacket"
+            [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py3-six py3-impacket"
             sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2
           fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -68,11 +68,11 @@ jobs:
               options: '--with-gnutls' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
               options: '-DCURL_USE_GNUTLS=ON' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
+          - { os: 'netbsd'      , version: '10.1' , build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
               options: '--with-openssl --with-gssapi' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd'     , version: '7.8'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl skipall' }
+          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall' }
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               options: '--with-openssl' }
       fail-fast: false
@@ -107,7 +107,7 @@ jobs:
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake-core ninja'
             else
-              tools='autoconf automake libtool'
+              tools='devel/autoconf automake libtool'
             fi
             sudo mport -q install ${tools} perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -138,7 +138,7 @@ jobs:
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake ninja'
             else
-              tools='autoconf-2.72p0 automake-1.18 libtool'
+              tools='autoconf-2.72p0 automake-1.18 libtool'  # why mandatory to hardwire versions?
             fi
             if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
               tools="${tools} libidn2 openldap-client--"  # unrelated to tests, just limit to no-test runs to save install time
@@ -151,7 +151,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: |
           if [ "${MATRIX_OS}" = 'openbsd' ]; then
-            export AUTOCONF_VERSION=2.72  # silliest thing
+            export AUTOCONF_VERSION=2.72  # why, oh why!
           fi
           autoreconf -fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -153,6 +153,9 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
               -DCURL_ENABLE_NTLM=ON ${MATRIX_OPTIONS}
           else
+            if [ "${MATRIX_OS}" = 'openbsd' ]; then
+              export AUTOMAKE_VERSION=1.18  # also why, oh why!
+            fi
             if [ "${MATRIX_ARCH}" != 'x86_64' ]; then
               options='--disable-manual --disable-docs'  # Slow with autotools, skip on emulated CPU
             fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -63,7 +63,7 @@ jobs:
               install: 'cmake ninja' }
 
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
-              install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel py311-impacket',
+              install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel',
               options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
 
           - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity skiprun !examples',
@@ -71,11 +71,11 @@ jobs:
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
 
           - { os: 'freebsd'     , version: '14.3',  build: 'autotools', arch: 'arm64' , cc: 'clang', desc: 'openssl !examples',
-              install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel py311-impacket',
+              install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel',
               options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
 
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
-              install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2 stunnel py311-impacket',
+              install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2 stunnel',
               options: '-DCURL_USE_GSSAPI=ON' }
 
           - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools' , arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
@@ -91,7 +91,7 @@ jobs:
               options: '--with-openssl --with-gssapi' }
 
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
-              install: 'cmake ninja-build mit-krb5 openldap-client libidn2 py311-impacket',
+              install: 'cmake ninja-build mit-krb5 openldap-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON' }
 
           - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
@@ -99,7 +99,7 @@ jobs:
               options: '--with-openssl --disable-unity' }
 
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
-              install: 'cmake ninja openldap-client-- libidn2 py3-six py3-impacket' }
+              install: 'cmake ninja openldap-client-- libidn2' }
 
       fail-fast: false
     steps:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -83,9 +83,9 @@ jobs:
 
           # https://app.midnightbsd.org/
           # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools' , arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
-              install: 'autoconf autoconf-archive automake libtool gnutls',
-              options: '--with-gnutls' }
+          # { os: 'midnightbsd' , version: '4.0.4', build: 'autotools' , arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
+          #   install: 'autoconf autoconf-archive automake libtool gnutls',
+          #   options: '--with-gnutls' }
 
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
               install: 'cmake-core ninja perl5 gnutls openldap26-client libidn2',

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -107,6 +107,10 @@ jobs:
               install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
               options: '--with-openssl --disable-debug' }
 
+          - { os: 'openbsd'     , version: '7.9'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
+              install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
+              options: '--with-openssl' }
+
           - { os: 'openbsd'     , version: '7.9'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               install: 'cmake ninja openldap-client-- libidn2' }
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
-              install: 'autoconf automake libtool perl5 openldap26-client libidn2',
+              install: 'autoconf automake libtool openldap26-client libidn2',
               options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
 
           - { os: 'dragonflybsd', version: '6.4.2', build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
@@ -96,7 +96,7 @@ jobs:
 
           - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
               install: 'autoconf-2.72p0 automake-1.18 libtool',  # why mandatory to hardwire versions?
-              options: '--with-openssl' }
+              options: '--with-openssl --disable-unity' }
 
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               install: 'cmake ninja openldap-client-- libidn2 py3-six py3-impacket' }

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -127,7 +127,7 @@ jobs:
             echo '=== upgrade'
             sudo mport upgrade | grep -v -E 'Downloading.+%'
             echo '=== install'
-            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E '(Downloading.+%|^/usr/local)' || true
+            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E '(Downloading.+%|/usr/local)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -49,6 +49,7 @@ jobs:
       MAKEFLAGS: -j 3
       MATRIX_ARCH: '${{ matrix.arch }}'
       MATRIX_BUILD: '${{ matrix.build }}'
+      MATRIX_INSTALL: '${{ matrix.install }}'
       MATRIX_OPTIONS: '${{ matrix.options }}'
       MATRIX_OS: '${{ matrix.os }}'
       MATRIX_DESC: '${{ matrix.desc }}'
@@ -57,24 +58,37 @@ jobs:
         include:
           # { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
           #   options: '--with-openssl' }
+
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
-              options: '--with-openssl --with-gssapi' }
+              install: 'openldap26-client libidn2',
+              options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
           - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity skiprun !examples',
+              install: 'krb5-devel openldap26-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
           - { os: 'freebsd'     , version: '14.3',  build: 'autotools', arch: 'arm64' , cc: 'clang', desc: 'openssl !examples',
-              options: '--with-openssl --with-gssapi' }
+              install: 'krb5-devel openldap26-client libidn2',
+              options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
+              install: 'krb5-devel openldap26-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON' }
+
           - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
-              options: '--with-gnutls' }
+              install: '',
+              options: '--with-gnutls --enable-ldap --enable-ldaps --with-libidn2' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
+              install: '',
               options: '-DCURL_USE_GNUTLS=ON' }
+
           - { os: 'netbsd'      , version: '10.1' , build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall !examples',
-              options: '--with-openssl --with-gssapi' }
+              install: '',
+              options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
+              install: '',
               options: '-DCURL_USE_GSSAPI=ON' }
+
           - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
-              options: '--with-openssl' }
+              install: '',
+              options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
       fail-fast: false
     steps:
@@ -85,7 +99,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_OPTIONS MATRIX_OS MATRIX_DESC'
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS MATRIX_DESC'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'
@@ -169,7 +183,7 @@ jobs:
             mkdir bld && cd bld
             ../configure --prefix="$HOME"/curl-install --enable-unity --enable-debug --enable-warnings --enable-werror --disable-static \
               --disable-dependency-tracking --enable-option-checking=fatal \
-              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2  \
+              --with-brotli --with-libssh2 --with-nghttp2  \
               ${options} ${MATRIX_OPTIONS}
           fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -54,17 +54,17 @@ jobs:
     strategy:
       matrix:
         include:
-          # { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl !runtests',
+          # { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
           #   options: '--with-openssl' }
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               options: '--with-openssl --with-gssapi' }
-          - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity !runtests !examples',
+          - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity skiprun !examples',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
           - { os: 'freebsd'     , version: '14.3',  build: 'autotools', arch: 'arm64' , cc: 'clang', desc: 'openssl !examples',
               options: '--with-openssl --with-gssapi' }
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls !runtests',
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
               options: '-DCURL_USE_GNUTLS=ON' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
@@ -159,7 +159,7 @@ jobs:
           fi
 
       - name: 'build tests'
-        if: ${{ matrix.arch == 'x86_64' }}  # Slow on emulated CPU
+        if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, 'skipall') }}  # Slow on emulated CPU
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --target testdeps
@@ -168,7 +168,7 @@ jobs:
           fi
 
       - name: 'run tests'
-        if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, '!runtests') }}  # Slow on emulated CPU
+        if: ${{ matrix.arch == 'x86_64' && !contains(matrix.desc, 'skipall') && !contains(matrix.desc, 'skiprun') }}  # Slow on emulated CPU
         run: |
           export TFLAGS='-j8'
           if [ "${MATRIX_OS}" = 'openbsd' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -59,6 +59,9 @@ jobs:
               install: 'autoconf automake libtool perl5 openldap26-client libidn2',
               options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
 
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
+              install: 'cmake ninja' }
+
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel py311-impacket',
               options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
@@ -115,6 +118,9 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
+            if [ "${MATRIX_INSTALL#*cmake*}" != "${MATRIX_INSTALL}" ]; then
+              sudo pkg upgrade -y
+            fi
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
@@ -122,11 +128,10 @@ jobs:
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            echo '=== index'
-            sudo mport index | grep -v -E 'Downloading.+%'
-            echo '=== upgrade'
-            sudo mport upgrade | grep -v -E 'Downloading.+%'
-            echo '=== install'
+            if [ "${MATRIX_INSTALL#*autoconf*}" != "${MATRIX_INSTALL}" ]; then
+              sudo mport index | grep -v -E 'Downloading.+%'
+              sudo mport upgrade | grep -v -E 'Downloading.+%'
+            fi
             sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E '(Downloading.+%|/usr/local)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -51,6 +51,7 @@ jobs:
       MATRIX_BUILD: '${{ matrix.build }}'
       MATRIX_OPTIONS: '${{ matrix.options }}'
       MATRIX_OS: '${{ matrix.os }}'
+      MATRIX_DESC: '${{ matrix.desc }}'
     strategy:
       matrix:
         include:
@@ -100,7 +101,8 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools+=' stunnel py311-impacket'
+            sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
@@ -119,7 +121,8 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
+            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools+=' py311-impacket'
+            sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html
@@ -128,7 +131,8 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
+            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools+=' py3-six py3-impacket'
+            sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2
           fi
 
       - name: 'autoreconf'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -105,8 +105,23 @@ jobs:
               install: 'autoconf-2.72p0 automake-1.18 libtool',  # why mandatory to hardwire versions?
               options: '--with-openssl --disable-unity' }
 
+          - { os: 'openbsd'     , version: '7.7'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
+              install: 'autoconf-2.72p0 automake-1.18 libtool',  # why mandatory to hardwire versions?
+              options: '--with-openssl --disable-unity' }
+
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               install: 'cmake ninja openldap-client-- libidn2' }
+
+      run: |
+        sudo pkg_add -u
+        sudo pkg_add -I ${{ (matrix.version == '7.9') && 'ghostscript-10.07.0' || (matrix.version == '7.8') && 'ghostscript-10.06.0' || (matrix.version == '7.7') && 'ghostscript-10.05.0' || (matrix.version == '7.6') && 'ghostscript-10.03.1p2' || (matrix.version == '7.5') && 'ghostscript-10.03.1' || (matrix.version == '7.4') && 'ghostscript-10.02.0' || 'ghostscript' }}
+        sudo pkg_add -I ${{ (matrix.version == '7.9') && 'autoconf-2.72p0 automake-1.18.1' || (matrix.version == '7.8') && 'autoconf-2.72p0 automake-1.18' || (matrix.version == '7.7') && 'autoconf-2.72p0 automake-1.17 pkgconf' || (matrix.version == '7.6') && 'autoconf-2.72p0 automake-1.16.5 pkgconf' || (matrix.version == '7.5') && 'autoconf-2.71 automake-1.16.5 pkgconf' || (matrix.version == '7.4') && 'autoconf-2.71 automake-1.16.5 pkgconf' || 'autoconf automake pkgconf' }}
+        sudo pkg_add -I subversion p5-XML-XPath git mawk gmake autoconf-archive libtool libltdl help2man doxygen mpg123 libogg libvorbis flac libsndfile pulseaudio portaudio-svn sdl2
+    - name: Build
+      shell: cpa.sh {0} --sync-files none
+      run: |
+        export MAKEFLAGS="-j$(sysctl -n hw.ncpu)"; ${{ (matrix.version == '7.9') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.8') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.7') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.6') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.5') && 'export AUTOCONF_VERSION=2.71' || (matrix.version == '7.4') && 'export AUTOCONF_VERSION=2.71' || '' }} ; ${{ (matrix.version == '7.9') && 'export AUTOMAKE_VERSION=1.18' || (matrix.version == '7.8') && 'export AUTOMAKE_VERSION=1.18' || (matrix.version == '7.7') && 'export AUTOMAKE_VERSION=1.17' || (matrix.version == '7.6') && 'export AUTOMAKE_VERSION=1.16' || (matrix.version == '7.5') && 'export AUTOMAKE_VERSION=1.16' || (matrix.version == '7.4') && 'export AUTOMAKE_VERSION=1.16' || '' }} ;./build/autotools/autoconfiscate.sh
+
 
       fail-fast: false
     steps:
@@ -115,7 +130,7 @@ jobs:
           persist-credentials: false
 
       - name: 'setup VM'
-        uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
+        uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
           environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS'
           operating_system: '${{ matrix.os }}'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -129,7 +129,7 @@ jobs:
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake ninja'
             else
-              tools='autoconf automake libtool'
+              tools='autoconf-- automake-- libtool'
             fi
             [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools+=' py3-six py3-impacket'
             sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -142,6 +142,7 @@ jobs:
         run: |
           if [ "${MATRIX_OS}" = 'openbsd' ]; then
             export AUTOCONF_VERSION=2.72  # why, oh why!
+            export AUTOMAKE_VERSION=1.18  # why, oh why!
           fi
           autoreconf -fi
 
@@ -153,9 +154,6 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
               -DCURL_ENABLE_NTLM=ON ${MATRIX_OPTIONS}
           else
-            if [ "${MATRIX_OS}" = 'openbsd' ]; then
-              export AUTOMAKE_VERSION=1.18  # also why, oh why!
-            fi
             if [ "${MATRIX_ARCH}" != 'x86_64' ]; then
               options='--disable-manual --disable-docs'  # Slow with autotools, skip on emulated CPU
             fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -64,11 +64,11 @@ jobs:
           #   install: 'cmake ninja' }
 
           # https://ports.freebsd.org/
-          - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
+          - { os: 'freebsd'     , version: '15.1',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel',
               options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
 
-          - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity skiprun !examples',
+          - { os: 'freebsd'     , version: '15.1',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity skiprun !examples',
               install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -64,11 +64,17 @@ jobs:
               options: '--with-openssl --with-gssapi' }
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall',
+              options: '--with-gnutls' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
               options: '-DCURL_USE_GNUTLS=ON' }
+          - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
+              options: '--with-openssl --with-gssapi' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl skipall' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
+              options: '--with-openssl' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -104,14 +104,29 @@ jobs:
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            sudo mport -q install cmake-core ninja perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
+            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+              tools='cmake-core ninja'
+            else
+              tools='autoconf automake libtool'
+            fi
+            sudo mport -q install ${tools} perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake ninja-build pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
+            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+              tools='cmake ninja-build'
+            else
+              tools='autoconf automake libtool'
+            fi
+            sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2 py311-impacket
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html
-            sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
+            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+              tools='cmake ninja'
+            else
+              tools='autoconf automake libtool'
+            fi
+            sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
           fi
 
       - name: 'autoreconf'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -72,7 +72,7 @@ jobs:
               options: '--with-openssl --with-gssapi' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl skipall' }
+          - { os: 'openbsd'     , version: '7.8'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl skipall' }
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               options: '--with-openssl' }
       fail-fast: false

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -111,12 +111,15 @@ jobs:
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake-core ninja'
             else
-              tools="${tools} mit-krb5 openldap26-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
+              tools="${tools} openldap26-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
               tools='autoconf autoconf-archive automake libtool gmake'
+              echo '---------------- index ----------------'
               sudo mport index | grep -v -F 'Downloading'
-              sudo mport upgrade | grep -v -F 'Downloading'
+              echo '---------------- upgrade ----------------'
+              sudo mport upgrade >/dev/null
             fi
-            sudo mport install ${tools} perl5 pkgconf brotli gnutls libnghttp2 | grep -v -E '(Downloading.+100|Installing)' || true
+            echo '---------------- install ----------------'
+            sudo mport install ${tools} perl5 pkgconf brotli mit-krb5 gnutls libnghttp2 | grep -v -E '(Downloading|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -135,7 +135,7 @@ jobs:
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
-            if [ "${MATRIX_INSTALL#*autoconf*}" != "${MATRIX_INSTALL}" ]; then
+            if [ "${MATRIX_BUILD}" = 'autotools' ]; then
               sudo mport index | grep -v -E 'Downloading.+%'
               sudo mport upgrade | grep -v -E '(Downloading.+%|^/usr/local)'
             fi
@@ -144,7 +144,9 @@ jobs:
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             sudo pkg_add -I brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
-            sudo pkg_delete -I curl
+            if [ "${MATRIX_BUILD}" = 'autotools' ]; then
+              sudo pkg_delete -I curl  # to avoid autotools build linking against system libcurl
+            fi
           fi
 
       - name: 'autoreconf'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -143,8 +143,8 @@ jobs:
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
-            sudo pkg_add brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
-            sudo pkg_delete curl
+            sudo pkg_add -I brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
+            sudo pkg_delete -I curl
           fi
 
       - name: 'autoreconf'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -118,9 +118,6 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            if [ "${MATRIX_INSTALL#*cmake*}" != "${MATRIX_INSTALL}" ]; then
-              sudo pkg upgrade -y
-            fi
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -52,44 +52,51 @@ jobs:
       MATRIX_INSTALL: '${{ matrix.install }}'
       MATRIX_OPTIONS: '${{ matrix.options }}'
       MATRIX_OS: '${{ matrix.os }}'
-      MATRIX_DESC: '${{ matrix.desc }}'
     strategy:
       matrix:
         include:
-          # { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
-          #   options: '--with-openssl' }
+          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
+              install: 'autoconf automake libtool perl5 openldap26-client libidn2',
+              options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
 
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
-              install: 'openldap26-client libidn2',
+              install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel py311-impacket',
               options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
+
           - { os: 'freebsd'     , version: '15.0',  build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'openssl !unity skiprun !examples',
-              install: 'krb5-devel openldap26-client libidn2',
+              install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
+
           - { os: 'freebsd'     , version: '14.3',  build: 'autotools', arch: 'arm64' , cc: 'clang', desc: 'openssl !examples',
-              install: 'krb5-devel openldap26-client libidn2',
+              install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel py311-impacket',
               options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
+
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
-              install: 'krb5-devel openldap26-client libidn2',
+              install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2 stunnel py311-impacket',
               options: '-DCURL_USE_GSSAPI=ON' }
 
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
-              install: '',
-              options: '--with-gnutls --enable-ldap --enable-ldaps --with-libidn2' }
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools' , arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
+              install: 'autoconf autoconf-archive automake libtool gnutls',
+              options: '--with-gnutls' }
+
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
-              install: '',
+              install: 'cmake-core ninja perl5 gnutls openldap26-client libidn2',
               options: '-DCURL_USE_GNUTLS=ON' }
 
           - { os: 'netbsd'      , version: '10.1' , build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall !examples',
-              install: '',
-              options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
+              install: 'autoconf automake libtool mit-krb5',
+              options: '--with-openssl --with-gssapi' }
+
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
-              install: '',
+              install: 'cmake ninja-build mit-krb5 openldap-client libidn2 py311-impacket',
               options: '-DCURL_USE_GSSAPI=ON' }
 
-          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples' }
+          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
+              install: 'autoconf-2.72p0 automake-1.18 libtool',  # why mandatory to hardwire versions?
+              options: '--with-openssl' }
+
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
-              install: 'openldap-client-- libidn2',
-              options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
+              install: 'cmake ninja openldap-client-- libidn2 py3-six py3-impacket' }
 
       fail-fast: false
     steps:
@@ -100,7 +107,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS MATRIX_DESC'
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'
@@ -108,58 +115,26 @@ jobs:
       - name: 'install prereqs'
         run: |
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
-            sudo pkg install -y autoconf automake libtool perl5 pkgconf brotli openldap26-client libidn2 libnghttp2
+            sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
             # https://ports.freebsd.org/
-            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              tools='cmake-core ninja perl5'
-            else
-              tools='autoconf automake libtool'
-            fi
-            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
-              tools="${tools} stunnel py311-impacket"
-            fi
-            sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
+            sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
-            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              tools='cmake-core ninja'
-            else
-              tools="${tools} openldap26-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
-              tools='autoconf autoconf-archive automake libtool gmake'
-              echo '---------------- index ----------------'
-              sudo mport index # | grep -v -F 'Downloading'
-              echo '---------------- upgrade ----------------'
-              sudo mport upgrade # >/dev/null
-            fi
-            echo '---------------- install ----------------'
-            sudo mport install ${tools} perl5 pkgconf brotli mit-krb5 gnutls libnghttp2 # | grep -v -E '(Downloading|Installing)' || true
+            echo '=== index'
+            sudo mport index # | grep -v -F 'Downloading'
+            echo '=== upgrade'
+            sudo mport upgrade # >/dev/null
+            echo '=== install'
+            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} # | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
-            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              tools='cmake ninja-build'
-            else
-              tools='autoconf automake libtool'
-            fi
-            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
-              tools="${tools} openldap-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
-              tools="${tools} py311-impacket"
-            fi
-            sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 libssh2 libpsl nghttp2
+            sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html
-            if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-              tools='cmake ninja'
-            else
-              tools='autoconf-2.72p0 automake-1.18 libtool'  # why mandatory to hardwire versions?
-            fi
-            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
-              tools="${tools}"  # unrelated to tests, just limit to no-test runs to save install time
-              tools="${tools} py3-six py3-impacket"
-            fi
-            sudo pkg_add ${tools} brotli libssh2 libpsl nghttp2
+            sudo pkg_add brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           fi
 
       - name: 'autoreconf'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -101,7 +101,7 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} stunnel py311-impacket"
+            [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} stunnel py311-impacket"
             sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
@@ -121,7 +121,7 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py311-impacket"
+            [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py311-impacket"
             sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
@@ -129,9 +129,9 @@ jobs:
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake ninja'
             else
-              tools='autoconf-- automake-- libtool'
+              tools='autoconf-2.72p0 automake-1.18 libtool'
             fi
-            [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py3-six py3-impacket"
+            [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py3-six py3-impacket"
             sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2
           fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -101,7 +101,9 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} stunnel py311-impacket"
+            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
+              tools="${tools} stunnel py311-impacket"
+            fi
             sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
@@ -109,10 +111,12 @@ jobs:
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake-core ninja'
             else
+              tools="${tools} mit-krb5 openldap26-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
               tools='autoconf autoconf-archive automake libtool gmake'
+              sudo mport index | grep -v -F 'Downloading'
+              sudo mport upgrade | grep -v -F 'Downloading'
             fi
-            sudo mport index | grep -v -F 'Downloading'
-            sudo mport install ${tools} perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -v -E '(Downloading.+100|Installing)' || true
+            sudo mport install ${tools} perl5 pkgconf brotli gnutls libnghttp2 | grep -v -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
@@ -120,11 +124,11 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] &&
-               [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
+            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
+              tools="${tools} mit-krb5 openldap-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
               tools="${tools} py311-impacket"
             fi
-            sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2
+            sudo pkgin -y install ${tools} pkg-config perl brotli libssh2 libpsl nghttp2
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html
@@ -133,8 +137,11 @@ jobs:
             else
               tools='autoconf-2.72p0 automake-1.18 libtool'
             fi
-            [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py3-six py3-impacket"
-            sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2
+            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
+              tools="${tools} libidn2 openldap-client--"  # unrelated to tests, just limit to no-test runs to save install time
+              tools="${tools} py3-six py3-impacket"
+            fi
+            sudo pkg_add ${tools} brotli libssh2 libpsl nghttp2
           fi
 
       - name: 'autoreconf'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -107,8 +107,10 @@ jobs:
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
               tools='cmake-core ninja'
             else
-              tools='devel/autoconf automake libtool'
+              tools='autoconf autoconf-archive automake libtool gmake'
             fi
+            #sudo mport index
+            #sudo mport upgrade
             sudo mport -q install ${tools} perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -125,10 +125,10 @@ jobs:
               tools='autoconf automake libtool'
             fi
             if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
-              tools="${tools} mit-krb5 openldap-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
+              tools="${tools} openldap-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
               tools="${tools} py311-impacket"
             fi
-            sudo pkgin -y install ${tools} pkg-config perl brotli libssh2 libpsl nghttp2
+            sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 libssh2 libpsl nghttp2
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -111,8 +111,8 @@ jobs:
             else
               tools='autoconf autoconf-archive automake libtool gmake'
             fi
-            #sudo mport index
-            #sudo mport upgrade
+            sudo mport index
+            sudo mport upgrade
             sudo mport -q install ${tools} perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -105,7 +105,7 @@ jobs:
           # https://github.com/OpenMPT/openmpt/blob/master/.github/workflows/OpenBSD-Autotools.yml
           - { os: 'openbsd'     , version: '7.9'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
               install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
-              options: '--with-openssl --disable-unity' }
+              options: '--with-openssl --disable-debug' }
 
           - { os: 'openbsd'     , version: '7.9'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               install: 'cmake ninja openldap-client-- libidn2' }

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -107,7 +107,7 @@ jobs:
               install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
               options: '--with-openssl --disable-unity' }
 
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
+          - { os: 'openbsd'     , version: '7.9'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               install: 'cmake ninja openldap-client-- libidn2' }
 
       fail-fast: false

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -180,7 +180,7 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld
           else
-            make -C bld
+            make -C bld V=1
           fi
 
       - name: 'curl -V'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -52,6 +52,7 @@ jobs:
       MATRIX_INSTALL: '${{ matrix.install }}'
       MATRIX_OPTIONS: '${{ matrix.options }}'
       MATRIX_OS: '${{ matrix.os }}'
+      MATRIX_VERSION: '${{ matrix.version }}'
     strategy:
       matrix:
         include:
@@ -101,27 +102,17 @@ jobs:
 
           # https://openbsd.app/
           # https://www.openbsd.org/faq/faq15.html
-          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
-              install: 'autoconf-2.72p0 automake-1.18 libtool',  # why mandatory to hardwire versions?
+          # https://github.com/OpenMPT/openmpt/blob/master/.github/workflows/OpenBSD-Autotools.yml
+          - { os: 'openbsd'     , version: '7.9'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
+              install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
               options: '--with-openssl --disable-unity' }
 
           - { os: 'openbsd'     , version: '7.7'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
-              install: 'autoconf-2.72p0 automake-1.18 libtool',  # why mandatory to hardwire versions?
+              install: 'autoconf-2.72p0 automake-1.17 libtool',  # why mandatory to hardwire versions?
               options: '--with-openssl --disable-unity' }
 
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               install: 'cmake ninja openldap-client-- libidn2' }
-
-      run: |
-        sudo pkg_add -u
-        sudo pkg_add -I ${{ (matrix.version == '7.9') && 'ghostscript-10.07.0' || (matrix.version == '7.8') && 'ghostscript-10.06.0' || (matrix.version == '7.7') && 'ghostscript-10.05.0' || (matrix.version == '7.6') && 'ghostscript-10.03.1p2' || (matrix.version == '7.5') && 'ghostscript-10.03.1' || (matrix.version == '7.4') && 'ghostscript-10.02.0' || 'ghostscript' }}
-        sudo pkg_add -I ${{ (matrix.version == '7.9') && 'autoconf-2.72p0 automake-1.18.1' || (matrix.version == '7.8') && 'autoconf-2.72p0 automake-1.18' || (matrix.version == '7.7') && 'autoconf-2.72p0 automake-1.17 pkgconf' || (matrix.version == '7.6') && 'autoconf-2.72p0 automake-1.16.5 pkgconf' || (matrix.version == '7.5') && 'autoconf-2.71 automake-1.16.5 pkgconf' || (matrix.version == '7.4') && 'autoconf-2.71 automake-1.16.5 pkgconf' || 'autoconf automake pkgconf' }}
-        sudo pkg_add -I subversion p5-XML-XPath git mawk gmake autoconf-archive libtool libltdl help2man doxygen mpg123 libogg libvorbis flac libsndfile pulseaudio portaudio-svn sdl2
-    - name: Build
-      shell: cpa.sh {0} --sync-files none
-      run: |
-        export MAKEFLAGS="-j$(sysctl -n hw.ncpu)"; ${{ (matrix.version == '7.9') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.8') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.7') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.6') && 'export AUTOCONF_VERSION=2.72' || (matrix.version == '7.5') && 'export AUTOCONF_VERSION=2.71' || (matrix.version == '7.4') && 'export AUTOCONF_VERSION=2.71' || '' }} ; ${{ (matrix.version == '7.9') && 'export AUTOMAKE_VERSION=1.18' || (matrix.version == '7.8') && 'export AUTOMAKE_VERSION=1.18' || (matrix.version == '7.7') && 'export AUTOMAKE_VERSION=1.17' || (matrix.version == '7.6') && 'export AUTOMAKE_VERSION=1.16' || (matrix.version == '7.5') && 'export AUTOMAKE_VERSION=1.16' || (matrix.version == '7.4') && 'export AUTOMAKE_VERSION=1.16' || '' }} ;./build/autotools/autoconfiscate.sh
-
 
       fail-fast: false
     steps:
@@ -132,7 +123,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@5ea7e8e4677bd726033a10b094ba1c5762b15dee # v1.3.0
         with:
-          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS'
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS MATRIX_VERSION'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'
@@ -159,8 +150,14 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: |
           if [ "${MATRIX_OS}" = 'openbsd' ]; then
-            export AUTOCONF_VERSION=2.72  # why, oh why!
-            export AUTOMAKE_VERSION=1.18  # why, oh why!
+            if [ "${MATRIX_VERSION}" = '7.9' ] ||
+               [ "${MATRIX_VERSION}" = '7.8' ]; then
+              export AUTOCONF_VERSION=2.72
+              export AUTOMAKE_VERSION=1.18
+            elif [ "${MATRIX_VERSION}" = '7.7' ]; then
+              export AUTOCONF_VERSION=2.72
+              export AUTOMAKE_VERSION=1.17
+            fi
           fi
           autoreconf -fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -86,10 +86,11 @@ jobs:
               install: '',
               options: '-DCURL_USE_GSSAPI=ON' }
 
-          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
-              install: '',
+          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
+              install: 'openldap-client-- libidn2',
               options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
+
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -155,7 +156,7 @@ jobs:
               tools='autoconf-2.72p0 automake-1.18 libtool'  # why mandatory to hardwire versions?
             fi
             if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
-              tools="${tools} libidn2 openldap-client--"  # unrelated to tests, just limit to no-test runs to save install time
+              tools="${tools}"  # unrelated to tests, just limit to no-test runs to save install time
               tools="${tools} py3-six py3-impacket"
             fi
             sudo pkg_add ${tools} brotli libssh2 libpsl nghttp2

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -104,11 +104,7 @@ jobs:
           # https://www.openbsd.org/faq/faq15.html
           # https://github.com/OpenMPT/openmpt/blob/master/.github/workflows/OpenBSD-Autotools.yml
           - { os: 'openbsd'     , version: '7.9'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
-              install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
-              options: '--with-openssl --disable-debug' }
-
-          - { os: 'openbsd'     , version: '7.9'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
-              install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
+              install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # NOTE: also sync these versions with the autoreconf step!
               options: '--with-openssl' }
 
           - { os: 'openbsd'     , version: '7.9'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -85,7 +85,7 @@ jobs:
       - name: 'setup VM'
         uses: cross-platform-actions/action@0c165ad7eb2d6a7e8552d6af5aad2bbedfc646b0 # v1.1.0
         with:
-          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_OPTIONS MATRIX_OS'
+          environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_OPTIONS MATRIX_OS MATRIX_DESC'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'
@@ -111,9 +111,8 @@ jobs:
             else
               tools='autoconf autoconf-archive automake libtool gmake'
             fi
-            sudo mport index
-            sudo mport upgrade
-            sudo mport -q install ${tools} perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -E '(Downloading.+100|Installing)' || true
+            sudo mport index | grep -v -F 'Downloading'
+            sudo mport install ${tools} perl5 pkgconf brotli gnutls openldap26-client libidn2 libnghttp2 | grep -v -E '(Downloading.+100|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then
@@ -121,7 +120,10 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] && [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ] && tools="${tools} py311-impacket"
+            if [ "${MATRIX_DESC#*skipall*}" = "${MATRIX_DESC}" ] &&
+               [ "${MATRIX_DESC#*skiprun*}" = "${MATRIX_DESC}" ]; then
+              tools="${tools} py311-impacket"
+            fi
             sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -55,6 +55,7 @@ jobs:
     strategy:
       matrix:
         include:
+          # https://github.com/DragonFlyBSD/DPorts
           - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
               install: 'autoconf automake libtool openldap26-client libidn2',
               options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
@@ -62,6 +63,7 @@ jobs:
           - { os: 'dragonflybsd', version: '6.4.2', build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
               install: 'cmake ninja' }
 
+          # https://ports.freebsd.org/
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',
               install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel',
               options: '--with-openssl --with-gssapi --enable-ldap --enable-ldaps --with-libidn2' }
@@ -78,6 +80,8 @@ jobs:
               install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2 stunnel',
               options: '-DCURL_USE_GSSAPI=ON' }
 
+          # https://app.midnightbsd.org/
+          # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
           - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools' , arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
               install: 'autoconf autoconf-archive automake libtool gnutls',
               options: '--with-gnutls' }
@@ -86,6 +90,7 @@ jobs:
               install: 'cmake-core ninja perl5 gnutls openldap26-client libidn2',
               options: '-DCURL_USE_GNUTLS=ON' }
 
+          # https://pkgsrc.se/
           - { os: 'netbsd'      , version: '10.1' , build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall !examples',
               install: 'autoconf automake libtool mit-krb5',
               options: '--with-openssl --with-gssapi' }
@@ -94,6 +99,8 @@ jobs:
               install: 'cmake ninja-build mit-krb5 openldap-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON' }
 
+          # https://openbsd.app/
+          # https://www.openbsd.org/faq/faq15.html
           - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
               install: 'autoconf-2.72p0 automake-1.18 libtool',  # why mandatory to hardwire versions?
               options: '--with-openssl --disable-unity' }
@@ -120,22 +127,16 @@ jobs:
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
-            # https://ports.freebsd.org/
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
-            # https://app.midnightbsd.org/
-            # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
             if [ "${MATRIX_INSTALL#*autoconf*}" != "${MATRIX_INSTALL}" ]; then
               sudo mport index | grep -v -E 'Downloading.+%'
               sudo mport upgrade | grep -v -E 'Downloading.+%'
             fi
             sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E '(Downloading.+%|/usr/local)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
-            # https://pkgsrc.se/
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
-            # https://openbsd.app/
-            # https://www.openbsd.org/faq/faq15.html
             sudo pkg_add brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -146,7 +146,11 @@ jobs:
 
       - name: 'autoreconf'
         if: ${{ matrix.build == 'autotools' }}
-        run: autoreconf -fi
+        run: |
+          if [ "${MATRIX_OS}" = 'openbsd' ]; then
+            export AUTOCONF_VERSION=2.72  # silliest thing
+          fi
+          autoreconf -fi
 
       - name: 'configure'
         run: |

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -101,7 +101,7 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools+=' stunnel py311-impacket'
+            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools="${tools} stunnel py311-impacket"
             sudo pkg install -y ${tools} pkgconf brotli krb5-devel openldap26-client libidn2 libnghttp2
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             # https://app.midnightbsd.org/
@@ -121,7 +121,7 @@ jobs:
             else
               tools='autoconf automake libtool'
             fi
-            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools+=' py311-impacket'
+            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools="${tools} py311-impacket"
             sudo pkgin -y install ${tools} pkg-config perl brotli mit-krb5 openldap-client libssh2 libidn2 libpsl nghttp2
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then
             # https://openbsd.app/
@@ -131,7 +131,7 @@ jobs:
             else
               tools='autoconf-- automake-- libtool'
             fi
-            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools+=' py3-six py3-impacket'
+            [[ "${MATRIX_DESC}" != *'skiprun'* ]] && tools="${tools} py3-six py3-impacket"
             sudo pkg_add ${tools} brotli openldap-client-- libssh2 libidn2 libpsl nghttp2
           fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -64,17 +64,17 @@ jobs:
               options: '--with-openssl --with-gssapi' }
           - { os: 'freebsd'     , version: '14.3',  build: 'cmake'    , arch: 'arm64' , cc: 'clang', desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall',
+          - { os: 'midnightbsd' , version: '4.0.4', build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'gnutls skipall !examples',
               options: '--with-gnutls' }
           - { os: 'midnightbsd' , version: '4.0.4', build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'gnutls skiprun',
               options: '-DCURL_USE_GNUTLS=ON' }
-          - { os: 'netbsd'      , version: '10.1' , build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
+          - { os: 'netbsd'      , version: '10.1' , build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall !examples',
               options: '--with-openssl --with-gssapi' }
           - { os: 'netbsd'      , version: '10.1' , build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl',
               options: '-DCURL_USE_GSSAPI=ON' }
-          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall' }
-          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
+          - { os: 'openbsd'     , version: '7.8'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
               options: '--with-openssl' }
+          - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl' }
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -123,11 +123,11 @@ jobs:
             # https://app.midnightbsd.org/
             # https://man.midnightbsd.org/cgi-bin/man.cgi/mport
             echo '=== index'
-            sudo mport index # | grep -v -F 'Downloading'
+            sudo mport index | grep -v -E 'Downloading.+%'
             echo '=== upgrade'
-            sudo mport upgrade # >/dev/null
+            sudo mport upgrade | grep -v -E 'Downloading.+%'
             echo '=== install'
-            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} # | grep -E '(Downloading.+100|Installing)' || true
+            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E '(Downloading.+%|^/usr/local)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -114,12 +114,12 @@ jobs:
               tools="${tools} openldap26-client libidn2"  # unrelated to tests, just limit to no-test runs to save install time
               tools='autoconf autoconf-archive automake libtool gmake'
               echo '---------------- index ----------------'
-              sudo mport index | grep -v -F 'Downloading'
+              sudo mport index # | grep -v -F 'Downloading'
               echo '---------------- upgrade ----------------'
-              sudo mport upgrade >/dev/null
+              sudo mport upgrade # >/dev/null
             fi
             echo '---------------- install ----------------'
-            sudo mport install ${tools} perl5 pkgconf brotli mit-krb5 gnutls libnghttp2 | grep -v -E '(Downloading|Installing)' || true
+            sudo mport install ${tools} perl5 pkgconf brotli mit-krb5 gnutls libnghttp2 # | grep -v -E '(Downloading|Installing)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             # https://pkgsrc.se/
             if [ "${MATRIX_BUILD}" = 'cmake' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -139,7 +139,7 @@ jobs:
               sudo mport index | grep -v -E 'Downloading.+%'
               sudo mport upgrade | grep -v -E '(Downloading.+%|^/usr/local)'
             fi
-            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E 'Downloading.+%' || true
+            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E '(Downloading.+%|^/usr/local)' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -137,9 +137,9 @@ jobs:
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             if [ "${MATRIX_INSTALL#*autoconf*}" != "${MATRIX_INSTALL}" ]; then
               sudo mport index | grep -v -E 'Downloading.+%'
-              sudo mport upgrade | grep -v -E 'Downloading.+%'
+              sudo mport upgrade | grep -v -E '(Downloading.+%|^/usr/local)'
             fi
-            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E '(Downloading.+%|/usr/local)' || true
+            sudo mport install pkgconf brotli libnghttp2 ${MATRIX_INSTALL} | grep -v -E 'Downloading.+%' || true
           elif [ "${MATRIX_OS}" = 'netbsd' ]; then
             sudo pkgin -y install pkg-config perl brotli libssh2 libpsl nghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'openbsd' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -107,10 +107,6 @@ jobs:
               install: 'autoconf-2.72p0 automake-1.18.1 libtool',  # why mandatory to hardwire versions?
               options: '--with-openssl --disable-unity' }
 
-          - { os: 'openbsd'     , version: '7.7'  , build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'libressl skipall !examples',
-              install: 'autoconf-2.72p0 automake-1.17 libtool',  # why mandatory to hardwire versions?
-              options: '--with-openssl --disable-unity' }
-
           - { os: 'openbsd'     , version: '7.7'  , build: 'cmake'    , arch: 'x86_64', cc: 'clang', desc: 'libressl',
               install: 'cmake ninja openldap-client-- libidn2' }
 
@@ -150,13 +146,9 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: |
           if [ "${MATRIX_OS}" = 'openbsd' ]; then
-            if [ "${MATRIX_VERSION}" = '7.9' ] ||
-               [ "${MATRIX_VERSION}" = '7.8' ]; then
+            if [ "${MATRIX_VERSION}" = '7.9' ]; then
               export AUTOCONF_VERSION=2.72
               export AUTOMAKE_VERSION=1.18
-            elif [ "${MATRIX_VERSION}" = '7.7' ]; then
-              export AUTOCONF_VERSION=2.72
-              export AUTOMAKE_VERSION=1.17
             fi
           fi
           autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -56,12 +56,12 @@ jobs:
       matrix:
         include:
           # https://github.com/DragonFlyBSD/DPorts
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
-              install: 'autoconf automake libtool openldap26-client libidn2',
-              options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
+          # { os: 'dragonflybsd', version: '6.4.2', build: 'autotools', arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skiprun',
+          #   install: 'autoconf automake libtool openldap26-client libidn2',
+          #   options: '--with-openssl --enable-ldap --enable-ldaps --with-libidn2' }
 
-          - { os: 'dragonflybsd', version: '6.4.2', build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
-              install: 'cmake ninja' }
+          # { os: 'dragonflybsd', version: '6.4.2', build: 'cmake'    , arch: 'x86_64', cc: 'gcc'  , desc: 'openssl skipall',
+          #   install: 'cmake ninja' }
 
           # https://ports.freebsd.org/
           - { os: 'freebsd'     , version: '15.0',  build: 'autotools', arch: 'x86_64', cc: 'clang', desc: 'openssl',


### PR DESCRIPTION
- add autotools jobs for MidnightBSD, NetBSD, OpenBSD.
  Takes under 3 minutes per new job, under +6m in total.
  - comment out MidnightBSD to save CI time.
  - to make them as fast as possible, skip building tests and examples,
    and omit libidn2, openldap dependencies.
- add DragonFly BSD cmake job, which finally works.
  (keep it commented out since the package server fails frequently.)
- do `mport index/upgrade` to make MidnightBSD autotools builds work.
- rework filtering MidnightBSD package manager's excessive log output.
- fixup OpenBSD autotools job to uninstall system curl to avoid linking
  against it (and breaking debug builds).
- make OpenBSD package manager commands non-interactive.
- specify install packages for each matrix entry.
- make autotools build step verbose (to ease debugging).
- add link to DragonFly BSD package repo.
- bump cross-platform-actions from 1.1.0 to 1.3.0.
- bump FreeBSD 15.0 to 15.1.
- bump OpenBSD to 7.7 to 7.9.
  This did not go well last time with 7.8, let's see with 7.9.
  Ref: 8d00e28136baf661455f1fe5980a0d18c4d872e3 #19372
  Ref: c3b890b2c005401e18b54dacf9e63d33412e2b4f #19368
- sync test-skipper keywords with rest of workflows.
- drop installing impacket. It was unused.
  (also a slow install with many dependencies)

The original motivation was to prepare fixing OpenBSD's (and possibly
other platforms) `getaddrinfo()` thread-safety check.
Ref: https://github.com/curl/curl/pull/22138#issuecomment-4773617195
