### PR TITLE
configure: only check in the watt library if WATT_ROOT is set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1277,7 +1277,7 @@ if test "$HAVE_GETHOSTBYNAME" != "1"; then
   )
 fi
 
-if test "$HAVE_GETHOSTBYNAME" != "1"; then
+if test "$HAVE_GETHOSTBYNAME" != "1" && test -n "$WATT_ROOT"; then
   dnl gethostbyname in the watt lib?
   clean_CPPFLAGS=$CPPFLAGS
   clean_LDFLAGS=$LDFLAGS


### PR DESCRIPTION
Only look for gethostbyname in libwatt in $WATT_ROOT/lib if WATT_ROOT has actually been set.  This avoids configure trying to search in /lib, which won't every succeed and can cause problems in cross builds which check that host paths are not being searched.
