### PR TITLE
cmake: minor tidy-ups

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -225,7 +225,7 @@ int main(void)
 #endif
 
 #ifdef HAVE_IOCTL_SIOCGIFADDR
-/* headers for FIONBIO test */
+/* headers for SIOCGIFADDR test */
 #ifdef HAVE_SYS_TYPES_H
 #  include <sys/types.h>
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1937,9 +1937,8 @@ include(GNUInstallDirs)
 
 set(_install_cmake_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(_generated_dir "${PROJECT_BINARY_DIR}")
-set(_project_config "${_generated_dir}/${PROJECT_NAME}Config.cmake")
-set(_version_config "${_generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(_project_config "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
+set(_version_config "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
 
 option(BUILD_TESTING "Build tests" ON)
 if(BUILD_TESTING AND Perl_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2459,8 +2459,7 @@ if(NOT CURL_DISABLE_INSTALL)
     #   PROJECT_BINARY_DIR
     configure_file(
       "${PROJECT_SOURCE_DIR}/CMake/cmake_uninstall.in.cmake"
-      "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake"
-      @ONLY)
+      "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake" @ONLY)
 
     add_custom_target(curl_uninstall
       COMMAND ${CMAKE_COMMAND} -P "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake")

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -332,7 +332,7 @@ Details via CMake
 - `CMAKE_INSTALL_BINDIR`                    (see CMake)
 - `CMAKE_INSTALL_INCLUDEDIR`                (see CMake)
 - `CMAKE_INSTALL_LIBDIR`                    (see CMake)
-- `CMAKE_INSTALL_PREFIX`                    (see CMake)
+- `CMAKE_INSTALL_PREFIX`                    (see CMake) (in CMake 3.29+ also supported as environment)
 - `CMAKE_STATIC_LIBRARY_SUFFIX`             (see CMake)
 - `CMAKE_UNITY_BUILD_BATCH_SIZE`:           Set the number of sources in a "unity" unit. Default: `0` (all)
 - `CMAKE_UNITY_BUILD`:                      Enable "unity" (aka "jumbo") builds. Default: `OFF`


### PR DESCRIPTION
- INSTALL-CMAKE.md: document that `CMAKE_INSTALL_PREFIX`
  may be set as environment (with CMake 3.29+)
  Ref: https://cmake.org/cmake/help/v3.29/variable/CMAKE_INSTALL_PREFIX.html
- CurlTests: fix copy-paste typo in comment.
  Spotted by GitHub Code Quality
- optimized out `_generated_dir` local variable.
- unfold a `@ONLY` to match rest of code.
