### PR TITLE
openssl: replace stray legacy API variant with `EVP_DigestInit_ex()`

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5451,7 +5451,7 @@ static CURLcode ossl_sha256sum(const unsigned char *input,
   mdctx = EVP_MD_CTX_new();
   if(!mdctx)
     return CURLE_OUT_OF_MEMORY;
-  if(!EVP_DigestInit(mdctx, EVP_sha256())) {
+  if(!EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL)) {
     result = CURLE_FAILED_INIT;
     goto out;
   }


### PR DESCRIPTION
To match rest of code, use the modern variant and avoid an unnecessary
internal reset/cleanup.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
