### PR TITLE
lib1587: fix gcc `-Wconversion` with LibreSSL on Windows, test in CI

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-nocertdata-win-x64-noWINE'
+          export CW_CONFIG='-main-werror-unitybatch-nocertdata-curltests-win-x64-noWINE'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default
@@ -185,7 +185,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-nocertdata-win-x64-gcc-zlibold-noWINE'
+          export CW_CONFIG='-main-werror-unitybatch-nocertdata-curltests-win-x64-gcc-zlibold-noWINE'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-nocertdata-curltests-win-x64-noWINE'
+          export CW_CONFIG='-main-werror-unitybatch-nocertdata-win-x64-noWINE'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2630,14 +2630,6 @@ static CURLcode ossl_set_ssl_version_min_max(struct Curl_cfilter *cf,
   return CURLE_OK;
 }
 
-#ifdef LIBRESSL_VERSION_NUMBER
-typedef long ctx_option_t;
-#elif defined(HAVE_BORINGSSL_LIKE)
-typedef uint32_t ctx_option_t;
-#else
-typedef uint64_t ctx_option_t;
-#endif
-
 CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
                                struct Curl_easy *data,
                                const char *ssl_peer_key,

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -100,6 +100,14 @@
 #define HAVE_OPENSSL_EARLYDATA
 #endif
 
+#ifdef LIBRESSL_VERSION_NUMBER
+typedef long ctx_option_t;
+#elif defined(HAVE_BORINGSSL_LIKE)
+typedef uint32_t ctx_option_t;
+#else
+typedef uint64_t ctx_option_t;
+#endif
+
 struct alpn_spec;
 struct ssl_peer;
 struct Curl_ssl_session;

--- a/tests/libtest/lib1587.c
+++ b/tests/libtest/lib1587.c
@@ -26,13 +26,6 @@
 #ifdef USE_OPENSSL
 #include <vtls/openssl.h>
 
-#ifdef HAVE_BORINGSSL_LIKE
-/* AWS-LC and BoringSSL */
-typedef uint32_t opt1587;
-#else
-typedef uint64_t opt1587;
-#endif
-
 static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   const struct curl_tlssessioninfo *info;
@@ -46,7 +39,7 @@ static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 
     if(result == CURLE_OK) {
       /* set and read stuff using the SSL_CTX to verify it */
-      opt1587 opts = SSL_CTX_get_options(info->internals);
+      ctx_option_t opts = SSL_CTX_get_options(info->internals);
       SSL_CTX_set_options(info->internals, opts);
       curl_mprintf("CURLINFO_TLS_SESSION: OK\n");
     }
@@ -55,7 +48,7 @@ static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 
     if(result == CURLE_OK) {
       /* set and read stuff using the SSL pointer to verify it */
-      opt1587 opts = SSL_get_options(info->internals);
+      ctx_option_t opts = SSL_get_options(info->internals);
       SSL_set_options(info->internals, opts);
       curl_mprintf("CURLINFO_TLS_SSL_PTR: OK\n");
     }


### PR DESCRIPTION
By exposing and reusing existing custom type via `vtls/openss.h`.

Also:
- GHA/curl-for-win: test in CI by enabling building tests.
  Cost is 45s per job, so limit it to the gcc job.

Seen with Windows x64 gcc (not tested in CI prior to this patch):
```
tests/libtest/lib1587.c:50:7: error: conversion from 'opt1587' {aka 'long long unsigned int'} to 'long int' may change value [-Werror=conversion]
   50 |       SSL_CTX_set_options(info->internals, opts);
      |       ^~~~~~~~~~~~~~~~~~~
tests/libtest/lib1587.c:59:7: error: conversion from 'opt1587' {aka 'long long unsigned int'} to 'long int' may change value [-Werror=conversion]
   59 |       SSL_set_options(info->internals, opts);
      |       ^~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/28258372229/job/83727170184?pr=22195#step:3:4884

Ref: da2f05e6f6cee66ea46b8b1ca3943e5a6dde0b91 #22198
Ref: 616356646159379ab091502cdc90113dc8cc11eb #22197
Follow-up to 3e40ccb87581b0f6180fbd9c1eef9c50f270c806 #21290
Follow-up to 2db8ae480fdcae7f005bf847fbbf837821c8184c #17809 #17801
