### PR TITLE
mbedtls: replace `memset()` with `psa_hash_operation_init()`

### DIFF
--- a/lib/md5.c
+++ b/lib/md5.c
@@ -128,8 +128,9 @@ typedef psa_hash_operation_t my_md5_ctx;
 
 static CURLcode my_md5_init(void *ctx)
 {
-  memset(ctx, 0, sizeof(my_md5_ctx));
-  if(psa_hash_setup(ctx, PSA_ALG_MD5) != PSA_SUCCESS)
+  psa_hash_operation_t *pctx = (psa_hash_operation_t *)ctx;
+  *pctx = psa_hash_operation_init();
+  if(psa_hash_setup(pctx, PSA_ALG_MD5) != PSA_SUCCESS)
     return CURLE_OUT_OF_MEMORY;
   return CURLE_OK;
 }

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -148,8 +148,9 @@ typedef psa_hash_operation_t my_sha256_ctx;
 
 static CURLcode my_sha256_init(void *ctx)
 {
-  memset(ctx, 0, sizeof(my_sha256_ctx));
-  if(psa_hash_setup(ctx, PSA_ALG_SHA_256) != PSA_SUCCESS)
+  psa_hash_operation_t *pctx = (psa_hash_operation_t *)ctx;
+  *pctx = psa_hash_operation_init();
+  if(psa_hash_setup(pctx, PSA_ALG_SHA_256) != PSA_SUCCESS)
     return CURLE_OUT_OF_MEMORY;
   return CURLE_OK;
 }


### PR DESCRIPTION
To initialize hash contexts.

Ref: https://arm-software.github.io/psa-api/crypto/1.1/api/ops/hashes.html#c.psa_hash_operation_init
Follow-up to 3a305831d1a9d10b2bfd4fa3939ed41275fee7f7 #19077
