### PR TITLE
tool_operate: remove call to abort()

### DIFF
--- a/docs/examples/multi-event.c
+++ b/docs/examples/multi-event.c
@@ -205,7 +205,7 @@ static int handle_socket(CURL *curl, curl_socket_t s, int action, void *userp,
     }
     break;
   default:
-    abort();
+    return -1; /* unknown */
   }
 
   return 0;

--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -219,7 +219,7 @@ static int cb_socket(CURL *curl, curl_socket_t s, int action,
     }
     break;
   default:
-    abort();
+    return -1; /* unknown */
   }
 
   return 0;

--- a/docs/internals/CODE_STYLE.md
+++ b/docs/internals/CODE_STYLE.md
@@ -348,6 +348,7 @@ This is the full list of functions generally banned.
     _wfopen
     _wfreopen
     _wopen
+    abort
     accept
     accept4
     access

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -65,6 +65,7 @@ my %banfunc = (
     "_wfopen" => 1,
     "_wfreopen" => 1,
     "_wopen" => 1,
+    "abort" => 1,
     "accept" => 1,
     "accept4" => 1,
     "access" => 1,

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1768,7 +1768,8 @@ static int cb_socket(CURL *easy, curl_socket_t s, int action,
     }
     break;
   default:
-    abort();
+    DEBUGASSERT(0);
+    return -1;
   }
 
   return 0;


### PR DESCRIPTION
Make an assert and return a plain error instead. No abort in release code.
