### PR TITLE
CURLOPT_SSH_*_KEYFILE: used for setting up, then no more

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
@@ -33,8 +33,7 @@ used, libcurl defaults to **$HOME/.ssh/id_rsa** or **$HOME/.ssh/id_dsa** if
 the HOME environment variable is set, and in the current directory if HOME is
 not set.
 
-If the file is password-protected, set the password with
-CURLOPT_KEYPASSWD(3).
+If the file is password-protected, set the password with CURLOPT_KEYPASSWD(3).
 
 The SSH library derives the public key from this private key when possible. If
 the SSH library cannot derive the public key from the private one and no
@@ -43,6 +42,11 @@ fails.
 
 The application does not have to keep the string around after setting this
 option.
+
+This option is used to setup a new connection only. The private key is used
+when libcurl establishes a new SSH connection; once that connection has been
+successfully setup and verified, it is deemed vetted and may be reused by
+libcurl even if this option is changed.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
@@ -43,9 +43,9 @@ fails.
 The application does not have to keep the string around after setting this
 option.
 
-This option is used to setup a new connection only. The private key is used
+This option is used to set up a new connection only. The private key is used
 when libcurl establishes a new SSH connection; once that connection has been
-successfully setup and verified, it is deemed vetted and may be reused by
+successfully set up and verified, it is deemed vetted and may be reused by
 libcurl even if this option is changed.
 
 # DEFAULT

--- a/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
@@ -40,6 +40,11 @@ no public one is provided, the transfer fails.
 The application does not have to keep the string around after setting this
 option.
 
+This option is used to setup a new connection only. The public key is used
+when libcurl establishes a new SSH connection; once that connection has been
+successfully setup and verified, it is deemed vetted and may be reused by
+libcurl even if this option is changed.
+
 # DEFAULT
 
 NULL

--- a/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
@@ -40,9 +40,9 @@ no public one is provided, the transfer fails.
 The application does not have to keep the string around after setting this
 option.
 
-This option is used to setup a new connection only. The public key is used
+This option is used to set up a new connection only. The public key is used
 when libcurl establishes a new SSH connection; once that connection has been
-successfully setup and verified, it is deemed vetted and may be reused by
+successfully set up and verified, it is deemed vetted and may be reused by
 libcurl even if this option is changed.
 
 # DEFAULT


### PR DESCRIPTION
So changing them after the connection is made still allows libcurl to reuse the existing connections.
