### PR TITLE
cmake: stop probing unused `float.h` for `STDC_HEADERS`

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -118,7 +118,6 @@ int main(void)
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <float.h>
 int main(void)
 {
   return 0;


### PR DESCRIPTION
Also to sync up with current autotools, which stopped testing for it at
one point.

Follow-up to 4c5307b45655ba75ab066564afdc0c111a8b9291

---

- [x] I plan to give `STDC_HEADER` a closer look after this. → #22206

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
