### PR TITLE
add debug tracing to test311 to debug macos+wolfssl failures

### DIFF
--- a/tests/data/test311
+++ b/tests/data/test311
@@ -24,6 +24,9 @@ https test-localhost0h.pem
 <name>
 HTTPS wrong subjectAltName but right CN
 </name>
+<setenv>
+CURL_DEBUG=all
+</setenv>
 <command>
 -4 --cacert %CERTDIR/certs/test-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>


### PR DESCRIPTION
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
