### PR TITLE
tidy-up: `TEXT()` vs `_TEXT()` vs `_T()` use (Windows)

### DIFF
--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -101,7 +101,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   xcharp_u passwd, dup_passwd;
   size_t domlen = 0;
 
-  domain.const_tchar_ptr = TEXT("");
+  domain.const_tchar_ptr = _TEXT("");
 
   /* Initialize the identity */
   memset(identity, 0, sizeof(*identity));
@@ -110,9 +110,9 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   if(!useranddomain.tchar_ptr)
     return CURLE_OUT_OF_MEMORY;
 
-  user.const_tchar_ptr = _tcschr(useranddomain.const_tchar_ptr, TEXT('\\'));
+  user.const_tchar_ptr = _tcschr(useranddomain.const_tchar_ptr, _TEXT('\\'));
   if(!user.const_tchar_ptr)
-    user.const_tchar_ptr = _tcschr(useranddomain.const_tchar_ptr, TEXT('/'));
+    user.const_tchar_ptr = _tcschr(useranddomain.const_tchar_ptr, _TEXT('/'));
 
   if(user.tchar_ptr) {
     domain.tchar_ptr = useranddomain.tchar_ptr;
@@ -121,7 +121,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   }
   else {
     user.tchar_ptr = useranddomain.tchar_ptr;
-    domain.const_tchar_ptr = TEXT("");
+    domain.const_tchar_ptr = _TEXT("");
     domlen = 0;
   }
 

--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -121,7 +121,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
   *out = NULL;
 
   /* skip paths already normalized */
-  if(!_tcsncmp(in, _T("\\\\?\\"), 4))
+  if(!_tcsncmp(in, _TEXT("\\\\?\\"), 4))
     goto cleanup;
 
 #ifndef _UNICODE

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -316,34 +316,35 @@ static CURLcode get_cert_location(TCHAR *path, DWORD *store_name,
   TCHAR *store_path_start;
   size_t store_name_len;
 
-  sep = _tcschr(path, TEXT('\\'));
+  sep = _tcschr(path, _TEXT('\\'));
   if(!sep)
     return CURLE_SSL_CERTPROBLEM;
 
   store_name_len = sep - path;
 
-  if(_tcsncmp(path, TEXT("CurrentUser"), store_name_len) == 0)
+  if(_tcsncmp(path, _TEXT("CurrentUser"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_CURRENT_USER;
-  else if(_tcsncmp(path, TEXT("LocalMachine"), store_name_len) == 0)
+  else if(_tcsncmp(path, _TEXT("LocalMachine"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE;
-  else if(_tcsncmp(path, TEXT("CurrentService"), store_name_len) == 0)
+  else if(_tcsncmp(path, _TEXT("CurrentService"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_CURRENT_SERVICE;
-  else if(_tcsncmp(path, TEXT("Services"), store_name_len) == 0)
+  else if(_tcsncmp(path, _TEXT("Services"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_SERVICES;
-  else if(_tcsncmp(path, TEXT("Users"), store_name_len) == 0)
+  else if(_tcsncmp(path, _TEXT("Users"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_USERS;
-  else if(_tcsncmp(path, TEXT("CurrentUserGroupPolicy"), store_name_len) == 0)
+  else if(_tcsncmp(path, _TEXT("CurrentUserGroupPolicy"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY;
-  else if(_tcsncmp(path, TEXT("LocalMachineGroupPolicy"), store_name_len) == 0)
+  else if(_tcsncmp(path, _TEXT("LocalMachineGroupPolicy"), store_name_len)
+          == 0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY;
-  else if(_tcsncmp(path, TEXT("LocalMachineEnterprise"), store_name_len) == 0)
+  else if(_tcsncmp(path, _TEXT("LocalMachineEnterprise"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE;
   else
     return CURLE_SSL_CERTPROBLEM;
 
   store_path_start = sep + 1;
 
-  sep = _tcschr(store_path_start, TEXT('\\'));
+  sep = _tcschr(store_path_start, _TEXT('\\'));
   if(!sep)
     return CURLE_SSL_CERTPROBLEM;
 
@@ -351,9 +352,9 @@ static CURLcode get_cert_location(TCHAR *path, DWORD *store_name,
   if(_tcslen(*thumbprint) != CERT_THUMBPRINT_STR_LEN)
     return CURLE_SSL_CERTPROBLEM;
 
-  *sep = TEXT('\0');
+  *sep = _TEXT('\0');
   *store_path = curlx_tcsdup(store_path_start);
-  *sep = TEXT('\\');
+  *sep = _TEXT('\\');
   if(!*store_path)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -334,8 +334,8 @@ static CURLcode get_cert_location(TCHAR *path, DWORD *store_name,
     *store_name = CERT_SYSTEM_STORE_USERS;
   else if(_tcsncmp(path, _TEXT("CurrentUserGroupPolicy"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY;
-  else if(_tcsncmp(path, _TEXT("LocalMachineGroupPolicy"), store_name_len)
-          == 0)
+  else if(_tcsncmp(path, _TEXT("LocalMachineGroupPolicy"), store_name_len) ==
+          0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY;
   else if(_tcsncmp(path, _TEXT("LocalMachineEnterprise"), store_name_len) == 0)
     *store_name = CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE;

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
   /* Undocumented diagnostic option to list the full paths of all loaded
      modules. This is purposely pre-init. */
-  if(argc == 2 && !_tcscmp(argv[1], _T("--dump-module-paths"))) {
+  if(argc == 2 && !_tcscmp(argv[1], _TEXT("--dump-module-paths"))) {
     struct curl_slist *item, *head = GetLoadedModulePaths();
     for(item = head; item; item = item->next)
       curl_mprintf("%s\n", item->data);


### PR DESCRIPTION
Use `_TEXT()` when interacting with CRT functions (also prefer over
synonym `_T()`), `TEXT()` for Win32 functions.

Within curl, they mean the same because CRT/Win32 Unicode mode are
always enabled in sync.

Ref: https://devblogs.microsoft.com/oldnewthing/20040212-00/?p=40643/

---

I'm not firmly for `_TEXT()` over `_T()`. Just assumed the former is the
official macro based on Raymond not knowing about the short form. We
may stick with the short one, less symmetry, rarer, less greppable, but
shorter. Altogether rarely used in the code.
