### PR TITLE
cmake: drop logic for `GNU/kFreeBSD` systems

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -251,7 +251,6 @@ if(BUILD_SHARED_LIBS)
     CMAKE_SYSTEM_NAME STREQUAL "SunOS" OR
     CMAKE_SYSTEM_NAME STREQUAL "Haiku" OR
     CMAKE_SYSTEM_NAME STREQUAL "OHOS" OR  # OpenHarmony
-    CMAKE_SYSTEM_NAME STREQUAL "GNU/kFreeBSD" OR
     # FreeBSD comes with the a.out and ELF flavors but a.out was supported
     # up to v3.x and ELF from v3.x. I cannot imagine someone running CMake
     # on those ancient systems.


### PR DESCRIPTION
Adopting change made in CMake, with description: "kFreeBSD is no longer
maintained or supported and was never an officially-supported release
architecture for Debian."

This system name was also dropped by CMake 4.1+:
https://cmake.org/cmake/help/v4.2/variable/CMAKE_SYSTEM_NAME.html

Credits-to: Roger Leigh
Ref: https://gitlab.kitware.com/cmake/cmake/-/commit/99c8abed55c354f5674e52b25bb65391d4afca52
Ref: https://gitlab.kitware.com/cmake/cmake/-/work_items/26742
Ref: https://gitlab.kitware.com/cmake/cmake/-/work_items/26722

Follow-up to 5de6848f104d7cb0017080e31216265ac19d0dde #10023 #5935
