### PR TITLE
test2114: fix reading from stdin

### DIFF
--- a/tests/data/test2114
+++ b/tests/data/test2114
@@ -21,7 +21,7 @@ FTP username with embedded CRLF is rejected
 # read the credentials from a config file so the raw CR LF reaches curl intact
 # regardless of how the platform passes command line arguments
 <file name="%LOGDIR/test%TESTNUMBER.config">
-user = "anonymous\r\nSTOR /%TESTNUMBER"
+user = "anonymous\r\nSTOR: /%TESTNUMBER"
 </file>
 <command>
 ftp://%HOSTIP:%FTPPORT/%TESTNUMBER -K %LOGDIR/test%TESTNUMBER.config


### PR DESCRIPTION
The test provides an invalid username, but no ':' with password, so that the curl tool tries to read the password from stdin. That makes the test hang, also in CI.

The check for invalid characters is happening when the CURLOPT_USERPWD is applied to the URL, so when the transfer is started. Maybe the check should happen also in setopt already.

The test hangs because tool_paramhlp.c:548 `checkpasswd()` does not see a ':' and tries to read the password from stdin.

Fix: add a ':' in the tests invalid user setting, so that the read does not happen.

