### PR TITLE
GHA/linux: drop unused pip packages from Alpine job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -503,7 +503,6 @@ jobs:
           apk add --no-cache build-base autoconf automake libtool perl openssl-dev \
             libssh2-dev zlib-dev brotli-dev zstd-dev libidn2-dev openldap-dev \
             krb5-dev libpsl-dev c-ares-dev \
-            py3-asn1 py3-pycryptodomex \
             perl-time-hires openssh stunnel sudo git openssl
 
       - name: 'install Fil-C'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -503,7 +503,7 @@ jobs:
           apk add --no-cache build-base autoconf automake libtool perl openssl-dev \
             libssh2-dev zlib-dev brotli-dev zstd-dev libidn2-dev openldap-dev \
             krb5-dev libpsl-dev c-ares-dev \
-            py3-impacket py3-asn1 py3-six py3-pycryptodomex \
+            py3-asn1 py3-pycryptodomex \
             perl-time-hires openssh stunnel sudo git openssl
 
       - name: 'install Fil-C'


### PR DESCRIPTION
py3-impacket, py3-asn1, py3-six and py3-pycryptodomex.

Number of tests run remain 1848 / 1847 for the two jobs respectively.
Number of installed packages go from 158 to 117, and from 177 to 142
(for the two jobs respectively; using different Alpine versions).

---

Before:
https://github.com/curl/curl/actions/runs/28078394316/job/83127475458
https://github.com/curl/curl/actions/runs/28078394316/job/83127472677
After:
https://github.com/curl/curl/actions/runs/28087932522/job/83160977891?pr=22153
https://github.com/curl/curl/actions/runs/28087932522/job/83160978893?pr=22153
