### PR TITLE
test798: force IPv4 to avoid cross-runner port aliasing

### DIFF
--- a/tests/data/test798
+++ b/tests/data/test798
@@ -36,7 +36,7 @@ http
 HTTP cookies in a folded header
 </name>
 <command>
-http://localhost:%HTTPPORT/we/want/%TESTNUMBER -b none -c %LOGDIR/jar%TESTNUMBER.txt
+-4 http://localhost:%HTTPPORT/we/want/%TESTNUMBER -b none -c %LOGDIR/jar%TESTNUMBER.txt
 </command>
 <features>
 cookies


### PR DESCRIPTION
`test798` is the only test fetching `http://localhost:%HTTPPORT` without `-4`, since it needs the hostname for its folded `domain=localhost` cookie. curl tries `::1` first, but the test HTTP server is IPv4-only. On the BSDs, IPv4 and IPv6 have separate ephemeral port namespaces, so with every test server binding port 0, another parallel runner's IPv6-bound server can hold the same numeric port. curl then connects to the wrong runner's server, which cannot open its own `log/N/test798` and closes without a response, giving exit 52 and an empty `server.input`.

This PR fixes this flake by adding `-4` matches what tests 389 and 392 already do. Linux is immune because wildcard IPv6 binds occupy the IPv4 port too. Seen in https://github.com/curl/curl/actions/runs/29229170329/job/86749470571.