### PR TITLE
wolfssl: fix build for wolfssl without bio chain support

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1539,15 +1539,17 @@ static CURLcode wssl_connect_step1(struct Curl_cfilter *cf,
     wolfSSL_set_bio(wssl->ssl, bio, bio);
   }
 #else /* !USE_BIO_CHAIN */
-  curl_socket_t sockfd = Curl_conn_cf_get_socket(cf, data);
-  if(sockfd > INT_MAX) {
-    failf(data, "SSL: socket value too large");
-    return CURLE_SSL_CONNECT_ERROR;
-  }
-  /* pass the raw socket into the SSL layer */
-  if(!wolfSSL_set_fd(wssl->ssl, (int)sockfd)) {
-    failf(data, "SSL: wolfSSL_set_fd failed");
-    return CURLE_SSL_CONNECT_ERROR;
+  {
+    curl_socket_t sockfd = Curl_conn_cf_get_socket(cf, data);
+    if(sockfd > INT_MAX) {
+      failf(data, "SSL: socket value too large");
+      return CURLE_SSL_CONNECT_ERROR;
+    }
+    /* pass the raw socket into the SSL layer */
+    if(!wolfSSL_set_fd(wssl->ssl, (int)sockfd)) {
+      failf(data, "SSL: wolfSSL_set_fd failed");
+      return CURLE_SSL_CONNECT_ERROR;
+    }
   }
 #endif /* USE_BIO_CHAIN */
 


### PR DESCRIPTION
- Do not mix declarations and code. (ISO C90 build error)

Ref: https://github.com/curl/curl/pull/22252#issuecomment-4871171567

Closes #xxxx

---

~~~
../../lib/vtls/wolfssl.c: In function 'wssl_connect_step1':
../../lib/vtls/wolfssl.c:1542:3: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
 1542 |   curl_socket_t sockfd = Curl_conn_cf_get_socket(cf, data);
      |   ^~~~~~~~~~~~~
~~~

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
