### PR TITLE
setopt: reject CR and LF in string options

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -43,6 +43,7 @@
 #include "curl_trc.h"
 #include "hostip.h"
 #include "setopt.h"
+#include "easyoptions.h"
 #include "altsvc.h"
 #include "hsts.h"
 #include "tftp.h"
@@ -2479,6 +2480,28 @@ static CURLcode setopt_cptr_misc(struct Curl_easy *data, CURLoption option,
   return result;
 }
 
+/* A string option that curl writes into a protocol request line or header
+   must not carry a CR or LF: such a byte ends the line and lets an extra
+   request or header be injected onto the connection. Reject them here so every
+   string option is covered in one place. Only CURLOT_STRING options are
+   checked; object and callback-pointer options (the POST body, the error
+   buffer, user data pointers) share this path but are left untouched. */
+static CURLcode setopt_check_str(CURLoption option, const char *ptr)
+{
+  if(ptr) {
+    const struct curl_easyoption *o = &Curl_easyopts[0];
+    do {
+      if((o->id == option) && !(o->flags & CURLOT_FLAG_ALIAS)) {
+        if((o->type == CURLOT_STRING) && ptr[strcspn(ptr, "\r\n")])
+          return CURLE_BAD_FUNCTION_ARGUMENT;
+        break;
+      }
+      o++;
+    } while(o->name);
+  }
+  return CURLE_OK;
+}
+
 static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
                             char *ptr)
 {
@@ -2504,9 +2527,12 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     setopt_cptr_misc,
   };
   size_t i;
+  CURLcode result = setopt_check_str(option, ptr);
+  if(result)
+    return result;
 
   for(i = 0; i < CURL_ARRAYSIZE(setopt_call); i++) {
-    CURLcode result = setopt_call[i](data, option, ptr);
+    result = setopt_call[i](data, option, ptr);
     if(result != CURLE_UNKNOWN_OPTION)
       return result;
   }

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -42,6 +42,7 @@
 #include "vtls/vtls.h"
 #include "curl_trc.h"
 #include "setopt.h"
+#include "easyoptions.h"
 #include "altsvc.h"
 #include "hsts.h"
 #include "tftp.h"
@@ -2495,6 +2496,44 @@ static CURLcode setopt_cptr_misc(struct Curl_easy *data, CURLoption option,
   return result;
 }
 
+/* A string option that curl writes into a protocol request line or header
+   must not carry a CR or LF: such a byte ends the line and lets an extra
+   request or header be injected onto the connection. Reject them here so every
+   string option is covered in one place. Only CURLOT_STRING options are
+   checked; object and callback-pointer options (the POST body, the error
+   buffer, user data pointers) share this path but are left untouched. */
+static CURLcode setopt_check_str(CURLoption option, const char *ptr)
+{
+  if(ptr) {
+    const struct curl_easyoption *o;
+    switch(option) {
+    case CURLOPT_URL:
+      /* the URL parser rejects these bytes with CURLE_URL_MALFORMAT */
+    case CURLOPT_USERPWD:
+    case CURLOPT_USERNAME:
+    case CURLOPT_PASSWORD:
+    case CURLOPT_PROXYUSERPWD:
+    case CURLOPT_PROXYUSERNAME:
+    case CURLOPT_PROXYPASSWORD:
+      /* checked at transfer time instead: protocols that encode credentials
+         accept these bytes, the others reject them (PROTOPT_USERPWDCTRL) */
+      return CURLE_OK;
+    default:
+      break;
+    }
+    o = &Curl_easyopts[0];
+    do {
+      if((o->id == option) && !(o->flags & CURLOT_FLAG_ALIAS)) {
+        if((o->type == CURLOT_STRING) && ptr[strcspn(ptr, "\r\n")])
+          return CURLE_BAD_FUNCTION_ARGUMENT;
+        break;
+      }
+      o++;
+    } while(o->name);
+  }
+  return CURLE_OK;
+}
+
 static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
                             char *ptr)
 {
@@ -2521,9 +2560,12 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #endif
   };
   size_t i;
+  CURLcode result = setopt_check_str(option, ptr);
+  if(result)
+    return result;
 
   for(i = 0; i < CURL_ARRAYSIZE(setopt_call); i++) {
-    CURLcode result = setopt_call[i](data, option, ptr);
+    result = setopt_call[i](data, option, ptr);
     if(result != CURLE_UNKNOWN_OPTION)
       return result;
   }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -97,7 +97,8 @@ test618 test619 test620 test621 test622 test623 test624 test625 test626 \
 test627 test628 test629 test630 test631 test632 test633 test634 test635 \
 test636 test637 test638 test639 test640 test641 test642 test643 test644 \
 test645 test646 test647 test648 test649 test650 test651 test652 test653 \
-test654 test655 test656 test658 test659 test660 test661 test662 test663 \
+test654 test655 test656 test657 test658 test659 test660 test661 test662 \
+test663 \
 test664 test665 test666 test667 test668 test669 test670 test671 test672 \
 test673 test674 test675 test676 test677 test678 test679 test680 test681 \
 test682 test683 test684 test685 test686 test687 test688 test689 test690 \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -679,6 +679,7 @@ TESTCASES = \
   test654 \
   test655 \
   test656 \
+  test657 \
   test658 \
   test659 \
   test660 \

--- a/tests/data/test2110
+++ b/tests/data/test2110
@@ -36,14 +36,11 @@ smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt recipient@example.com -K %LOGDI
 
 # Verify data after the test has been "shot"
 <verify>
-# 43 - CURLE_BAD_FUNCTION_ARGUMENT
+# 43 - CURLE_BAD_FUNCTION_ARGUMENT. curl_easy_setopt() rejects the CR LF before
+# the transfer starts, so curl never connects and the injected DATA command is
+# never sent.
 <errorcode>
 43
 </errorcode>
-# the injected DATA command must never reach the server
-<protocol crlf="yes">
-EHLO %TESTNUMBER
-QUIT
-</protocol>
 </verify>
 </testcase>

--- a/tests/data/test2115
+++ b/tests/data/test2115
@@ -32,15 +32,11 @@ ftp://%HOSTIP:%FTPPORT/%TESTNUMBER -K %LOGDIR/test%TESTNUMBER.config
 
 # Verify data after the test has been "shot"
 <verify>
-# 43 - CURLE_BAD_FUNCTION_ARGUMENT
+# 43 - CURLE_BAD_FUNCTION_ARGUMENT. curl_easy_setopt() rejects the CR LF before
+# the transfer starts, so curl never connects and the injected DELE command is
+# never sent.
 <errorcode>
 43
 </errorcode>
-# the account is rejected before ACCT is built, so the injected DELE command
-# must never reach the server
-<protocol crlf="yes">
-USER anonymous
-PASS ftp@example.com
-</protocol>
 </verify>
 </testcase>

--- a/tests/data/test2116
+++ b/tests/data/test2116
@@ -32,14 +32,11 @@ ftp://%HOSTIP:%FTPPORT/%TESTNUMBER/ -K %LOGDIR/test%TESTNUMBER.config
 
 # Verify data after the test has been "shot"
 <verify>
-# 43 - CURLE_BAD_FUNCTION_ARGUMENT
+# 43 - CURLE_BAD_FUNCTION_ARGUMENT. curl_easy_setopt() rejects the CR LF before
+# the transfer starts, so curl never connects and the injected DELE command is
+# never sent.
 <errorcode>
 43
 </errorcode>
-# the replacement command is rejected before it is sent, so the injected DELE
-# command must never reach the server
-<protocol crlf="yes">
-USER anonymous
-</protocol>
 </verify>
 </testcase>

--- a/tests/data/test657
+++ b/tests/data/test657
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+curl_easy_setopt
+CRLF injection
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<name>
+verify that curl_easy_setopt() rejects CR and LF in string options
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -79,7 +79,8 @@ TESTS_C = \
   lib586.c                   lib589.c lib590.c lib591.c \
   lib597.c lib598.c lib599.c \
   lib643.c \
-  lib650.c lib651.c lib652.c lib653.c lib654.c lib655.c lib658.c lib659.c \
+  lib650.c lib651.c lib652.c lib653.c lib654.c lib655.c lib657.c lib658.c \
+  lib659.c \
   lib661.c                                     lib666.c lib667.c lib668.c \
   lib670.c                            lib674.c lib676.c lib677.c lib678.c \
   lib694.c lib695.c \

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -146,6 +146,7 @@ TESTS_C = \
   lib653.c \
   lib654.c \
   lib655.c \
+  lib657.c \
   lib658.c \
   lib659.c \
   lib661.c \

--- a/tests/libtest/lib657.c
+++ b/tests/libtest/lib657.c
@@ -1,0 +1,92 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+/*
+ * A CR or LF in a string option would let curl write an extra request line or
+ * header onto the connection, so curl_easy_setopt() must reject it. Object and
+ * callback-pointer options such as the POST body are not affected.
+ */
+static CURLcode test_lib657(const char *URL)
+{
+  const struct curl_easyoption *o;
+  CURL *curl;
+  int error = 0;
+  (void)URL;
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  curl = curl_easy_init();
+  if(!curl) {
+    curl_global_cleanup();
+    return TEST_ERR_EASY_INIT;
+  }
+
+  /* every string option must refuse a value carrying a CR or LF */
+  for(o = curl_easy_option_next(NULL); o; o = curl_easy_option_next(o)) {
+    if(o->type == CURLOT_STRING) {
+      CURLcode result = curl_easy_setopt(curl, o->id, "curl\r\nInjected: 1");
+      switch(result) {
+      case CURLE_BAD_FUNCTION_ARGUMENT: /* rejected, as wanted */
+      case CURLE_UNKNOWN_OPTION:        /* left out from the build */
+      case CURLE_NOT_BUILT_IN:          /* not supported */
+      case CURLE_UNSUPPORTED_PROTOCOL:  /* detected by protocol2num() */
+        break;
+      default:
+        curl_mfprintf(stderr, "curl_easy_setopt(%s, CRLF) returned %d\n",
+                      o->name, (int)result);
+        error++;
+        break;
+      }
+    }
+  }
+
+  /* a lone CR and a lone LF are both refused */
+  if(curl_easy_setopt(curl, CURLOPT_URL, "http://a/\rb") !=
+     CURLE_BAD_FUNCTION_ARGUMENT) {
+    curl_mfprintf(stderr, "CR in URL not rejected\n");
+    error++;
+  }
+  if(curl_easy_setopt(curl, CURLOPT_URL, "http://a/\nb") !=
+     CURLE_BAD_FUNCTION_ARGUMENT) {
+    curl_mfprintf(stderr, "LF in URL not rejected\n");
+    error++;
+  }
+
+  /* a clean value is still accepted */
+  if(curl_easy_setopt(curl, CURLOPT_URL, "http://example.com/") != CURLE_OK) {
+    curl_mfprintf(stderr, "clean URL rejected\n");
+    error++;
+  }
+
+  /* the POST body is not a string option and may carry a CR or LF */
+  if(curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "a\r\nb") != CURLE_OK) {
+    curl_mfprintf(stderr, "CRLF POST body rejected\n");
+    error++;
+  }
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return error ? TEST_ERR_FAILURE : CURLE_OK;
+}

--- a/tests/libtest/lib657.c
+++ b/tests/libtest/lib657.c
@@ -1,0 +1,115 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+/*
+ * A CR or LF in a string option would let curl write an extra request line or
+ * header onto the connection, so curl_easy_setopt() must reject it. Object and
+ * callback-pointer options such as the POST body are not affected. The URL is
+ * left for the URL parser to reject and credentials are checked per protocol
+ * at transfer time instead (test 1910 verifies the HTTP case).
+ */
+static CURLcode test_lib657(const char *URL)
+{
+  const struct curl_easyoption *o;
+  CURL *curl;
+  int error = 0;
+  (void)URL;
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  curl = curl_easy_init();
+  if(!curl) {
+    curl_global_cleanup();
+    return TEST_ERR_EASY_INIT;
+  }
+
+  /* every string option must refuse a value carrying a CR or LF */
+  for(o = curl_easy_option_next(NULL); o; o = curl_easy_option_next(o)) {
+    if(o->type == CURLOT_STRING) {
+      CURLcode result;
+      switch(o->id) {
+      case CURLOPT_URL:           /* the URL parser rejects these bytes */
+      case CURLOPT_USERPWD:       /* credentials are checked per protocol */
+      case CURLOPT_USERNAME:
+      case CURLOPT_PASSWORD:
+      case CURLOPT_PROXYUSERPWD:
+      case CURLOPT_PROXYUSERNAME:
+      case CURLOPT_PROXYPASSWORD:
+        continue;
+      default:
+        break;
+      }
+      result = curl_easy_setopt(curl, o->id, "curl\r\nInjected: 1");
+      switch(result) {
+      case CURLE_BAD_FUNCTION_ARGUMENT: /* rejected, as wanted */
+      case CURLE_UNKNOWN_OPTION:        /* left out from the build */
+      case CURLE_NOT_BUILT_IN:          /* not supported */
+      case CURLE_UNSUPPORTED_PROTOCOL:  /* detected by protocol2num() */
+        break;
+      default:
+        curl_mfprintf(stderr, "curl_easy_setopt(%s, CRLF) returned %d\n",
+                      o->name, (int)result);
+        error++;
+        break;
+      }
+    }
+  }
+
+  /* a lone CR and a lone LF are both refused */
+  if(curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "GET\rX") !=
+     CURLE_BAD_FUNCTION_ARGUMENT) {
+    curl_mfprintf(stderr, "CR in custom request not rejected\n");
+    error++;
+  }
+  if(curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "GET\nX") !=
+     CURLE_BAD_FUNCTION_ARGUMENT) {
+    curl_mfprintf(stderr, "LF in custom request not rejected\n");
+    error++;
+  }
+
+  /* a clean value is still accepted */
+  if(curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "GET") != CURLE_OK) {
+    curl_mfprintf(stderr, "clean custom request rejected\n");
+    error++;
+  }
+
+  /* the POST body is not a string option and may carry a CR or LF */
+  if(curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "a\r\nb") != CURLE_OK) {
+    curl_mfprintf(stderr, "CRLF POST body rejected\n");
+    error++;
+  }
+
+  /* credentials may carry these bytes at setopt time; protocols that cannot
+     take them reject them when the transfer starts */
+  if(curl_easy_setopt(curl, CURLOPT_USERPWD, "user\nname:pass\nword") !=
+     CURLE_OK) {
+    curl_mfprintf(stderr, "LF in credentials rejected at setopt\n");
+    error++;
+  }
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return error ? TEST_ERR_FAILURE : CURLE_OK;
+}


### PR DESCRIPTION
`Repro:` pass a value holding a `CR` or `LF` to any string `setopt()` option that curl later writes into a protocol command or header, e.g. `CURLOPT_RTSP_STREAM_URI` = `rtsp://example/\r\nOPTIONS rtsp://evil/ RTSP/1.0`, or `CURLOPT_MAIL_FROM` / `CURLOPT_FTP_ACCOUNT`, then issue the request.

`Cause:` `curl_easy_setopt()` stored these strings verbatim, so an embedded `CRLF` ended the request line/header and smuggled an extra request or header onto the connection. The checks lived per-protocol (FTP/SMTP/gopher/MQTT, and the RTSP fields here) or not at all.

`Fix:` reject a `CR` or `LF` in every `CURLOT_STRING` option from one place at the top of the char-pointer `setopt` path, returning `CURLE_BAD_FUNCTION_ARGUMENT`. Object and callback-pointer options (the POST body, the error buffer, user pointers) share the path but are keyed out by type, so values that may legitimately carry these bytes are untouched.

New test `657` walks every string option and confirms the rejection. `2110`, `2115` and `2116` now stop at `setopt` instead of mid-transfer.
