### PR TITLE
CURLOPT_HEADERFUNCTION.md: document folded header unfolding

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
@@ -92,10 +92,11 @@ curl_easy_header(3).
 
 # LIMITATIONS
 
-libcurl does not unfold HTTP "folded headers" (deprecated since RFC 7230). A
-folded header is a header that continues on a subsequent line and starts with
-a whitespace. Such folds are passed to the header callback as separate ones,
-although strictly they are continuations of the previous lines.
+For legacy HTTP/1 "folded headers" (deprecated since RFC 7230), libcurl
+unfolds the lines before calling the header callback. A folded header is a
+header that continues on a subsequent line and starts with whitespace. The
+callback gets the full single header with one whitespace between the lines.
+This unfolding is done since 8.18.0.
 
 # DEFAULT
 


### PR DESCRIPTION
Update CURLOPT_HEADERFUNCTION documentation to match current HTTP/1 folded-header handling. Since 8.18.0, folded response headers are unfolded before the header callback gets them.

Closes #22296