### PR TITLE
cd2nroff: stricter checks for asterisks for italics

### DIFF
--- a/docs/libcurl/opts/CURLINFO_CERTINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.md
@@ -33,7 +33,7 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_CERTINFO,
 
 # DESCRIPTION
 
-Pass a pointer to a *struct curl_certinfo ** and it is set to point to a
+Pass a pointer to a `struct curl_certinfo *` and it is set to point to a
 struct that holds info about the server's certificate chain, assuming you had
 CURLOPT_CERTINFO(3) enabled when the request was made.
 

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -421,7 +421,7 @@ sub single {
         # **bold**
         $d =~ s/\*\*(\S.*?)\*\*/\\fB$1\\fP/g;
         # *italics*
-        $d =~ s/\*(\S.*?)\*/\\fI$1\\fP/g;
+        $d =~ s/\*(\w.*?[\w)])\*/\\fI$1\\fP/g;
 
         my $back = $d;
 


### PR DESCRIPTION
The nroff (man page) version of the markdown docs could get asterisks mistreated as emphasis - seen in the CURLOPT_WRITEDATA manpage. The regex now more stricter requires a word character to follow an italics starting asterisk and there needs to be a word character or a closing parenthesis before the italics ending asterisk.

Also: fix CURLINFO_CERTINFO.md which used wrong italics - it was not rendered correctly on GitHub and with other generic markdown parsers.

Reported-by: Christian Ullrich
Fixes #22257