### PR TITLE
openssl: prefer modern API flavors for `EVP_MD_CTX` new/free

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -126,7 +126,7 @@ static CURLcode Curl_sha512_256_init(void *context)
   }
 
   /* Cleanup */
-  EVP_MD_CTX_destroy(*ctx);
+  EVP_MD_CTX_free(*ctx);
   return CURLE_FAILED_INIT;
 }
 
@@ -178,7 +178,7 @@ static CURLcode Curl_sha512_256_finish(unsigned char *digest, void *context)
     CURLE_OK : CURLE_BAD_FUNCTION_ARGUMENT;
 #endif /* NEED_NETBSD_SHA512_256_WORKAROUND */
 
-  EVP_MD_CTX_destroy(*ctx);
+  EVP_MD_CTX_free(*ctx);
   *ctx = NULL;
 
   return result;

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -112,7 +112,7 @@ static CURLcode Curl_sha512_256_init(void *context)
 {
   Curl_sha512_256_ctx * const ctx = (Curl_sha512_256_ctx *)context;
 
-  *ctx = EVP_MD_CTX_create();
+  *ctx = EVP_MD_CTX_new();
   if(!*ctx)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -61,7 +61,7 @@ typedef struct ossl_sha256_ctx my_sha256_ctx;
 static CURLcode my_sha256_init(void *in)
 {
   my_sha256_ctx *ctx = (my_sha256_ctx *)in;
-  ctx->openssl_ctx = EVP_MD_CTX_create();
+  ctx->openssl_ctx = EVP_MD_CTX_new();
   if(!ctx->openssl_ctx)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -66,7 +66,7 @@ static CURLcode my_sha256_init(void *in)
     return CURLE_OUT_OF_MEMORY;
 
   if(!EVP_DigestInit_ex(ctx->openssl_ctx, EVP_sha256(), NULL)) {
-    EVP_MD_CTX_destroy(ctx->openssl_ctx);
+    EVP_MD_CTX_free(ctx->openssl_ctx);
     return CURLE_FAILED_INIT;
   }
   return CURLE_OK;
@@ -84,7 +84,7 @@ static void my_sha256_final(unsigned char *digest, void *in)
 {
   my_sha256_ctx *ctx = (my_sha256_ctx *)in;
   EVP_DigestFinal_ex(ctx->openssl_ctx, digest, NULL);
-  EVP_MD_CTX_destroy(ctx->openssl_ctx);
+  EVP_MD_CTX_free(ctx->openssl_ctx);
 }
 
 #elif defined(USE_WOLFSSL)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5459,7 +5459,7 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
      !EVP_DigestFinal_ex(mdctx, sha256sum, NULL))
     result = CURLE_BAD_FUNCTION_ARGUMENT;
 out:
-  EVP_MD_CTX_destroy(mdctx);
+  EVP_MD_CTX_free(mdctx);
   return result;
 }
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5448,7 +5448,7 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
   EVP_MD_CTX *mdctx;
   (void)unused;
 
-  mdctx = EVP_MD_CTX_create();
+  mdctx = EVP_MD_CTX_new();
   if(!mdctx)
     return CURLE_OUT_OF_MEMORY;
   if(!EVP_DigestInit(mdctx, EVP_sha256())) {


### PR DESCRIPTION
Available in all supported OpenSSL flavors and versions. They are 
functionally identical to the legacy API calls.
