### PR TITLE
sws: allow connection-monitor to log all disconnects

### DIFF
--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2327,7 +2327,6 @@ static int test_sws(int argc, const char *argv[])
             if(req->connmon) {
               const char *keepopen = "[DISCONNECT]\n";
               storerequest(keepopen, strlen(keepopen), REQUEST_DUMP_FILENAME);
-              req->connmon = FALSE;
             }
 
             if(!req->open)


### PR DESCRIPTION
Remove the suppression of connmon after the first disconnect event. The connmon flag is set per-test via the 'connection-monitor' server command and should remain active for the lifetime of that test's connections to properly detect connection reuse failures.

The suppression was introduced in 510fdad to work around a connection reuse regression that has since been resolved by the credentials refactoring in 8f71d0f. With the underlying issue fixed, restoring full disconnect logging strengthens tests like 338 to catch future regressions in connection reuse logic.

Closes #22158
