### PR TITLE
tests: skip test 311 for wolfSSL 5.9.2

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -327,9 +327,6 @@ jobs:
           cd ~
           git clone --quiet --depth 1 --branch "v${WOLFSSL_VERSION}-stable" https://github.com/wolfSSL/wolfssl
           cd wolfssl
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 30 --retry 6 --retry-connrefused \
-            https://github.com/wolfSSL/wolfssl/commit/7dd269fc52228cbc854b9f0ed8c3938b95d8a2c8.diff --output pkg.patch
-          patch -p1 -i pkg.patch
           ./autogen.sh
           ./configure --disable-dependency-tracking --prefix="$PWD"/build --enable-all --enable-quic \
             --disable-benchmark --disable-crypttests --disable-examples

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -598,9 +598,6 @@ jobs:
             --location --proto-redir =https "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 30 --retry 6 --retry-connrefused \
-            https://github.com/wolfSSL/wolfssl/commit/7dd269fc52228cbc854b9f0ed8c3938b95d8a2c8.diff --output pkg.patch
-          patch -p1 -i pkg.patch
           ./autogen.sh
           ./configure --disable-dependency-tracking --prefix=/home/runner/wolfssl-all \
             --enable-tls13 --enable-harden --enable-all \
@@ -624,9 +621,6 @@ jobs:
             --location --proto-redir =https "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 30 --retry 6 --retry-connrefused \
-            https://github.com/wolfSSL/wolfssl/commit/7dd269fc52228cbc854b9f0ed8c3938b95d8a2c8.diff --output pkg.patch
-          patch -p1 -i pkg.patch
           ./autogen.sh
           ./configure --disable-dependency-tracking --prefix=/home/runner/wolfssl-opensslextra \
             --enable-tls13 --enable-harden --enable-ech --enable-ed25519 --enable-opensslextra \
@@ -650,9 +644,6 @@ jobs:
             --location --proto-redir =https "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" --output pkg.bin
           sha256sum pkg.bin && tar -xzf pkg.bin && rm -f pkg.bin
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 30 --retry 6 --retry-connrefused \
-            https://github.com/wolfSSL/wolfssl/commit/7dd269fc52228cbc854b9f0ed8c3938b95d8a2c8.diff --output pkg.patch
-          patch -p1 -i pkg.patch
           ./autogen.sh
           ./configure --disable-dependency-tracking --prefix=/home/runner/wolfssl-opensslextra \
             --enable-tls13 --enable-harden --enable-ech --enable-ed25519 --enable-opensslextra \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -343,7 +343,6 @@ jobs:
             install: brotli wolfssl zstd
             install_steps: pytest
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
-            tflags: '~311'  # fails on wolfSSL v5.9.2, fixed in upcoming release
 
           - name: 'mbedTLS !ldap brotli zstd MultiSSL AppleIDN'
             compiler: llvm@18

--- a/tests/data/test311
+++ b/tests/data/test311
@@ -17,7 +17,7 @@ PEM certificate
 <features>
 SSL
 local-http
-!wolfssl592
+!wolfssl-5.9.2
 </features>
 <server>
 https test-localhost0h.pem

--- a/tests/data/test311
+++ b/tests/data/test311
@@ -17,6 +17,7 @@ PEM certificate
 <features>
 SSL
 local-http
+!wolfssl592
 </features>
 <server>
 https test-localhost0h.pem

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -589,6 +589,9 @@ sub checksystemfeatures {
             elsif($libcurl =~ /\swolfssl\b/i) {
                 $feature{"wolfssl"} = 1;
                 $feature{"SSLpinning"} = 1;
+                if($libcurl =~ /\swolfssl\/5\.9\.2\b/i) {
+                    $feature{"wolfssl592"} = 1;
+                }
             }
             elsif($libcurl =~ /\s(AWS-LC|BoringSSL)\b/i) {
                 # OpenSSL compatible API

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -590,7 +590,7 @@ sub checksystemfeatures {
                 $feature{"wolfssl"} = 1;
                 $feature{"SSLpinning"} = 1;
                 if($libcurl =~ /\swolfssl\/5\.9\.2\b/i) {
-                    $feature{"wolfssl592"} = 1;
+                    $feature{"wolfssl-5.9.2"} = 1;
                 }
             }
             elsif($libcurl =~ /\s(AWS-LC|BoringSSL)\b/i) {


### PR DESCRIPTION
To fix this for everyone running curl tests.

Also: drop workarounds for CI.

Refs:
https://github.com/wolfSSL/wolfssl/pull/10793
https://github.com/wolfSSL/wolfssl/commit/7dd269fc52228cbc854b9f0ed8c3938b95d8a2c8

Ref: https://github.com/curl/curl/pull/22269#issuecomment-4892203666
Follow-up to 7183bec8fe7b4efcae3b0354dc5bf6de54384190 #22269
Follow-up to 03f9751585112cdc3c5f0a370217f08c05782de9 #22204
