### PR TITLE
cmake: robustify base path in local file reference

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -43,7 +43,7 @@ macro(curl_internal_test _curl_test)
     message(STATUS "Performing Test ${_curl_test}")
     try_compile(${_curl_test}
       ${PROJECT_BINARY_DIR}
-      "${CMAKE_CURRENT_SOURCE_DIR}/CMake/CurlTests.c"
+      "${PROJECT_SOURCE_DIR}/CMake/CurlTests.c"
       COMPILE_DEFINITIONS "-D${_curl_test}" ${CURL_TEST_DEFINES} ${CMAKE_REQUIRED_FLAGS} ${CMAKE_REQUIRED_DEFINITIONS}
       LINK_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}"
       OUTPUT_VARIABLE CURL_TEST_OUTPUT)


### PR DESCRIPTION
To make the macro find this file also when used elsewhere than the root
`CMakeLists.txt`. Current code only uses it from the root. 

Follow-up to 88c17d5587447b367c7ec836ff9b847860f52f75

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
