### PR TITLE
content_encoding: support concatenated gzip members

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -144,6 +144,29 @@ static CURLcode process_trailer(struct Curl_easy *data, struct zlib_writer *zp)
   return result;
 }
 
+static CURLcode gzip_member_end(struct Curl_easy *data, struct zlib_writer *zp,
+                                bool *keep_going)
+{
+  z_stream *z = &zp->z;
+
+  *keep_going = FALSE;
+
+  /* RFC 1952 section 2.2: a gzip stream may consist of several members. */
+  if(z->avail_in >= 2 && z->next_in[0] == 0x1f && z->next_in[1] == 0x8b) {
+    if(inflateReset2(z, MAX_WBITS + 32) != Z_OK)
+      return exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
+    zp->zlib_init = ZLIB_INIT_GZIP;
+    *keep_going = TRUE;
+    return CURLE_OK;
+  }
+  if(z->avail_in)
+    return exit_zlib(data, z, &zp->zlib_init, CURLE_WRITE_ERROR);
+  if(inflateReset2(z, MAX_WBITS + 32) != Z_OK)
+    return exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
+  zp->zlib_init = ZLIB_INIT_GZIP;
+  return CURLE_OK;
+}
+
 static CURLcode inflate_stream(struct Curl_easy *data,
                                struct Curl_cwriter *writer, int type,
                                zlibInitState started)
@@ -206,7 +229,14 @@ static CURLcode inflate_stream(struct Curl_easy *data,
       /* No more data to flush: exit loop. */
       break;
     case Z_STREAM_END:
-      result = process_trailer(data, zp);
+      if(zp->zlib_init == ZLIB_INIT_GZIP) {
+        bool keep_going = FALSE;
+        result = gzip_member_end(data, zp, &keep_going);
+        if(!result && keep_going)
+          done = FALSE;
+      }
+      else
+        result = process_trailer(data, zp);
       break;
     case Z_DATA_ERROR:
       /* some servers seem to not generate zlib headers, so this is an attempt

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -257,7 +257,7 @@ test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
 test2108 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
-test2208 \
+test2208 test2217 \
 \
 test2300 test2301 test2302 test2303 test2304 test2306 test2307 test2308 \
 test2309 test2310 test2311 \

--- a/tests/data/test2217
+++ b/tests/data/test2217
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+compressed
+</keywords>
+</info>
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+Date: Mon, 29 Nov 2004 21:56:53 GMT
+Server: Apache/1.3.31 (Debian GNU/Linux) mod_gzip/1.3.26.1a PHP/4.3.9-1 mod_ssl/2.8.20 OpenSSL/0.9.7d mod_perl/1.29
+Vary: Accept-Encoding
+Content-Type: text/html; charset=ISO-8859-1
+Content-Encoding: gzip
+Content-Length: 46
+
+%hex[%1f%8b%08%00%00%00%00%00%02%13%4b%cb%cf%07%00%21%65%73%8c%03%00%00%00%1f%8b%08%00%00%00%00%00%02%13%4b%4a%2c%02%00%aa%8c%ff%76%03%00%00%00]hex%
+</data>
+
+<datacheck crlf="headers" nonewline="yes">
+HTTP/1.1 200 OK
+Date: Mon, 29 Nov 2004 21:56:53 GMT
+Server: Apache/1.3.31 (Debian GNU/Linux) mod_gzip/1.3.26.1a PHP/4.3.9-1 mod_ssl/2.8.20 OpenSSL/0.9.7d mod_perl/1.29
+Vary: Accept-Encoding
+Content-Type: text/html; charset=ISO-8859-1
+Content-Encoding: gzip
+Content-Length: 46
+
+foobar
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+libz
+</features>
+<server>
+http
+</server>
+<name>
+HTTP GET concatenated gzip members
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strippart>
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
+</strippart>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Accept-Encoding: xxx
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Fixes #22156

## Summary
- Fix `--compressed` / `Content-Encoding: gzip` handling for concatenated gzip members (RFC 1952 section 2.2)
- On `Z_STREAM_END`, reset inflate for the next member instead of calling `exit_zlib()` early
- Added regression test `tests/data/test2217` with two gzip members (`foo` + `bar` → `foobar`)
Fixes #22156
## Problem
When a response contains multiple gzip members (common for rotated logs / `pigz` output), curl decoded only the first member and failed with `CURLE_WRITE_ERROR (23)`.
## Solution
Add gzip-specific member-end handling in `lib/content_encoding.c`:
- If the next bytes are gzip magic (`0x1f 0x8b`), `inflateReset2()` and continue
- If no input remains, reset state and wait for more body data (cleanup in `gzip_do_close()`)
- Leave deflate/raw-deflate paths unchanged
## Test plan
- [x] `./tests/runtests.pl -v 220 2217`
- [x] `make checksrc`