### PR TITLE
Add write out format pretty option

### DIFF
--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -365,6 +365,11 @@ started yet for the handle. The transfer id is unique among all transfers
 performed using the same connection cache.
 (Added in 8.2.0)
 
+The option allow a filter to be added to the variables that express a size.
+This allow to convert the size using the standard suffixes K, M, G... like
+what's printed by default on the CLI. To use it, add the `:pretty` suffix to
+the variable. For example, `--write-out '%{size_download:pretty}'`.
+
 ##
 
 TIME OUTPUT FORMAT

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -57,6 +57,14 @@ when using this option to properly escape. If this option is used at the
 command prompt then the % cannot be escaped and unintended expansion is
 possible.
 
+The option allow a filter to be added to the variables that express a size.
+This allow to convert the size using the standard suffixes K, M, G... like
+what's printed by default on the CLI. The output won't exceed 4 digits plus one
+suffix character. To use it, add the `:pretty` suffix to the variable. For
+example, `--write-out '%{size_download:pretty}'`. This only works with variable
+that output a size like parameter
+
+
 The variables available are:
 
 ## `certs`
@@ -364,11 +372,6 @@ The numerical identifier of the last transfer done. -1 if no transfer has been
 started yet for the handle. The transfer id is unique among all transfers
 performed using the same connection cache.
 (Added in 8.2.0)
-
-The option allow a filter to be added to the variables that express a size.
-This allow to convert the size using the standard suffixes K, M, G... like
-what's printed by default on the CLI. To use it, add the `:pretty` suffix to
-the variable. For example, `--write-out '%{size_download:pretty}'`.
 
 ##
 

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -57,12 +57,11 @@ when using this option to properly escape. If this option is used at the
 command prompt then the % cannot be escaped and unintended expansion is
 possible.
 
-The option allow a filter to be added to the variables that express a size.
-This allow to convert the size using the standard suffixes K, M, G... like
-what's printed by default on the CLI. The filter allow maximum 4 digits plus
-one suffix character. To use it, add the `:pretty` suffix to the variable. For
-example, `--write-out '%{size_download:pretty}'`. This only works with variable
-that output a size like parameter
+To format numerical output for better human readability, append the `:pretty`
+modifier to a numerical variable name (e.g., `--write-out '%{size_download:pretty}'`).
+This modifier applies standard SI metric suffixes (K, M, G, etc.) and
+constrains the output to a maximum width of 5 characters, including the
+suffix. This works only with numerical variables.
 
 The variables available are:
 

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -59,8 +59,8 @@ possible.
 
 The option allow a filter to be added to the variables that express a size.
 This allow to convert the size using the standard suffixes K, M, G... like
-what's printed by default on the CLI. The output won't exceed 4 digits plus one
-suffix character. To use it, add the `:pretty` suffix to the variable. For
+what's printed by default on the CLI. The filter allow maximum 4 digits plus
+one suffix character. To use it, add the `:pretty` suffix to the variable. For
 example, `--write-out '%{size_download:pretty}'`. This only works with variable
 that output a size like parameter
 

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -64,7 +64,6 @@ suffix character. To use it, add the `:pretty` suffix to the variable. For
 example, `--write-out '%{size_download:pretty}'`. This only works with variable
 that output a size like parameter
 
-
 The variables available are:
 
 ## `certs`

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -122,24 +122,27 @@ void customrequest_helper(HttpReq req, const char *method)
   }
 }
 
-char *max5data(curl_off_t bytes, char *max5, size_t mlen) {
-  /* a signed 64-bit value is 8192 petabytes maximum */ const char unit[] = {'k', 'M', 'G', 'T', 'P', 'E', 0};
+char *max5data(curl_off_t bytes, char *max5, size_t mlen)
+{
+  /* a signed 64-bit value is 8192 petabytes maximum */
+  const char unit[] = {'k', 'M', 'G', 'T', 'P', 'E', 0};
   int k = 0;
-  if (bytes < 100000) {
+  if(bytes < 100000) {
     curl_msnprintf(max5, mlen, "%5" CURL_FORMAT_CURL_OFF_T, bytes);
     return max5;
   }
 
   do {
     curl_off_t nbytes = bytes / 1024;
-    if (nbytes < 100) {
+    if(nbytes < 100) {
       /* display with a decimal */
       curl_msnprintf(max5, mlen,
                      "%2" CURL_FORMAT_CURL_OFF_T ".%" CURL_FORMAT_CURL_OFF_T
                      "%c",
                      bytes / 1024, (bytes % 1024) * 10 / 1024, unit[k]);
       break;
-    } else if (nbytes < 10000) {
+    }
+    else if(nbytes < 10000) {
       /* no decimals */
       curl_msnprintf(max5, mlen, "%4" CURL_FORMAT_CURL_OFF_T "%c", nbytes,
                      unit[k]);
@@ -148,6 +151,6 @@ char *max5data(curl_off_t bytes, char *max5, size_t mlen) {
     bytes = nbytes;
     k++;
     DEBUGASSERT(unit[k]);
-  } while (unit[k]);
+  } while(unit[k]);
   return max5;
 }

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -121,3 +121,33 @@ void customrequest_helper(HttpReq req, const char *method)
           "the way you want. Consider using -I/--head instead.");
   }
 }
+
+char *max5data(curl_off_t bytes, char *max5, size_t mlen) {
+  /* a signed 64-bit value is 8192 petabytes maximum */ const char unit[] = {'k', 'M', 'G', 'T', 'P', 'E', 0};
+  int k = 0;
+  if (bytes < 100000) {
+    curl_msnprintf(max5, mlen, "%5" CURL_FORMAT_CURL_OFF_T, bytes);
+    return max5;
+  }
+
+  do {
+    curl_off_t nbytes = bytes / 1024;
+    if (nbytes < 100) {
+      /* display with a decimal */
+      curl_msnprintf(max5, mlen,
+                     "%2" CURL_FORMAT_CURL_OFF_T ".%" CURL_FORMAT_CURL_OFF_T
+                     "%c",
+                     bytes / 1024, (bytes % 1024) * 10 / 1024, unit[k]);
+      break;
+    } else if (nbytes < 10000) {
+      /* no decimals */
+      curl_msnprintf(max5, mlen, "%4" CURL_FORMAT_CURL_OFF_T "%c", nbytes,
+                     unit[k]);
+      break;
+    }
+    bytes = nbytes;
+    k++;
+    DEBUGASSERT(unit[k]);
+  } while (unit[k]);
+  return max5;
+}

--- a/src/tool_helpers.h
+++ b/src/tool_helpers.h
@@ -29,4 +29,12 @@ const char *param2text(ParameterError error);
 int SetHTTPrequest(HttpReq req, HttpReq *store);
 void customrequest_helper(HttpReq req, const char *method);
 
+/* The point of this function would be to return a string of the input data,
+   but never longer than 5 columns (+ one zero byte).
+   Add suffix k, M, G when suitable...
+
+   Unit test @1622
+*/
+char *max5data(curl_off_t bytes, char *max5, size_t mlen);
+
 #endif /* HEADER_CURL_TOOL_HELPERS_H */

--- a/src/tool_helpers.h
+++ b/src/tool_helpers.h
@@ -23,6 +23,8 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
+#include "tool_getparam.h"
+#include "tool_sdecls.h"
 #include "tool_setup.h"
 
 const char *param2text(ParameterError error);

--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -26,44 +26,6 @@
 #include "tool_operate.h"
 #include "tool_progress.h"
 
-/* The point of this function would be to return a string of the input data,
-   but never longer than 5 columns (+ one zero byte).
-   Add suffix k, M, G when suitable...
-
-   Unit test 1622
- */
-UNITTEST char *max5data(curl_off_t bytes, char *max5, size_t mlen)
-{
-  /* a signed 64-bit value is 8192 petabytes maximum */
-  static const char unit[] = { 'k', 'M', 'G', 'T', 'P', 'E', 0 };
-  int k = 0;
-  if(bytes < 100000) {
-    curl_msnprintf(max5, mlen, "%5" CURL_FORMAT_CURL_OFF_T, bytes);
-    return max5;
-  }
-
-  do {
-    curl_off_t nbytes = bytes / 1024;
-    if(nbytes < 100) {
-      /* display with a decimal */
-      curl_msnprintf(max5, mlen, "%2" CURL_FORMAT_CURL_OFF_T ".%"
-                     CURL_FORMAT_CURL_OFF_T "%c", bytes / 1024,
-                     (bytes % 1024) * 10 / 1024, unit[k]);
-      break;
-    }
-    else if(nbytes < 10000) {
-      /* no decimals */
-      curl_msnprintf(max5, mlen, "%4" CURL_FORMAT_CURL_OFF_T "%c", nbytes,
-                     unit[k]);
-      break;
-    }
-    bytes = nbytes;
-    k++;
-    DEBUGASSERT(unit[k]);
-  } while(unit[k]);
-  return max5;
-}
-
 int xferinfo_cb(void *clientp,
                 curl_off_t dltotal,
                 curl_off_t dlnow,

--- a/src/tool_progress.h
+++ b/src/tool_progress.h
@@ -38,7 +38,6 @@ struct per_transfer;
 void progress_finalize(struct per_transfer *per);
 
 #ifdef UNITTESTS
-UNITTEST char *max5data(curl_off_t bytes, char *max5, size_t mlen);
 UNITTEST void timebuf(char *r, size_t rlen, curl_off_t seconds);
 #endif
 

--- a/src/tool_progress.h
+++ b/src/tool_progress.h
@@ -24,6 +24,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
+#include "tool_helpers.h"
 
 int xferinfo_cb(void *clientp,
                 curl_off_t dltotal,

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -831,6 +831,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
           }
           else {
             vlen = end - ptr;
+            filen = 0;
             if(curlx_dyn_addn(&fil_name, none, strlen(none))) {
               break;
             }
@@ -840,7 +841,8 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
                             sizeof(filters[0]), matchvar);
           if(!cur_fil) {
             curl_mfprintf(tool_stderr,
-                          "curl: unknown --write-out filter: '%.*s, skipping'\n",
+                          "curl: unknown --write-out filter: '%.*s, "
+                          "skipping'\n",
                           (int)filen, filter);
             curlx_dyn_reset(&fil_name);
             if(curlx_dyn_addn(&fil_name, none, strlen(none))) {
@@ -881,8 +883,8 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
               stream = tool_stderr;
               break;
             case VAR_JSON:
-              ourWriteOutJSON(stream, variables, CURL_ARRAYSIZE(variables), per,
-                              per_result, cur_fil);
+              ourWriteOutJSON(stream, variables, CURL_ARRAYSIZE(variables),
+                              per, per_result, cur_fil);
               break;
             case VAR_HEADER_JSON:
               headerJSON(stream, per);

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -21,12 +21,15 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
+#include "curl_setup.h"
+#include "curlx/dynbuf.h"
 #include "tool_setup.h"
 
 #include "tool_cfgable.h"
+#include "tool_helpers.h"
 #include "tool_writeout.h"
 #include "tool_writeout_json.h"
-#include "tool_helpers.h"
+#include <stdlib.h>
 
 struct httpmap {
   const char *str;
@@ -44,8 +47,7 @@ static const struct httpmap http_version[] = {
 
 static int writeTime(FILE *stream, const struct writeoutvar *wovar,
                      struct per_transfer *per, CURLcode per_result,
-                     bool use_json)
-{
+                     bool use_json, const struct writeoutfilter *filter) {
   bool valid = FALSE;
   curl_off_t us = 0;
 
@@ -70,6 +72,14 @@ static int writeTime(FILE *stream, const struct writeoutvar *wovar,
 
     curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T
                   ".%06" CURL_FORMAT_CURL_OFF_T, secs, us);
+    switch(filter->id) {
+    case FILTER_NONE:
+      break;
+    default:
+      curl_mfprintf(stream, ":%s", filter->name);
+      break;
+    }
+
   }
   else {
     if(use_json)
@@ -80,8 +90,7 @@ static int writeTime(FILE *stream, const struct writeoutvar *wovar,
 }
 
 static int urlpart(struct per_transfer *per, writeoutid vid,
-                   const char **contentp)
-{
+                   const char **contentp) {
   CURLU *uh = curl_url();
   int rc = 0;
   if(uh) {
@@ -172,8 +181,7 @@ static void certinfo(struct per_transfer *per)
 
 static int writeString(FILE *stream, const struct writeoutvar *wovar,
                        struct per_transfer *per, CURLcode per_result,
-                       bool use_json)
-{
+                       bool use_json, const struct writeoutfilter *filter) {
   bool valid = FALSE;
   const char *strinfo = NULL;
   const char *freestr = NULL;
@@ -308,8 +316,16 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
       curl_mfprintf(stream, "\"%s\":", wovar->name);
       jsonWriteString(stream, strinfo, FALSE);
     }
-    else
+    else {
       fputs(strinfo, stream);
+      switch(filter->id) {
+      case FILTER_NONE:
+        break;
+      default:
+        curl_mfprintf(stream, ":%s", filter->name);
+        break;
+      }
+    }
   }
   else {
     if(use_json)
@@ -323,8 +339,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
 
 static int writeLong(FILE *stream, const struct writeoutvar *wovar,
                      struct per_transfer *per, CURLcode per_result,
-                     bool use_json)
-{
+                     bool use_json, const struct writeoutfilter *filter) {
   bool valid = FALSE;
   long longinfo = 0;
 
@@ -365,8 +380,16 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
     else {
       if(wovar->id == VAR_HTTP_CODE || wovar->id == VAR_HTTP_CODE_PROXY)
         curl_mfprintf(stream, "%03ld", longinfo);
-      else
+      else {
         curl_mfprintf(stream, "%ld", longinfo);
+        switch(filter->id) {
+        case FILTER_NONE:
+          break;
+        default:
+          curl_mfprintf(stream, ":%s", filter->name);
+          break;
+        }
+      }
     }
   }
   else {
@@ -379,10 +402,10 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
 
 static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
                        struct per_transfer *per, CURLcode per_result,
-                       bool use_json)
-{
+                       bool use_json, const struct writeoutfilter *filter) {
   bool valid = FALSE;
   curl_off_t offinfo = 0;
+  char prettyOff[6];
 
   (void)per;
   (void)per_result;
@@ -409,7 +432,19 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
     if(use_json)
       curl_mfprintf(stream, "\"%s\":", wovar->name);
 
-    curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T, offinfo);
+    switch(filter->id) {
+    case FILTER_NONE:
+
+      curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T, offinfo);
+      break;
+    case FILTER_BYTES_PRETTY:
+      curl_mfprintf(stream, "%s",
+                    max5data(offinfo, prettyOff, sizeof(prettyOff)));
+      break;
+    default:
+      curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ":%s", offinfo,
+                    filter->name);
+    }
   }
   else {
     if(use_json)
@@ -417,49 +452,6 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
   }
 
   return 1; /* return 1 if anything was written */
-}
-
-
-static int writePretty(FILE *stream, const struct writeoutvar *wovar,
-                       struct per_transfer *per, CURLcode per_result,
-                       bool use_json) {
-  bool valid = FALSE;
-  curl_off_t offinfo = 0;
-  char prettyOff[6];
-
-  (void)per;
-  (void)per_result;
-  DEBUGASSERT(wovar->writefunc == writeOffset);
-
-  if (wovar->ci) {
-    if (!curl_easy_getinfo(per->curl, wovar->ci, &offinfo))
-      valid = TRUE;
-  } else {
-    switch (wovar->id) {
-    case VAR_URLNUM:
-      if (per->urlnum <= INT_MAX) {
-        offinfo = per->urlnum;
-        valid = TRUE;
-      }
-      break;
-    default:
-      DEBUGASSERT(0);
-    }
-  }
-
-  if (valid) {
-    if (use_json)
-      curl_mfprintf(stream, "\"%s\":", wovar->name);
-
-
-    curl_mfprintf(stream, "%s",
-                  max5data(offinfo, prettyOff, sizeof(prettyOff)));
-  } else {
-    if (use_json)
-      curl_mfprintf(stream, "\"%s\":null", wovar->name);
-  }
-
-  return 1;
 }
 
 /* The designated write function should be the same as the CURLINFO return type
@@ -507,18 +499,11 @@ static const struct writeoutvar variables[] = {
   { "scheme", VAR_SCHEME, CURLINFO_SCHEME, writeString },
   { "size_delivered", VAR_SIZE_DELIVERED, CURLINFO_SIZE_DELIVERED,
     writeOffset },
-  { "size_delivered_pretty", VAR_SIZE_DELIVERED, CURLINFO_SIZE_DELIVERED,
-    writePretty },
   { "size_download", VAR_SIZE_DOWNLOAD, CURLINFO_SIZE_DOWNLOAD_T,
     writeOffset },
-  { "size_download_pretty", VAR_SIZE_DOWNLOAD, CURLINFO_SIZE_DOWNLOAD_T,
-    writePretty },
   { "size_header", VAR_HEADER_SIZE, CURLINFO_HEADER_SIZE, writeLong },
-  { "size_header_pretty", VAR_HEADER_SIZE, CURLINFO_HEADER_SIZE, writePretty },
   { "size_request", VAR_REQUEST_SIZE, CURLINFO_REQUEST_SIZE, writeLong },
-  { "size_request_pretty", VAR_REQUEST_SIZE, CURLINFO_REQUEST_SIZE, writePretty },
   { "size_upload", VAR_SIZE_UPLOAD, CURLINFO_SIZE_UPLOAD_T, writeOffset },
-  { "size_upload_pretty", VAR_SIZE_UPLOAD, CURLINFO_SIZE_UPLOAD_T, writePretty },
   { "speed_download", VAR_SPEED_DOWNLOAD, CURLINFO_SPEED_DOWNLOAD_T,
     writeOffset },
   { "speed_upload", VAR_SPEED_UPLOAD, CURLINFO_SPEED_UPLOAD_T, writeOffset },
@@ -569,6 +554,13 @@ static const struct writeoutvar variables[] = {
 };
 
 #define MAX_WRITEOUT_NAME_LENGTH 24
+
+static const struct writeoutfilter filters[] = {
+    {"none", FILTER_NONE},
+    {"pretty", FILTER_BYTES_PRETTY},
+};
+
+#define MAX_WRITEOUT_FILTER_LENGTH 7
 
 /* return the position after %time{} */
 static const char *outtime(const char *ptr, /* %time{ ... */
@@ -810,17 +802,55 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
       else {
         /* this is meant as a variable to output */
         const char *end;
-        size_t vlen;
+        const char *filter;
+        size_t vlen, filen;
         if('{' == ptr[1]) {
+          struct dynbuf fil_name;
           const struct writeoutvar *wv = NULL;
-          struct writeoutvar find = { 0 };
+          const struct writeoutfilter *cur_fil = NULL;
+          struct writeoutvar find = {0};
+          struct writeoutfilter filter_find = {0};
+          const char *none = "none";
+          filter = strchr(ptr, ':');
           end = strchr(ptr, '}');
           ptr += 2; /* pass the % and the { */
           if(!end) {
             fputs("%{", stream);
             continue;
           }
-          vlen = end - ptr;
+          curlx_dyn_init(&fil_name, MAX_WRITEOUT_FILTER_LENGTH);
+          if(filter) {
+
+            vlen = filter - ptr;
+            filen = end - filter;
+
+            if(curlx_dyn_addn(&fil_name, filter + 1, filen - 1)) {
+              break;
+            }
+
+          }
+          else {
+            vlen = end - ptr;
+            if(curlx_dyn_addn(&fil_name, none, strlen(none))) {
+              break;
+            }
+          }
+          filter_find.name = curlx_dyn_ptr(&fil_name);
+          cur_fil = bsearch(&filter_find, filters, CURL_ARRAYSIZE(filters),
+                            sizeof(filters[0]), matchvar);
+          if(!cur_fil) {
+            curl_mfprintf(tool_stderr,
+                          "curl: unknown --write-out filter: '%.*s, skipping'\n",
+                          (int)filen, filter);
+            curlx_dyn_reset(&fil_name);
+            if(curlx_dyn_addn(&fil_name, none, strlen(none))) {
+              break;
+            }
+            filter_find.name = curlx_dyn_ptr(&fil_name);
+            cur_fil = bsearch(&filter_find, filters, CURL_ARRAYSIZE(filters),
+                              sizeof(filters[0]), matchvar);
+          }
+
 
           curlx_dyn_reset(&name);
           if(!curlx_dyn_addn(&name, ptr, vlen)) {
@@ -851,15 +881,14 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
               stream = tool_stderr;
               break;
             case VAR_JSON:
-              ourWriteOutJSON(stream, variables,
-                              CURL_ARRAYSIZE(variables),
-                              per, per_result);
+              ourWriteOutJSON(stream, variables, CURL_ARRAYSIZE(variables), per,
+                              per_result, cur_fil);
               break;
             case VAR_HEADER_JSON:
               headerJSON(stream, per);
               break;
             default:
-              (void)wv->writefunc(stream, wv, per, per_result, FALSE);
+              (void)wv->writefunc(stream, wv, per, per_result, FALSE, cur_fil);
               break;
             }
           }
@@ -869,6 +898,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
                           (int)vlen, ptr);
           }
           ptr = end + 1; /* pass the end */
+          curlx_dyn_free(&fil_name);
         }
         else if(!strncmp("header{", &ptr[1], 7)) {
           ptr += 8;

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -26,6 +26,7 @@
 #include "tool_cfgable.h"
 #include "tool_writeout.h"
 #include "tool_writeout_json.h"
+#include "tool_helpers.h"
 
 struct httpmap {
   const char *str;
@@ -418,6 +419,49 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
   return 1; /* return 1 if anything was written */
 }
 
+
+static int writePretty(FILE *stream, const struct writeoutvar *wovar,
+                       struct per_transfer *per, CURLcode per_result,
+                       bool use_json) {
+  bool valid = FALSE;
+  curl_off_t offinfo = 0;
+  char prettyOff[6];
+
+  (void)per;
+  (void)per_result;
+  DEBUGASSERT(wovar->writefunc == writeOffset);
+
+  if (wovar->ci) {
+    if (!curl_easy_getinfo(per->curl, wovar->ci, &offinfo))
+      valid = TRUE;
+  } else {
+    switch (wovar->id) {
+    case VAR_URLNUM:
+      if (per->urlnum <= INT_MAX) {
+        offinfo = per->urlnum;
+        valid = TRUE;
+      }
+      break;
+    default:
+      DEBUGASSERT(0);
+    }
+  }
+
+  if (valid) {
+    if (use_json)
+      curl_mfprintf(stream, "\"%s\":", wovar->name);
+
+
+    curl_mfprintf(stream, "%s",
+                  max5data(offinfo, prettyOff, sizeof(prettyOff)));
+  } else {
+    if (use_json)
+      curl_mfprintf(stream, "\"%s\":null", wovar->name);
+  }
+
+  return 1;
+}
+
 /* The designated write function should be the same as the CURLINFO return type
    with exceptions special cased in the respective function. For example,
    http_version uses CURLINFO_HTTP_VERSION which returns the version as a long,
@@ -463,11 +507,18 @@ static const struct writeoutvar variables[] = {
   { "scheme", VAR_SCHEME, CURLINFO_SCHEME, writeString },
   { "size_delivered", VAR_SIZE_DELIVERED, CURLINFO_SIZE_DELIVERED,
     writeOffset },
+  { "size_delivered_pretty", VAR_SIZE_DELIVERED, CURLINFO_SIZE_DELIVERED,
+    writePretty },
   { "size_download", VAR_SIZE_DOWNLOAD, CURLINFO_SIZE_DOWNLOAD_T,
     writeOffset },
+  { "size_download_pretty", VAR_SIZE_DOWNLOAD, CURLINFO_SIZE_DOWNLOAD_T,
+    writePretty },
   { "size_header", VAR_HEADER_SIZE, CURLINFO_HEADER_SIZE, writeLong },
+  { "size_header_pretty", VAR_HEADER_SIZE, CURLINFO_HEADER_SIZE, writePretty },
   { "size_request", VAR_REQUEST_SIZE, CURLINFO_REQUEST_SIZE, writeLong },
+  { "size_request_pretty", VAR_REQUEST_SIZE, CURLINFO_REQUEST_SIZE, writePretty },
   { "size_upload", VAR_SIZE_UPLOAD, CURLINFO_SIZE_UPLOAD_T, writeOffset },
+  { "size_upload_pretty", VAR_SIZE_UPLOAD, CURLINFO_SIZE_UPLOAD_T, writePretty },
   { "speed_download", VAR_SPEED_DOWNLOAD, CURLINFO_SPEED_DOWNLOAD_T,
     writeOffset },
   { "speed_upload", VAR_SPEED_UPLOAD, CURLINFO_SPEED_UPLOAD_T, writeOffset },

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -78,7 +78,8 @@ static int writeTime(FILE *stream, const struct writeoutvar *wovar,
     case FILTER_NONE:
       break;
     default:
-      curl_mfprintf(stream, ":%s", filter->name);
+      errorf("Filter %s not compatible with variable %s",
+             filter->name, wovar->name);
       break;
     }
   }
@@ -323,7 +324,8 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
       case FILTER_NONE:
         break;
       default:
-        curl_mfprintf(stream, ":%s", filter->name);
+        errorf("Filter %s not compatible with variable %s",
+               filter->name, wovar->name);
         break;
       }
     }
@@ -343,6 +345,7 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
                      bool use_json, const struct writeoutfilter *filter) {
   bool valid = FALSE;
   long longinfo = 0;
+  char prettyOff[6];
 
   DEBUGASSERT(wovar->writefunc == writeLong);
 
@@ -385,10 +388,14 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
         curl_mfprintf(stream, "%ld", longinfo);
         switch(filter->id) {
         case FILTER_NONE:
+          curl_mfprintf(stream, "%ld", longinfo);
+          break;
+        case FILTER_BYTES_PRETTY:
+          fputs(max5data(longinfo, prettyOff, sizeof(prettyOff)), stream);
           break;
         default:
-          curl_mfprintf(stream, ":%s", filter->name);
-          break;
+          errorf("Filter %s not compatible with variable %s",
+                 filter->name, wovar->name);
         }
       }
     }
@@ -435,15 +442,14 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
 
     switch(filter->id) {
     case FILTER_NONE:
-
       curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T, offinfo);
       break;
     case FILTER_BYTES_PRETTY:
       fputs(max5data(offinfo, prettyOff, sizeof(prettyOff)), stream);
       break;
     default:
-      curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ":%s", offinfo,
-                    filter->name);
+      errorf("Filter %s not compatible with variable %s",
+             filter->name, wovar->name);
     }
   }
   else {

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -439,8 +439,7 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
       curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T, offinfo);
       break;
     case FILTER_BYTES_PRETTY:
-      curl_mfprintf(stream, "%s",
-                    max5data(offinfo, prettyOff, sizeof(prettyOff)));
+      fputs(max5data(offinfo, prettyOff, sizeof(prettyOff)), stream);
       break;
     default:
       curl_mfprintf(stream, "%" CURL_FORMAT_CURL_OFF_T ":%s", offinfo,

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -81,7 +81,6 @@ static int writeTime(FILE *stream, const struct writeoutvar *wovar,
       curl_mfprintf(stream, ":%s", filter->name);
       break;
     }
-
   }
   else {
     if(use_json)
@@ -826,8 +825,6 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
               errorf("Unknown --write-out filter: %s", filter);
               break;
             }
-
-
           }
           else {
             vlen = end - ptr;

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -385,7 +385,6 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
       if(wovar->id == VAR_HTTP_CODE || wovar->id == VAR_HTTP_CODE_PROXY)
         curl_mfprintf(stream, "%03ld", longinfo);
       else {
-        curl_mfprintf(stream, "%ld", longinfo);
         switch(filter->id) {
         case FILTER_NONE:
           curl_mfprintf(stream, "%ld", longinfo);

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -556,7 +556,6 @@ static const struct writeoutvar variables[] = {
 
 #define MAX_WRITEOUT_NAME_LENGTH 24
 
-
 /* return the position after %time{} */
 static const char *outtime(const char *ptr, /* %time{ ... */
                            FILE *stream)
@@ -830,8 +829,6 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
             cur_fil.name = "none";
             cur_fil.id = FILTER_NONE;
           }
-
-
           curlx_dyn_reset(&name);
           if(!curlx_dyn_addn(&name, ptr, vlen)) {
             find.name = curlx_dyn_ptr(&name);

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -818,7 +818,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
             vlen = filter - ptr;
 
             filter += 1; /* remove the : */
-            filen = end - filter;
+            filen = end - filter + 1;
 
             if(strncmp("pretty}", filter, filen) == 0) {
               cur_fil.name = "pretty";

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -810,8 +810,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
             fputs("%{", stream);
             continue;
           }
-          if(filter) {
-
+          if(filter && filter < end) {
             vlen = filter - ptr;
 
             filter += 1; /* remove the : */

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 #include "curlx/dynbuf.h"
+#include "tool_msgs.h"
 #include "tool_setup.h"
 
 #include "tool_cfgable.h"
@@ -30,6 +31,7 @@
 #include "tool_writeout.h"
 #include "tool_writeout_json.h"
 #include <stdlib.h>
+#include <string.h>
 
 struct httpmap {
   const char *str;
@@ -555,12 +557,6 @@ static const struct writeoutvar variables[] = {
 
 #define MAX_WRITEOUT_NAME_LENGTH 24
 
-static const struct writeoutfilter filters[] = {
-    {"none", FILTER_NONE},
-    {"pretty", FILTER_BYTES_PRETTY},
-};
-
-#define MAX_WRITEOUT_FILTER_LENGTH 7
 
 /* return the position after %time{} */
 static const char *outtime(const char *ptr, /* %time{ ... */
@@ -805,12 +801,9 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
         const char *filter;
         size_t vlen, filen;
         if('{' == ptr[1]) {
-          struct dynbuf fil_name;
           const struct writeoutvar *wv = NULL;
-          const struct writeoutfilter *cur_fil = NULL;
+          struct writeoutfilter cur_fil;
           struct writeoutvar find = {0};
-          struct writeoutfilter filter_find = {0};
-          const char *none = "none";
           filter = strchr(ptr, ':');
           end = strchr(ptr, '}');
           ptr += 2; /* pass the % and the { */
@@ -818,39 +811,28 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
             fputs("%{", stream);
             continue;
           }
-          curlx_dyn_init(&fil_name, MAX_WRITEOUT_FILTER_LENGTH);
           if(filter) {
 
             vlen = filter - ptr;
+
+            filter += 1; /* remove the : */
             filen = end - filter;
 
-            if(curlx_dyn_addn(&fil_name, filter + 1, filen - 1)) {
+            if(strncmp("pretty}", filter, filen) == 0) {
+              cur_fil.name = "pretty";
+              cur_fil.id = FILTER_BYTES_PRETTY;
+            }
+            else {
+              errorf("Unknown --write-out filter: %s", filter);
               break;
             }
+
 
           }
           else {
             vlen = end - ptr;
-            filen = 0;
-            if(curlx_dyn_addn(&fil_name, none, strlen(none))) {
-              break;
-            }
-          }
-          filter_find.name = curlx_dyn_ptr(&fil_name);
-          cur_fil = bsearch(&filter_find, filters, CURL_ARRAYSIZE(filters),
-                            sizeof(filters[0]), matchvar);
-          if(!cur_fil) {
-            curl_mfprintf(tool_stderr,
-                          "curl: unknown --write-out filter: '%.*s, "
-                          "skipping'\n",
-                          (int)filen, filter);
-            curlx_dyn_reset(&fil_name);
-            if(curlx_dyn_addn(&fil_name, none, strlen(none))) {
-              break;
-            }
-            filter_find.name = curlx_dyn_ptr(&fil_name);
-            cur_fil = bsearch(&filter_find, filters, CURL_ARRAYSIZE(filters),
-                              sizeof(filters[0]), matchvar);
+            cur_fil.name = "none";
+            cur_fil.id = FILTER_NONE;
           }
 
 
@@ -884,13 +866,14 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
               break;
             case VAR_JSON:
               ourWriteOutJSON(stream, variables, CURL_ARRAYSIZE(variables),
-                              per, per_result, cur_fil);
+                              per, per_result, &cur_fil);
               break;
             case VAR_HEADER_JSON:
               headerJSON(stream, per);
               break;
             default:
-              (void)wv->writefunc(stream, wv, per, per_result, FALSE, cur_fil);
+              (void)wv->writefunc(stream, wv, per, per_result, FALSE,
+                                  &cur_fil);
               break;
             }
           }
@@ -900,7 +883,6 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
                           (int)vlen, ptr);
           }
           ptr = end + 1; /* pass the end */
-          curlx_dyn_free(&fil_name);
         }
         else if(!strncmp("header{", &ptr[1], 7)) {
           ptr += 8;

--- a/src/tool_writeout.h
+++ b/src/tool_writeout.h
@@ -105,13 +105,23 @@ typedef enum {
   VAR_NUM_OF_VARS /* must be the last */
 } writeoutid;
 
+typedef enum {
+  FILTER_NONE,
+  FILTER_BYTES_PRETTY,
+} writeoutfilterid;
+
+struct writeoutfilter {
+  const char *name;
+  writeoutfilterid id;
+};
+
 struct writeoutvar {
   const char *name;
   writeoutid id;
   CURLINFO ci;
   int (*writefunc)(FILE *stream, const struct writeoutvar *wovar,
-                   struct per_transfer *per, CURLcode per_result,
-                   bool use_json);
+                   struct per_transfer *per, CURLcode per_result, bool use_json,
+                   const struct writeoutfilter *filter);
 };
 
 void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,

--- a/src/tool_writeout.h
+++ b/src/tool_writeout.h
@@ -120,8 +120,8 @@ struct writeoutvar {
   writeoutid id;
   CURLINFO ci;
   int (*writefunc)(FILE *stream, const struct writeoutvar *wovar,
-                   struct per_transfer *per, CURLcode per_result, bool use_json,
-                   const struct writeoutfilter *filter);
+                   struct per_transfer *per, CURLcode per_result,
+                   bool use_json, const struct writeoutfilter *filter);
 };
 
 void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,

--- a/src/tool_writeout.h
+++ b/src/tool_writeout.h
@@ -107,7 +107,7 @@ typedef enum {
 
 typedef enum {
   FILTER_NONE,
-  FILTER_BYTES_PRETTY,
+  FILTER_BYTES_PRETTY
 } writeoutfilterid;
 
 struct writeoutfilter {

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -24,8 +24,8 @@
 #include "tool_setup.h"
 
 #include "tool_cfgable.h"
-#include "tool_writeout_json.h"
 #include "tool_writeout.h"
+#include "tool_writeout_json.h"
 
 #define MAX_JSON_STRING 100000
 
@@ -95,8 +95,8 @@ void jsonWriteString(FILE *stream, const char *in, bool lowercase)
 }
 
 void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
-                     size_t nentries,
-                     struct per_transfer *per, CURLcode per_result)
+                     size_t nentries, struct per_transfer *per,
+                     CURLcode per_result, const struct writeoutfilter *filter)
 {
   size_t i;
 
@@ -104,7 +104,8 @@ void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
 
   for(i = 0; i < nentries; i++) {
     if(mappings[i].writefunc &&
-       mappings[i].writefunc(stream, &mappings[i], per, per_result, TRUE))
+       mappings[i].writefunc(stream, &mappings[i], per, per_result, TRUE,
+                             filter))
       fputs(",", stream);
   }
 

--- a/src/tool_writeout_json.h
+++ b/src/tool_writeout_json.h
@@ -30,8 +30,8 @@
 int jsonquoted(const char *in, size_t len, struct dynbuf *out, bool lowercase);
 
 void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
-                     size_t nentries,
-                     struct per_transfer *per, CURLcode per_result);
+                     size_t nentries, struct per_transfer *per,
+                     CURLcode per_result, const struct writeoutfilter *filter);
 void headerJSON(FILE *stream, struct per_transfer *per);
 void jsonWriteString(FILE *stream, const char *in, bool lowercase);
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -295,7 +295,7 @@ test4000 test4001 \
 test5000 test5001 test5002 test5003 test5004 test5005 test5006 test5007 \
 test5008 test5009 test5010 test5011 test5012 test5013 test5014 test5015 \
 test5016 test5017 test5018 test5019 test5020 test5021 test5022 test5023 \
-test5024 test5025
+test5024 test5025 test5026
 
 EXTRA_DIST = $(TESTCASES) DISABLED data-xml1 \
 data1461.txt data1463.txt  \

--- a/tests/data/test5026
+++ b/tests/data/test5026
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+CLI
+write-out
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Sat, 08 Aug 2026 16:58:38 GMT
+Server: test-server/fake
+Content-Length: 600000
+Connection: close
+Content-Type: text/html
+
+%repeat[100000 x foobar]%
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Check pretty filter
+</name>
+<command>
+--no-progress-meter --out-null --write-out "%{size_download:pretty}\n%{content_type:pretty}\n" http://%HOSTIP:%HTTPPORT/file%TESTNUMBER
+</command>
+</client>
+
+# Verify the data apply the filter as expected
+<verify>
+<stdout>
+ 585k
+text/html
+</stdout>
+<stderr>
+curl: Filter pretty not compatible with variable content_type
+</stderr>
+</verify>
+</testcase>

--- a/tests/tunit/tool1622.c
+++ b/tests/tunit/tool1622.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "unitcheck.h"
 #include "tool_progress.h"
+#include "tool_helpers.h"
 
 static CURLcode test_tool1622(const char *arg)
 {


### PR DESCRIPTION
The idea is to have a human readable output when printing size with write-out by reusing the code from the status update during download. I'm not sure that's the best way to do it since it duplicate all the size size the _pretty identifier, but it avoid creating a complex template engine to have filter on value. If you think it can be merged, I need to update the documentation also. 

I'm not sure the `_pretty` identifier is the best, maybe `_human` is better as in `ls --human-readable`.

Also, I'm not sure `tool_helpers` is the best file to host the function. 

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
