### PR TITLE
setopt: error for CURLOPT_SHARE when easy handle is used

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1449,6 +1449,26 @@ static CURLcode setopt_mimepost(struct Curl_easy *data, curl_mime *mimep)
 #endif /* !CURL_DISABLE_MIME */
 #endif /* !CURL_DISABLE_HTTP || !CURL_DISABLE_SMTP || !CURL_DISABLE_IMAP */
 
+static CURLcode setopt_share(struct Curl_easy *data, struct Curl_share *set)
+{
+  CURLcode result;
+
+  if(data->conn) {
+    /* As this handle already has a connection attached, changing share now
+       would be complicated and error-prone */
+    infof(data, "Cannot change share object while in use");
+    result = CURLE_BAD_FUNCTION_ARGUMENT;
+  }
+  else {
+    /* disconnect from old share, if any and possible */
+    result = Curl_share_easy_unlink(data);
+    if(!result && GOOD_SHARE_HANDLE(set))
+      /* use new share if it set */
+      result = Curl_share_easy_link(data, set);
+  }
+  return result;
+}
+
 /* assorted pointer type arguments */
 static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
                                 va_list param)
@@ -1496,22 +1516,8 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
     if(!s->err)
       s->err = stderr;
     break;
-  case CURLOPT_SHARE: {
-    struct Curl_share *set = va_arg(param, struct Curl_share *);
-
-    /* disconnect from old share, if any and possible */
-    result = Curl_share_easy_unlink(data);
-    if(result)
-      return result;
-
-    /* use new share if it set */
-    if(GOOD_SHARE_HANDLE(set)) {
-      result = Curl_share_easy_link(data, set);
-      if(result)
-        return result;
-    }
-    break;
-  }
+  case CURLOPT_SHARE:
+    return setopt_share(data, va_arg(param, struct Curl_share *));
 
   default:
     return CURLE_UNKNOWN_OPTION;


### PR DESCRIPTION
Changing the share while driving would be complicated and error-prone.

URL: https://curl.se/mail/lib-2026-07/0000.html