### PR TITLE
curl_trc: store callback info in a uint8, not a bool

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -51,7 +51,7 @@ static void trc_write(struct Curl_easy *data, curl_infotype type,
 {
   if(data->set.verbose) {
     if(data->set.fdebug) {
-      bool inCallback = Curl_is_in_callback(data);
+      uint8_t inCallback = Curl_is_in_callback(data);
       Curl_set_in_callback(data, TRUE);
       (void)(*data->set.fdebug)(data, type, CURL_UNCONST(ptr), size,
                                 data->set.debugdata);
@@ -133,7 +133,7 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
     char buf[TRC_LINE_MAX];
     size_t len;
     if(data->set.fdebug) {
-      bool inCallback = Curl_is_in_callback(data);
+      uint8_t inCallback = Curl_is_in_callback(data);
 
       if(CURL_TRC_IDS(data) && (size < TRC_LINE_MAX)) {
         len = trc_print_ids(data, buf, TRC_LINE_MAX);


### PR DESCRIPTION
The state is no longer just a bool so make sure to use a proper uint8_t so that it gets restored properly.

Follow-up to a6af50c484f6bbd1c01573685d
