### PR TITLE
fopen: do not truncate the destination file before the rename

### DIFF
--- a/lib/curl_fopen.c
+++ b/lib/curl_fopen.c
@@ -90,19 +90,52 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   char *tempstore = NULL;
 #ifndef _WIN32
   curlx_struct_stat sb;
+  int pfd;
 #endif
   int fd = -1;
   char *dir = NULL;
   *tempname = NULL;
 
 #ifndef _WIN32
-  *fh = curlx_fopen(filename, FOPEN_WRITETEXT);
-  if(!*fh)
-    goto fail;
-  if(curlx_fstat(fileno(*fh), &sb) == -1 || !S_ISREG(sb.st_mode)) {
-    return CURLE_OK;
+  /* probe the destination without O_TRUNC so that an existing file is not
+     modified, then classify it from the descriptor to avoid acting on a
+     name that a check looked at earlier */
+  pfd = curlx_open(filename, O_WRONLY);
+  if(pfd != -1) {
+    if(curlx_fstat(pfd, &sb) == -1) {
+      curlx_close(pfd);
+      goto fail;
+    }
+    if(!S_ISREG(sb.st_mode)) {
+      /* a non-regular file, write to it directly */
+      *fh = curlx_fdopen(pfd, FOPEN_WRITETEXT);
+      if(*fh)
+        return CURLE_OK;
+      curlx_close(pfd);
+      goto fail;
+    }
+    /* an existing regular file, leave it untouched until the temp file
+       is renamed into place */
+    curlx_close(pfd);
   }
-  curlx_fclose(*fh);
+  else if(errno == ENOENT) {
+    /* nothing here yet, create the file - exclusively, to not follow a
+       symlink planted in the meantime */
+    pfd = curlx_open(filename, O_WRONLY | O_CREAT | O_EXCL, 0666);
+    if(pfd == -1)
+      goto fail;
+    *fh = curlx_fdopen(pfd, FOPEN_WRITETEXT);
+    if(*fh)
+      return CURLE_OK;
+    curlx_close(pfd);
+    goto fail;
+  }
+  else {
+    /* not writable, but an existing regular file can still be replaced
+       by the rename below */
+    if(curlx_stat(filename, &sb) == -1 || !S_ISREG(sb.st_mode))
+      goto fail;
+  }
 #ifdef HAVE_GETEUID
   /* If the existing file is not owned by the user, do not inherit
    * its permissions at the temp file created below. The permissions

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -220,7 +220,7 @@ test1645 test1646 test1647 test1648 test1649 test1650 test1651 test1652 \
 test1653 test1654 test1655 test1656 test1657 test1658 test1659 test1660 \
 test1661 test1662 test1663 test1664 test1665 test1666 test1667 test1668 \
 test1669 test1670 test1671 test1672 test1673 test1674 test1675 test1676 \
-test1677 test1678          test1680 test1681 test1682 test1683 test1684 \
+test1677 test1678 test1679 test1680 test1681 test1682 test1683 test1684 \
 test1685 test1686 \
 \
 test1700          test1702 test1703 test1704 test1705 test1706 test1707 \

--- a/tests/data/test1679
+++ b/tests/data/test1679
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+cookies
+</keywords>
+</info>
+
+<client>
+<features>
+unittest
+</features>
+<name>
+Curl_fopen must not clobber an existing destination file
+</name>
+<command>
+%LOGDIR/fopen%TESTNUMBER
+</command>
+</client>
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -42,7 +42,7 @@ TESTS_C = \
   unit1650.c unit1651.c unit1652.c unit1653.c unit1654.c unit1655.c unit1656.c \
   unit1657.c unit1658.c            unit1660.c unit1661.c unit1663.c unit1664.c \
              unit1666.c unit1667.c unit1668.c unit1669.c \
-  unit1674.c unit1675.c unit1676.c \
+  unit1674.c unit1675.c unit1676.c unit1679.c \
   unit1961.c unit1979.c unit1980.c \
   unit2413.c \
   unit2600.c unit2601.c unit2602.c unit2603.c unit2604.c unit2605.c \

--- a/tests/unit/unit1679.c
+++ b/tests/unit/unit1679.c
@@ -1,0 +1,208 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+
+#if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_ALTSVC) || \
+  !defined(CURL_DISABLE_HSTS)
+
+#include "urldata.h"
+#include "curl_fopen.h"
+
+static void write_unit1679(const char *file, const char *content)
+{
+  FILE *f = curlx_fopen(file, FOPEN_WRITETEXT);
+  if(f) {
+    fputs(content, f);
+    curlx_fclose(f);
+  }
+}
+
+/* return TRUE if the file holds exactly the given content */
+static bool check_unit1679(const char *file, const char *content)
+{
+  char buf[80];
+  size_t nread;
+  FILE *f = curlx_fopen(file, FOPEN_READTEXT);
+  if(!f)
+    return FALSE;
+  nread = fread(buf, 1, sizeof(buf) - 1, f);
+  curlx_fclose(f);
+  buf[nread] = '\0';
+  return !strcmp(buf, content);
+}
+
+/* Curl_fopen() writes to a temp file, so an existing file at the target
+   name keeps its content until the temp file is renamed into place. */
+static CURLcode test_unit1679(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+
+  CURL *easy;
+  FILE *fh = NULL;
+  char *tempname = NULL;
+  CURLcode result;
+  char file[256];
+  static const char before[] = "original file content\n";
+  static const char after[] = "new file content\n";
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  easy = curl_easy_init();
+  abort_unless(easy, "curl_easy_init()");
+
+  curl_msnprintf(file, sizeof(file), "%s.txt", arg);
+
+  /* write to an existing file: it must keep its content until the temp
+     file replaces it in the rename */
+  write_unit1679(file, before);
+  result = Curl_fopen(easy, file, &fh, &tempname);
+  fail_unless(!result && fh, "Curl_fopen() on an existing file");
+  if(!result && fh) {
+    fail_unless(check_unit1679(file, before), "original file was clobbered");
+    fputs(after, fh);
+    curlx_fclose(fh);
+    fh = NULL;
+    fail_unless(tempname, "no temp file name was returned");
+    if(tempname) {
+      fail_unless(!curlx_rename(tempname, file), "rename to target failed");
+      fail_unless(check_unit1679(file, after), "bad content after rename");
+      curlx_safefree(tempname);
+    }
+  }
+
+#ifndef _WIN32
+  {
+    /* writing via a symlink must not touch the link target, the rename
+       replaces the symlink itself */
+    char slink[256];
+    const char *base = strrchr(file, '/');
+    base = base ? base + 1 : file;
+    curl_msnprintf(slink, sizeof(slink), "%s.link", arg);
+    write_unit1679(file, before);
+    unlink(slink);
+    /* the link sits in the same directory as the target file */
+    if(!symlink(base, slink)) {
+      result = Curl_fopen(easy, slink, &fh, &tempname);
+      fail_unless(!result && fh, "Curl_fopen() on a symlink");
+      if(!result && fh) {
+        fail_unless(check_unit1679(file, before),
+                    "symlink target was clobbered");
+        fputs(after, fh);
+        curlx_fclose(fh);
+        fh = NULL;
+        if(tempname) {
+          fail_unless(!curlx_rename(tempname, slink),
+                      "rename to symlink failed");
+          fail_unless(check_unit1679(file, before),
+                      "symlink target was overwritten");
+          fail_unless(check_unit1679(slink, after),
+                      "bad content after rename");
+          curlx_safefree(tempname);
+        }
+      }
+    }
+  }
+  {
+    /* failing to create the temp file must not hurt the original file */
+    char dir[256];
+    char rofile[512];
+    int dfd;
+    curl_msnprintf(dir, sizeof(dir), "%s.dir", arg);
+    if(!mkdir(dir, 0700)) {
+      dfd = curlx_open(dir, O_RDONLY);
+      curl_msnprintf(rofile, sizeof(rofile), "%s/target.txt", dir);
+      write_unit1679(rofile, before);
+      if(dfd != -1 && !fchmod(dfd, 0500)) {
+        /* the open fails unless running privileged, but either way the
+           original file content must remain untouched */
+        result = Curl_fopen(easy, rofile, &fh, &tempname);
+        fail_unless(check_unit1679(rofile, before),
+                    "original file was clobbered in the failure path");
+        if(!result && fh) {
+          curlx_fclose(fh);
+          fh = NULL;
+          if(tempname)
+            unlink(tempname);
+          curlx_safefree(tempname);
+        }
+        fchmod(dfd, 0700);
+      }
+      if(dfd != -1)
+        curlx_close(dfd);
+    }
+  }
+  {
+    /* a missing file gets created and written to directly */
+    char newf[256];
+    curl_msnprintf(newf, sizeof(newf), "%s.new", arg);
+    unlink(newf);
+    result = Curl_fopen(easy, newf, &fh, &tempname);
+    fail_unless(!result && fh, "Curl_fopen() creating a missing file");
+    if(!result && fh) {
+      fputs(after, fh);
+      curlx_fclose(fh);
+      fh = NULL;
+      if(tempname)
+        fail_unless(!curlx_rename(tempname, newf), "rename failed");
+      curlx_safefree(tempname);
+      fail_unless(check_unit1679(newf, after), "bad content in new file");
+    }
+  }
+  {
+    /* a file lacking write permission is still replaced via the temp
+       file, as long as the directory allows it */
+    int ffd;
+    write_unit1679(file, before);
+    ffd = curlx_open(file, O_RDONLY);
+    if(ffd != -1) {
+      if(!fchmod(ffd, 0400)) {
+        result = Curl_fopen(easy, file, &fh, &tempname);
+        fail_unless(!result && fh, "Curl_fopen() on a write-protected file");
+        if(!result && fh) {
+          fputs(after, fh);
+          curlx_fclose(fh);
+          fh = NULL;
+          if(tempname)
+            fail_unless(!curlx_rename(tempname, file), "rename failed");
+          curlx_safefree(tempname);
+          fail_unless(check_unit1679(file, after),
+                      "bad content after replacing a write-protected file");
+        }
+      }
+      curlx_close(ffd);
+    }
+  }
+#endif /* !_WIN32 */
+
+  curl_easy_cleanup(easy);
+
+  UNITTEST_END(curl_global_cleanup())
+}
+#else
+static CURLcode test_unit1679(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+  puts("nothing to do without cookies, alt-svc or hsts support");
+  UNITTEST_END_SIMPLE
+}
+#endif


### PR DESCRIPTION
Since 0c667188e0 (curl 8.2.0) `Curl_fopen()` does `fopen(filename, "w")`
first to find out whether the target is a regular file, and that
truncates the destination right away. If creating the temp file then
fails, for example in a directory that does not allow writes, the
existing cookie jar/hsts/alt-svc file is destroyed by the failed save.
It also truncates the target of a symlink, since `fopen()` follows the
link while the rename later replaces the link itself.

This goes back to a `stat()` check that leaves the destination alone
until the rename, as before that commit, while keeping the newer temp
file mode cloning and its geteuid check.

It is basically the diff sketched in the issue, completed: that version
kept the `fstat()`/`fclose()` of a handle that was no longer opened,
which should be what made it fail the tests.

Verified on macOS with a cookie jar in a write-protected directory and
one behind a symlink: both files ended up zero-length before, both keep
their content now. The new unit test 1679 checks these scenarios and
fails on current master.

Fixes #21610