### PR TITLE
http: avoid length underflow in `Curl_compareheader`

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1440,6 +1440,10 @@ bool Curl_compareheader(const char *headerline, /* line to check */
       do
         curlx_str_passblanks(&p);
       while(!curlx_str_single(&p, ','));
+      /* trailing blanks may move the parsing point past the value end,
+         then there is nothing left to match */
+      if((size_t)(p - o) > len)
+        break;
       len -= (p - o);
     }
   }

--- a/tests/data/test1625
+++ b/tests/data/test1625
@@ -19,7 +19,7 @@ Curl_compareheader unit test
 
 <verify>
 <stdout mode="text">
-31 invokes
+33 invokes
 </stdout>
 </verify>
 </testcase>

--- a/tests/unit/unit1625.c
+++ b/tests/unit/unit1625.c
@@ -102,6 +102,11 @@ static CURLcode test_unit1625(const char *arg)
     { "Encoding: super-nice", "Encoding:", "super-nice", TRUE },
     /* hyphenated second token */
     { "Encoding: extra-good, super-nice", "Encoding:", "super-nice", TRUE },
+    /* trailing blanks after the last comma */
+    { "Encoding: gzipped,  ", "Encoding:", "gzip", FALSE },
+    /* the scan must not cross into a second line */
+    { "Encoding: gzipped,  \r\nEncoding: gzip, chunked", "Encoding:",
+      "chunked", FALSE },
   };
 
   for(i = 0; i < CURL_ARRAYSIZE(list); i++) {


### PR DESCRIPTION
Since curl 8.20.0, the comma scan in `Curl_compareheader` subtracts the bytes consumed in each round from the remaining value length, but skipping trailing blanks can move the parsing point past the trimmed value end, wrapping the unsigned length. The scan then continues beyond the value and can match a token after an embedded newline. This adds a guard that stops the loop at the value end, with new unit 1625 cases covering both shapes.