### PR TITLE
multi_ev: refresh sock entry after remove callback

### DIFF
--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -213,7 +213,11 @@ static CURLMcode mev_forget_socket(struct Curl_multi *multi,
     rc = multi->socket_cb(data, s, CURL_POLL_REMOVE,
                           multi->socket_userp, entry->user_data);
     mev_in_callback(multi, FALSE);
-    entry->announced = FALSE;
+    /* curl_easy_pause() is documented as callable from any callback; it
+     * re-enters mev_assess() which may free this 'entry'. Re-fetch. */
+    entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+    if(entry)
+      entry->announced = FALSE;
   }
 
   mev_sh_entry_kill(multi, s);


### PR DESCRIPTION
This was missed in the fix for CVE-2026-9080.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
