### PR TITLE
configure: remove double check for GnuTLS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5276,7 +5276,6 @@ if test "$CURL_DISABLE_HTTP" != "1"; then
        test "$GNUTLS_ENABLED" = "1" ||
        test "$RUSTLS_ENABLED" = "1" ||
        test "$SCHANNEL_ENABLED" = "1" ||
-       test "$GNUTLS_ENABLED" = "1" ||
        test "$MBEDTLS_ENABLED" = "1"; then
       SUPPORT_FEATURES="$SUPPORT_FEATURES HTTPS-proxy"
       AC_MSG_RESULT([yes])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -289,7 +289,7 @@ if test "x$OPT_OPENSSL" != "xno"; then
           #endif
         ]])
       ],[],[
-        AC_MSG_ERROR([OpenSSL 3.0.0 or upper required.])
+        AC_MSG_ERROR([OpenSSL 3.0.0 or later required.])
       ])
     fi
   fi


### PR DESCRIPTION
`GNUTLS_ENABLED` was checked twice in the HTTPS-proxy support block, making the second check redundant.

Pointed out by the GitHub AI thing
