### PR TITLE
http: obey Retry-After in redirects

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -315,6 +315,7 @@ static const char * const Curl_trc_timer_names[] = {
   "FTP_ACCEPT",
   "ALPN_EYEBALLS",
   "SHUTDOWN",
+  "RETRY_AFTER",
 };
 
 static const char *trc_timer_name(int tid)
@@ -366,6 +367,7 @@ static const char * const Curl_trc_mstate_names[] = {
   "DID",
   "PERFORMING",
   "RATELIMITING",
+  "RETRYAFTER",
   "DONE",
   "COMPLETED",
   "MSGSENT",

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -316,6 +316,7 @@ static const char * const Curl_trc_timer_names[] = {
   "FTP_ACCEPT",
   "ALPN_EYEBALLS",
   "SHUTDOWN",
+  "RETRY_AFTER",
 };
 
 static const char *trc_timer_name(int tid)
@@ -367,6 +368,7 @@ static const char * const Curl_trc_mstate_names[] = {
   "DID",
   "PERFORMING",
   "RATELIMITING",
+  "RETRYAFTER",
   "DONE",
   "COMPLETED",
   "MSGSENT",

--- a/lib/http.c
+++ b/lib/http.c
@@ -3729,6 +3729,8 @@ static CURLcode http_statusline(struct Curl_easy *data,
 
   data->info.httpcode = k->httpcode;
   data->info.httpversion = k->httpversion;
+  /* clear it, it might have been set in a previous response */
+  data->info.retry_after = 0;
   conn->httpversion_seen = k->httpversion;
 
   if(!data->state.http_neg.rcvd_min ||

--- a/lib/http.c
+++ b/lib/http.c
@@ -3772,6 +3772,8 @@ static CURLcode http_statusline(struct Curl_easy *data,
 
   data->info.httpcode = k->httpcode;
   data->info.httpversion = k->httpversion;
+  /* clear it, it might have been set in a previous response */
+  data->info.retry_after = 0;
   conn->httpversion_seen = k->httpversion;
 
   if(!data->state.http_neg.rcvd_min ||

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -184,6 +184,7 @@ static void mstate(struct Curl_easy *data, CURLMstate state
     mstate_enter_did,          /* DID */
     NULL,                      /* PERFORMING */
     NULL,                      /* RATELIMITING */
+    NULL,                      /* RETRYAFTER */
     mstate_enter_done,         /* DONE */
     mstate_enter_completed,    /* COMPLETED */
     NULL                       /* MSGSENT */
@@ -1198,6 +1199,7 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
       break;
 
     case MSTATE_RATELIMITING:
+    case MSTATE_RETRYAFTER:
       /* we need to let time pass, ignore socket(s) */
       break;
 
@@ -2126,7 +2128,19 @@ static CURLMcode multistate_performing(struct Curl_easy *data,
       /* multi_done() might return CURLE_GOT_NOTHING */
       result = multi_follow(data, handler, newurl, follow);
       if(!result) {
-        multistate(data, MSTATE_SETUP);
+        if(data->info.retry_after && (follow == FOLLOW_REDIR)) {
+          timediff_t delay_ms = (timediff_t)data->info.retry_after * 1000;
+          data->state.retry_time = *Curl_pgrs_now(data);
+          data->state.retry_time.tv_sec += (time_t)data->info.retry_after;
+
+          infof(data, "Waiting %ld seconds as instructed by Retry-After header"
+                " before following redirect",
+                (long)data->info.retry_after);
+          multistate(data, MSTATE_RETRYAFTER);
+          Curl_expire(data, delay_ms, EXPIRE_RETRY_AFTER);
+        }
+        else
+          multistate(data, MSTATE_SETUP);
         mresult = CURLM_CALL_MULTI_PERFORM;
       }
     }
@@ -2318,6 +2332,27 @@ static CURLMcode multistate_ratelimiting(struct Curl_easy *data,
   }
   *resultp = result;
   return mresult;
+}
+
+static CURLMcode multistate_retryafter(struct Curl_easy *data,
+                                       CURLcode *resultp)
+{
+  struct curltime now = *Curl_pgrs_now(data);
+  timediff_t delay_ms;
+  *resultp = CURLE_OK;
+
+  if(curlx_ptimediff_ms(&now, &data->state.retry_time) >= 0) {
+    /* done waiting */
+    multistate(data, MSTATE_SETUP);
+    return CURLM_CALL_MULTI_PERFORM;
+  }
+
+  /* not expired yet, ensure the timer is still set */
+  delay_ms = curlx_ptimediff_ms(&data->state.retry_time, &now);
+  if(delay_ms < 0)
+    delay_ms = 0;
+  Curl_expire(data, delay_ms, EXPIRE_RETRY_AFTER);
+  return CURLM_OK;
 }
 
 static CURLMcode multistate_connect(struct Curl_multi *multi,
@@ -2765,7 +2800,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     }
 
     if(data->mstate > MSTATE_CONNECT &&
-       data->mstate < MSTATE_COMPLETED) {
+       data->mstate < MSTATE_COMPLETED &&
+       data->mstate != MSTATE_RETRYAFTER) {
       /* Make sure we set the connection's current owner */
       DEBUGASSERT(data->conn);
       if(!data->conn)
@@ -2832,6 +2868,10 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     case MSTATE_RATELIMITING: /* limit-rate exceeded in either direction */
       mresult = multistate_ratelimiting(data, &result);
+      break;
+
+    case MSTATE_RETRYAFTER:
+      mresult = multistate_retryafter(data, &result);
       break;
 
     case MSTATE_PERFORMING:

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -168,6 +168,7 @@ static void mstate(struct Curl_easy *data, CURLMstate state
     mstate_enter_did,          /* DID */
     NULL,                      /* PERFORMING */
     NULL,                      /* RATELIMITING */
+    NULL,                      /* RETRYAFTER */
     mstate_enter_done,         /* DONE */
     mstate_enter_completed,    /* COMPLETED */
     NULL                       /* MSGSENT */
@@ -1198,6 +1199,7 @@ CURLMcode Curl_multi_pollset(struct Curl_easy *data,
       break;
 
     case MSTATE_RATELIMITING:
+    case MSTATE_RETRYAFTER:
       /* we need to let time pass, ignore socket(s) */
       break;
 
@@ -2137,7 +2139,19 @@ static CURLMcode multistate_performing(struct Curl_easy *data,
       /* multi_done() might return CURLE_GOT_NOTHING */
       result = multi_follow(data, handler, newurl, follow);
       if(!result) {
-        multistate(data, MSTATE_SETUP);
+        if(data->info.retry_after && (follow == FOLLOW_REDIR)) {
+          timediff_t delay_ms = (timediff_t)data->info.retry_after * 1000;
+          data->state.retry_time = *Curl_pgrs_now(data);
+          data->state.retry_time.tv_sec += (time_t)data->info.retry_after;
+
+          infof(data, "Waiting %ld seconds as instructed by Retry-After header"
+                " before following redirect",
+                (long)data->info.retry_after);
+          multistate(data, MSTATE_RETRYAFTER);
+          Curl_expire(data, delay_ms, EXPIRE_RETRY_AFTER);
+        }
+        else
+          multistate(data, MSTATE_SETUP);
         mresult = CURLM_CALL_MULTI_PERFORM;
       }
     }
@@ -2330,6 +2344,25 @@ static CURLMcode multistate_ratelimiting(struct Curl_easy *data,
   }
   *resultp = result;
   return mresult;
+}
+
+static CURLMcode multistate_retryafter(struct Curl_easy *data,
+                                       CURLcode *resultp)
+{
+  struct curltime now = *Curl_pgrs_now(data);
+  timediff_t diff;
+  *resultp = CURLE_OK;
+
+  diff = curlx_ptimediff_ms(&now, &data->state.retry_time);
+  if(diff >= 0) {
+    /* done waiting */
+    multistate(data, MSTATE_SETUP);
+    return CURLM_CALL_MULTI_PERFORM;
+  }
+
+  /* not expired yet, ensure the timer is still set */
+  Curl_expire(data, -diff, EXPIRE_RETRY_AFTER);
+  return CURLM_OK;
 }
 
 static CURLMcode multistate_connect(struct Curl_multi *multi,
@@ -2770,7 +2803,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     }
 
     if(data->mstate > MSTATE_CONNECT &&
-       data->mstate < MSTATE_COMPLETED) {
+       data->mstate < MSTATE_COMPLETED &&
+       data->mstate != MSTATE_RETRYAFTER) {
       /* Make sure we set the connection's current owner */
       DEBUGASSERT(data->conn);
       if(!data->conn) {
@@ -2839,6 +2873,10 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     case MSTATE_RATELIMITING: /* limit-rate exceeded in either direction */
       mresult = multistate_ratelimiting(data, &result);
+      break;
+
+    case MSTATE_RETRYAFTER:
+      mresult = multistate_retryafter(data, &result);
       break;
 
     case MSTATE_PERFORMING:

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -62,6 +62,7 @@ typedef enum {
   MSTATE_DID,          /* done sending off request */
   MSTATE_PERFORMING,   /* transfer data */
   MSTATE_RATELIMITING, /* wait because limit-rate exceeded */
+  MSTATE_RETRYAFTER,   /* wait because Retry-After */
   MSTATE_DONE,         /* post data transfer operation */
   MSTATE_COMPLETED,    /* operation complete */
   MSTATE_MSGSENT,      /* the operation complete message is sent */

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -64,6 +64,7 @@ typedef enum {
   MSTATE_DID,          /* done sending off request */
   MSTATE_PERFORMING,   /* transfer data */
   MSTATE_RATELIMITING, /* wait because limit-rate exceeded */
+  MSTATE_RETRYAFTER,   /* wait because Retry-After */
   MSTATE_DONE,         /* post data transfer operation */
   MSTATE_COMPLETED,    /* operation complete */
   MSTATE_MSGSENT,      /* the operation complete message is sent */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -545,6 +545,7 @@ typedef enum {
   EXPIRE_FTP_ACCEPT,
   EXPIRE_ALPN_EYEBALLS,
   EXPIRE_SHUTDOWN,
+  EXPIRE_RETRY_AFTER,
   EXPIRE_LAST /* not an actual timer, used as a marker only */
 } expire_id;
 
@@ -704,6 +705,7 @@ struct UrlState {
   uint8_t httpreq; /* Curl_HttpReq; what kind of HTTP request (if any)
                             is this */
 
+  struct curltime retry_time; /* when to retry after a redirect */
   BIT(really_alive); /* transfer is really alive in multi, passed INIT */
   BIT(this_is_a_follow); /* this is a followed Location: request */
   BIT(refused_stream); /* this was refused, try again */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -507,6 +507,7 @@ typedef enum {
   EXPIRE_FTP_ACCEPT,
   EXPIRE_ALPN_EYEBALLS,
   EXPIRE_SHUTDOWN,
+  EXPIRE_RETRY_AFTER,
   EXPIRE_LAST /* not an actual timer, used as a marker only */
 } expire_id;
 
@@ -635,6 +636,8 @@ struct UrlState {
 #ifdef USE_OPENSSL
   BIT(provider_loaded);
 #endif /* USE_OPENSSL */
+
+  struct curltime retry_time; /* when to retry after a redirect */
   BIT(really_alive); /* transfer is really alive in multi, passed INIT */
   BIT(this_is_a_follow); /* this is a followed Location: request */
   BIT(refused_stream); /* this was refused, try again */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -220,7 +220,7 @@ test1645 test1646 test1647 test1648 test1649 test1650 test1651 test1652 \
 test1653 test1654 test1655 test1656 test1657 test1658 test1659 test1660 \
 test1661 test1662 test1663 test1664 test1665 test1666 test1667 test1668 \
 test1669 test1670 test1671 test1672 test1673 test1674 test1675 test1676 \
-test1677                   test1680 test1681 test1682 test1683 test1684 \
+test1677 test1678          test1680 test1681 test1682 test1683 test1684 \
 test1685 test1686 \
 \
 test1700 test1701 test1702 test1703 test1704 test1705 test1706 test1707 \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -220,7 +220,7 @@ test1645 test1646 test1647 test1648 test1649 test1650 test1651 test1652 \
 test1653 test1654 test1655 test1656 test1657 test1658 test1659 test1660 \
 test1661 test1662 test1663 test1664 test1665 test1666 test1667 test1668 \
 test1669 test1670 test1671 test1672 test1673 test1674 test1675 test1676 \
-test1677 test1678          test1680 test1681 test1682 test1683 test1684 \
+test1677 test1678 test1679 test1680 test1681 test1682 test1683 test1684 \
 test1685 test1686 \
 \
 test1700          test1702 test1703 test1704 test1705 test1706 test1707 \

--- a/tests/data/test1678
+++ b/tests/data/test1678
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+Retry-After
+redirect
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 301 Moved Permanently
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Location: /%TESTNUMBER0002
+Retry-After: 1
+Content-Length: 0
+Connection: close
+
+</data>
+<data2 crlf="headers">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:01 GMT
+Server: test-server/fake
+Content-Length: 3
+Connection: close
+
+OK
+</data2>
+<datacheck crlf="headers">
+HTTP/1.1 301 Moved Permanently
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Location: /%TESTNUMBER0002
+Retry-After: 1
+Content-Length: 0
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:01 GMT
+Server: test-server/fake
+Content-Length: 3
+Connection: close
+
+OK
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP redirect with Retry-After
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -L
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test1679
+++ b/tests/data/test1679
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+Retry-After
+redirect
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 301 Moved Permanently
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Location: /%TESTNUMBER0002
+Retry-After: 2
+Content-Length: 0
+Connection: close
+
+</data>
+<datacheck crlf="headers">
+HTTP/1.1 301 Moved Permanently
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Location: /%TESTNUMBER0002
+Retry-After: 2
+Content-Length: 0
+Connection: close
+
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP redirect with Retry-After
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -L --max-time 1
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+28
+</errorcode>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
 When a redirect (e.g. 301, 302, 308) includes a `Retry-After` header, curl now pauses execution for the requested
 time before issuing the new request.

 A new multi state `MSTATE_RETRYAFTER` is introduced to handle the wait time asynchronously without blocking,
 utilizing `Curl_expire`. To prevent leaking the delay to subsequent redirects, the retry value is reset upon
 processing each HTTP status line.
  
References #11447