### PR TITLE
reader/writer fixes

### DIFF
--- a/lib/request.h
+++ b/lib/request.h
@@ -109,7 +109,6 @@ struct SingleRequest {
    * checks, pausing by client callbacks. */
   struct {
     struct Curl_creader *stack;
-    BIT(paused);
   } reader;
   struct bufq sendbuf; /* data which needs to be send to the server */
   size_t sendbuf_hds_len; /* amount of header bytes in sendbuf */

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -53,6 +53,7 @@ static void cl_reset_writer(struct Curl_easy *data)
     curlx_free(writer);
     writer = data->req.writer.stack;
   }
+  data->req.writer.paused = FALSE;
 }
 
 static void cl_reset_reader(struct Curl_easy *data)


### PR DESCRIPTION
- clear writer paused bit when destroying writer stack
- remove the reader paused bit that turned out not to be a good idea

