### PR TITLE
ngtcp2: clean up after ngtcp2 in `curl_global_cleanup`

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -267,6 +267,7 @@ void curl_global_cleanup(void)
   }
 
   Curl_ssl_cleanup();
+  Curl_vquic_cleanup();
   Curl_async_global_cleanup();
 
 #ifdef _WIN32

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -66,6 +66,14 @@ int Curl_vquic_init(void)
   return 1;
 }
 
+void Curl_vquic_cleanup(void)
+{
+#if defined(USE_NGTCP2) && defined(OPENSSL_QUIC_API2) && \
+  (NGTCP2_VERSION_NUM >= 0x011800)
+  ngtcp2_crypto_ossl_free();
+#endif
+}
+
 void Curl_quic_ver(char *p, size_t len)
 {
 #if defined(USE_NGTCP2) && defined(USE_NGHTTP3)

--- a/lib/vquic/vquic.h
+++ b/lib/vquic/vquic.h
@@ -33,6 +33,7 @@ struct Curl_addrinfo;
 
 void Curl_quic_ver(char *p, size_t len);
 int Curl_vquic_init(void);
+void Curl_vquic_cleanup(void);
 
 CURLcode Curl_qlogdir(struct Curl_easy *data,
                       unsigned char *scid,
@@ -80,6 +81,7 @@ extern struct Curl_cftype Curl_cft_h3_proxy;
 
 #else
 #define Curl_vquic_init() 1
+#define Curl_vquic_cleanup()
 #endif /* !CURL_DISABLE_HTTP && USE_HTTP3 */
 
 CURLcode Curl_conn_may_http3(struct Curl_easy *data,


### PR DESCRIPTION
Frees the memory allocated by `ngtcp2_crypto_ossl_init`, thus making Valgrind happy. The check for the version is similar to https://github.com/curl/curl/commit/99859ecca85708576e6567d02a24d2ef7501707d.

Ref: https://github.com/ngtcp2/ngtcp2/issues/2207

Couldn't figure out how to ignore those leaks related to the `LD_LIBRARY_PATH` override without a suppression file, but here's the difference:

<details><summary>Before:</summary>

```console
$ ./configure --with-openssl --with-ngtcp2 --enable-debug
$ make -j
$ make -C docs/examples simple
$ export LD_LIBRARY_PATH=lib/.libs
$ valgrind --leak-check=full --show-leak-kinds=all -q docs/examples/.libs/simple >/dev/null
==2673384== 3 bytes in 1 blocks are still reachable in loss record 1 of 20
==2673384==    at 0x48577AF: realloc (vg_replace_malloc.c:1741)
==2673384==    by 0x4F53E2E: CRYPTO_realloc (mem.c:339)
==2673384==    by 0x4F69685: ossl_provider_set_operation_bit (provider_core.c:2035)
==2673384==    by 0x4F4DB57: ossl_method_construct_postcondition (core_fetch.c:100)
==2673384==    by 0x4F4D829: algorithm_do_map (core_algorithm.c:84)
==2673384==    by 0x4F4D829: algorithm_do_this (core_algorithm.c:122)
==2673384==    by 0x4F692AD: ossl_provider_doall_activated (provider_core.c:1603)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4ECB604: inner_ossl_decoder_fetch (decoder_meth.c:385)
==2673384==    by 0x4ECB604: OSSL_DECODER_do_all_provided (decoder_meth.c:562)
==2673384==    by 0x4ECCD18: ossl_decoder_ctx_setup_for_pkey (decoder_pkey.c:524)
==2673384==    by 0x4ECCD18: OSSL_DECODER_CTX_new_for_pkey (decoder_pkey.c:890)
==2673384==    by 0x5109E77: x509_pubkey_ex_d2i_ex (x_pubkey.c:210)
==2673384==    by 0x4DE6D28: asn1_item_embed_d2i (tasn_dec.c:288)
==2673384== 
==2673384== 5 bytes in 1 blocks are still reachable in loss record 2 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53D8D: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F55FA2: CRYPTO_strndup (o_str.c:47)
==2673384==    by 0x4F17F18: evp_kdf_from_algorithm (kdf_meth.c:71)
==2673384==    by 0x4F0CDAC: construct_evp_method (evp_fetch.c:230)
==2673384==    by 0x4F4DA98: ossl_method_construct_this (core_fetch.c:110)
==2673384==    by 0x4F4D804: algorithm_do_map (core_algorithm.c:77)
==2673384==    by 0x4F4D804: algorithm_do_this (core_algorithm.c:122)
==2673384==    by 0x4F692AD: ossl_provider_doall_activated (provider_core.c:1603)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F18321: EVP_KDF_fetch (kdf_meth.c:172)
==2673384== 
==2673384== 8 bytes in 1 blocks are still reachable in loss record 3 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53D8D: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F55ED7: CRYPTO_strdup (o_str.c:31)
==2673384==    by 0x4F6605D: provider_new (provider_core.c:469)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1478)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384==    by 0x49A223E: Curl_vquic_init (vquic.c:62)
==2673384== 
==2673384== 18 bytes in 2 blocks are still reachable in loss record 4 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53D8D: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F55FA2: CRYPTO_strndup (o_str.c:47)
==2673384==    by 0x4EEE526: evp_md_from_algorithm (digest.c:1040)
==2673384==    by 0x4F0CDAC: construct_evp_method (evp_fetch.c:230)
==2673384==    by 0x4F4DA98: ossl_method_construct_this (core_fetch.c:110)
==2673384==    by 0x4F4D804: algorithm_do_map (core_algorithm.c:77)
==2673384==    by 0x4F4D804: algorithm_do_this (core_algorithm.c:122)
==2673384==    by 0x4F692AD: ossl_provider_doall_activated (provider_core.c:1603)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4EF0391: EVP_MD_fetch (digest.c:1163)
==2673384== 
==2673384== 19 bytes in 1 blocks are still reachable in loss record 5 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53D8D: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F55ED7: CRYPTO_strdup (o_str.c:31)
==2673384==    by 0x4DFB058: BIO_meth_new (bio_meth.c:42)
==2673384==    by 0x510F2BD: ossl_bio_prov_init_bio_method (bio_prov.c:210)
==2673384==    by 0x510EAE2: ossl_default_provider_init (defltprov.c:798)
==2673384==    by 0x4F66659: provider_init (provider_core.c:1052)
==2673384==    by 0x4F66659: provider_activate (provider_core.c:1268)
==2673384==    by 0x4F66D1F: provider_activate_fallbacks (provider_core.c:1492)
==2673384==    by 0x4F66D1F: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384== 
==2673384== 32 bytes in 1 blocks are still reachable in loss record 6 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x510EAD2: ossl_default_provider_init (defltprov.c:797)
==2673384==    by 0x4F66659: provider_init (provider_core.c:1052)
==2673384==    by 0x4F66659: provider_activate (provider_core.c:1268)
==2673384==    by 0x4F66D1F: provider_activate_fallbacks (provider_core.c:1492)
==2673384==    by 0x4F66D1F: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384==    by 0x49A223E: Curl_vquic_init (vquic.c:62)
==2673384== 
==2673384== 40 bytes in 1 blocks are still reachable in loss record 7 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53D8D: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x50BA6F8: OPENSSL_sk_deep_copy (stack.c:91)
==2673384==    by 0x4F66040: sk_INFOPAIR_deep_copy (provider_local.h:16)
==2673384==    by 0x4F66040: provider_new (provider_core.c:461)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1478)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384==    by 0x49A223E: Curl_vquic_init (vquic.c:62)
==2673384== 
==2673384== 56 bytes in 1 blocks are still reachable in loss record 8 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4F6C2C2: CRYPTO_THREAD_lock_new (threads_pthread.c:910)
==2673384==    by 0x4F65FFE: provider_new (provider_core.c:453)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1478)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384==    by 0x49A223E: Curl_vquic_init (vquic.c:62)
==2673384== 
==2673384== 56 bytes in 1 blocks are still reachable in loss record 9 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4F6C2C2: CRYPTO_THREAD_lock_new (threads_pthread.c:910)
==2673384==    by 0x4F66010: provider_new (provider_core.c:459)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1478)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384==    by 0x49A223E: Curl_vquic_init (vquic.c:62)
==2673384== 
==2673384== 56 bytes in 1 blocks are still reachable in loss record 10 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4F6C2C2: CRYPTO_THREAD_lock_new (threads_pthread.c:910)
==2673384==    by 0x4F66021: provider_new (provider_core.c:460)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1478)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384==    by 0x49A223E: Curl_vquic_init (vquic.c:62)
==2673384== 
==2673384== 65 bytes in 2 blocks are still reachable in loss record 11 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x40310BF: malloc (rtld-malloc.h:56)
==2673384==    by 0x40310BF: strdup (strdup.c:42)
==2673384==    by 0x401EA89: _dl_load_cache_lookup (dl-cache.c:498)
==2673384==    by 0x4010847: _dl_map_new_object (dl-load.c:2054)
==2673384==    by 0x40153C1: dl_open_worker_begin (dl-open.c:535)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4014665: _dl_open (dl-open.c:900)
==2673384==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2673384== 
==2673384== 65 bytes in 2 blocks are still reachable in loss record 12 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4013F68: malloc (rtld-malloc.h:56)
==2673384==    by 0x4013F68: _dl_new_object (dl-object.c:199)
==2673384==    by 0x400E605: _dl_map_object_from_fd (dl-load.c:1065)
==2673384==    by 0x4010389: _dl_map_new_object (dl-load.c:2187)
==2673384==    by 0x40153C1: dl_open_worker_begin (dl-open.c:535)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4014665: _dl_open (dl-open.c:900)
==2673384==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2673384== 
==2673384== 87 bytes in 7 blocks are still reachable in loss record 13 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53D8D: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F55FA2: CRYPTO_strndup (o_str.c:47)
==2673384==    by 0x4F05F69: evp_cipher_from_algorithm (evp_enc.c:1912)
==2673384==    by 0x4F0CDAC: construct_evp_method (evp_fetch.c:230)
==2673384==    by 0x4F4DA98: ossl_method_construct_this (core_fetch.c:110)
==2673384==    by 0x4F4D804: algorithm_do_map (core_algorithm.c:77)
==2673384==    by 0x4F4D804: algorithm_do_this (core_algorithm.c:122)
==2673384==    by 0x4F692AD: ossl_provider_doall_activated (provider_core.c:1603)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384== 
==2673384== 112 bytes in 1 blocks are still reachable in loss record 14 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4DFB03C: BIO_meth_new (bio_meth.c:39)
==2673384==    by 0x510F2BD: ossl_bio_prov_init_bio_method (bio_prov.c:210)
==2673384==    by 0x510EAE2: ossl_default_provider_init (defltprov.c:798)
==2673384==    by 0x4F66659: provider_init (provider_core.c:1052)
==2673384==    by 0x4F66659: provider_activate (provider_core.c:1268)
==2673384==    by 0x4F66D1F: provider_activate_fallbacks (provider_core.c:1492)
==2673384==    by 0x4F66D1F: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384== 
==2673384== 144 bytes in 1 blocks are still reachable in loss record 15 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4F17EEE: evp_kdf_new (kdf_meth.c:50)
==2673384==    by 0x4F17EEE: evp_kdf_from_algorithm (kdf_meth.c:66)
==2673384==    by 0x4F0CDAC: construct_evp_method (evp_fetch.c:230)
==2673384==    by 0x4F4DA98: ossl_method_construct_this (core_fetch.c:110)
==2673384==    by 0x4F4D804: algorithm_do_map (core_algorithm.c:77)
==2673384==    by 0x4F4D804: algorithm_do_this (core_algorithm.c:122)
==2673384==    by 0x4F692AD: ossl_provider_doall_activated (provider_core.c:1603)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F18321: EVP_KDF_fetch (kdf_meth.c:172)
==2673384==    by 0x4AB9736: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384== 
==2673384== 232 bytes in 1 blocks are still reachable in loss record 16 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4F65FE9: provider_new (provider_core.c:447)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1478)
==2673384==    by 0x4F66CF6: provider_activate_fallbacks (provider_core.c:1435)
==2673384==    by 0x4F68FB6: ossl_provider_doall_activated (provider_core.c:1543)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384==    by 0x49A223E: Curl_vquic_init (vquic.c:62)
==2673384==    by 0x48D1E9D: global_init (easy.c:148)
==2673384== 
==2673384== 496 bytes in 2 blocks are still reachable in loss record 17 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4EEE4D0: evp_md_new (digest.c:944)
==2673384==    by 0x4EEE4D0: evp_md_from_algorithm (digest.c:1025)
==2673384==    by 0x4F0CDAC: construct_evp_method (evp_fetch.c:230)
==2673384==    by 0x4F4DA98: ossl_method_construct_this (core_fetch.c:110)
==2673384==    by 0x4F4D804: algorithm_do_map (core_algorithm.c:77)
==2673384==    by 0x4F4D804: algorithm_do_this (core_algorithm.c:122)
==2673384==    by 0x4F692AD: ossl_provider_doall_activated (provider_core.c:1603)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4EF0391: EVP_MD_fetch (digest.c:1163)
==2673384==    by 0x4AB9708: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384== 
==2673384== 1,344 bytes in 2 blocks are still reachable in loss record 18 of 20
==2673384==    at 0x4857573: calloc (vg_replace_malloc.c:1616)
==2673384==    by 0x401E297: calloc (rtld-malloc.h:44)
==2673384==    by 0x401E297: _dl_check_map_versions (dl-version.c:280)
==2673384==    by 0x4014FFB: dl_open_worker_begin (dl-open.c:617)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4014665: _dl_open (dl-open.c:900)
==2673384==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2673384==    by 0x5668D68: dlerror_run (dl-libc.c:45)
==2673384==    by 0x5668D68: __libc_dlopen_mode (dl-libc.c:162)
==2673384==    by 0x563CB03: module_load (nss_module.c:187)
==2673384== 
==2673384== 2,072 bytes in 7 blocks are still reachable in loss record 19 of 20
==2673384==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2673384==    by 0x4F53FB6: CRYPTO_malloc (mem.c:214)
==2673384==    by 0x4F53FB6: CRYPTO_zalloc (mem.c:226)
==2673384==    by 0x4F05F0E: evp_cipher_new (evp_enc.c:1849)
==2673384==    by 0x4F05F0E: evp_cipher_from_algorithm (evp_enc.c:1897)
==2673384==    by 0x4F0CDAC: construct_evp_method (evp_fetch.c:230)
==2673384==    by 0x4F4DA98: ossl_method_construct_this (core_fetch.c:110)
==2673384==    by 0x4F4D804: algorithm_do_map (core_algorithm.c:77)
==2673384==    by 0x4F4D804: algorithm_do_this (core_algorithm.c:122)
==2673384==    by 0x4F692AD: ossl_provider_doall_activated (provider_core.c:1603)
==2673384==    by 0x4F4D953: ossl_algorithm_do_all (core_algorithm.c:164)
==2673384==    by 0x4F4DCD6: ossl_method_construct (core_fetch.c:157)
==2673384==    by 0x4F0D4A9: inner_evp_generic_fetch (evp_fetch.c:333)
==2673384==    by 0x4F0D4A9: evp_generic_fetch (evp_fetch.c:404)
==2673384==    by 0x4F0CB21: EVP_CIPHER_fetch (evp_enc.c:2077)
==2673384==    by 0x4AB9667: ngtcp2_crypto_ossl_init (in /usr/lib64/libngtcp2_crypto_ossl.so.0.3.0)
==2673384== 
==2673384== 2,523 bytes in 2 blocks are still reachable in loss record 20 of 20
==2673384==    at 0x4857573: calloc (vg_replace_malloc.c:1616)
==2673384==    by 0x4013C0C: calloc (rtld-malloc.h:44)
==2673384==    by 0x4013C0C: _dl_new_object (dl-object.c:92)
==2673384==    by 0x400E605: _dl_map_object_from_fd (dl-load.c:1065)
==2673384==    by 0x4010389: _dl_map_new_object (dl-load.c:2187)
==2673384==    by 0x40153C1: dl_open_worker_begin (dl-open.c:535)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4014665: _dl_open (dl-open.c:900)
==2673384==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2673384==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2673384==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2673384==
```
</details>

<details><summary>After:</summary>

```console
$ ./configure --with-openssl --with-ngtcp2 --enable-debug
$ make -j
$ make -C docs/examples simple
$ export LD_LIBRARY_PATH=lib/.libs
$ valgrind --leak-check=full --show-leak-kinds=all -q docs/examples/.libs/simple >/dev/null
==2619506== 65 bytes in 2 blocks are still reachable in loss record 1 of 4
==2619506==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2619506==    by 0x40310BF: malloc (rtld-malloc.h:56)
==2619506==    by 0x40310BF: strdup (strdup.c:42)
==2619506==    by 0x401EA89: _dl_load_cache_lookup (dl-cache.c:498)
==2619506==    by 0x4010847: _dl_map_new_object (dl-load.c:2054)
==2619506==    by 0x40153C1: dl_open_worker_begin (dl-open.c:535)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4014665: _dl_open (dl-open.c:900)
==2619506==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2619506== 
==2619506== 65 bytes in 2 blocks are still reachable in loss record 2 of 4
==2619506==    at 0x484F8D8: malloc (vg_replace_malloc.c:447)
==2619506==    by 0x4013F68: malloc (rtld-malloc.h:56)
==2619506==    by 0x4013F68: _dl_new_object (dl-object.c:199)
==2619506==    by 0x400E605: _dl_map_object_from_fd (dl-load.c:1065)
==2619506==    by 0x4010389: _dl_map_new_object (dl-load.c:2187)
==2619506==    by 0x40153C1: dl_open_worker_begin (dl-open.c:535)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4014665: _dl_open (dl-open.c:900)
==2619506==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2619506== 
==2619506== 1,344 bytes in 2 blocks are still reachable in loss record 3 of 4
==2619506==    at 0x4857573: calloc (vg_replace_malloc.c:1616)
==2619506==    by 0x401E297: calloc (rtld-malloc.h:44)
==2619506==    by 0x401E297: _dl_check_map_versions (dl-version.c:280)
==2619506==    by 0x4014FFB: dl_open_worker_begin (dl-open.c:617)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4014665: _dl_open (dl-open.c:900)
==2619506==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2619506==    by 0x5668D68: dlerror_run (dl-libc.c:45)
==2619506==    by 0x5668D68: __libc_dlopen_mode (dl-libc.c:162)
==2619506==    by 0x563CB03: module_load (nss_module.c:187)
==2619506== 
==2619506== 2,523 bytes in 2 blocks are still reachable in loss record 4 of 4
==2619506==    at 0x4857573: calloc (vg_replace_malloc.c:1616)
==2619506==    by 0x4013C0C: calloc (rtld-malloc.h:44)
==2619506==    by 0x4013C0C: _dl_new_object (dl-object.c:92)
==2619506==    by 0x400E605: _dl_map_object_from_fd (dl-load.c:1065)
==2619506==    by 0x4010389: _dl_map_new_object (dl-load.c:2187)
==2619506==    by 0x40153C1: dl_open_worker_begin (dl-open.c:535)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x40141CB: dl_open_worker (dl-open.c:762)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4014665: _dl_open (dl-open.c:900)
==2619506==    by 0x5668C04: do_dlopen (dl-libc.c:95)
==2619506==    by 0x4007540: _dl_catch_exception (dl-catch.c:241)
==2619506==    by 0x4007698: _dl_catch_error (dl-catch.c:260)
==2619506==
```
</details>