### PR TITLE
[TEST] GHA/macos: try gcc-16 job

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -244,7 +244,7 @@ jobs:
 
           - name: 'OpenSSL libssh2'
             compiler: gcc-16
-            install: openssl@4 libssh2
+            install: openssl@4 libssh2 gcc-16
             configure: --enable-debug --with-libssh2 --with-openssl=/opt/homebrew/opt/openssl@4 --enable-ech
 
           - name: 'OpenSSL libssh'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -253,6 +253,14 @@ jobs:
             install: openssl gcc
             CFLAGS: -O3 -DNDEBUG
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
+
+          - name: 'OpenSSL libssh2 -O3 moreopt'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG -fno-delete-null-pointer-checks -fno-strict-aliasing -fno-strict-overflow -ftrivial-auto-var-init=zero -fzero-init-padding-bits=all -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mbranch-protection=standard -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-ident
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
 
           - name: 'OpenSSL libssh'
             compiler: llvm@18

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -247,6 +247,16 @@ jobs:
             install: openssl gcc
             configure: --enable-debug --with-libssh2 --with-openssl=/opt/homebrew/opt/openssl
 
+          - name: 'OpenSSL libssh2 CM'
+            compiler: gcc-16
+            install: openssl gcc
+            generate: DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl
+
+          - name: 'OpenSSL libssh2 T1'
+            compiler: gcc-16
+            install: openssl@4 gcc
+            configure: --enable-debug --with-libssh2=/opt/homebrew/opt/libssh2 --with-openssl=/opt/homebrew/opt/openssl@4
+
           - name: 'OpenSSL libssh'
             compiler: llvm@18
             install: libssh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -248,34 +248,6 @@ jobs:
             CFLAGS: -DNDEBUG
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
 
-          - name: 'OpenSSL libssh2 -O3 moreopt'
-            compiler: gcc-16
-            install: openssl gcc
-            CFLAGS: -O3 -DNDEBUG -fno-delete-null-pointer-checks -fno-strict-aliasing -fno-strict-overflow -ftrivial-auto-var-init=zero -fzero-init-padding-bits=all -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mbranch-protection=standard -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-ident
-            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
-            macos-version-min: '10.12'  # Catalina (2019)
-
-          - name: 'OpenSSL libssh2 -O3 moreopt-1'
-            compiler: gcc-16
-            install: openssl gcc
-            CFLAGS: -O3 -DNDEBUG -fno-delete-null-pointer-checks -fno-strict-aliasing -fno-strict-overflow -ftrivial-auto-var-init=zero -fzero-init-padding-bits=all
-            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
-            macos-version-min: '10.12'  # Catalina (2019)
-
-          - name: 'OpenSSL libssh2 -O3 moreopt-2'
-            compiler: gcc-16
-            install: openssl gcc
-            CFLAGS: -O3 -DNDEBUG                                                                                                                                     -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mbranch-protection=standard -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-ident
-            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
-            macos-version-min: '10.12'  # Catalina (2019)
-
-          - name: 'OpenSSL libssh2 -O3 moreopt-3'
-            compiler: gcc-16
-            install: openssl gcc
-            CFLAGS: -O3 -DNDEBUG -fno-delete-null-pointer-checks -fno-strict-aliasing -fno-strict-overflow
-            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
-            macos-version-min: '10.12'  # Catalina (2019)
-
           - name: 'OpenSSL libssh2 -O3 moreopt-4'
             compiler: gcc-16
             install: openssl gcc
@@ -286,14 +258,14 @@ jobs:
           - name: 'OpenSSL libssh2 -O3 moreopt-5'
             compiler: gcc-16
             install: openssl gcc
-            CFLAGS: -O3 -DNDEBUG                                                                                                                                     -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mbranch-protection=standard
+            CFLAGS: -O3 -DNDEBUG                                                                           -ftrivial-auto-var-init=zero
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
             macos-version-min: '10.12'  # Catalina (2019)
 
           - name: 'OpenSSL libssh2 -O3 moreopt-6'
             compiler: gcc-16
             install: openssl gcc
-            CFLAGS: -O3 -DNDEBUG                                                                                                                                                                                                                       -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-ident
+            CFLAGS: -O3 -DNDEBUG                                                                           -fzero-init-padding-bits=all
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
             macos-version-min: '10.12'  # Catalina (2019)
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -242,20 +242,10 @@ jobs:
             install: openssl@4 libssh
             configure: --enable-debug --with-libssh --with-openssl=/opt/homebrew/opt/openssl@4 --enable-ech --enable-ares --with-fish-functions-dir --with-zsh-functions-dir
 
-          - name: 'OpenSSL libssh2'
-            compiler: gcc-16
-            install: openssl gcc
-            configure: --enable-debug --with-libssh2 --with-openssl=/opt/homebrew/opt/openssl
-
           - name: 'OpenSSL libssh2 CM'
             compiler: gcc-16
             install: openssl gcc
-            generate: DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl
-
-          - name: 'OpenSSL libssh2 T1'
-            compiler: gcc-16
-            install: openssl@4 gcc
-            configure: --enable-debug --with-libssh2=/opt/homebrew/opt/libssh2 --with-openssl=/opt/homebrew/opt/openssl@4
+            generate: -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
 
           - name: 'OpenSSL libssh'
             compiler: llvm@18

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -242,6 +242,11 @@ jobs:
             install: openssl@4 libssh
             configure: --enable-debug --with-libssh --with-openssl=/opt/homebrew/opt/openssl@4 --enable-ech --enable-ares --with-fish-functions-dir --with-zsh-functions-dir
 
+          - name: 'OpenSSL libssh2'
+            compiler: gcc-16
+            install: openssl@4 libssh2
+            configure: --enable-debug --with-libssh2 --with-openssl=/opt/homebrew/opt/openssl@4 --enable-ech
+
           - name: 'OpenSSL libssh'
             compiler: llvm@18
             install: libssh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -248,6 +248,12 @@ jobs:
             CFLAGS: -DNDEBUG
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
 
+          - name: 'OpenSSL libssh2 -O3'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+
           - name: 'OpenSSL libssh'
             compiler: llvm@18
             install: libssh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -245,7 +245,7 @@ jobs:
           - name: 'OpenSSL libssh2'
             compiler: gcc-16
             install: openssl gcc
-            #CFLAGS: -DNDEBUG
+            CFLAGS: -DNDEBUG
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
 
           - name: 'OpenSSL libssh'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -248,17 +248,52 @@ jobs:
             CFLAGS: -DNDEBUG
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
 
-          - name: 'OpenSSL libssh2 -O3'
-            compiler: gcc-16
-            install: openssl gcc
-            CFLAGS: -O3 -DNDEBUG
-            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
-            macos-version-min: '10.12'  # Catalina (2019)
-
           - name: 'OpenSSL libssh2 -O3 moreopt'
             compiler: gcc-16
             install: openssl gcc
             CFLAGS: -O3 -DNDEBUG -fno-delete-null-pointer-checks -fno-strict-aliasing -fno-strict-overflow -ftrivial-auto-var-init=zero -fzero-init-padding-bits=all -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mbranch-protection=standard -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-ident
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
+
+          - name: 'OpenSSL libssh2 -O3 moreopt-1'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG -fno-delete-null-pointer-checks -fno-strict-aliasing -fno-strict-overflow -ftrivial-auto-var-init=zero -fzero-init-padding-bits=all
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
+
+          - name: 'OpenSSL libssh2 -O3 moreopt-2'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG                                                                                                                                     -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mbranch-protection=standard -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-ident
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
+
+          - name: 'OpenSSL libssh2 -O3 moreopt-3'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG -fno-delete-null-pointer-checks -fno-strict-aliasing -fno-strict-overflow
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
+
+          - name: 'OpenSSL libssh2 -O3 moreopt-4'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG                                                                           -ftrivial-auto-var-init=zero -fzero-init-padding-bits=all
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
+
+          - name: 'OpenSSL libssh2 -O3 moreopt-5'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG                                                                                                                                     -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mbranch-protection=standard
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            macos-version-min: '10.12'  # Catalina (2019)
+
+          - name: 'OpenSSL libssh2 -O3 moreopt-6'
+            compiler: gcc-16
+            install: openssl gcc
+            CFLAGS: -O3 -DNDEBUG                                                                                                                                                                                                                       -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-ident
             generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
             macos-version-min: '10.12'  # Catalina (2019)
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -242,10 +242,11 @@ jobs:
             install: openssl@4 libssh
             configure: --enable-debug --with-libssh --with-openssl=/opt/homebrew/opt/openssl@4 --enable-ech --enable-ares --with-fish-functions-dir --with-zsh-functions-dir
 
-          - name: 'OpenSSL libssh2 CM'
+          - name: 'OpenSSL libssh2'
             compiler: gcc-16
             install: openssl gcc
-            generate: -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
+            #CFLAGS: -DNDEBUG
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCMAKE_BUILD_TYPE=Release
 
           - name: 'OpenSSL libssh'
             compiler: llvm@18

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -244,8 +244,8 @@ jobs:
 
           - name: 'OpenSSL libssh2'
             compiler: gcc-16
-            install: openssl@4 libssh2 gcc
-            configure: --enable-debug --with-libssh2 --with-openssl=/opt/homebrew/opt/openssl@4 --enable-ech
+            install: openssl gcc
+            configure: --enable-debug --with-libssh2 --with-openssl=/opt/homebrew/opt/openssl
 
           - name: 'OpenSSL libssh'
             compiler: llvm@18

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -244,7 +244,7 @@ jobs:
 
           - name: 'OpenSSL libssh2'
             compiler: gcc-16
-            install: openssl@4 libssh2 gcc-16
+            install: openssl@4 libssh2 gcc
             configure: --enable-debug --with-libssh2 --with-openssl=/opt/homebrew/opt/openssl@4 --enable-ech
 
           - name: 'OpenSSL libssh'

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -949,7 +949,7 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data,
     else
       /* An invalid mailbox was provided but we let the server worry
          about that and reply with a 501 error */
-      from = curl_maprintf("<%s>%s", address, suffix);
+      from = curl_maprintf("<%s>%s", address ? address : "(null)", suffix);
 
     curlx_free(address);
   }


### PR DESCRIPTION
Refs:
https://github.com/curl/curl-for-win/actions/runs/28085131387/job/83149170063#step:3:5012
https://github.com/curl/curl-for-win/actions/runs/29448506817/job/87464901787

Trying to reproduce a false-positive gcc-16 warning, seen in curl-for-win mac-gcc job
for a while now.

Trigger: `-ftrivial-auto-var-init=zero`
https://github.com/curl/curl/actions/runs/29958777720/job/89054416774?pr=22209

---

```
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c:207:6: error: 'out.str' may be used uninitialized [-Werror=maybe-uninitialized]
  207 |   if(header_has_value(&header, &out)) {
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c: In function 'Curl_http':
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c:186:19: note: 'out.str' was declared here
  186 |   struct Curl_str out;
      |                   ^~~
In function 'copy_custom_value',
    inlined from 'http_add_connection_hd' at /Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c:2791:16,
    inlined from 'http_add_hd' at /Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c:3005:14,
    inlined from 'Curl_http' at /Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c:3083:14:
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c:207:6: error: 'out.len' may be used uninitialized [-Werror=maybe-uninitialized]
  207 |   if(header_has_value(&header, &out)) {
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c: In function 'Curl_http':
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/http.c:186:19: note: 'out.len' was declared here
  186 |   struct Curl_str out;
      |                   ^~~
```
