### PR TITLE
openssl: drop unused pre-OpenSSL3 `ctx_option_t` typedef

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2630,14 +2630,12 @@ static CURLcode ossl_set_ssl_version_min_max(struct Curl_cfilter *cf,
   return CURLE_OK;
 }
 
-#ifdef HAVE_BORINGSSL_LIKE
-typedef uint32_t ctx_option_t;
-#elif defined(HAVE_OPENSSL3)
-typedef uint64_t ctx_option_t;
-#elif defined(LIBRESSL_VERSION_NUMBER)
+#ifdef LIBRESSL_VERSION_NUMBER
 typedef long ctx_option_t;
+#elif defined(HAVE_BORINGSSL_LIKE)
+typedef uint32_t ctx_option_t;
 #else
-typedef unsigned long ctx_option_t;
+typedef uint64_t ctx_option_t;
 #endif
 
 CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,


### PR DESCRIPTION
Follow-up to 69c89bf3d3137fcbb2b8bc57233182adcf1e2817 #18330
