### PR TITLE
configure: link `-lcrypt32` instead of `-lm` for wolfSSL on Windows

### DIFF
--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -76,6 +76,8 @@ if test "$OPT_WOLFSSL" != "no"; then
 
   if test "$curl_cv_apple" = "yes"; then
     addlib="$addlib -framework Security -framework CoreFoundation"
+  elif test "$curl_cv_native_windows" = "yes"; then
+    addlib="$addlib -lcrypt32"
   else
     addlib="$addlib -lm"
   fi


### PR DESCRIPTION
Syncing it with CMake/FindWolfSSL.

`-lm` is not needed on Windows. As of mingw-w64 14.0.0 it's offered as
a dummy library; in such case it wasn't causing an actual issue.
`-lcryp32` is necessary when linking wolfSSL statically.

Ref: #22249
