### PR TITLE
content_encoding: give a clear error on multi-member gzip

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -206,6 +206,14 @@ static CURLcode inflate_stream(struct Curl_easy *data,
       /* No more data to flush: exit loop. */
       break;
     case Z_STREAM_END:
+      if((started == ZLIB_INIT_GZIP) && (z->avail_in >= 2) &&
+         (z->next_in[0] == 0x1f) && (z->next_in[1] == 0x8b)) {
+        /* a second gzip member follows; curl does not support
+           multi-member gzip responses */
+        failf(data, "Multi-member gzip response not supported");
+        result = exit_zlib(data, z, &zp->zlib_init, CURLE_WRITE_ERROR);
+        break;
+      }
       result = process_trailer(data, zp);
       break;
     case Z_DATA_ERROR:

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -259,7 +259,7 @@ test2108 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 test2208 \
 \
-test2300 test2301 test2302 test2303 test2304 test2306 test2307 test2308 \
+test2300 test2301 test2302 test2303 test2304 test2305 test2306 test2307 test2308 \
 test2309 test2310 test2311 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 test2407 \

--- a/tests/data/test2305
+++ b/tests/data/test2305
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+compressed
+</keywords>
+</info>
+# Server-side
+<reply>
+<data nocheck="yes" crlf="headers">
+HTTP/1.1 200 OK
+Date: Mon, 29 Nov 2004 21:56:53 GMT
+Server: test-server/fake
+Content-Type: text/plain; charset=UTF-8
+Content-Encoding: gzip
+Content-Length: 54
+
+%hex[%1f%8b%08%00%00%00%00%00%02%13%f3%48%cd%c9%c9%d7%51%00%00%05%6f%57%de%07%00%00%00%1f%8b%08%00%00%00%00%00%02%13%0b%cf%2f%ca%49%51%e4%02%00%dd%d1%ca%53%07%00%00%00]hex%
+</data>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+libz
+</features>
+<server>
+http
+</server>
+<name>
+HTTP GET gzip compressed content with two concatenated gzip members fails with clear error
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed --silent --show-error
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strippart>
+s/^Accept-Encoding: [a-zA-Z, ]*/Accept-Encoding: xxx/
+</strippart>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Accept-Encoding: xxx
+
+</protocol>
+<errorcode>
+23
+</errorcode>
+<stderr mode="text">
+curl: (23) Multi-member gzip response not supported
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
Follow-up to the discussion in #22156.

Rather than decoding multi-member gzip responses, this keeps curl failing
on them as discussed there, but swaps the bare CURLE_WRITE_ERROR for a
message that says what actually happened.

When inflate reaches the end of the first gzip member and the next bytes
are another gzip header (1f 8b), curl now fails with:

    curl: (23) Multi-member gzip response not supported

instead of the generic "Failed writing received data to disk/application",
which gave no hint about the cause.

Adds test 2305.

Ref: #22156
