### PR TITLE
ci: retain curl-for-win artifacts for a longer time

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: 'curl-windows-snapshot-tool'
-          retention-days: 3
+          retention-days: 42
           path: curl-*-*-*/curl*
 
   win-gcc-zlibold-x64:


### PR DESCRIPTION
- Retain for 42 days because 3 days seems too short.

Follow-up to adf843fb.

Closes #xxxx

---

Thanks for adding artifacts support for curl-for-win in PRs but 3 days seems too short. Is there any disadvantage to having a longer time period? I am proposing 42 since that's what's used by curl-for-win repo in daily. Open to suggestions.
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
