### PR TITLE
urlapi: preserve empty markers in relative URLs

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1271,16 +1271,16 @@ static CURLUcode redirect_url(const char *base, const char *relurl,
 
   case '#':
     /* fragment-only change */
-    if(u->fragment)
+    if(u->fragment_present)
       cutoff = strchr(protsep, '#');
     break;
 
   default:
     /* path or query-only change */
-    if(u->query && u->query[0])
+    if(u->query_present)
       /* remove existing query */
       cutoff = strchr(protsep, '?');
-    else if(u->fragment && u->fragment[0])
+    else if(u->fragment_present)
       /* Remove existing fragment */
       cutoff = strchr(protsep, '#');
 
@@ -1764,7 +1764,10 @@ static CURLUcode set_url(CURLU *u, const char *url, size_t part_size,
   /* if the old URL is incomplete (we cannot get an absolute URL in
      'oldurl'), replace the existing with the new.
      Always include "scheme://" to make the URL "complete" */
-  uc = curl_url_get(u, CURLUPART_URL, &oldurl, flags & ~CURLU_NO_GUESS_SCHEME);
+  /* Preserve empty query/fragment separators: they affect where relative
+     references splice into the base URL. */
+  uc = curl_url_get(u, CURLUPART_URL, &oldurl,
+                    (flags & ~CURLU_NO_GUESS_SCHEME) | CURLU_GET_EMPTY);
   if(uc == CURLUE_OUT_OF_MEMORY)
     return uc;
   else if(uc)

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1552,19 +1552,26 @@ static const struct redircase set_url_list[] = {
    0, 0, CURLUE_OK},
   {"http://example.org/foo/bar",
    "#",
-   "http://example.org/foo/bar",
-   /* This happens because the parser removes empty fragments */
+   "http://example.org/foo/bar#",
    0, 0, CURLUE_OK},
   {"http://example.org/foo/bar",
    "?",
-   "http://example.org/foo/bar",
-   /* This happens because the parser removes empty queries */
+   "http://example.org/foo/bar?",
    0, 0, CURLUE_OK},
   {"http://example.org/foo/bar",
    "?#",
-   "http://example.org/foo/bar",
-   /* This happens because the parser removes empty queries and fragments */
+   "http://example.org/foo/bar?#",
    0, 0, CURLUE_OK},
+  {"http://host/path?", "#new",
+   "http://host/path?#new", 0, 0, CURLUE_OK},
+  {"http://host/path?#", "#new",
+   "http://host/path?#new", 0, 0, CURLUE_OK},
+  {"http://host/path#", "?new",
+   "http://host/path?new", 0, 0, CURLUE_OK},
+  {"http://host/path?#", "?new",
+   "http://host/path?new", 0, 0, CURLUE_OK},
+  {"http://host/path?#", "sub",
+   "http://host/sub", 0, 0, CURLUE_OK},
   {"http://example.com/please/../gimme/%TESTNUMBER?foobar#hello",
    "http://example.net/there/it/is/../../tes t case=/%TESTNUMBER0002? yes no",
    "http://example.net/there/tes%20t%20case=/%TESTNUMBER0002?+yes+no",
@@ -1639,7 +1646,7 @@ static int set_url(void)
       }
       else {
         char *url = NULL;
-        rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
+        rc = curl_url_get(urlp, CURLUPART_URL, &url, CURLU_GET_EMPTY);
         if(rc) {
           curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
                         __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -194,54 +194,6 @@ static CURLcode test_unit1675(const char *arg)
     abort_if(fails, "urlencode_str tests failed");
   }
 
-  /* Test relative URL resolution with empty query and fragment markers. */
-  {
-    int fails = 0;
-    unsigned int i;
-    struct empty_rel_test {
-      const char *base;
-      const char *rel;
-      const char *out;
-    };
-    const struct empty_rel_test tests[] = {
-      { "http://host/path?", "#new", "http://host/path?#new" },
-      { "http://host/path?#", "#new", "http://host/path?#new" },
-      { "http://host/path#", "?new", "http://host/path?new" },
-      { "http://host/path?#", "?new", "http://host/path?new" },
-      { "http://host/path?#", "sub", "http://host/sub" }
-    };
-
-    for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
-      CURLU *u = curl_url();
-      char *url = NULL;
-      CURLUcode uc;
-
-      if(!u)
-        unittest_abort("curl_url failed");
-
-      uc = curl_url_set(u, CURLUPART_URL, tests[i].base, 0);
-      if(!uc)
-        uc = curl_url_set(u, CURLUPART_URL, tests[i].rel, 0);
-      if(!uc)
-        uc = curl_url_get(u, CURLUPART_URL, &url, CURLU_GET_EMPTY);
-      if(uc) {
-        curl_mfprintf(stderr, "empty relative URL test %u returned %d (%s)\n",
-                      i, (int)uc, curl_url_strerror(uc));
-        fails++;
-      }
-      else if(strcmp(url, tests[i].out)) {
-        curl_mfprintf(stderr, "empty relative URL test %u failed: "
-                      "expected '%s', got '%s'\n",
-                      i, tests[i].out, url);
-        fails++;
-      }
-
-      curl_free(url);
-      curl_url_cleanup(u);
-    }
-    abort_if(fails, "empty relative URL tests failed");
-  }
-
   /* Test ipv6_parse */
   {
     struct Curl_URL u;

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -194,6 +194,54 @@ static CURLcode test_unit1675(const char *arg)
     abort_if(fails, "urlencode_str tests failed");
   }
 
+  /* Test relative URL resolution with empty query and fragment markers. */
+  {
+    int fails = 0;
+    unsigned int i;
+    struct empty_rel_test {
+      const char *base;
+      const char *rel;
+      const char *out;
+    };
+    const struct empty_rel_test tests[] = {
+      { "http://host/path?", "#new", "http://host/path?#new" },
+      { "http://host/path?#", "#new", "http://host/path?#new" },
+      { "http://host/path#", "?new", "http://host/path?new" },
+      { "http://host/path?#", "?new", "http://host/path?new" },
+      { "http://host/path?#", "sub", "http://host/sub" }
+    };
+
+    for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
+      CURLU *u = curl_url();
+      char *url = NULL;
+      CURLUcode uc;
+
+      if(!u)
+        unittest_abort("curl_url failed");
+
+      uc = curl_url_set(u, CURLUPART_URL, tests[i].base, 0);
+      if(!uc)
+        uc = curl_url_set(u, CURLUPART_URL, tests[i].rel, 0);
+      if(!uc)
+        uc = curl_url_get(u, CURLUPART_URL, &url, CURLU_GET_EMPTY);
+      if(uc) {
+        curl_mfprintf(stderr, "empty relative URL test %u returned %d (%s)\n",
+                      i, (int)uc, curl_url_strerror(uc));
+        fails++;
+      }
+      else if(strcmp(url, tests[i].out)) {
+        curl_mfprintf(stderr, "empty relative URL test %u failed: "
+                      "expected '%s', got '%s'\n",
+                      i, tests[i].out, url);
+        fails++;
+      }
+
+      curl_free(url);
+      curl_url_cleanup(u);
+    }
+    abort_if(fails, "empty relative URL tests failed");
+  }
+
   /* Test ipv6_parse */
   {
     struct Curl_URL u;


### PR DESCRIPTION
## What

Relative URL resolution currently loses explicit empty query/fragment markers when those markers are needed to compute the splice point.

Example before this patch:

```c
curl_url_set(u, CURLUPART_URL, "http://host/path?#", 0);
curl_url_set(u, CURLUPART_URL, "#new", 0);
curl_url_get(u, CURLUPART_URL, &url, CURLU_GET_EMPTY);
```

Expected:

```text
http://host/path?#new
```

Actual before this patch:

```text
http://host/path#new
```

The empty query marker is significant when the caller asks for empty components with `CURLU_GET_EMPTY`.

This patch fixes the relative-resolution path by:

- preserving empty query/fragment separators when serializing the existing base URL for relative resolution
- using `query_present` and `fragment_present` when choosing the cutoff point, instead of only checking for non-empty query/fragment strings
- adding focused `unit1675` coverage for fragment-only, query-only, and path-relative references across explicit empty query/fragment markers

## Tests

```text
cmake --build _build --target units -j2 && ./_build/tests/unit/units unit1675
```

```text
perl ../../tests/runtests.pl -c ../src/curl -a -n 1675
```

I also checked the public URL API behavior with a small local probe for the examples above.

Disclosure: AI assistance was used while inspecting and drafting this patch; the behavior and focused tests listed above were verified locally.
