### PR TITLE
tool: fix memory use in parallel mode

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1552,7 +1552,13 @@ static CURLcode add_parallel_transfers(CURLM *multi, CURLSH *share,
     return CURLE_UNKNOWN_OPTION;
   }
 
-  if(nxfers < (curl_off_t)(global->parallel_max * 2)) {
+  if(all_added >= global->parallel_max) {
+    /* we are at max parallelism, no need to create more transfers */
+    *morep = TRUE; /* pretend there are, we have not checked */
+    return CURLE_OK;
+  }
+  /* if the list is empty, create one to kickstart the loop */
+  if(!transfers) {
     bool skipped = FALSE;
     do {
       result = create_transfer(share, addedp, &skipped);
@@ -1560,6 +1566,7 @@ static CURLcode add_parallel_transfers(CURLM *multi, CURLSH *share,
         return result;
     } while(skipped);
   }
+  /* add transfers until max parallelism is achieved again */
   for(per = transfers; per && (all_added < global->parallel_max);
       per = per->next) {
     if(per->added || per->skip)

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -729,7 +729,10 @@ class CurlClient:
         if extra_args is None:
             extra_args = []
         if no_save:
-            extra_args.extend(['--out-null'])
+            if self.env.curl_version_at_least('8.16.0'):
+                extra_args.extend(['--out-null'])
+            else:
+                extra_args.extend(['-o', '/dev/null'])
         else:
             extra_args.extend(['-o', 'download_#1.data'])
         if limit_rate:

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -513,6 +513,13 @@ class Env:
         return Env.CONFIG.curl_props["version_string"]
 
     @staticmethod
+    def curl_version_at_least(min_version) -> bool:
+        version = Env.curl_version()
+        return Env.CONFIG.versiontuple(min_version) <= Env.CONFIG.versiontuple(
+                version
+            )
+
+    @staticmethod
     def curl_features_string() -> str:
         return Env.CONFIG.curl_props["features_string"]
 


### PR DESCRIPTION
The curl tool was creating a new transfer every time it checked if it needed to add one to reach max parallelism. This led to eventually all configured transfers to have easy handles created.

Limit the creation again to the ones needed for max parallelism.

scorecard.py: set --out-null only for curl versions that support it

When measuring mem use in scorecard for a non-debug curl build, notice the memory use when going from 1 parallel transfer to 6:
```sh
> python3 tests/http/scorecard.py -r --request-count=20000 --samples=3 h2
curl  Requests in parallel to httpd/2.4.67
version  size  total     1 max [cpu/rss]          6 max [cpu/rss]         25 max [cpu/rss]         50 max [cpu/rss]        100 max [cpu/rss]        300 max [cpu/rss]
8.15.0   10KB  20000  3130 r/s [50.3%/12MB]    9178 r/s [92.5%/13MB]   10827 r/s [98.3%/19MB]   10912 r/s [99.0%/26MB]   10857 r/s [99.4%/36MB]   10408 r/s [99.6%/65MB]
8.16.0   10KB  20000  3351 r/s [47.4%/12MB]   10851 r/s [94.9%/41MB]   14171 r/s [97.5%/31MB]   14657 r/s [98.8%/30MB]   15044 r/s [99.3%/27MB]   14802 r/s [99.5%/32MB]
8.17.0   10KB  20000  3391 r/s [47.2%/12MB]   10879 r/s [94.2%/42MB]   14501 r/s [98.1%/33MB]   15021 r/s [98.8%/30MB]   15337 r/s [99.3%/26MB]   15199 r/s [99.5%/31MB]
8.18.0   10KB  20000  3474 r/s [50.8%/11MB]   10394 r/s [95.6%/44MB]   13005 r/s [98.2%/34MB]   13451 r/s [98.8%/29MB]   13668 r/s [99.3%/27MB]   13701 r/s [99.6%/31MB]
8.19.0   10KB  20000  3430 r/s [50.3%/12MB]   10614 r/s [95.8%/39MB]   13099 r/s [96.2%/32MB]   13629 r/s [98.8%/28MB]   14066 r/s [99.3%/25MB]   13726 r/s [99.6%/28MB]
8.20.0   10KB  20000  3446 r/s [50.5%/11MB]   10768 r/s [95.4%/59MB]   13365 r/s [98.3%/42MB]   13749 r/s [98.8%/34MB]   14136 r/s [99.3%/30MB]   13946 r/s [99.6%/30MB]
8.21.0   10KB  20000  3395 r/s [50.9%/11MB]   10634 r/s [95.3%/57MB]   13370 r/s [98.3%/38MB]   13506 r/s [98.8%/33MB]   13908 r/s [99.3%/30MB]   13734 r/s [99.4%/30MB]
master   10KB  20000  3952 r/s [48.6%/11MB]   12184 r/s [95.1%/58MB]   15636 r/s [99.8%/44MB]   16070 r/s [99.8%/36MB]   15867 r/s [99.8%/29MB]   15841 r/s [99.9%/30MB]
PR       10KB  20000  3984 r/s [49.2%/11MB]   12711 r/s [95.1%/11MB]   16034 r/s [99.8%/12MB]   16596 r/s [99.9%/14MB]   16503 r/s [99.9%/16MB]   16303 r/s [99.9%/25MB]
```