### PR TITLE
sasl: fix zero-length response encoding.

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -229,7 +229,7 @@ static CURLcode get_server_message(struct SASL *sasl, struct Curl_easy *data,
   if(!result && (sasl->params->flags & SASL_FLAG_BASE64)) {
     const char *serverdata = Curl_bufref_ptr(out);
 
-    if(!*serverdata || *serverdata == '=')
+    if(!*serverdata)
       Curl_bufref_set(out, NULL, 0, NULL);
     else {
       unsigned char *msg;
@@ -252,9 +252,7 @@ static CURLcode build_message(struct SASL *sasl, struct bufref *msg)
   if(sasl->params->flags & SASL_FLAG_BASE64) {
     if(!Curl_bufref_ptr(msg))                   /* Empty message. */
       Curl_bufref_set(msg, "", 0, NULL);
-    else if(!Curl_bufref_len(msg))              /* Explicit empty response. */
-      Curl_bufref_set(msg, "=", 1, NULL);
-    else {
+    else if(Curl_bufref_len(msg)) {
       char *base64;
       size_t base64len;
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -641,7 +641,8 @@ static CURLcode imap_perform_authenticate(struct Curl_easy *data,
     return CURLE_FAILED_INIT;
   if(ir) {
     /* Send the AUTHENTICATE command with the initial response */
-    result = imap_sendf(data, imapc, "AUTHENTICATE %s %s", mech, ir);
+    result = imap_sendf(data, imapc, "AUTHENTICATE %s %s",
+                        mech, *ir ? ir : "=");
   }
   else {
     /* Send the AUTHENTICATE command */

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -620,7 +620,8 @@ static CURLcode pop3_perform_auth(struct Curl_easy *data,
 
   if(ir) {                                  /* AUTH <mech> ...<crlf> */
     /* Send the AUTH command with the initial response */
-    result = Curl_pp_sendf(data, &pop3c->pp, "AUTH %s %s", mech, ir);
+    result = Curl_pp_sendf(data, &pop3c->pp, "AUTH %s %s",
+                           mech, *ir ? ir : "=");
   }
   else {
     /* Send the AUTH command */

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -736,7 +736,8 @@ static CURLcode smtp_perform_auth(struct Curl_easy *data,
 
   if(ir) {                                  /* AUTH <mech> ...<crlf> */
     /* Send the AUTH command with the initial response */
-    result = Curl_pp_sendf(data, &smtpc->pp, "AUTH %s %s", mech, ir);
+    result = Curl_pp_sendf(data, &smtpc->pp, "AUTH %s %s",
+                           mech, *ir ? ir : "=");
   }
   else {
     /* Send the AUTH command */

--- a/tests/data/test838
+++ b/tests/data/test838
@@ -14,7 +14,7 @@ RFC4422
 <servercmd>
 AUTH EXTERNAL
 REPLY AUTHENTICATE +
-REPLY = A002 OK AUTHENTICATE completed
+REPLY  A002 OK AUTHENTICATE completed
 </servercmd>
 <data crlf="yes">
 From: me@somewhere
@@ -45,7 +45,7 @@ IMAP external authentication without credentials
 <protocol crlf="yes">
 A001 CAPABILITY
 A002 AUTHENTICATE EXTERNAL
-=
+
 A003 SELECT %TESTNUMBER
 A004 FETCH 1 BODY[]
 A005 LOGOUT

--- a/tests/data/test884
+++ b/tests/data/test884
@@ -16,7 +16,7 @@ RFC5034
 <servercmd>
 AUTH EXTERNAL
 REPLY AUTH +
-REPLY = +OK Login successful
+REPLY  +OK Login successful
 </servercmd>
 <data crlf="yes">
 From: me@somewhere
@@ -47,7 +47,7 @@ POP3 external authentication without credentials
 <protocol crlf="yes">
 CAPA
 AUTH EXTERNAL
-=
+
 RETR %TESTNUMBER
 QUIT
 </protocol>

--- a/tests/data/test943
+++ b/tests/data/test943
@@ -15,7 +15,7 @@ RFC4954
 <servercmd>
 AUTH EXTERNAL
 REPLY AUTH 334 EXTERNAL supported
-REPLY = 235 Authenticated
+REPLY  235 Authenticated
 </servercmd>
 </reply>
 
@@ -40,7 +40,7 @@ mail body
 <protocol crlf="yes">
 EHLO %TESTNUMBER
 AUTH EXTERNAL
-=
+
 MAIL FROM:%LTsender@example.com%GT
 RCPT TO:%LTrecipient@example.com%GT
 DATA


### PR DESCRIPTION
A sasl zero-length normal response is an empty string, unlike an initial response.
Since the encoding of a zero-length initial response is protocol dependent, move its handling to the protocol-specific sendauth procedure. Similarly, do not check for an '=' server message, as this should normally never occur.

Update the erroneous tests accordingly.