### PR TITLE
ldap: base64-encode LDIF values beginning with colon or less-than

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -238,8 +238,10 @@ static bool ldap_value_needs_base64(const char *attr, size_t attr_len,
   if((attr_len > 7) && curl_strequal(";binary", attr + attr_len - 7))
     return TRUE;
 
-  /* check for leading or trailing whitespace */
-  if(val->bv_len && (ISBLANK(val->bv_val[0]) ||
+  /* check for a leading ':' or '<' (not a SAFE-INIT-CHAR per RFC 2849) or
+     leading or trailing whitespace */
+  if(val->bv_len && ((val->bv_val[0] == ':') || (val->bv_val[0] == '<') ||
+                     ISBLANK(val->bv_val[0]) ||
                      ISBLANK(val->bv_val[val->bv_len - 1])))
     return TRUE;
 

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1206,9 +1206,11 @@ static CURLcode oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
           break;
 
         if(!binary) {
-          /* check for leading or trailing whitespace */
+          /* check for a leading ':' or '<' (not a SAFE-INIT-CHAR per RFC
+             2849) or leading or trailing whitespace */
           if(bvals[i].bv_len &&
-             (ISBLANK(bvals[i].bv_val[0]) ||
+             ((bvals[i].bv_val[0] == ':') || (bvals[i].bv_val[0] == '<') ||
+              ISBLANK(bvals[i].bv_val[0]) ||
               ISBLANK(bvals[i].bv_val[bvals[i].bv_len - 1])))
             binval = TRUE;
           else {


### PR DESCRIPTION
Repro: an `ldap://` reply carrying an attribute value whose first byte is `:` or `<` (both printable) is written to the client as `\tattr: :value`.
Cause: `ldap_value_needs_base64()` in `ldap.c` and the inline check in `oldap_recv()` in `openldap.c` base64 a value that holds a control byte or leading/trailing blank, but not one that begins with `:` or `<`. RFC 2849 excludes both from `SAFE-INIT-CHAR`, so the unencoded line is not valid LDIF and `ldapsearch` base64s these.
Fix: treat a leading `:` or `<` as needing base64 in both backends.
