### PR TITLE
tool: do not flush on out-null

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -671,7 +671,7 @@ static CURLcode post_output_handling(struct per_transfer *per,
       return CURLE_WRITE_ERROR;
   }
 
-  if(!outs->regular_file && outs->stream) {
+  if(!outs->regular_file && outs->stream && !outs->out_null) {
     /* Dump standard stream buffered data */
     rc = fflush(outs->stream);
     if(!result && rc) {


### PR DESCRIPTION
Do not flush output when --out-null is set.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
