### PR TITLE
tests: avoid stale test file parts on retries

### DIFF
--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -3142,7 +3142,8 @@ while(1) {
     $| = 1;
 
     &customize(); # read test control instructions
-    loadtest("$logdir/test$testno");
+    # force a reload, a test retry may have regenerated the file
+    loadtest("$logdir/test$testno", 0, 1);
 
     my $welcome = $commandreply{"welcome"};
     if(!$welcome) {

--- a/tests/getpart.pm
+++ b/tests/getpart.pm
@@ -44,7 +44,7 @@ BEGIN {
     );
 }
 
-use Memoize;
+use Memoize qw(memoize flush_cache);
 
 my @xml;      # test data file contents
 my $xmlfile;  # test data filename
@@ -199,15 +199,20 @@ sub partexists {
 # memoize('partexists', NORMALIZER => 'normalize_part');  # cache each result
 
 sub loadtest {
-    my ($file, $original) = @_;
+    my ($file, $original, $force) = @_;
 
-    if(defined $xmlfile && $file eq $xmlfile) {
+    if(!$force && defined $xmlfile && $file eq $xmlfile) {
         # This test is already loaded
         return
     }
 
     undef @xml;
     $xmlfile = "";
+
+    # flush results cached from an earlier load, the file may have been
+    # regenerated since with new variable substitutions
+    flush_cache('getpart');
+    flush_cache('getpartattr');
 
     if(open(my $xmlh, "<", $file)) {
         if($original) {

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -655,8 +655,8 @@ sub singletest_preprocess {
     }
     close($fulltesth) or die "Failure writing test file";
 
-    # in case the process changed the file, reload it
-    loadtest("$LOGDIR/test${testnum}");
+    # the file contents just changed, force it to be reloaded
+    loadtest("$LOGDIR/test${testnum}", 0, 1);
 }
 
 #######################################################################

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -655,7 +655,7 @@ sub singletest_preprocess {
     }
     close($fulltesth) or die "Failure writing test file";
 
-    # the file contents just changed, force it to be reloaded
+    # in case the process changed the file, force a reload
     loadtest("$LOGDIR/test${testnum}", 0, 1);
 }
 


### PR DESCRIPTION
`getpart` and `getpartattr` results are memoized keyed on section, part and filename (2039253c6e). When a test is retried, `singletest_preprocess` regenerates the preprocessed file with fresh variable substitutions, such as a new server port, but the stale cached parts keep being returned, so retries reuse the old port and `--retry` cannot recover. One flaky hit of test 798 (the root cause of which I fixed in https://github.com/curl/curl/pull/22318) thus became five identical failures and a red job.

This PR adjusts `loadtest` to flush the memoized caches whenever it actually reads a file, and `singletest_preprocess` to force the reload past the already-loaded check. Repeated same-file calls still return early with a warm cache.

The same staleness also exists in `ftpserver.pl`, which holds its own copy of these caches in a long lived process and leans on the already-loaded check in every command handler. A retry landing on the same runner would keep serving the previous attempt's file, and that predates the memoization since the check also keeps the old file contents. The server now forces a reload whenever a client connects, while lookups within a connection stay warm.
