### PR TITLE
GHA/windows: exclude `diffutils` for 32-bit builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -344,7 +344,7 @@ jobs:
           install: >-
             mingw-w64-${{ matrix.env }}-cc
             mingw-w64-${{ matrix.env }}-${{ matrix.build }} ${{ matrix.build == 'autotools' && 'make' || '' }}
-            mingw-w64-${{ matrix.env }}-diffutils
+            ${{ matrix.sys != 'mingw32' && format('mingw-w64-{0}-diffutils', matrix.env) || '' }}
             mingw-w64-${{ matrix.env }}-libpsl
             ${{ matrix.install }}
 


### PR DESCRIPTION
It's no longer offered by MSYS2.

Bug: https://github.com/curl/curl/pull/22239#issuecomment-4856772868
Ref: https://github.com/msys2/MINGW-packages/commit/b13c6d3af1dde801a7d2e16e6daa7e4b5a21cc36
Ref: c4e776cafa22533fe8a6113a39f6a9f624e8c467 #17103

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
