### PR TITLE
tidy-up: syntax and code nits

### DIFF
--- a/.github/scripts/cmp-config.pl
+++ b/.github/scripts/cmp-config.pl
@@ -105,7 +105,7 @@ sub grepit {
     my ($input, $output) = @_;
     my @defines;
     # first get all the #define lines
-    open(F, "<$input");
+    open(F, "<", $input);
     while(<F>) {
         if($_ =~ /^#def/) {
             chomp;
@@ -114,7 +114,7 @@ sub grepit {
     }
     close(F);
 
-    open(O, ">$output");
+    open(O, ">", $output);
 
     # output the sorted list through the filter
     foreach my $d(sort @defines) {

--- a/.github/scripts/cmp-pkg-config.sh
+++ b/.github/scripts/cmp-pkg-config.sh
@@ -44,6 +44,6 @@ am=$(mktemp -t autotools.XXX); sort_lists "$1" > "${am}"
 cm=$(mktemp -t cmake.XXX)    ; sort_lists "$2" > "${cm}"
 diff -u "${am}" "${cm}"
 res="$?"
-rm -r -f "${am}" "${cm}"
+rm -rf "${am}" "${cm}"
 
 exit "${res}"

--- a/.github/scripts/verify-synopsis.pl
+++ b/.github/scripts/verify-synopsis.pl
@@ -45,8 +45,8 @@ sub extract {
     my $syn = 0;
     my $l = 0;
     my $iline = 0;
-    open(F, "<$f");
-    open(O, ">$cfile");
+    open(F, "<", $f);
+    open(O, ">", $cfile);
     while(<F>) {
         $iline++;
         if(/^# SYNOPSIS/) {

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -219,7 +219,7 @@ jobs:
         run: echo 'needs-build=true' >> "$GITHUB_OUTPUT"
 
       - name: 'install build prereqs'
-        if: ${{ steps.settings.outputs.needs-build == 'true' }}
+        if: ${{ steps.settings.outputs.needs-build }}
         timeout-minutes: 2
         run: |
           sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -65,7 +65,7 @@ int main(void)
 #include <netdb.h>
 int main(void)
 {
-  const char *address = "example.com";
+  const char *address = "localhost";
   struct hostent h;
   int rc = 0;
 #if   defined(HAVE_GETHOSTBYNAME_R_3) || \

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -48,7 +48,7 @@ int main(void)
 {
   /* O_NONBLOCK source test */
   int flags = 0;
-  if(0 != fcntl(0, F_SETFL, flags | O_NONBLOCK))
+  if(fcntl(0, F_SETFL, flags | O_NONBLOCK))
     return 1;
   return 0;
 }
@@ -162,7 +162,7 @@ int main(void)
 int main(void)
 {
   /* IoctlSocket source code */
-  if(0 != IoctlSocket(0, 0, 0))
+  if(IoctlSocket(0, 0, 0))
     return 1;
   return 0;
 }
@@ -177,7 +177,7 @@ int main(void)
 {
   /* IoctlSocket source code */
   long flags = 0;
-  if(0 != IoctlSocket(0, FIONBIO, &flags))
+  if(IoctlSocket(0, FIONBIO, &flags))
     return 1;
   (void)flags;
   return 0;
@@ -191,7 +191,7 @@ int main(void)
 int main(void)
 {
   unsigned long flags = 0;
-  if(0 != ioctlsocket(0, FIONBIO, &flags))
+  if(ioctlsocket(0, FIONBIO, &flags))
     return 1;
   (void)flags;
   return 0;
@@ -218,7 +218,7 @@ int main(void)
 int main(void)
 {
   int flags = 0;
-  if(0 != ioctl(0, FIONBIO, &flags))
+  if(ioctl(0, FIONBIO, &flags))
     return 1;
   (void)flags;
   return 0;
@@ -246,7 +246,7 @@ int main(void)
 int main(void)
 {
   struct ifreq ifr;
-  if(0 != ioctl(0, SIOCGIFADDR, &ifr))
+  if(ioctl(0, SIOCGIFADDR, &ifr))
     return 1;
   (void)ifr;
   return 0;
@@ -265,7 +265,7 @@ int main(void)
 #endif
 int main(void)
 {
-  if(0 != setsockopt(0, SOL_SOCKET, SO_NONBLOCK, 0, 0))
+  if(setsockopt(0, SOL_SOCKET, SO_NONBLOCK, 0, 0))
     return 1;
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -5156,7 +5156,7 @@ fi
 AC_SUBST(LIBCURL_PC_REQUIRES)
 AC_SUBST(LIBCURL_PC_LIBS)
 
-rm $compilersh
+rm "$compilersh"
 
 dnl
 dnl For keeping supported features and protocols also in pkg-config file

--- a/docs/examples/adddocsref.pl
+++ b/docs/examples/adddocsref.pl
@@ -33,8 +33,8 @@ use File::Copy;
 my $docroot = "https://curl.se/libcurl/c";
 
 for my $f (@ARGV) {
-    open(NEW, ">$f.new");
-    open(F, "<$f");
+    open(NEW, ">", "$f.new");
+    open(F, "<", $f);
     while(<F>) {
         my $l = $_;
         if($l =~ /\/* $docroot/) {

--- a/docs/examples/log_failed_transfers.c
+++ b/docs/examples/log_failed_transfers.c
@@ -305,7 +305,7 @@ int main(void)
     if(failed) {
       FILE *fp = fopen(t->logfile, "wb");
 
-      if(fp && t->log.len == fwrite(t->log.buf, 1, t->log.len, fp))
+      if(fp && fwrite(t->log.buf, 1, t->log.len, fp) == t->log.len)
         fprintf(stderr, "Transfer log written to %s\n", t->logfile);
       else {
         fprintf(stderr, "Failed to write transfer log to %s: %s\n",

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -300,7 +300,8 @@ int main(int argc, const char *argv[])
     /* Get current system time and local time */
     GetSystemTime(&SYSTime);
     GetLocalTime(&LOCALTime);
-    snprintf(timeBuf, 60, "%s, %02d %s %04d %02d:%02d:%02d.%03d, ",
+    snprintf(timeBuf, sizeof(timeBuf) - 1,
+             "%s, %02d %s %04d %02d:%02d:%02d.%03d, ",
              DayStr[LOCALTime.wDayOfWeek], LOCALTime.wDay,
              MthStr[LOCALTime.wMonth - 1], LOCALTime.wYear, LOCALTime.wHour,
              LOCALTime.wMinute, LOCALTime.wSecond, LOCALTime.wMilliseconds);
@@ -314,7 +315,8 @@ int main(int argc, const char *argv[])
 
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
     GetLocalTime(&LOCALTime);
-    snprintf(timeBuf, 60, "%s, %02d %s %04d %02d:%02d:%02d.%03d, ",
+    snprintf(timeBuf, sizeof(timeBuf) - 1,
+             "%s, %02d %s %04d %02d:%02d:%02d.%03d, ",
              DayStr[LOCALTime.wDayOfWeek], LOCALTime.wDay,
              MthStr[LOCALTime.wMonth - 1], LOCALTime.wYear, LOCALTime.wHour,
              LOCALTime.wMinute, LOCALTime.wSecond, LOCALTime.wMilliseconds);
@@ -329,7 +331,8 @@ int main(int argc, const char *argv[])
       else {
         /* Successfully re-adjusted computer clock */
         GetLocalTime(&LOCALTime);
-        snprintf(timeBuf, 60, "%s, %02d %s %04d %02d:%02d:%02d.%03d, ",
+        snprintf(timeBuf, sizeof(timeBuf) - 1,
+                 "%s, %02d %s %04d %02d:%02d:%02d.%03d, ",
                  DayStr[LOCALTime.wDayOfWeek], LOCALTime.wDay,
                  MthStr[LOCALTime.wMonth - 1], LOCALTime.wYear,
                  LOCALTime.wHour, LOCALTime.wMinute, LOCALTime.wSecond,

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -59,7 +59,7 @@
 
 #define SUBBUFSIZE 512
 
-#define CURL_SB_CLEAR(x) x->subpointer = (x)->subbuffer
+#define CURL_SB_CLEAR(x) (x)->subpointer = (x)->subbuffer
 #define CURL_SB_TERM(x)            \
   do {                             \
     (x)->subend = (x)->subpointer; \

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -584,7 +584,7 @@ UNITTEST int ipv4_normalize(struct dynbuf *host)
       return HOST_NAME;
     curlx_dyn_reset(host);
     result = curlx_dyn_addf(host, "%u.%u.%u.%u",
-                            (parts[0]),
+                            parts[0],
                             ((parts[1] >> 16) & 0xff),
                             ((parts[1] >> 8) & 0xff),
                             (parts[1] & 0xff));
@@ -594,8 +594,8 @@ UNITTEST int ipv4_normalize(struct dynbuf *host)
       return HOST_NAME;
     curlx_dyn_reset(host);
     result = curlx_dyn_addf(host, "%u.%u.%u.%u",
-                            (parts[0]),
-                            (parts[1]),
+                            parts[0],
+                            parts[1],
                             ((parts[2] >> 8) & 0xff),
                             (parts[2] & 0xff));
     break;
@@ -605,10 +605,10 @@ UNITTEST int ipv4_normalize(struct dynbuf *host)
       return HOST_NAME;
     curlx_dyn_reset(host);
     result = curlx_dyn_addf(host, "%u.%u.%u.%u",
-                            (parts[0]),
-                            (parts[1]),
-                            (parts[2]),
-                            (parts[3]));
+                            parts[0],
+                            parts[1],
+                            parts[2],
+                            parts[3]);
     break;
   }
   if(result)

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1961,7 +1961,7 @@ static CURLUcode url_sethost(CURLU *u, struct dynbuf *encp,
       bad = TRUE;
     curlx_free(decoded);
   }
-  else if(hostname_check(u, (char *)CURL_UNCONST(newp), n))
+  else if(hostname_check(u, newp, n))
     bad = TRUE;
   if(bad) {
     curlx_dyn_free(encp);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1468,19 +1468,19 @@ static CURLcode mbedtls_connect(struct Curl_cfilter *cf,
   *done = FALSE;
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
 
-  if(ssl_connect_1 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_1) {
     result = mbed_connect_step1(cf, data);
     if(result)
       return result;
   }
 
-  if(ssl_connect_2 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_2) {
     result = mbed_connect_step2(cf, data);
     if(result)
       return result;
   }
 
-  if(ssl_connect_3 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_3) {
     /* For tls1.3 we get notified about new sessions */
     struct ssl_connect_data *ctx = cf->ctx;
     struct mbed_ssl_backend_data *backend =
@@ -1495,7 +1495,7 @@ static CURLcode mbedtls_connect(struct Curl_cfilter *cf,
     connssl->connecting_state = ssl_connect_done;
   }
 
-  if(ssl_connect_done == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_done) {
     connssl->state = ssl_connection_complete;
     *done = TRUE;
   }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4014,7 +4014,7 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
   BIO *bio;
   CURLcode result;
 
-  DEBUGASSERT(ssl_connect_1 == connssl->connecting_state);
+  DEBUGASSERT(connssl->connecting_state == ssl_connect_1);
   DEBUGASSERT(octx);
   DEBUGASSERT(connssl->peer.origin);
 
@@ -4129,7 +4129,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct ossl_ctx *octx = (struct ossl_ctx *)connssl->backend;
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  DEBUGASSERT(ssl_connect_2 == connssl->connecting_state);
+  DEBUGASSERT(connssl->connecting_state == ssl_connect_2);
   DEBUGASSERT(octx);
 
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
@@ -4856,7 +4856,7 @@ static CURLcode ossl_connect_step3(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct ossl_ctx *octx = (struct ossl_ctx *)connssl->backend;
 
-  DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
+  DEBUGASSERT(connssl->connecting_state == ssl_connect_3);
 
   /*
    * We check certificates to authenticate the server; otherwise we risk
@@ -4968,7 +4968,7 @@ static CURLcode ossl_connect(struct Curl_cfilter *cf,
   *done = FALSE;
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
 
-  if(ssl_connect_1 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_1) {
     if(Curl_ossl_need_httpsrr(data) &&
        !Curl_conn_dns_resolved_https(data, cf->sockindex,
                                      connssl->peer.peer)) {
@@ -4981,7 +4981,7 @@ static CURLcode ossl_connect(struct Curl_cfilter *cf,
       goto out;
   }
 
-  if(ssl_connect_2 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_2) {
     CURL_TRC_CF(data, cf, "ossl_connect, step2");
 #ifdef HAVE_OPENSSL_EARLYDATA
     if(connssl->earlydata_state == ssl_earlydata_await) {
@@ -5002,7 +5002,7 @@ static CURLcode ossl_connect(struct Curl_cfilter *cf,
       goto out;
   }
 
-  if(ssl_connect_3 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_3) {
     CURL_TRC_CF(data, cf, "ossl_connect, step3");
     result = ossl_connect_step3(cf, data);
     if(result)
@@ -5020,7 +5020,7 @@ static CURLcode ossl_connect(struct Curl_cfilter *cf,
 #endif
   }
 
-  if(ssl_connect_done == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_done) {
     CURL_TRC_CF(data, cf, "ossl_connect, done");
     connssl->state = ssl_connection_complete;
   }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1898,7 +1898,7 @@ static CURLcode ossl_shutdown(struct Curl_cfilter *cf,
       *done = TRUE;
       goto out;
     }
-    if(SSL_ERROR_WANT_WRITE == SSL_get_error(octx->ssl, rc)) {
+    if(SSL_get_error(octx->ssl, rc) == SSL_ERROR_WANT_WRITE) {
       CURL_TRC_CF(data, cf, "SSL shutdown still wants to send");
       connssl->io_need = CURL_SSL_IO_NEED_SEND;
       goto out;
@@ -4161,25 +4161,25 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
     int detail = SSL_get_error(octx->ssl, err);
     CURL_TRC_CF(data, cf, "SSL_connect() -> err=%d, detail=%d", err, detail);
 
-    if(SSL_ERROR_WANT_READ == detail) {
+    if(detail == SSL_ERROR_WANT_READ) {
       CURL_TRC_CF(data, cf, "SSL_connect() -> want recv");
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
       return CURLE_AGAIN;
     }
-    if(SSL_ERROR_WANT_WRITE == detail) {
+    if(detail == SSL_ERROR_WANT_WRITE) {
       CURL_TRC_CF(data, cf, "SSL_connect() -> want send");
       connssl->io_need = CURL_SSL_IO_NEED_SEND;
       return CURLE_AGAIN;
     }
 #ifdef SSL_ERROR_WANT_ASYNC
-    if(SSL_ERROR_WANT_ASYNC == detail) {
+    if(detail == SSL_ERROR_WANT_ASYNC) {
       CURL_TRC_CF(data, cf, "SSL_connect() -> want async");
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
       return CURLE_AGAIN;
     }
 #endif
 #ifdef SSL_ERROR_WANT_RETRY_VERIFY
-    if(SSL_ERROR_WANT_RETRY_VERIFY == detail) {
+    if(detail == SSL_ERROR_WANT_RETRY_VERIFY) {
       CURL_TRC_CF(data, cf, "SSL_connect() -> want retry_verify");
       Curl_xfer_pause_recv(data, TRUE);
       return CURLE_AGAIN;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -452,8 +452,7 @@ static CURLcode get_client_cert(struct Curl_cfilter *cf,
           continue_reading = fseek(fInCert, 0, SEEK_SET) == 0;
         if(continue_reading && (certsize < CURL_MAX_INPUT_LENGTH))
           certdata = curlx_malloc(certsize + 1);
-        if((!certdata) ||
-           ((int) fread(certdata, certsize, 1, fInCert) != 1))
+        if(!certdata || ((int)fread(certdata, certsize, 1, fInCert) != 1))
           continue_reading = FALSE;
         curlx_fclose(fInCert);
         if(!continue_reading) {

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1595,7 +1595,7 @@ static CURLcode schannel_connect_step3(struct Curl_cfilter *cf,
   SecPkgContext_ApplicationProtocol alpn_result;
 #endif
 
-  DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
+  DEBUGASSERT(connssl->connecting_state == ssl_connect_3);
   DEBUGASSERT(backend);
 
   DEBUGF(infof(data, "schannel: SSL/TLS connection with %s port %d (step 3/3)",
@@ -1720,25 +1720,25 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
 
   *done = FALSE;
 
-  if(ssl_connect_1 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_1) {
     result = schannel_connect_step1(cf, data);
     if(result)
       return result;
   }
 
-  if(ssl_connect_2 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_2) {
     result = schannel_connect_step2(cf, data);
     if(result)
       return result;
   }
 
-  if(ssl_connect_3 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_3) {
     result = schannel_connect_step3(cf, data);
     if(result)
       return result;
   }
 
-  if(ssl_connect_done == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_done) {
     connssl->state = ssl_connection_complete;
 
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+, MS SDK 7.0A/VS2010+ */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -544,7 +544,7 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
     do {
       char buffer[1024];
       size_t want = left > sizeof(buffer) ? sizeof(buffer) : left;
-      if(want != fread(buffer, 1, want, fp))
+      if(fread(buffer, 1, want, fp) != want)
         goto end;
       if(curlx_dyn_addn(&buf, buffer, want))
         goto end;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -630,7 +630,7 @@ static CURLcode wssl_populate_x509_store(struct Curl_cfilter *cf,
                                            ssl_cafile,
                                            ssl_capath,
                                            WOLFSSL_LOAD_FLAG_IGNORE_ERR);
-    if(WOLFSSL_SUCCESS != rc) {
+    if(rc != WOLFSSL_SUCCESS) {
       if(conn_config->verifypeer &&
          !imported_native_ca && !imported_ca_info_blob) {
         /* Fail if we insist on successfully verifying the server. */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1723,15 +1723,15 @@ static CURLcode wssl_handshake(struct Curl_cfilter *cf, struct Curl_easy *data)
     return CURLE_OK;
   }
   else {
-    if(WOLFSSL_ERROR_WANT_READ == detail) {
+    if(detail == WOLFSSL_ERROR_WANT_READ) {
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
       return CURLE_AGAIN;
     }
-    else if(WOLFSSL_ERROR_WANT_WRITE == detail) {
+    else if(detail == WOLFSSL_ERROR_WANT_WRITE) {
       connssl->io_need = CURL_SSL_IO_NEED_SEND;
       return CURLE_AGAIN;
     }
-    else if(DOMAIN_NAME_MISMATCH == detail) {
+    else if(detail == DOMAIN_NAME_MISMATCH) {
       /* There is no easy way to override only the CN matching.
        * This enables the override of both mismatching SubjectAltNames
        * as also mismatching CN fields */
@@ -1739,7 +1739,7 @@ static CURLcode wssl_handshake(struct Curl_cfilter *cf, struct Curl_easy *data)
             connssl->peer.origin->hostname);
       return CURLE_PEER_FAILED_VERIFICATION;
     }
-    else if(ASN_NO_SIGNER_E == detail) {
+    else if(detail == ASN_NO_SIGNER_E) {
       if(conn_config->verifypeer) {
         failf(data, " CA signer not available for verification");
         return CURLE_SSL_CACERT_BADFILE;
@@ -1750,11 +1750,11 @@ static CURLcode wssl_handshake(struct Curl_cfilter *cf, struct Curl_easy *data)
                   "continuing anyway");
       return CURLE_OK;
     }
-    else if(ASN_AFTER_DATE_E == detail) {
+    else if(detail == ASN_AFTER_DATE_E) {
       failf(data, "server verification failed: certificate has expired.");
       return CURLE_PEER_FAILED_VERIFICATION;
     }
-    else if(ASN_BEFORE_DATE_E == detail) {
+    else if(detail == ASN_BEFORE_DATE_E) {
       failf(data, "server verification failed: certificate not valid yet.");
       return CURLE_PEER_FAILED_VERIFICATION;
     }
@@ -1923,7 +1923,7 @@ static CURLcode wssl_shutdown(struct Curl_cfilter *cf,
       *done = TRUE;
       goto out;
     }
-    if(WOLFSSL_ERROR_WANT_WRITE == wolfSSL_get_error(wctx->ssl, nread)) {
+    if(wolfSSL_get_error(wctx->ssl, nread) == WOLFSSL_ERROR_WANT_WRITE) {
       CURL_TRC_CF(data, cf, "SSL shutdown still wants to send");
       connssl->io_need = CURL_SSL_IO_NEED_SEND;
       goto out;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2116,7 +2116,7 @@ static CURLcode wssl_connect(struct Curl_cfilter *cf,
   *done = FALSE;
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
 
-  if(ssl_connect_1 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_1) {
 #ifdef HAVE_WOLFSSL_CTX_GENERATEECHCONFIG
     /* if we do ECH and need the HTTPS-RR information for it,
      * we delay the connect until it arrives or DNS resolve fails. */
@@ -2133,7 +2133,7 @@ static CURLcode wssl_connect(struct Curl_cfilter *cf,
     connssl->connecting_state = ssl_connect_2;
   }
 
-  if(ssl_connect_2 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_2) {
     if(connssl->earlydata_state == ssl_earlydata_await) {
       /* We defer the handshake until request data arrives. */
       DEBUGASSERT(connssl->state == ssl_connection_deferred);
@@ -2146,7 +2146,7 @@ static CURLcode wssl_connect(struct Curl_cfilter *cf,
     connssl->connecting_state = ssl_connect_3;
   }
 
-  if(ssl_connect_3 == connssl->connecting_state) {
+  if(connssl->connecting_state == ssl_connect_3) {
     /* Once the handshake has errored, it stays in that state and
      * errors again on every call. */
     if(wssl->hs_result) {

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -93,10 +93,9 @@ if test "x$OPT_OPENSSL" != "xno"; then
         fi
       fi
 
-      if test "$PKGTEST" != "yes"; then
-        if test ! -f "$PREFIX_OPENSSL/include/openssl/ssl.h"; then
-          AC_MSG_ERROR([$PREFIX_OPENSSL is a bad --with-openssl prefix!])
-        fi
+      if test "$PKGTEST" != "yes" &&
+         test ! -f "$PREFIX_OPENSSL/include/openssl/ssl.h"; then
+        AC_MSG_ERROR([$PREFIX_OPENSSL is a bad --with-openssl prefix!])
       fi
 
       dnl in case pkg-config comes up empty, use what we got

--- a/scripts/badwords
+++ b/scripts/badwords
@@ -149,7 +149,7 @@ sub sourcecode {
     my $flags = 0;
     my @lines;
     my $line;
-    open(F, "<$f");
+    open(F, "<", $f);
     while(<F>) {
         my $l = $_;
         ($state, $flags, $line) = srcline($state, $flags, $l);
@@ -175,7 +175,7 @@ my %wl;
 my @w;
 my @exact;
 my $file = shift @ARGV;
-open(CONFIG, "<$file") or die "Cannot open '$file': $!";
+open(CONFIG, "<", $file) or die "Cannot open '$file': $!";
 while(<CONFIG>) {
     chomp;
     if($_ =~ /^#/) {
@@ -261,7 +261,7 @@ sub highlight {
 sub document {
     my ($f) = @_;
     my @lines;
-    open(F, "<$f");
+    open(F, "<", $f);
     while(<F>) {
         push @lines, $_;
     }

--- a/scripts/cd2cd
+++ b/scripts/cd2cd
@@ -212,7 +212,7 @@ HEAD
     close(F);
 
     if($inplace) {
-        open(O, ">$f") or return 1;
+        open(O, ">", $f) or return 1;
         print O @desc;
         close(O);
     }

--- a/scripts/managen
+++ b/scripts/managen
@@ -1047,7 +1047,7 @@ sub header {
 sub sourcecategories {
     my ($dir) = @_;
     my %cats;
-    open(H, "<$dir/../../src/tool_help.h") or
+    open(H, "<", "$dir/../../src/tool_help.h") or
         die "cannot find the header file";
     while(<H>) {
         if(/^\#define CURLHELP_([A-Z0-9]*)/) {

--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -257,7 +257,7 @@ sub sha256 {
 
 sub oldhash {
     my $hash = "";
-    open(C, "<$_[0]") or return 0;
+    open(C, "<", $_[0]) or return 0;
     while(<C>) {
         chomp;
         if($_ =~ /^\#\# SHA256: (.*)/) {

--- a/scripts/verify-release
+++ b/scripts/verify-release
@@ -115,7 +115,7 @@ else
     mv "$f" _tarballs/
   done
 fi
-cd "_tarballs"
+cd _tarballs
 
 # compare the new tarball against the original
 sha256sum -c checksum

--- a/scripts/verify-release
+++ b/scripts/verify-release
@@ -39,14 +39,14 @@ tarball="${1:-}"
 
 if [ -z "$tarball" ]; then
   echo "Provide a curl release tarball name as argument"
-  exit
+  exit 1
 fi
 
 i="$(find . -maxdepth 1 -type d -name 'curl-*' | wc -l)"
 
 if test "$i" -gt 1; then
   echo "multiple curl-* entries found, disambiguate please"
-  exit
+  exit 1
 fi
 
 # check if this is in a git clone directory

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -178,7 +178,6 @@ static curl_off_t VmsSpecialSize(const char *name,
   case FAB$C_VAR:
   case FAB$C_VFC:
     return vms_realfilesize(name, stat_buf);
-    break;
   default:
     return stat_buf->st_size;
   }

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -161,18 +161,18 @@ static CURLcode tool_ssls_exp(CURL *easy, void *userptr,
   if(result)
     goto out;
   result = CURLE_WRITE_ERROR;
-  if(enc_len != fwrite(enc, 1, enc_len, ctx->fp))
+  if(fwrite(enc, 1, enc_len, ctx->fp) != enc_len)
     goto out;
-  if(EOF == fputc(':', ctx->fp))
+  if(fputc(':', ctx->fp) == EOF)
     goto out;
   curlx_safefree(enc);
   result = curlx_base64_encode(sdata, sdata_len, &enc, &enc_len);
   if(result)
     goto out;
   result = CURLE_WRITE_ERROR;
-  if(enc_len != fwrite(enc, 1, enc_len, ctx->fp))
+  if(fwrite(enc, 1, enc_len, ctx->fp) != enc_len)
     goto out;
-  if(EOF == fputc('\n', ctx->fp))
+  if(fputc('\n', ctx->fp) == EOF)
     goto out;
   result = CURLE_OK;
   ctx->exported++;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -137,7 +137,7 @@ endif
 
 # make sure that PERL is pointing to an executable
 perlcheck:
-	@if ! test -x "@PERL@"; then echo "No perl!"; exit 2; fi
+	@if ! test -x "@PERL@"; then echo 'No perl!'; exit 2; fi
 
 build-certs: perlcheck
 	(cd certs && $(MAKE))

--- a/tests/allversions.pm
+++ b/tests/allversions.pm
@@ -32,7 +32,7 @@ our %pastversion;
 
 sub allversions {
     my ($file) = @_;
-    open(A, "<$file") or
+    open(A, "<", $file) or
         die "cannot open the versions file $file\n";
     my $before = 1;
     my $relcount;

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -73,8 +73,8 @@ static CURLcode test_lib650(const char *URL)
   }
   headers = headers2;
   formrc = curl_formadd(&formpost, &lastptr,
-                        CURLFORM_COPYNAME, &testname,
-                        CURLFORM_COPYCONTENTS, &testdata,
+                        CURLFORM_COPYNAME, testname,
+                        CURLFORM_COPYCONTENTS, testdata,
                         CURLFORM_CONTENTHEADER, headers,
                         CURLFORM_END);
   if(formrc) {
@@ -145,7 +145,7 @@ static CURLcode test_lib650(const char *URL)
   formrc = curl_formadd(&formpost,
                         &lastptr,
                         CURLFORM_COPYNAME, "formlength",
-                        CURLFORM_COPYCONTENTS, &flbuf,
+                        CURLFORM_COPYCONTENTS, flbuf,
                         CURLFORM_END);
 
   if(formrc) {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -657,31 +657,31 @@ void install_signal_handlers(bool keep_sigalrm)
 void restore_signal_handlers(bool keep_sigalrm)
 {
 #ifdef SIGHUP
-  if(SIG_ERR != old_sighup_handler)
+  if(old_sighup_handler != SIG_ERR)
     (void)set_signal(SIGHUP, old_sighup_handler, FALSE);
 #endif
 #ifdef SIGPIPE
-  if(SIG_ERR != old_sigpipe_handler)
+  if(old_sigpipe_handler != SIG_ERR)
     (void)set_signal(SIGPIPE, old_sigpipe_handler, FALSE);
 #endif
 #ifdef SIGALRM
   if(!keep_sigalrm) {
-    if(SIG_ERR != old_sigalrm_handler)
+    if(old_sigalrm_handler != SIG_ERR)
       (void)set_signal(SIGALRM, old_sigalrm_handler, FALSE);
   }
 #else
   (void)keep_sigalrm;
 #endif
 #ifdef SIGINT
-  if(SIG_ERR != old_sigint_handler)
+  if(old_sigint_handler != SIG_ERR)
     (void)set_signal(SIGINT, old_sigint_handler, FALSE);
 #endif
 #ifdef SIGTERM
-  if(SIG_ERR != old_sigterm_handler)
+  if(old_sigterm_handler != SIG_ERR)
     (void)set_signal(SIGTERM, old_sigterm_handler, FALSE);
 #endif
 #if defined(SIGBREAK) && defined(_WIN32)
-  if(SIG_ERR != old_sigbreak_handler)
+  if(old_sigbreak_handler != SIG_ERR)
     (void)set_signal(SIGBREAK, old_sigbreak_handler, FALSE);
 #endif
 #ifdef _WIN32

--- a/tests/test1707.pl
+++ b/tests/test1707.pl
@@ -77,7 +77,7 @@ else {
     $fullopt = $longopt;
 }
 
-open(R, "<$txt");
+open(R, "<", $txt);
 my $show = 0;
 my @txtout;
 while(<R>) {

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -101,7 +101,7 @@ sub clearlogs {
 
 sub includefile {
     my ($f, $text) = @_;
-    open(F, "<$f");
+    open(F, "<", $f);
     if($text) {
         binmode F, ':crlf';
     }

--- a/tests/unit/unit2413.c
+++ b/tests/unit/unit2413.c
@@ -80,7 +80,6 @@ static CURLcode test_unit2413(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
   CURL *curl;
-  struct Curl_peer *peer = NULL;
 
   curl_global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
@@ -105,7 +104,6 @@ static CURLcode test_unit2413(const char *arg)
                   "::1", TRUE, "tada");
 
   curl_easy_cleanup(curl);
-  Curl_peer_unlink(&peer);
   curl_global_cleanup();
 
   UNITTEST_END_SIMPLE

--- a/tests/unit/unit2413.c
+++ b/tests/unit/unit2413.c
@@ -94,13 +94,13 @@ static CURLcode test_unit2413(const char *arg)
                   "127.0.0.1", FALSE, NULL);
   test_create2413("peer3", curl, &Curl_scheme_https, "::1", 1234,
                   "::1", TRUE, NULL);
-  test_create2413("peer3", curl, &Curl_scheme_https, "[::1]", 1234,
+  test_create2413("peer4", curl, &Curl_scheme_https, "[::1]", 1234,
                   "::1", TRUE, NULL);
-  test_create2413("peer4", curl, &Curl_scheme_https, "test.curl.se.", 1234,
+  test_create2413("peer5", curl, &Curl_scheme_https, "test.curl.se.", 1234,
                   "test.curl.se.", FALSE, NULL);
-  test_create2413("peer5", curl, &Curl_scheme_https, "[::1%tada]", 1234,
+  test_create2413("peer6", curl, &Curl_scheme_https, "[::1%tada]", 1234,
                   "::1", TRUE, "tada");
-  test_create2413("peer6", curl, &Curl_scheme_https, "::1%tada", 1234,
+  test_create2413("peer7", curl, &Curl_scheme_https, "::1%tada", 1234,
                   "::1", TRUE, "tada");
 
   curl_easy_cleanup(curl);


### PR DESCRIPTION
- cmp-pkg-config.sh: replace `-r -f` with `-rf` to match rest of repo.
- configure.ac: add double quotes for robustness (not a bug).
- curl-openssl.m4: merge nested `if`s.
- CurlTests.c: drop `!= 0`, also to sync with m4.
- CurlTests.c: replace `example.com` with `localhost` in
  `gethostbyname()` feature test code. (compile-only, not a bug)
- GHA/http3-linux: drop literal `true` from bool expression.
- lib650: drop redundant `&`.
- move variable/call to left-hand side of equality checks, where
  missing.
- perl: detach `<`/`>` from filename in `open()`, where missing.
- schannel: apply two nit fixes lost in rebase.
- scripts/verify-release: drop redundant double quotes.
- scripts/verify-release: exit with error code on error.
- synctime: replace magic numbers with `sizeof()`.
- telnet: add missing parentheses to macro value.
- tests/Makefile.am: use single quotes.
- tool_operate: drop redundant `break` after `return` in VMS code.
- unit2413: drop unused NULL pointer + free call.
- unit2413: fix duplicate test case name.
- urlapi: drop redundant parentheses.
- urlapi: drop `CURL_UNCONST()` that became redundant.
