### PR TITLE
GHA/windows: set `VCPKG_APPLOCAL_DEPS=OFF` for vcpkg jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1109,7 +1109,7 @@ jobs:
           /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 file --
           /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
           #if [ "${MATRIX_PLAT}" != 'uwp' ]; then  # Missing: ucrtbased.dll, VCRUNTIME140D.dll, VCRUNTIME140D_APP.dll
-            PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH"
+            PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/installed/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH"
             echo "|$PATH|"
             "bld/src/${MATRIX_TYPE}/curl.exe" --disable --version
           #fi
@@ -1187,7 +1187,7 @@ jobs:
               PATH="/c/OpenSSH-Win64:$PATH"
             fi
           fi
-          PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH:/c/my-stunnel/bin"
+          PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/installed/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH:/c/my-stunnel/bin"
           echo "|$PATH|"
           cmake --build bld --config "${MATRIX_TYPE}" --target test-ci
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1108,10 +1108,11 @@ jobs:
         run: |
           /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 file --
           /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
-          if [ "${MATRIX_PLAT}" != 'uwp' ]; then  # Missing: ucrtbased.dll, VCRUNTIME140D.dll, VCRUNTIME140D_APP.dll
-            PATH="$PWD/bld/lib/${MATRIX_TYPE}:$PATH"
+          #if [ "${MATRIX_PLAT}" != 'uwp' ]; then  # Missing: ucrtbased.dll, VCRUNTIME140D.dll, VCRUNTIME140D_APP.dll
+            PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH"
+            echo "|$PATH|"
             "bld/src/${MATRIX_TYPE}/curl.exe" --disable --version
-          fi
+          #fi
 
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
@@ -1186,7 +1187,8 @@ jobs:
               PATH="/c/OpenSSH-Win64:$PATH"
             fi
           fi
-          PATH="$PWD/bld/lib/${MATRIX_TYPE}:$PATH:/c/my-stunnel/bin"
+          PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH:/c/my-stunnel/bin"
+          echo "|$PATH|"
           cmake --build bld --config "${MATRIX_TYPE}" --target test-ci
 
       - name: 'build examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1070,6 +1070,7 @@ jobs:
               options+=" -DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed"
               options+=" -DVCPKG_TARGET_TRIPLET=${MATRIX_ARCH}-${MATRIX_PLAT}"
               options+=" -DCMAKE_C_COMPILER_TARGET=${MATRIX_ARCH}-${MATRIX_PLAT}"
+              options+=' -DVCPKG_APPLOCAL_DEPS=OFF'
             fi
             cmake -B "bld${_chkprefill}" ${options} \
               -DCMAKE_C_FLAGS="${cflags}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1108,11 +1108,10 @@ jobs:
         run: |
           /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 file --
           /usr/bin/find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' -o -name '*.pdb' \) -print0 | grep -z curl | xargs -0 stat -c '%10s bytes: %n' --
-          #if [ "${MATRIX_PLAT}" != 'uwp' ]; then  # Missing: ucrtbased.dll, VCRUNTIME140D.dll, VCRUNTIME140D_APP.dll
+          if [ "${MATRIX_PLAT}" != 'uwp' ]; then  # Missing: ucrtbased.dll, VCRUNTIME140D.dll, VCRUNTIME140D_APP.dll
             PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/installed/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH"
-            echo "|$PATH|"
             "bld/src/${MATRIX_TYPE}/curl.exe" --disable --version
-          #fi
+          fi
 
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
@@ -1188,7 +1187,6 @@ jobs:
             fi
           fi
           PATH="$PWD/bld/lib/${MATRIX_TYPE}:$(cygpath --unix "${VCPKG_INSTALLATION_ROOT}")/installed/${MATRIX_ARCH}-${MATRIX_PLAT}/${MATRIX_TYPE}/bin:$PATH:/c/my-stunnel/bin"
-          echo "|$PATH|"
           cmake --build bld --config "${MATRIX_TYPE}" --target test-ci
 
       - name: 'build examples'


### PR DESCRIPTION
Add the necessary directory to `PATH` instead.

To disable a vcpkg feature (auto-copying DLL dependencies next to the
build targets) that was causing CI flakiness in the libssh2 repository.
In curl it currently cannot cause flakiness because targets (with DLL
dependencies) reside in separate directories.

AFAIU this vcpkg feature has been present and enabled by default for
a long time, but only a recent update made it visible in the log and
flaky at the same time, due to switching implementation.

This patch removes log noise and potential issues, improves efficiency, 
and saves disk space: 74MB → 71 in UWP, and 69MB → 65 in the arm64 job.
Time saving is negligible with current jobs.

Refs:
https://github.com/libssh2/libssh2/pull/2114
https://github.com/libssh2/libssh2/commit/30a0484cb7b350d779dbca87dbf9d7ba18a03547
https://github.com/microsoft/vcpkg/pull/52315
https://learn.microsoft.com/vcpkg/reference/installation-tree-layout

---

uwp/MSBuild:
Before: https://github.com/curl/curl/actions/runs/28226112430/job/83618374862
After: https://github.com/curl/curl/actions/runs/28234192080/job/83644940422?pr=22189

arm64/Ninja:
Before: https://github.com/curl/curl/actions/runs/28226112430/job/83618374893
After: https://github.com/curl/curl/actions/runs/28235822558/job/83650422625?pr=22189

MSBuild in 'build' step:
```
  curl.vcxproj -> D:\a\curl\curl\bld\src\Debug\curl.exe
  D:/a/curl/curl/bld/src/Debug/curl.exe: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\zd.dll -> D:\a\curl\curl\bld\src\Debug\zd.dll done
  D:/a/curl/curl/bld/src/Debug\zd.dll: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\libssh2.dll -> D:\a\curl\curl\bld\src\Debug\libssh2.dll done
  D:/a/curl/curl/bld/src/Debug\libssh2.dll: message: deploying dependencies
```

MSBuild in 'build tests' step:
```
  D:/a/curl/curl/bld/src/Debug/curlinfo.exe: message: deploying dependencies
  D:/a/curl/curl/bld/tests/server/Debug/servers.exe: message: deploying dependencies
[...]
  D:/a/curl/curl/bld/tests/tunit/Debug/tunits.exe: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\libssh2.dll -> D:\a\curl\curl\bld\tests\tunit\Debug\libssh2.dll done
  D:/a/curl/curl/bld/tests/tunit/Debug\libssh2.dll: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\zd.dll -> D:\a\curl\curl\bld\tests\tunit\Debug\zd.dll done
  D:/a/curl/curl/bld/tests/tunit/Debug\zd.dll: message: deploying dependencies
  units.vcxproj -> D:\a\curl\curl\bld\tests\unit\Debug\units.exe
  D:/a/curl/curl/bld/tests/unit/Debug/units.exe: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\libssh2.dll -> D:\a\curl\curl\bld\tests\unit\Debug\libssh2.dll done
  D:/a/curl/curl/bld/tests/unit/Debug\libssh2.dll: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\zd.dll -> D:\a\curl\curl\bld\tests\unit\Debug\zd.dll done
  D:/a/curl/curl/bld/tests/unit/Debug\zd.dll: message: deploying dependencies
  libtests.vcxproj -> D:\a\curl\curl\bld\tests\libtest\Debug\libtests.exe
  D:/a/curl/curl/bld/tests/libtest/Debug/libtests.exe: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\zd.dll -> D:\a\curl\curl\bld\tests\libtest\Debug\zd.dll done
  D:/a/curl/curl/bld/tests/libtest/Debug\zd.dll: message: deploying dependencies
  C:\vcpkg\installed\x64-uwp\debug\bin\libssh2.dll -> D:\a\curl\curl\bld\tests\libtest\Debug\libssh2.dll done
  D:/a/curl/curl/bld/tests/libtest/Debug\libssh2.dll: message: deploying dependencies
```
