### PR TITLE
tidy-up: drop redundant includes

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -53,9 +53,8 @@
 #  endif
 #endif
 
-#include <sys/types.h>
-
 #ifdef __APPLE__
+#include <sys/types.h>
 #include <TargetConditionals.h>
 /* Fixup faulty target macro initialization in macOS SDK since v14.4 (as of
    15.0 beta). The SDK target detection in `TargetConditionals.h` correctly
@@ -507,6 +506,7 @@
 #endif
 
 #include <limits.h>
+#include <sys/types.h>
 
 #ifdef _WIN32
 #  ifdef HAVE_IO_H

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -53,8 +53,9 @@
 #  endif
 #endif
 
-#ifdef __APPLE__
 #include <sys/types.h>
+
+#ifdef __APPLE__
 #include <TargetConditionals.h>
 /* Fixup faulty target macro initialization in macOS SDK since v14.4 (as of
    15.0 beta). The SDK target detection in `TargetConditionals.h` correctly
@@ -511,7 +512,6 @@
 #  ifdef HAVE_IO_H
 #  include <io.h>
 #  endif
-#  include <sys/types.h>
 #  include <sys/stat.h>
    /* Large file (>2Gb) support using Win32 functions. */
 #  define curl_lseek                      _lseeki64
@@ -829,10 +829,6 @@
 #include <stdarg.h>
 #include <time.h>
 #include <errno.h>
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
 
 #include <sys/stat.h>
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -506,6 +506,8 @@
 #endif
 
 #include <limits.h>
+/* Include after setting any necessary system macros,
+   and before including sys/stat.h */
 #include <sys/types.h>
 
 #ifdef _WIN32

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -506,8 +506,9 @@
 #endif
 
 #include <limits.h>
-/* Include after setting any necessary system macros,
-   and before including sys/stat.h */
+/* Include after setting system macros that may affect type sizes
+   (e.g. 'off_t' or 'time_t'), or suppress warnings
+   (e.g. '_CRT_SECURE_NO_WARNINGS`), but before including sys/stat.h */
 #include <sys/types.h>
 
 #ifdef _WIN32

--- a/lib/file.c
+++ b/lib/file.c
@@ -47,10 +47,6 @@
 #include <sys/param.h>
 #endif
 
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -40,10 +40,6 @@
 
 #include "curl_setup.h"
 
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
 #include "urldata.h"
 #include "cfilters.h"
 #include "cf-dns.h"

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -40,10 +40,6 @@
 
 #include "curl_setup.h"
 
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
 #include "urldata.h"
 #include "setopt.h"
 #include "strcase.h"

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -25,10 +25,6 @@
 
 #ifdef USE_SSL
 
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
 #include "urldata.h"
 #include "cfilters.h"
 

--- a/src/tool_xattr.h
+++ b/src/tool_xattr.h
@@ -30,7 +30,6 @@
 #  define USE_XATTR
 #elif (defined(__FreeBSD_version) && (__FreeBSD_version > 500000)) || \
   defined(__MidnightBSD_version)
-#  include <sys/types.h>
 #  include <sys/extattr.h>
 #  define USE_XATTR
 #elif defined(_WIN32)

--- a/tests/unit/unit1961.c
+++ b/tests/unit/unit1961.c
@@ -23,12 +23,6 @@
  ***************************************************************************/
 #include "unitcheck.h"
 
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#ifndef _WIN32
-#include <sys/socket.h>
-#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
`sys/types.h` and `sys/socket.h` (non-Win32). They are included via 
`curl/curl.h` and `curl_setup.h`.

This drops `HAVE_SYS_TYPES_H` guards from the codebase. It's safe
because `sys/types.h` (POSIX) is already required unconditionally by
`curl/curl.h`. It remains used in feature checks by both autotools and
cmake; to be reviewed in a future step.
