### PR TITLE
test 679: add a quoted string name in a netrc test

### DIFF
--- a/tests/data/test679
+++ b/tests/data/test679
@@ -36,7 +36,7 @@ netrc with quoted password
 --netrc-optional --netrc-file %LOGDIR/netrc%TESTNUMBER http://%HOSTIP:%HTTPPORT/
 </command>
 <file name="%LOGDIR/netrc%TESTNUMBER" >
-machine %HOSTIP login user1 password "with spaces and \"\n\r\t\a"
+machine %HOSTIP login "user one" password "with spaces and \"\n\r\t\a"
 </file>
 </client>
 
@@ -45,7 +45,7 @@ machine %HOSTIP login user1 password "with spaces and \"\n\r\t\a"
 <protocol crlf="headers">
 GET / HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Basic %b64[user1:with%20spaces%20and%20"%0a%0d%09a]b64%
+Authorization: Basic %b64[user%20one:with%20spaces%20and%20"%0a%0d%09a]b64%
 User-Agent: curl/%VERSION
 Accept: */*
 


### PR DESCRIPTION
By using quotes a user name can have a space in netrc
