### PR TITLE
mod_curltest: fix compiler warnings

### DIFF
--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -328,15 +328,13 @@ static int curltest_tweak_handler(request_rec *r)
         }
         else if(!strcmp("chunk_size", arg)) {
           chunk_size = (int)apr_atoi64(val);
-          if(chunk_size) {
-            if(chunk_size > sizeof(buffer)) {
-              ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
-                            "chunk_size %zu too large", chunk_size);
-              ap_die(HTTP_BAD_REQUEST, r);
-              return OK;
-            }
-            continue;
+          if(chunk_size > sizeof(buffer)) {
+            ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
+                          "chunk_size %zu too large", chunk_size);
+            ap_die(HTTP_BAD_REQUEST, r);
+            return OK;
           }
+          continue;
         }
         else if(!strcmp("id", arg)) {
           /* an id for repeated requests with curl's URL globbing */

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -328,7 +328,7 @@ static int curltest_tweak_handler(request_rec *r)
         }
         else if(!strcmp("chunk_size", arg)) {
           chunk_size = (int)apr_atoi64(val);
-          if(chunk_size >= 0) {
+          if(chunk_size) {
             if(chunk_size > sizeof(buffer)) {
               ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                             "chunk_size %zu too large", chunk_size);
@@ -418,7 +418,7 @@ static int curltest_tweak_handler(request_rec *r)
   /* Discourage content-encodings */
   apr_table_unset(r->headers_out, "Content-Encoding");
   if(x_hd_len > 0) {
-    int i, hd_len = (16 * 1024);
+    int hd_len = (16 * 1024);
     int n = (x_hd_len / hd_len);
     char *hd_val = apr_palloc(r->pool, hd_len);
     memset(hd_val, 'X', hd_len);
@@ -497,7 +497,7 @@ cleanup:
     r->connection->keepalive = AP_CONN_CLOSE;
   }
   ap_log_rerror(APLOG_MARK, APLOG_TRACE1, rv, r,
-                "error_handler: request cleanup, r->status=%d, aborted=%d, "
+                "error_handler: request cleanup, r->status=%d, aborted=%u, "
                 "close=%d", r->status, c->aborted, close_conn);
   if(rv == APR_SUCCESS) {
     return OK;
@@ -833,7 +833,7 @@ struct curltest_limit_rec {
 };
 
 static struct curltest_limit_rec limitrec = {
-  0, 5, 0, 2
+  0, 5, 0, 2, NULL
 };
 
 static int curltest_limit_handler(request_rec *r)
@@ -911,7 +911,7 @@ static int curltest_limit_handler(request_rec *r)
   apr_table_setn(r->subprocess_env, "no-gzip", "1");
 
   if(denied) {
-    char *v = apr_psprintf(r->pool, "%d", limitrec.duration_sec);
+    char *v = apr_psprintf(r->pool, "%ld", limitrec.duration_sec);
     apr_table_set(r->headers_out, "Retry-After", v);
   }
 
@@ -953,7 +953,6 @@ static int curltest_post_config(apr_pool_t *p, apr_pool_t *plog,
 {
   void *data = NULL;
   const char *key = "mod_curltest_init_counter";
-  apr_status_t rv;
 
   (void)p;
   (void)plog;


### PR DESCRIPTION
```
mod_curltest.c:331:25: warning: result of comparison of unsigned expression >= 0 is always true [-Wtautological-unsigned-zero-compare]
  331 |           if(chunk_size >= 0) {
      |              ~~~~~~~~~~ ^  ~
mod_curltest.c:421:9: warning: declaration shadows a local variable [-Wshadow]
  421 |     int i, hd_len = (16 * 1024);
      |         ^
mod_curltest.c:288:7: note: previous declaration is here
  288 |   int i, chunks = 3, error_bucket = 1;
      |       ^
mod_curltest.c:501:40: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
  500 |                 "error_handler: request cleanup, r->status=%d, aborted=%d, "
      |                                                                        ~~
      |                                                                        %u
  501 |                 "close=%d", r->status, c->aborted, close_conn);
      |                                        ^~~~~~~~~~
mod_curltest.c:837:1: warning: missing field 'lock' initializer [-Wmissing-field-initializers]
  837 | };
      | ^
mod_curltest.c:914:43: warning: format specifies type 'int' but the argument has type 'apr_time_t' (aka 'long') [-Wformat]
  914 |     char *v = apr_psprintf(r->pool, "%d", limitrec.duration_sec);
      |                                      ~~   ^~~~~~~~~~~~~~~~~~~~~
      |                                      %ld
mod_curltest.c:956:16: warning: unused variable 'rv' [-Wunused-variable]
  956 |   apr_status_t rv;
      |                ^~
```

---

https://github.com/curl/curl/pull/22214/files?w=1

```sh
clang -c mod_curltest.c \
  -isystem /opt/homebrew/opt/apr-util/include/apr-1 \
  -isystem /opt/homebrew/opt/apr/include/apr-1 \
  -isystem /opt/homebrew/opt/httpd/include/httpd \
  \
  -Weverything \
  \
  -pedantic-errors -Werror=partial-availability \
  -Werror-implicit-function-declaration -Wextra -Wall -Wpedantic \
  -Wbad-function-cast -Wconversion -Wmissing-declarations \
  -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wno-multichar \
  -Wpointer-arith -Wshadow -Wsign-compare -Wundef -Wunused \
  -Wwrite-strings -Waddress -Wattributes -Wcast-align -Wcast-qual \
  -Wdeclaration-after-statement -Wdiv-by-zero -Wempty-body \
  -Wendif-labels -Wfloat-equal -Wformat-security -Wignored-qualifiers \
  -Wmissing-field-initializers -Wmissing-noreturn -Wno-padded \
  -Wno-sign-conversion -Wno-switch-default -Wno-switch-enum \
  -Wno-system-headers -Wold-style-definition -Wredundant-decls \
  -Wstrict-prototypes -Wtype-limits -Wunreachable-code \
  -Wunused-parameter -Wvla -Wconditional-uninitialized \
  -Wno-used-but-marked-unused -Wshift-sign-overflow -Wshorten-64-to-32 \
  -Wformat=2 -Wlanguage-extension-token -Wno-covered-switch-default \
  -Wno-disabled-macro-expansion -Wformat-non-iso -Wenum-conversion \
  -Wmissing-variable-declarations -Wno-documentation-unknown-command \
  -Wsometimes-uninitialized -Wdouble-promotion -Wheader-guard -Wpragmas \
  -Wunused-const-variable -Wcomma -Wassign-enum -Wextra-semi-stmt \
  -Wimplicit-fallthrough -Wxor-used-as-pow -Wcast-function-type \
  -Wreserved-identifier -Wno-reserved-macro-identifier \
  -Wformat-signedness \
  -Wno-unsafe-buffer-usage -Wcast-function-type-strict \
  \
  -Wno-cast-align -Wno-cast-qual -Wno-poison-system-directories
```
