### PR TITLE
spacecheck: cap number of lines per file

### DIFF
--- a/scripts/spacecheck.pl
+++ b/scripts/spacecheck.pl
@@ -144,7 +144,7 @@ while(my $filename = <$git_ls_files>) {
     my $eol = eol_detect($cnt_cr, $cnt_lf);
 
     if($eol eq '') {
-        push @err, 'content: has mixed EOL types (or is a binary)';
+        push @err, 'content: has mixed EOL types';
     }
 
     if($eol ne 'crlf' &&

--- a/scripts/spacecheck.pl
+++ b/scripts/spacecheck.pl
@@ -84,10 +84,7 @@ sub fn_match {
 }
 
 sub eol_detect {
-    my ($content) = @_;
-
-    my $cr = () = $content =~ /\r/g;
-    my $lf = () = $content =~ /\n/g;
+    my ($content, $cr, $lf) = @_;
 
     if($cr > 0 && $lf == 0) {
         return 'cr';
@@ -107,6 +104,7 @@ sub eol_detect {
 
 my $max_repeat_space = 79;
 my $max_line_len = 192;
+my $max_lines = 10000;
 my $max_path_len = 64;
 my $max_filename_len = 48;
 
@@ -140,10 +138,13 @@ while(my $filename = <$git_ls_files>) {
         push @err, 'content: has tab';
     }
 
-    my $eol = eol_detect($content);
+    my $cnt_cr = () = $content =~ /\r/g;
+    my $cnt_lf = () = $content =~ /\n/g;
+
+    my $eol = eol_detect($content, $cnt_cr, $cnt_lf);
 
     if($eol eq '') {
-        push @err, 'content: has mixed EOL types';
+        push @err, 'content: has mixed EOL types (or is a binary)';
     }
 
     if($eol ne 'crlf' &&
@@ -154,6 +155,13 @@ while(my $filename = <$git_ls_files>) {
     if($eol ne 'lf' && $content ne '' &&
        !fn_match($filename, @need_crlf)) {
         push @err, 'content: must use LF EOL for this file type';
+    }
+
+    if($cnt_cr > $max_lines) {
+        push @err, sprintf('content: too many lines (%d > %d)', $cnt_cr, $max_lines);
+    }
+    elsif($cnt_lf > $max_lines) {
+        push @err, sprintf('content: too many lines (%d > %d)', $cnt_lf, $max_lines);
     }
 
     if($content =~ /[ \t]\n/) {

--- a/scripts/spacecheck.pl
+++ b/scripts/spacecheck.pl
@@ -84,7 +84,7 @@ sub fn_match {
 }
 
 sub eol_detect {
-    my ($content, $cr, $lf) = @_;
+    my ($cr, $lf) = @_;
 
     if($cr > 0 && $lf == 0) {
         return 'cr';
@@ -141,7 +141,7 @@ while(my $filename = <$git_ls_files>) {
     my $cnt_cr = () = $content =~ /\r/g;
     my $cnt_lf = () = $content =~ /\n/g;
 
-    my $eol = eol_detect($content, $cnt_cr, $cnt_lf);
+    my $eol = eol_detect($cnt_cr, $cnt_lf);
 
     if($eol eq '') {
         push @err, 'content: has mixed EOL types (or is a binary)';


### PR DESCRIPTION
To prevent merging large text files by accident.

Set the cap at 10k lines. The current line number top list is:
```
    5577 configure.ac
    5561 lib/vtls/openssl.c
    5077 lib/http.c
    4517 lib/ftp.c
    4284 lib/multi.c
```
