### PR TITLE
lib: add "Curl_" prefix to two global functions

### DIFF
--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -1031,13 +1031,13 @@ out:
   return result;
 }
 
-CURLcode cf_ip_happy_insert_after(struct Curl_cfilter *cf_at,
-                                  struct Curl_easy *data,
-                                  struct Curl_peer *origin,
-                                  struct Curl_peer *peer,
-                                  uint8_t transport_peer,
-                                  struct Curl_peer *tunnel_peer,
-                                  uint8_t tunnel_transport)
+CURLcode Curl_cf_ip_happy_insert_after(struct Curl_cfilter *cf_at,
+                                       struct Curl_easy *data,
+                                       struct Curl_peer *origin,
+                                       struct Curl_peer *peer,
+                                       uint8_t transport_peer,
+                                       struct Curl_peer *tunnel_peer,
+                                       uint8_t tunnel_transport)
 {
   struct Curl_cfilter *cf;
   CURLcode result;

--- a/lib/cf-ip-happy.h
+++ b/lib/cf-ip-happy.h
@@ -60,13 +60,13 @@ typedef CURLcode cf_ip_connect_create(struct Curl_cfilter **pcf,
  * With a `tunnel_peer` present, the filter will be used to proxy tunnel
  * to it and the tunnel will use `tunnel_transport`.
  */
-CURLcode cf_ip_happy_insert_after(struct Curl_cfilter *cf_at,
-                                  struct Curl_easy *data,
-                                  struct Curl_peer *origin,
-                                  struct Curl_peer *peer,
-                                  uint8_t transport_peer,
-                                  struct Curl_peer *tunnel_peer,
-                                  uint8_t tunnel_transport);
+CURLcode Curl_cf_ip_happy_insert_after(struct Curl_cfilter *cf_at,
+                                       struct Curl_easy *data,
+                                       struct Curl_peer *origin,
+                                       struct Curl_peer *peer,
+                                       uint8_t transport_peer,
+                                       struct Curl_peer *tunnel_peer,
+                                       uint8_t tunnel_transport);
 
 extern struct Curl_cftype Curl_cft_ip_happy;
 

--- a/lib/cf-setup.c
+++ b/lib/cf-setup.c
@@ -202,9 +202,9 @@ static CURLcode cf_setup_add_ip_happy(struct Curl_cfilter *cf,
     }
 #endif /* !CURL_DISABLE_PROXY && !CURL_DISABLE_HTTP */
 
-    result = cf_ip_happy_insert_after(cf, data, first_origin, first_peer,
-                                      first_transport,
-                                      tunnel_peer, ctx->transport);
+    result = Curl_cf_ip_happy_insert_after(cf, data, first_origin, first_peer,
+                                           first_transport,
+                                           tunnel_peer, ctx->transport);
     if(result) {
       CURL_TRC_CF(data, cf, "adding happy eyeballs failed -> %d", (int)result);
       return result;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4449,7 +4449,7 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
   return result;
 }
 
-bool ftp_conns_match(struct connectdata *needle, struct connectdata *conn)
+bool Curl_ftp_conns_match(struct connectdata *needle, struct connectdata *conn)
 {
   struct ftp_conn *nftpc = Curl_conn_meta_get(needle, CURL_META_FTP_CONN);
   struct ftp_conn *cftpc = Curl_conn_meta_get(conn, CURL_META_FTP_CONN);

--- a/lib/ftp.h
+++ b/lib/ftp.h
@@ -28,7 +28,8 @@
 #ifndef CURL_DISABLE_FTP
 extern const struct Curl_protocol Curl_protocol_ftp;
 
-bool ftp_conns_match(struct connectdata *needle, struct connectdata *conn);
+bool Curl_ftp_conns_match(struct connectdata *needle,
+                          struct connectdata *conn);
 
 typedef enum {
   FTPFILE_MULTICWD  = 1, /* as defined by RFC1738 */

--- a/lib/url.c
+++ b/lib/url.c
@@ -942,7 +942,7 @@ static bool url_match_proto_config(struct connectdata *conn,
 #endif
 #ifndef CURL_DISABLE_FTP
   else if(get_protocol_family(m->needle->scheme) & PROTO_FAMILY_FTP) {
-    if(!ftp_conns_match(m->needle, conn))
+    if(!Curl_ftp_conns_match(m->needle, conn))
       return FALSE;
   }
 #endif


### PR DESCRIPTION
To make it clear what they are and according to our styleguide.

- Curl_cf_ip_happy_insert_after
- Curl_ftp_conns_match

Found with:

~~~
$ nm lib/.libs/libcurl.a | grep ' T ' | grep -vi ' curl'
