### PR TITLE
ratelimit timestamps

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -284,8 +284,7 @@ static struct h2_stream_ctx *h2_stream_ctx_create(struct cf_h2_ctx *ctx)
 static int32_t cf_h2_get_desired_local_win(struct Curl_cfilter *cf,
                                            struct Curl_easy *data)
 {
-  curl_off_t avail = Curl_rlimit_avail(&data->progress.dl.rlimit,
-                                       Curl_pgrs_now(data));
+  curl_off_t avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
 
   (void)cf;
   if(avail < CURL_OFF_T_MAX) { /* limit in place */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -284,7 +284,7 @@ static struct h2_stream_ctx *h2_stream_ctx_create(struct cf_h2_ctx *ctx)
 static int32_t cf_h2_get_desired_local_win(struct Curl_cfilter *cf,
                                            struct Curl_easy *data)
 {
-  curl_off_t avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
+  curl_off_t avail = Curl_rlimit_avail(&data->progress.dl.rlimit, NULL);
 
   (void)cf;
   if(avail < CURL_OFF_T_MAX) { /* limit in place */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -996,8 +996,8 @@ static CURLcode multi_adjust_pollset(struct Curl_easy *data,
   if(ps->n) {
     bool send_blocked, recv_blocked;
 
-    recv_blocked = (Curl_rlimit_avail(&data->progress.dl.rlimit) <= 0);
-    send_blocked = (Curl_rlimit_avail(&data->progress.ul.rlimit) <= 0);
+    recv_blocked = (Curl_rlimit_avail(&data->progress.dl.rlimit, NULL) <= 0);
+    send_blocked = (Curl_rlimit_avail(&data->progress.ul.rlimit, NULL) <= 0);
     if(send_blocked || recv_blocked) {
       int i;
       for(i = 0; i <= SECONDARYSOCKET; ++i) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -994,11 +994,10 @@ static CURLcode multi_adjust_pollset(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
 
   if(ps->n) {
-    const struct curltime *pnow = Curl_pgrs_now(data);
     bool send_blocked, recv_blocked;
 
-    recv_blocked = (Curl_rlimit_avail(&data->progress.dl.rlimit, pnow) <= 0);
-    send_blocked = (Curl_rlimit_avail(&data->progress.ul.rlimit, pnow) <= 0);
+    recv_blocked = (Curl_rlimit_avail(&data->progress.dl.rlimit) <= 0);
+    send_blocked = (Curl_rlimit_avail(&data->progress.ul.rlimit) <= 0);
     if(send_blocked || recv_blocked) {
       int i;
       for(i = 0; i <= SECONDARYSOCKET; ++i) {

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -172,10 +172,15 @@ UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
 
 const struct curltime *Curl_pgrs_now(struct Curl_easy *data)
 {
+#if 0
   struct curltime *pnow = data->multi ?
                           &data->multi->now : &data->progress.now;
   curlx_pnow(pnow);
   return pnow;
+#else
+  curlx_pnow(&data->progress.now);
+  return &data->progress.now;
+#endif
 }
 
 /*
@@ -392,7 +397,7 @@ void Curl_pgrs_download_inc(struct Curl_easy *data, size_t delta)
 {
   if(delta) {
     data->progress.dl.cur_size += delta;
-    Curl_rlimit_drain(&data->progress.dl.rlimit, delta, Curl_pgrs_now(data));
+    Curl_rlimit_drain(&data->progress.dl.rlimit, delta);
   }
 }
 
@@ -400,7 +405,7 @@ void Curl_pgrs_upload_inc(struct Curl_easy *data, size_t delta)
 {
   if(delta) {
     data->progress.ul.cur_size += delta;
-    Curl_rlimit_drain(&data->progress.ul.rlimit, delta, Curl_pgrs_now(data));
+    Curl_rlimit_drain(&data->progress.ul.rlimit, delta);
   }
 }
 

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -172,15 +172,8 @@ UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
 
 const struct curltime *Curl_pgrs_now(struct Curl_easy *data)
 {
-#if 0
-  struct curltime *pnow = data->multi ?
-                          &data->multi->now : &data->progress.now;
-  curlx_pnow(pnow);
-  return pnow;
-#else
   curlx_pnow(&data->progress.now);
   return &data->progress.now;
-#endif
 }
 
 /*

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -397,7 +397,7 @@ void Curl_pgrs_download_inc(struct Curl_easy *data, size_t delta)
 {
   if(delta) {
     data->progress.dl.cur_size += delta;
-    Curl_rlimit_drain(&data->progress.dl.rlimit, delta);
+    Curl_rlimit_drain(&data->progress.dl.rlimit, delta, NULL);
   }
 }
 
@@ -405,7 +405,7 @@ void Curl_pgrs_upload_inc(struct Curl_easy *data, size_t delta)
 {
   if(delta) {
     data->progress.ul.cur_size += delta;
-    Curl_rlimit_drain(&data->progress.ul.rlimit, delta);
+    Curl_rlimit_drain(&data->progress.ul.rlimit, delta, NULL);
   }
 }
 

--- a/lib/ratelimit.c
+++ b/lib/ratelimit.c
@@ -197,27 +197,30 @@ bool Curl_rlimit_is_blocked(struct Curl_rlimit *r)
   return (bool)r->blocked;
 }
 
-int64_t Curl_rlimit_avail(struct Curl_rlimit *r,
-                          const struct curltime *pts)
+int64_t Curl_rlimit_avail(struct Curl_rlimit *r)
 {
+  struct curltime ts;
+
   if(r->blocked)
     return 0;
   else if(r->rate_per_step) {
-    rlimit_update(r, pts);
+    curlx_pnow(&ts);
+    rlimit_update(r, &ts);
     return r->tokens;
   }
   else
     return INT64_MAX;
 }
 
-void Curl_rlimit_drain(struct Curl_rlimit *r,
-                       size_t tokens,
-                       const struct curltime *pts)
+void Curl_rlimit_drain(struct Curl_rlimit *r, size_t tokens)
 {
+  struct curltime ts;
+
   if(r->blocked || !r->rate_per_step)
     return;
 
-  rlimit_update(r, pts);
+  curlx_pnow(&ts);
+  rlimit_update(r, &ts);
 #if 8 <= SIZEOF_SIZE_T
   if(tokens > INT64_MAX) {
     r->tokens = INT64_MAX;

--- a/lib/ratelimit.c
+++ b/lib/ratelimit.c
@@ -197,30 +197,38 @@ bool Curl_rlimit_is_blocked(struct Curl_rlimit *r)
   return (bool)r->blocked;
 }
 
-int64_t Curl_rlimit_avail(struct Curl_rlimit *r)
+int64_t Curl_rlimit_avail(struct Curl_rlimit *r,
+                          const struct curltime *pts)
 {
   struct curltime ts;
 
   if(r->blocked)
     return 0;
   else if(r->rate_per_step) {
-    curlx_pnow(&ts);
-    rlimit_update(r, &ts);
+    if(!pts) {
+      curlx_pnow(&ts);
+      pts = &ts;
+    }
+    rlimit_update(r, pts);
     return r->tokens;
   }
   else
     return INT64_MAX;
 }
 
-void Curl_rlimit_drain(struct Curl_rlimit *r, size_t tokens)
+void Curl_rlimit_drain(struct Curl_rlimit *r, size_t tokens,
+                       const struct curltime *pts)
 {
   struct curltime ts;
 
   if(r->blocked || !r->rate_per_step)
     return;
 
-  curlx_pnow(&ts);
-  rlimit_update(r, &ts);
+  if(!pts) {
+    curlx_pnow(&ts);
+    pts = &ts;
+  }
+  rlimit_update(r, pts);
 #if 8 <= SIZEOF_SIZE_T
   if(tokens > INT64_MAX) {
     r->tokens = INT64_MAX;

--- a/lib/ratelimit.h
+++ b/lib/ratelimit.h
@@ -91,11 +91,13 @@ bool Curl_rlimit_is_blocked(struct Curl_rlimit *r);
 int64_t Curl_rlimit_per_step(struct Curl_rlimit *r);
 
 /* Return how many tokens are available to spend, may be negative */
-int64_t Curl_rlimit_avail(struct Curl_rlimit *r);
+int64_t Curl_rlimit_avail(struct Curl_rlimit *r,
+                          const struct curltime *pts);
 
 /* Drain tokens from the ratelimit, give an estimate of how many tokens
  * remain to be drained in the future (-1 for unknown). */
-void Curl_rlimit_drain(struct Curl_rlimit *r, size_t tokens);
+void Curl_rlimit_drain(struct Curl_rlimit *r, size_t tokens,
+                       const struct curltime *pts);
 
 /* Block/unblock ratelimiting. A blocked ratelimit has 0 tokens available. */
 void Curl_rlimit_block(struct Curl_rlimit *r,

--- a/lib/ratelimit.h
+++ b/lib/ratelimit.h
@@ -91,14 +91,11 @@ bool Curl_rlimit_is_blocked(struct Curl_rlimit *r);
 int64_t Curl_rlimit_per_step(struct Curl_rlimit *r);
 
 /* Return how many tokens are available to spend, may be negative */
-int64_t Curl_rlimit_avail(struct Curl_rlimit *r,
-                          const struct curltime *pts);
+int64_t Curl_rlimit_avail(struct Curl_rlimit *r);
 
 /* Drain tokens from the ratelimit, give an estimate of how many tokens
  * remain to be drained in the future (-1 for unknown). */
-void Curl_rlimit_drain(struct Curl_rlimit *r,
-                       size_t tokens,
-                       const struct curltime *pts);
+void Curl_rlimit_drain(struct Curl_rlimit *r, size_t tokens);
 
 /* Block/unblock ratelimiting. A blocked ratelimit has 0 tokens available. */
 void Curl_rlimit_block(struct Curl_rlimit *r,

--- a/lib/ratelimit.h
+++ b/lib/ratelimit.h
@@ -90,12 +90,14 @@ bool Curl_rlimit_active(struct Curl_rlimit *r);
 bool Curl_rlimit_is_blocked(struct Curl_rlimit *r);
 int64_t Curl_rlimit_per_step(struct Curl_rlimit *r);
 
-/* Return how many tokens are available to spend, may be negative */
+/* Return how many tokens are available to spend, may be negative.
+ * Pass timestamp or NULL. */
 int64_t Curl_rlimit_avail(struct Curl_rlimit *r,
                           const struct curltime *pts);
 
 /* Drain tokens from the ratelimit, give an estimate of how many tokens
- * remain to be drained in the future (-1 for unknown). */
+ * remain to be drained in the future (-1 for unknown).
+ * Pass timestamp or NULL. */
 void Curl_rlimit_drain(struct Curl_rlimit *r, size_t tokens,
                        const struct curltime *pts);
 

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1203,8 +1203,7 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
   }
 
   if(Curl_rlimit_active(&data->progress.ul.rlimit)) {
-    curl_off_t ul_avail = Curl_rlimit_avail(&data->progress.ul.rlimit,
-                                            Curl_pgrs_now(data));
+    curl_off_t ul_avail = Curl_rlimit_avail(&data->progress.ul.rlimit);
     if(ul_avail <= 0) {
       result = CURLE_OK;
       *eos = FALSE;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1203,7 +1203,7 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
   }
 
   if(Curl_rlimit_active(&data->progress.ul.rlimit)) {
-    curl_off_t ul_avail = Curl_rlimit_avail(&data->progress.ul.rlimit);
+    curl_off_t ul_avail = Curl_rlimit_avail(&data->progress.ul.rlimit, NULL);
     if(ul_avail <= 0) {
       result = CURLE_OK;
       *eos = FALSE;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -250,7 +250,7 @@ static CURLcode sendrecv_dl(struct Curl_easy *data,
     bytestoread = xfer_blen;
 
     if(bytestoread && Curl_rlimit_active(&data->progress.dl.rlimit)) {
-      curl_off_t dl_avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
+      curl_off_t dl_avail = Curl_rlimit_avail(&data->progress.dl.rlimit, NULL);
 #if 0
       DEBUGF(infof(data, "dl_rlimit, available=%" FMT_OFF_T, dl_avail));
 #endif

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -250,8 +250,7 @@ static CURLcode sendrecv_dl(struct Curl_easy *data,
     bytestoread = xfer_blen;
 
     if(bytestoread && Curl_rlimit_active(&data->progress.dl.rlimit)) {
-      curl_off_t dl_avail = Curl_rlimit_avail(&data->progress.dl.rlimit,
-                                              Curl_pgrs_now(data));
+      curl_off_t dl_avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
 #if 0
       DEBUGF(infof(data, "dl_rlimit, available=%" FMT_OFF_T, dl_avail));
 #endif

--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -281,7 +281,7 @@ static void cf_h3_proxy_upd_rx_win(struct Curl_cfilter *cf,
     if(!stream->rx_offset)
       return;
 
-    avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
+    avail = Curl_rlimit_avail(&data->progress.dl.rlimit, NULL);
     if(avail <= 0) {
       /* nothing available, do not extend the rx offset */
       CURL_TRC_CF(data, cf, "[%" PRId64 "] dl rate limit exhausted (%" PRId64

--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -281,7 +281,7 @@ static void cf_h3_proxy_upd_rx_win(struct Curl_cfilter *cf,
     if(!stream->rx_offset)
       return;
 
-    avail = Curl_rlimit_avail(&data->progress.dl.rlimit, Curl_pgrs_now(data));
+    avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
     if(avail <= 0) {
       /* nothing available, do not extend the rx offset */
       CURL_TRC_CF(data, cf, "[%" PRId64 "] dl rate limit exhausted (%" PRId64

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -175,7 +175,7 @@ static void cf_ngtcp2_upd_rx_win(struct Curl_cfilter *cf,
     if(!stream->rx_offset)
       return;
 
-    avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
+    avail = Curl_rlimit_avail(&data->progress.dl.rlimit, NULL);
     if(avail <= 0) {
       /* nothing available, do not extend the rx offset */
       CURL_TRC_CF(data, cf, "[%" PRId64 "] dl rate limit exhausted (%" PRId64

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -175,7 +175,7 @@ static void cf_ngtcp2_upd_rx_win(struct Curl_cfilter *cf,
     if(!stream->rx_offset)
       return;
 
-    avail = Curl_rlimit_avail(&data->progress.dl.rlimit, Curl_pgrs_now(data));
+    avail = Curl_rlimit_avail(&data->progress.dl.rlimit);
     if(avail <= 0) {
       /* nothing available, do not extend the rx offset */
       CURL_TRC_CF(data, cf, "[%" PRId64 "] dl rate limit exhausted (%" PRId64

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -71,6 +71,8 @@ class Card:
     def fmt_mbs(cls, val):
         if val is None or val < 0:
             return '--'
+        if val >= (1024 * 1024 * 1024):
+            return f'{val / (1024 * 1024 * 1024):.3g}GB/s'
         if val >= (1024 * 1024):
             return f'{val / (1024 * 1024):.3g} MB/s'
         if val >= 1024:

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -72,7 +72,7 @@ class Card:
         if val is None or val < 0:
             return '--'
         if val >= (1024 * 1024 * 1024):
-            return f'{val / (1024 * 1024 * 1024):.3g}GB/s'
+            return f'{val / (1024 * 1024 * 1024):.3g} GB/s'
         if val >= (1024 * 1024):
             return f'{val / (1024 * 1024):.3g} MB/s'
         if val >= 1024:


### PR DESCRIPTION
Make timestamp passed for ratelimit checks optional arguments. Let the limit calculation obtain a timestamp when it needs it and none was passed. Most transfers run without active ratelimits and getting a fresh timestamp is unnecessary.

