### PR TITLE
tool: init progress bar on demand

### DIFF
--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -129,6 +129,9 @@ int tool_progress_cb(void *clientp,
   curl_off_t total;
   curl_off_t point;
 
+  if(!bar->calls)
+    update_width(bar);
+
   /* Calculate expected transfer size. initial_size can be less than zero when
      indicating that we are expecting to get the filesize from the remote */
   if(bar->initial_size < 0) {
@@ -229,8 +232,6 @@ void progressbarinit(struct ProgressData *bar, struct OperationConfig *config)
    * display progress towards total file not the part that is left. */
   if(config->use_resume)
     bar->initial_size = config->resume_from;
-
-  update_width(bar);
 
   bar->out = tool_stderr;
   bar->tick = 150;


### PR DESCRIPTION
Determine the terminal size on first invocation, not for all transfers.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
