### PR TITLE
scripts: replace/extend `--` with `--end-of-options` in git commands

### DIFF
--- a/.github/scripts/cleancmd.pl
+++ b/.github/scripts/cleancmd.pl
@@ -122,7 +122,7 @@ sub process {
 }
 
 my @filemasks = @ARGV;
-open(my $git_ls_files, '-|', 'git', 'ls-files', '--', @filemasks) or die "Failed running git ls-files: $!";
+open(my $git_ls_files, '-|', 'git', 'ls-files', '--end-of-options', @filemasks) or die "Failed running git ls-files: $!";
 while(my $f = <$git_ls_files>) {
     chomp $f;
     process($f);

--- a/scripts/badwords
+++ b/scripts/badwords
@@ -318,7 +318,7 @@ sub file {
 }
 
 my @filemasks = @ARGV;
-open(my $git_ls_files, '-|', 'git', 'ls-files', '--', ":!:$file", @filemasks) or die "Failed running git ls-files: $!";
+open(my $git_ls_files, '-|', 'git', 'ls-files', '--end-of-options', ":!:$file", @filemasks) or die "Failed running git ls-files: $!";
 my @files;
 while(my $each = <$git_ls_files>) {
     chomp $each;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -1241,7 +1241,7 @@ sub scanfile {
         }
         else {
             # min-parents=1 to ignore wrong initial commit in truncated repos
-            my $grl = qx(git rev-list --max-count=1 --min-parents=1 --timestamp HEAD --end-of-options "$file");
+            my $grl = qx(git rev-list --max-count=1 --min-parents=1 --timestamp --end-of-options HEAD -- "$file");
             if($grl) {
                 chomp $grl;
                 $commityear = (localtime((split(/ /, $grl))[0]))[5] + 1900;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -1236,12 +1236,12 @@ sub scanfile {
         @copyright = sort {$$b{year} cmp $$a{year}} @copyright;
 
         # if the file is modified, assume commit year this year
-        if(qx(git status -s -- "$file") =~ /^ [MARCU]/) {
+        if(qx(git status -s --end-of-options "$file") =~ /^ [MARCU]/) {
             $commityear = (localtime(time))[5] + 1900;
         }
         else {
             # min-parents=1 to ignore wrong initial commit in truncated repos
-            my $grl = qx(git rev-list --max-count=1 --min-parents=1 --timestamp HEAD -- "$file");
+            my $grl = qx(git rev-list --max-count=1 --min-parents=1 --timestamp HEAD --end-of-options "$file");
             if($grl) {
                 chomp $grl;
                 $commityear = (localtime((split(/ /, $grl))[0]))[5] + 1900;

--- a/scripts/delta
+++ b/scripts/delta
@@ -131,8 +131,8 @@ my $total = $now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
 my $totalhttpget = $now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
 
 # Number of public functions in libcurl
-my $apublic = cmd('git', 'grep', '^CURL_EXTERN', '--', 'include/curl');
-my $bpublic = cmd('git', 'grep', '^CURL_EXTERN', $start, '--', 'include/curl');
+my $apublic = cmd('git', 'grep', '^CURL_EXTERN', '--end-of-options', 'include/curl');
+my $bpublic = cmd('git', 'grep', '^CURL_EXTERN', $start, '--end-of-options', 'include/curl');
 my $public = $apublic - $bpublic;
 
 # diffstat

--- a/scripts/delta
+++ b/scripts/delta
@@ -131,8 +131,8 @@ my $total = $now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
 my $totalhttpget = $now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
 
 # Number of public functions in libcurl
-my $apublic = cmd('git', 'grep', '^CURL_EXTERN', '--end-of-options', 'include/curl');
-my $bpublic = cmd('git', 'grep', '^CURL_EXTERN', $start, '--end-of-options', 'include/curl');
+my $apublic = cmd('git', 'grep', '--end-of-options', '^CURL_EXTERN', 'include/curl');
+my $bpublic = cmd('git', 'grep', '--end-of-options', '^CURL_EXTERN', $start, '--', 'include/curl');
 my $public = $apublic - $bpublic;
 
 # diffstat

--- a/scripts/delta
+++ b/scripts/delta
@@ -131,7 +131,7 @@ my $total = $now - Time::Piece->strptime('19980320', '%Y%m%d')->epoch;
 my $totalhttpget = $now - Time::Piece->strptime('19961111', '%Y%m%d')->epoch;
 
 # Number of public functions in libcurl
-my $apublic = cmd('git', 'grep', '--end-of-options', '^CURL_EXTERN', 'include/curl');
+my $apublic = cmd('git', 'grep', '--end-of-options', '^CURL_EXTERN', '--', 'include/curl');
 my $bpublic = cmd('git', 'grep', '--end-of-options', '^CURL_EXTERN', $start, '--', 'include/curl');
 my $public = $apublic - $bpublic;
 

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -167,7 +167,7 @@ my %api = (
 
 sub doublecheck {
     my ($f, $used) = @_;
-    open(F, '-|', 'git', 'grep', '-Fwle', $f, '--', 'lib', @unittests, 'projects');
+    open(F, '-|', 'git', 'grep', '-Fwle', $f, '--end-of-options', 'lib', @unittests, 'projects');
     my @also;
     while(<F>) {
         my $e = $_;

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -167,7 +167,7 @@ my %api = (
 
 sub doublecheck {
     my ($f, $used) = @_;
-    open(F, '-|', 'git', 'grep', '-Fwle', $f, '--end-of-options', 'lib', @unittests, 'projects');
+    open(F, '-|', 'git', 'grep', '-Fwle', '--end-of-options', $f, 'lib', @unittests, 'projects');
     my @also;
     while(<F>) {
         my $e = $_;

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -167,7 +167,7 @@ my %api = (
 
 sub doublecheck {
     my ($f, $used) = @_;
-    open(F, '-|', 'git', 'grep', '-Fwle', '--end-of-options', $f, 'lib', @unittests, 'projects');
+    open(F, '-|', 'git', 'grep', '-Fwle', '--end-of-options', $f, '--', 'lib', @unittests, 'projects');
     my @also;
     while(<F>) {
         my $e = $_;

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -167,7 +167,7 @@ my %api = (
 
 sub doublecheck {
     my ($f, $used) = @_;
-    open(F, '-|', 'git', 'grep', '-Fwle', '--end-of-options', $f, '--', 'lib', @unittests, 'projects');
+    open(F, '-|', 'git', 'grep', '-Fwl', '--end-of-options', $f, '--', 'lib', @unittests, 'projects');
     my @also;
     while(<F>) {
         my $e = $_;

--- a/tests/test1275.pl
+++ b/tests/test1275.pl
@@ -29,7 +29,7 @@ use warnings;
 my $root = $ARGV[0] || "..";
 
 my @m;
-if(open(O, '-|', 'git', 'ls-files', '--', $root)) {
+if(open(O, '-|', 'git', 'ls-files', '--end-of-options', $root)) {
     push @m, <O>;
     close(O);
 }


### PR DESCRIPTION
It makes these scripts require Git 2.24.0+ (2019-11-04).

Refs:
https://git-scm.com/docs/gitcli
https://nesbitt.io/2026/07/21/end-of-options.html
https://github.com/git/git/commit/19e8789b236dfe33667747d5523d6689bb59b5ef

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
