### PR TITLE
GHA/curl-for-win: upload snapshot Windows curl tool binary

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -178,7 +178,7 @@ jobs:
         with:
           name: 'curl-windows-snapshot-tool'
           retention-days: 3
-          path: curl-*-*-*/curl*
+          path: curl-*/curl*
 
   win-gcc-zlibold-x64:
     name: 'Windows gcc zlib-classic (x64)'

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -149,7 +149,6 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 10
     env:
-      CW_NOPKG: ''
       CW_PKG_NODELETE: '1'
       CW_PKG_FLATTEN: '1'
     steps:

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -178,9 +178,7 @@ jobs:
         with:
           name: 'curl-windows-snapshot-tool'
           retention-days: 3
-          path: |
-            curl-*-*-*/curl*
-            curl-*-*-*/trurl*
+          path: curl-*-*-*/curl*
 
   win-gcc-zlibold-x64:
     name: 'Windows gcc zlib-classic (x64)'

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -149,6 +149,7 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 10
     env:
+      CW_NOPKG: ''
       CW_PKG_NODELETE: '1'
       CW_PKG_FLATTEN: '1'
     steps:

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -173,6 +173,15 @@ jobs:
               '^(CW_|DO_NOT_TRACK|GITHUB_)') \
             "${OCI_IMAGE_DEBIAN}" \
             sh -c ./_ci-linux-debian.sh
+          echo '-------------------'
+          tree || true
+          echo '-------------------'
+          ls -l || true
+          echo '-------------------'
+          find . | sort || true
+          echo '-------------------'
+          find . -type d | sort || true
+          echo '-------------------'
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -148,6 +148,9 @@ jobs:
     name: 'Windows llvm (x64)'
     runs-on: ubuntu-26.04
     timeout-minutes: 10
+    env:
+      CW_PKG_NODELETE: '1'
+      CW_PKG_FLATTEN: '1'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -170,6 +173,14 @@ jobs:
               '^(CW_|DO_NOT_TRACK|GITHUB_)') \
             "${OCI_IMAGE_DEBIAN}" \
             sh -c ./_ci-linux-debian.sh
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: 'curl-windows-snapshot-tool'
+          retention-days: 3
+          path: |
+            curl-*-*-*/curl*
+            curl-*-*-*/trurl*
 
   win-gcc-zlibold-x64:
     name: 'Windows gcc zlib-classic (x64)'

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -174,21 +174,12 @@ jobs:
               '^(CW_|DO_NOT_TRACK|GITHUB_)') \
             "${OCI_IMAGE_DEBIAN}" \
             sh -c ./_ci-linux-debian.sh
-          echo '-------------------'
-          tree || true
-          echo '-------------------'
-          ls -l || true
-          echo '-------------------'
-          find . | sort || true
-          echo '-------------------'
-          find . -type d | sort || true
-          echo '-------------------'
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: 'curl-windows-snapshot-tool'
           retention-days: 3
-          path: curl-*/curl*
+          path: curl-*-*-*/curl*
 
   win-gcc-zlibold-x64:
     name: 'Windows gcc zlib-classic (x64)'


### PR DESCRIPTION
These are generated for every PR and master pushes. Retain for 3 days.
Size is 1.8MB zipped per artifact. (Takes 1 second extra job time.)

Ref: #22162
Ref: https://github.com/curl/curl-for-win/commit/1b0e3569b393c31572a5895ed65ae6f60a8cba55?w=1
