### PR TITLE
shut off experimental TLS 1.3 support for windows 10 and add support for windows server 22 or later

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -593,11 +593,10 @@ static CURLcode acquire_sspi_handle(struct Curl_cfilter *cf,
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CURLcode result;
 
-  /* We support TLS 1.3 starting in Windows 10 version 1809 (OS build 17763) as
-     long as the user did not set a legacy algorithm list
-     (CURLOPT_SSL_CIPHER_LIST). */
+  /* We support TLS 1.3 starting in Windows server 22 or later
+   * (OS build 20348) */
   if(!conn_config->cipher_list &&
-     curlx_verify_windows_version(10, 0, 17763, PLATFORM_WINNT,
+     curlx_verify_windows_version(10, 0, 20348, PLATFORM_WINNT,
                                   VERSION_GREATER_THAN_EQUAL)) {
 
     SCH_CREDENTIALS credentials = { 0 };


### PR DESCRIPTION
This PR fixes an inconsistency in the Schannel TLS 1.3 version check.

Due to broken TLS 1.3 implementation on windows 10, we move to support only windows server 22 or later.

For more information, see: #21719 