### PR TITLE
cmake: flatten build tree, tidy up base dir variables

### DIFF
--- a/CMake/cmake_uninstall.in.cmake
+++ b/CMake/cmake_uninstall.in.cmake
@@ -21,8 +21,8 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+if(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @PROJECT_BINARY_DIR@/install_manifest.txt")
 endif()
 
 if(NOT DEFINED CMAKE_INSTALL_PREFIX)
@@ -30,7 +30,7 @@ if(NOT DEFINED CMAKE_INSTALL_PREFIX)
 endif()
 message(${CMAKE_INSTALL_PREFIX})
 
-file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" _files)
+file(READ "@PROJECT_BINARY_DIR@/install_manifest.txt" _files)
 string(REGEX REPLACE "\n" ";" _files "${_files}")
 foreach(_file ${_files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${_file}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1939,7 +1939,7 @@ include(GNUInstallDirs)
 
 set(_install_cmake_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(_generated_dir "${CMAKE_CURRENT_BINARY_DIR}")
+set(_generated_dir "${PROJECT_BINARY_DIR}")
 set(_project_config "${_generated_dir}/${PROJECT_NAME}Config.cmake")
 set(_version_config "${_generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 
@@ -2457,15 +2457,15 @@ if(NOT CURL_DISABLE_INSTALL)
   if(NOT TARGET curl_uninstall)
     # Consumed variables:
     #   CMAKE_COMMAND
-    #   CMAKE_CURRENT_BINARY_DIR
     #   CMAKE_INSTALL_PREFIX
+    #   PROJECT_BINARY_DIR
     configure_file(
       "${PROJECT_SOURCE_DIR}/CMake/cmake_uninstall.in.cmake"
-      "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+      "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake"
       @ONLY)
 
     add_custom_target(curl_uninstall
-      COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+      COMMAND ${CMAKE_COMMAND} -P "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake")
   endif()
 
   if(BUILD_CURL_EXE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2380,7 +2380,7 @@ if(NOT CURL_DISABLE_INSTALL)
     endif()
     ${_generated_version_config}")
 
-  # Consumed custom variables:
+  # Consumed variables:
   #   CMAKE_MINIMUM_REQUIRED_VERSION
   #   CURLVERSION
   #   LIBCURL_PC_LIBS_PRIVATE_LIST
@@ -2455,6 +2455,10 @@ if(NOT CURL_DISABLE_INSTALL)
     DESTINATION ${_install_cmake_dir})
 
   if(NOT TARGET curl_uninstall)
+    # Consumed variables:
+    #   CMAKE_COMMAND
+    #   CMAKE_CURRENT_BINARY_DIR
+    #   CMAKE_INSTALL_PREFIX
     configure_file(
       "${PROJECT_SOURCE_DIR}/CMake/cmake_uninstall.in.cmake"
       "${CMAKE_CURRENT_BINARY_DIR}/CMake/cmake_uninstall.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1939,7 +1939,7 @@ include(GNUInstallDirs)
 
 set(_install_cmake_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(_generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(_generated_dir "${CMAKE_CURRENT_BINARY_DIR}")
 set(_project_config "${_generated_dir}/${PROJECT_NAME}Config.cmake")
 set(_version_config "${_generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2461,11 +2461,11 @@ if(NOT CURL_DISABLE_INSTALL)
     #   CMAKE_INSTALL_PREFIX
     configure_file(
       "${PROJECT_SOURCE_DIR}/CMake/cmake_uninstall.in.cmake"
-      "${CMAKE_CURRENT_BINARY_DIR}/CMake/cmake_uninstall.cmake"
+      "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
       @ONLY)
 
     add_custom_target(curl_uninstall
-      COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/CMake/cmake_uninstall.cmake")
+      COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
   endif()
 
   if(BUILD_CURL_EXE)


### PR DESCRIPTION
- drop `generated` subdir, move these files to build root.
  To move them next to CPack and other config files, and to avoid
  a subdirectory for only 2 files.
  Follow-up to 69328490fc91bfa00a6a90da84239524b01f5527 #2849

- add 'Consumed variables' comment for `CMake/cmake_uninstall.in.cmake`.

- move generated `cmake_uninstall.cmake` to the build root directory
  (from `CMake/`). To:
  - avoid creating a `CMake` subdirectory within the build directory
    with this single file in it.
  - move it next to its `cmake_install.cmake` counterpart.
  - move it next to `install_manifest.txt` which it relies on.

  Follow-up to 27e2a4733c3321fb0b1a127360e8e96bc3d4ae53

- Use `PROJECT_SOURCE_DIR` for these files, replacing
  `CMAKE_CURRENT_SOURCE_DIR`, to make it consistent with rest of CMake
  sources, and to reduce ambiguity in `CMake/cmake_uninstall.in.cmake`
  template.

Follow-up to 8198e388d31919ec610908d496d34ced2daf4fea #22188
Follow-up to 4839029645bae1ff7f17e0f1c7543bc3eb30f471 #22187
Follow-up to 9126eb5a8ad96f156586942facb069383a09c046 #15331

---

Note: the `ninja curl_uninstall` feature does not work in certain cases.
It also does not remove empty directories.
