### PR TITLE
configure: set ldap lib to no by default for non-finds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2671,6 +2671,9 @@ if test "$CURL_DISABLE_LDAP" != "1" && test "$want_ldap" != "no"; then
   CURL_CHECK_HEADER_LDAP
   CURL_CHECK_HEADER_LDAP_SSL
 
+  dnl Default to failure; AC_CHECK_LIB success paths set this to yes.
+  ldap_lib_ok="no"
+
   if test -z "$LDAPLIBNAME"; then
     if test "$curl_cv_native_windows" = "yes" && test "$curl_cv_winuwp" != "yes"; then
       dnl Windows uses a single and unique LDAP library name


### PR DESCRIPTION
`ldap_lib_ok` is never actually set at the start, so a prior cached autoconf result could lead to an incorrect value.

Pointed out by the GitHub AI
