### PR TITLE
Enhance terminal size detection for multiple outputs

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -62,6 +62,10 @@ unsigned int get_terminal_columns(void)
     struct winsize ts;
     if(!ioctl(STDIN_FILENO, TIOCGWINSZ, &ts))
       cols = (int)ts.ws_col;
+    else if(!ioctl(STDOUT_FILENO, TIOCGWINSZ, &ts))
+      cols = (int)ts.ws_col;
+    else if(!ioctl(STDERR_FILENO, TIOCGWINSZ, &ts))
+      cols = (int)ts.ws_col;
 #elif defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
     {
       HANDLE stderr_hnd = GetStdHandle(STD_ERROR_HANDLE);


### PR DESCRIPTION
Added additional checks for terminal size using STDERR and STDOUT.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
