### PR TITLE
unit3214: avoid a false failure on CHERI

### DIFF
--- a/tests/unit/unit3214.c
+++ b/tests/unit/unit3214.c
@@ -26,6 +26,12 @@
 
 static void checksize(const char *name, size_t size, size_t allowed)
 {
+  /*
+   * Some platforms, e.g., CHERI, have 128-bit pointers. Allow structs to be
+   * double the size of what we would typically expect.
+   */
+  if(sizeof(void *) > 8)
+    allowed *= sizeof(void *) / 8;
   if(size > allowed) {
     curl_mfprintf(stderr, "BAD: struct %s is %zu bytes, "
                   "allowed to be %zu: %zu bytes too big\n",
@@ -39,7 +45,10 @@ static void checksize(const char *name, size_t size, size_t allowed)
   }
 }
 
-/* the maximum sizes we allow specific structs to grow to */
+/*
+ * The maximum sizes we allow specific structs to grow to.
+ * These sizes were chosen with platforms with 64-bit pointers in mind.
+ */
 #define MAX_CURL_EASY           5370
 #define MAX_CONNECTDATA         1300
 #define MAX_CURL_MULTI          850


### PR DESCRIPTION
On CHERI pointers are 128 bits [1]. This causes the unit3214 test to fail, which was written with more traditional platforms in mind. Here is the output of log/stderr3214:

    URL: -
    BAD: struct Curl_easy is 7984 bytes, allowed to be 5370: 2614 bytes too big
    BAD: struct connectdata is 1408 bytes, allowed to be 1300: 108 bytes too big
    BAD: struct Curl_multi is 1248 bytes, allowed to be 850: 398 bytes too big
    BAD: struct curl_httppost is 224 bytes, allowed to be 112: 112 bytes too big
    BAD: struct curl_slist is 32 bytes, allowed to be 16: 16 bytes too big
    BAD: struct curl_khkey is 32 bytes, allowed to be 24: 8 bytes too big
    BAD: struct curl_hstsentry is 48 bytes, allowed to be 40: 8 bytes too big
    BAD: struct curl_mime is 144 bytes, allowed to be 96: 48 bytes too big
    BAD: struct curl_mimepart is 592 bytes, allowed to be 440: 152 bytes too big
    BAD: struct curl_certinfo is 32 bytes, allowed to be 16: 16 bytes too big
    BAD: struct curl_tlssessioninfo is 32 bytes, allowed to be 16: 16 bytes too big
    BAD: struct curl_blob is 32 bytes, allowed to be 24: 8 bytes too big
    BAD: struct CURLMsg is 48 bytes, allowed to be 24: 24 bytes too big
    BAD: struct curl_header is 80 bytes, allowed to be 48: 32 bytes too big
    Test ended with result 14

Since most platforms will have 32-bit or 64-bit bits, doubling the allowed size on CHERI seems reasonable and allows the test to pass.

[1] https://www.cl.cam.ac.uk/research/security/ctsrd/pdfs/20171017a-cheri-poster.pdf

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
