### PR TITLE
tidy-up: miscellaneous

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -133,7 +133,7 @@ int main(void)
 
 #ifdef HAVE_IOCTLSOCKET
 #ifdef _WIN32
-#  include <winsock2.h>
+#include <winsock2.h>
 #endif
 int main(void)
 {
@@ -160,7 +160,7 @@ int main(void)
 #ifdef HAVE_IOCTLSOCKET_CAMEL_FIONBIO
 #include <proto/bsdsocket.h>
 #ifdef HAVE_SYS_IOCTL_H
-#  include <sys/ioctl.h>
+#include <sys/ioctl.h>
 #endif
 int main(void)
 {
@@ -175,7 +175,7 @@ int main(void)
 
 #ifdef HAVE_IOCTLSOCKET_FIONBIO
 #ifdef _WIN32
-#  include <winsock2.h>
+#include <winsock2.h>
 #endif
 int main(void)
 {
@@ -190,19 +190,19 @@ int main(void)
 #ifdef HAVE_IOCTL_FIONBIO
 /* headers for FIONBIO test */
 #ifdef HAVE_SYS_TYPES_H
-#  include <sys/types.h>
+#include <sys/types.h>
 #endif
 #ifdef HAVE_UNISTD_H
-#  include <unistd.h>
+#include <unistd.h>
 #endif
 #ifndef _WIN32
-#  include <sys/socket.h>
+#include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_IOCTL_H
-#  include <sys/ioctl.h>
+#include <sys/ioctl.h>
 #endif
 #ifdef HAVE_STROPTS_H
-#  include <stropts.h>
+#include <stropts.h>
 #endif
 int main(void)
 {
@@ -217,19 +217,19 @@ int main(void)
 #ifdef HAVE_IOCTL_SIOCGIFADDR
 /* headers for SIOCGIFADDR test */
 #ifdef HAVE_SYS_TYPES_H
-#  include <sys/types.h>
+#include <sys/types.h>
 #endif
 #ifdef HAVE_UNISTD_H
-#  include <unistd.h>
+#include <unistd.h>
 #endif
 #ifndef _WIN32
-#  include <sys/socket.h>
+#include <sys/socket.h>
 #endif
 #ifdef HAVE_SYS_IOCTL_H
-#  include <sys/ioctl.h>
+#include <sys/ioctl.h>
 #endif
 #ifdef HAVE_STROPTS_H
-#  include <stropts.h>
+#include <stropts.h>
 #endif
 #include <net/if.h>
 int main(void)
@@ -244,13 +244,13 @@ int main(void)
 
 #ifdef HAVE_SETSOCKOPT_SO_NONBLOCK
 #ifdef _WIN32
-#  include <winsock2.h>
+#include <winsock2.h>
 #endif
 #ifdef HAVE_SYS_TYPES_H
-#  include <sys/types.h>
+#include <sys/types.h>
 #endif
 #ifndef _WIN32
-#  include <sys/socket.h>
+#include <sys/socket.h>
 #endif
 int main(void)
 {
@@ -338,13 +338,13 @@ int main(void)
 
 #ifdef HAVE_ATOMIC
 #ifdef HAVE_SYS_TYPES_H
-#  include <sys/types.h>
+#include <sys/types.h>
 #endif
 #ifdef HAVE_UNISTD_H
-#  include <unistd.h>
+#include <unistd.h>
 #endif
 #ifdef HAVE_STDATOMIC_H
-#  include <stdatomic.h>
+#include <stdatomic.h>
 #endif
 int main(void)
 {
@@ -356,10 +356,10 @@ int main(void)
 
 #ifdef HAVE_WIN32_WINNT
 #ifdef _WIN32
-#  ifndef NOGDI
-#  define NOGDI
-#  endif
-#  include <windows.h>
+#ifndef NOGDI
+#define NOGDI
+#endif
+#include <windows.h>
 #endif
 
 #define enquote(x) #x
@@ -374,7 +374,7 @@ int main(void)
 
 #ifdef MINGW64_VERSION
 #ifdef __MINGW32__
-#  include <_mingw.h>
+#include <_mingw.h>
 #endif
 
 #define enquote(x) #x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,7 +617,7 @@ include(CheckSymbolExists)
 include(CheckTypeSize)
 include(CheckCSourceCompiles)
 
-option(_CURL_PREFILL "Fast-track known feature detection results (Windows, some Apple)" "${WIN32}")
+option(_CURL_PREFILL "Pre-fill known feature detection results (Windows, some Apple)" "${WIN32}")
 mark_as_advanced(_CURL_PREFILL)
 if(_CURL_PREFILL)
   if(WIN32)

--- a/configure.ac
+++ b/configure.ac
@@ -3814,7 +3814,7 @@ if test "$want_quiche" != "no"; then
     AC_CHECK_LIB(quiche, quiche_conn_send_ack_eliciting,
       [
         AC_CHECK_HEADERS(quiche.h,
-          experimental="$experimental Quiche"
+          experimental="$experimental quiche"
           AC_MSG_NOTICE([HTTP3 support is experimental])
           curl_h3_msg="enabled (quiche)"
           AC_DEFINE(USE_QUICHE, 1, [if quiche is in use])

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -53,7 +53,7 @@ Graduation requirements:
 
 - implementation stability over time with no known severe regressions
 
-### The Quiche backend
+### The quiche backend
 
 Graduation requirements:
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -90,7 +90,7 @@
 /* Disable Visual Studio warnings: 4127 "conditional expression is constant" */
 #pragma warning(disable:4127)
 #ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS  /* for getenv(), sscanf() */
+#define _CRT_SECURE_NO_WARNINGS  /* for getenv(), sscanf(), vsnprintf() */
 #endif
 #endif /* _MSC_VER */
 

--- a/lib/curlx/fopen.c
+++ b/lib/curlx/fopen.c
@@ -110,7 +110,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
   const wchar_t *in_w;
   wchar_t *fbuf = NULL;
 
-  /* MS documented "approximate" limit for the maximum path length */
+  /* MS-documented "approximate" limit for the maximum path length */
   const size_t max_path_len = 32767;
 
 #ifndef _UNICODE

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -373,8 +373,8 @@ static CURLcode ssh_knownhost(struct Curl_easy *data,
                                           (conn->origin->port != PORT_SSH) ?
                                           conn->origin->port : -1,
                                           remotekey, keylen,
-                                          LIBSSH2_KNOWNHOST_TYPE_PLAIN|
-                                          LIBSSH2_KNOWNHOST_KEYENC_RAW|
+                                          LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+                                          LIBSSH2_KNOWNHOST_KEYENC_RAW |
                                           keybit,
                                           &host);
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1368,7 +1368,7 @@ static CURLcode schannel_connect_step2(struct Curl_cfilter *cf,
       /* check if the handshake needs to be continued */
       result = CURLE_OK;
       for(i = 0; i < 3; i++) {
-        /* search for handshake tokens that need to be send */
+        /* search for handshake tokens that need to be sent */
         if(outbuf[i].BufferType == SECBUFFER_TOKEN && outbuf[i].cbBuffer > 0) {
           size_t written = 0;
           DEBUGF(infof(data, "schannel: sending next handshake data: "

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -474,7 +474,7 @@ class ScoreRunner:
         if self._limit_rate:
             title = f'Download Speed ({self.protocol}), limit={Card.fmt_speed(self._limit_rate_num)}, from {meta["server"]}'
         else:
-            title = f'Downloads ({self.protocol})from {meta["server"]}'
+            title = f'Downloads ({self.protocol}) from {meta["server"]}'
         if self._socks_args:
             title += f' via {self._socks_args}'
         return {

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -394,8 +394,7 @@ static int curltest_tweak_handler(request_rec *r)
         continue;
       }
       ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "query parameter not "
-                    "understood: '%s' in %s",
-                    arg, r->args);
+                    "understood: '%s' in %s", arg, r->args);
       ap_die(HTTP_BAD_REQUEST, r);
       return OK;
     }
@@ -574,8 +573,7 @@ static int curltest_put_handler(request_rec *r)
         }
       }
       ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "query parameter not "
-                    "understood: '%s' in %s",
-                    arg, r->args);
+                    "understood: '%s' in %s", arg, r->args);
       ap_die(HTTP_BAD_REQUEST, r);
       return OK;
     }
@@ -760,8 +758,7 @@ static int curltest_sslinfo_handler(request_rec *r)
         continue;
       }
       ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "query parameter not "
-                    "understood: '%s' in %s",
-                    arg, r->args);
+                    "understood: '%s' in %s", arg, r->args);
       ap_die(HTTP_BAD_REQUEST, r);
       return OK;
     }
@@ -869,8 +866,7 @@ static int curltest_limit_handler(request_rec *r)
         }
       }
       ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "query parameter not "
-                    "understood: '%s' in %s",
-                    arg, r->args);
+                    "understood: '%s' in %s", arg, r->args);
       ap_die(HTTP_BAD_REQUEST, r);
       return OK;
     }


### PR DESCRIPTION
- CMake/CurlTests.c: sync indent with rest of file and most of code.
- cmake: sync term in `_CURL_PREFILL` description with rest of code.
- curl_setup.h: document function relying on `_CRT_SECURE_NO_WARNINGS`.
- tests/http/scorecard.py: typo in message.
- 'Quiche' → 'quiche'.
- fix comment and formatting nits.
