### PR TITLE
ldap: support empty username and password

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -282,10 +282,8 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 #else
   char *host = NULL;
 #endif
-  const char *user = Curl_creds_has_user(data->state.creds) ?
-    data->state.creds->user : NULL;
-  const char *passwd = Curl_creds_has_passwd(data->state.creds) ?
-    data->state.creds->passwd : NULL;
+  const char *user = data->state.creds ? data->state.creds->user : NULL;
+  const char *passwd = data->state.creds ? data->state.creds->passwd : NULL;
   struct ip_quadruple ipquad;
   bool is_ipv6;
   BerElement *ber = NULL;


### PR DESCRIPTION
Prior to this change an empty username or password was passed to the LDAP bind function as NULL instead of an empty string.

Regression since 8f71d0fd.

Reported-by: Yoshiro Yoneya

Fixes https://github.com/curl/curl/issues/22162
Closes #xxxx

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
