### PR TITLE
multi: reduce clock_gettime calls to optimize cpu

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -88,7 +88,8 @@ static void multi_xfer_tbl_dump(struct Curl_multi *multi);
 
 static const struct curltime *multi_now(struct Curl_multi *multi)
 {
-  curlx_pnow(&multi->now);
+  if(!multi->processing_socket)
+    curlx_pnow(&multi->now);
   return &multi->now;
 }
 
@@ -3286,6 +3287,9 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   (void)ev_bitmask;
   sigpipe_init(&pipe_ctx);
 
+  curlx_pnow(&multi->now);
+  multi->processing_socket = TRUE;
+
   if(checkall) {
     /* *perform() deals with running_handles on its own */
     mresult = multi_perform(multi, running_handles);
@@ -3318,7 +3322,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
       goto out;
   }
 
-  multi_mark_expired_as_dirty(multi, multi_now(multi));
+  multi_mark_expired_as_dirty(multi, &multi->now);
   mresult = multi_run_dirty(multi, &pipe_ctx, &run_xfers);
   if(mresult)
     goto out;
@@ -3349,6 +3353,7 @@ out:
 
   if(CURLM_OK >= mresult)
     mresult = Curl_update_timer(multi);
+  multi->processing_socket = FALSE;
   return mresult;
 }
 
@@ -3750,7 +3755,10 @@ void Curl_expire_ex(struct Curl_easy *data,
 
   DEBUGASSERT(id < EXPIRE_LAST);
 
-  set = *Curl_pgrs_now(data);
+  if(multi->processing_socket)
+    set = multi->now;
+  else
+    curlx_pnow(&set);
   set.tv_sec += (time_t)(milli / 1000); /* may be a 64 to 32-bit conversion */
   set.tv_usec += (int)(milli % 1000) * 1000;
 

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -206,6 +206,7 @@ struct Curl_multi {
   BIT(xfer_buf_borrowed);      /* xfer_buf is currently being borrowed */
   BIT(xfer_ulbuf_borrowed);    /* xfer_ulbuf is currently being borrowed */
   BIT(xfer_sockbuf_borrowed);  /* xfer_sockbuf is currently being borrowed */
+  BIT(processing_socket);
   BIT(quick_exit);             /* do not join threads on cleanup */
 #ifdef DEBUGBUILD
   BIT(warned);                 /* true after user warned of DEBUGBUILD */


### PR DESCRIPTION
call clock_gettime once at the start of multi_socket_action, reuse it for the entire call instead of calling it once per transfer.
