### PR TITLE
test_06_13, skip on network not observing rfc6666

### DIFF
--- a/tests/http/test_06_eyeballs.py
+++ b/tests/http/test_06_eyeballs.py
@@ -109,7 +109,16 @@ class TestEyeballs:
     @pytest.mark.skipif(condition=not Env.curl_is_verbose(), reason="needs curl verbose strings")
     def test_06_13_timers(self, env: Env):
         curl = CurlClient(env=env)
-        # IPv6 0100::/64 is supposed to go into the void (rfc6666)
+        # IPv6 0100::/64 is supposed to go into the void (rfc6666), but in
+        # some implementations, this is broken. Try to detect this
+        r = curl.http_download(urls=['https://xxx.invalid/'], extra_args=[
+            '--resolve', 'xxx.invalid:443:0100::1',
+            '--connect-timeout', '0.5',
+        ])
+        # this should error with CURLE_OPERATION_TIMEDOUT
+        if r.exit_code != 28:
+            pytest.skip(f'system does not blackhole 0100::/64')
+
         r = curl.http_download(urls=['https://xxx.invalid/'], extra_args=[
             '--resolve', 'xxx.invalid:443:0100::1,0100::2,0100::3',
             '--connect-timeout', '1',

--- a/tests/http/test_06_eyeballs.py
+++ b/tests/http/test_06_eyeballs.py
@@ -117,7 +117,7 @@ class TestEyeballs:
         ])
         # this should error with CURLE_OPERATION_TIMEDOUT
         if r.exit_code != 28:
-            pytest.skip(f'system does not blackhole 0100::/64')
+            pytest.skip('system does not blackhole 0100::/64')
 
         r = curl.http_download(urls=['https://xxx.invalid/'], extra_args=[
             '--resolve', 'xxx.invalid:443:0100::1,0100::2,0100::3',

--- a/tests/http/test_06_eyeballs.py
+++ b/tests/http/test_06_eyeballs.py
@@ -142,7 +142,7 @@ class TestEyeballs:
             # no immediately failed attempts, as should be
             he_timers_set = [line for line in r.trace_lines
                              if re.match(r'.*\[TIMER] \[HAPPY_EYEBALLS] set for', line)]
-            assert len(he_timers_set) == 2, f'found: {"".join(he_timers_set)}\n{r.dump_logs()}'
+            assert len(he_timers_set) >= 2, f'found: {"".join(he_timers_set)}\n{r.dump_logs()}'
 
     # download using HTTP/3 on missing server with alt-svc pointing there
     @pytest.mark.skipif(condition=not Env.have_h3(), reason="missing HTTP/3 support")


### PR DESCRIPTION
In test_06_13 check that 0100::/64 is being blackholed and skip test if system disregards rfc6666.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
