### PR TITLE
ldap: support insecure mode for Windows native LDAP

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -253,10 +253,10 @@ static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
 
 #ifdef USE_WIN32_LDAP
 static BOOLEAN bypass_cert_verify(PLDAP Connection,
-                                  PCCERT_CONTEXT *pServerCert)
+                                  PCCERT_CONTEXT *ppServerCert)
 {
   (void)Connection;
-  CertFreeCertificateContext(*((PCCERT_CONTEXT*)pServerCert));
+  CertFreeCertificateContext(*ppServerCert);
   /* approve any certificate since the verification is set to bypass */
   return TRUE;
 }
@@ -355,9 +355,8 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     ldap_set_option(server, LDAP_OPT_SSL, LDAP_OPT_ON);
     if(!conn->ssl_config.verifypeer) {
       if(conn->ssl_config.verifyhost) {
-        failf(data, "LDAP local: peer verification is disabled and host "
-              "verification is enabled which is not a currently supported "
-              "combination for Windows native LDAP");
+        failf(data, "LDAP local: host verification cannot be enabled when "
+              "peer verification is disabled for Windows native LDAP");
         result = CURLE_NOT_BUILT_IN;
         goto quit;
       }

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -252,7 +252,8 @@ static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
 }
 
 #ifdef USE_WIN32_LDAP
-BOOLEAN bypass_cert_verify(PLDAP Connection, PCCERT_CONTEXT *pServerCert)
+static BOOLEAN bypass_cert_verify(PLDAP Connection,
+                                  PCCERT_CONTEXT *pServerCert)
 {
   (void)Connection;
   CertFreeCertificateContext(*((PCCERT_CONTEXT*)pServerCert));

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -251,6 +251,16 @@ static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
   return FALSE;
 }
 
+#ifdef USE_WIN32_LDAP
+BOOLEAN bypass_cert_verify(PLDAP Connection, PCCERT_CONTEXT *pServerCert)
+{
+  (void)Connection;
+  CertFreeCertificateContext(*((PCCERT_CONTEXT*)pServerCert));
+  /* approve any certificate since the verification is set to bypass */
+  return TRUE;
+}
+#endif
+
 static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 {
   CURLcode result = CURLE_OK;
@@ -340,8 +350,19 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
   if(ldap_ssl) {
 #ifdef HAVE_LDAP_SSL
 #ifdef USE_WIN32_LDAP
-    /* Win32 LDAP SDK does not support insecure mode without CA! */
+    /* Win32 LDAP uses the Windows CA store to verify certificates */
     ldap_set_option(server, LDAP_OPT_SSL, LDAP_OPT_ON);
+    if(!conn->ssl_config.verifypeer) {
+      if(conn->ssl_config.verifyhost) {
+        failf(data, "LDAP local: peer verification is disabled and host "
+              "verification is enabled which is not a currently supported "
+              "combination for Windows native LDAP");
+        result = CURLE_NOT_BUILT_IN;
+        goto quit;
+      }
+      ldap_set_option(server, LDAP_OPT_SERVER_CERTIFICATE,
+                      (void *)(uintptr_t)bypass_cert_verify);
+    }
 #else /* !USE_WIN32_LDAP */
     int ldap_option;
     const char *ldap_ca = conn->ssl_config.CAfile;


### PR DESCRIPTION
- Bypass cert verification if verifypeer is disabled.

Prior to this change libcurl lacked the ability to bypass certificate verification for Windows native LDAP (USE_WIN32_LDAP). A comment said "Win32 LDAP SDK does not support insecure mode without CA!" but I found that we can bypass the check by setting a verify callback to override Windows' internal verify check.

Closes #xxxx
