### PR TITLE
runtests: restore `-k` option and actively process as no-op

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2539,6 +2539,9 @@ while(@ARGV) {
             $jobs = $1;
         }
     }
+    elsif($ARGV[0] eq "-k") {
+        # no-op, kept for compatibility
+    }
     elsif($ARGV[0] eq "-r") {
         # run time statistics needs Time::HiRes
         if($Time::HiRes::VERSION) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2539,7 +2539,7 @@ while(@ARGV) {
             $jobs = $1;
         }
     }
-    elsif($ARGV[0] eq "-k") {  # delete this check after March 2026
+    elsif($ARGV[0] eq "-k") {  # delete this check December 2026
         print "Option -k became always-on in 7.65.2 (2019) and now a no-op. Delete it to continue.\n";
         exit;
     }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2539,8 +2539,9 @@ while(@ARGV) {
             $jobs = $1;
         }
     }
-    elsif($ARGV[0] eq "-k") {
-        # no-op, kept for compatibility
+    elsif($ARGV[0] eq "-k") {  # delete this check after March 2026
+        print "Option -k became always-on in 7.65.2 (2019) and now a no-op. Delete it to continue.\n";
+        exit;
     }
     elsif($ARGV[0] eq "-r") {
         # run time statistics needs Time::HiRes


### PR DESCRIPTION
Restore processing this option to avoid falling it through and
misinterpreted as something else, which in turn disables tests.

Exit with an error instead. We delete completely in December 2026.

Reported-by: Sam James
Bug: https://github.com/curl/curl/pull/22100#issuecomment-4789828929
Follow-up to 04305a3e40989d3731e97bd0ef41bbd55c680a3f #22100
Follow-up to 6617db6a7ed322d28322896aa20bcabf3a479e7c #4035

---

- [x] decide if this is a good idea, or overkill / too late / unnecessary.
