### PR TITLE
timeval: rename timer frequency variable

### DIFF
--- a/lib/curlx/timeval.c
+++ b/lib/curlx/timeval.c
@@ -27,24 +27,24 @@
 
 #include "system_win32.h"
 
-static LARGE_INTEGER time_freq;
+static LARGE_INTEGER s_time_freq;
 
 /* For tool or tests, we must initialize before calling curlx_now().
    Providing this function here is wrong. */
 void curlx_now_init(void)
 {
-  QueryPerformanceFrequency(&time_freq);
+  QueryPerformanceFrequency(&s_time_freq);
 }
 
 /* In case of bug fix this function has a counterpart in tool_util.c */
 void curlx_pnow(struct curltime *pnow)
 {
   LARGE_INTEGER count;
-  DEBUGASSERT(time_freq.QuadPart);
+  DEBUGASSERT(s_time_freq.QuadPart);
   QueryPerformanceCounter(&count);
-  pnow->tv_sec = (time_t)(count.QuadPart / time_freq.QuadPart);
-  pnow->tv_usec = (int)((count.QuadPart % time_freq.QuadPart) * 1000000 /
-                        time_freq.QuadPart);
+  pnow->tv_sec = (time_t)(count.QuadPart / s_time_freq.QuadPart);
+  pnow->tv_usec = (int)((count.QuadPart % s_time_freq.QuadPart) * 1000000 /
+                        s_time_freq.QuadPart);
 }
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC) || \

--- a/lib/curlx/timeval.c
+++ b/lib/curlx/timeval.c
@@ -27,24 +27,24 @@
 
 #include "system_win32.h"
 
-static LARGE_INTEGER Curl_freq;
+static LARGE_INTEGER time_freq;
 
 /* For tool or tests, we must initialize before calling curlx_now().
    Providing this function here is wrong. */
 void curlx_now_init(void)
 {
-  QueryPerformanceFrequency(&Curl_freq);
+  QueryPerformanceFrequency(&time_freq);
 }
 
 /* In case of bug fix this function has a counterpart in tool_util.c */
 void curlx_pnow(struct curltime *pnow)
 {
   LARGE_INTEGER count;
-  DEBUGASSERT(Curl_freq.QuadPart);
+  DEBUGASSERT(time_freq.QuadPart);
   QueryPerformanceCounter(&count);
-  pnow->tv_sec = (time_t)(count.QuadPart / Curl_freq.QuadPart);
-  pnow->tv_usec = (int)((count.QuadPart % Curl_freq.QuadPart) * 1000000 /
-                        Curl_freq.QuadPart);
+  pnow->tv_sec = (time_t)(count.QuadPart / time_freq.QuadPart);
+  pnow->tv_usec = (int)((count.QuadPart % time_freq.QuadPart) * 1000000 /
+                        time_freq.QuadPart);
 }
 
 #elif defined(HAVE_CLOCK_GETTIME_MONOTONIC) || \


### PR DESCRIPTION
It's no longer a global variable.

Follow-up to 1027d07704836c8d642abbed34ab98535de47433 #22346

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
