### PR TITLE
runtests: fix `mode="warn"` tests passing unconditionally, fix test 1752

### DIFF
--- a/tests/data/test1712
+++ b/tests/data/test1712
@@ -55,7 +55,7 @@ Content-Type: application/x-www-form-urlencoded
 </protocol>
 <stderr mode="warn">
 Warning: %LOGDIR/config:1 Option 'data' uses argument with leading single quote.%SP
-It is probably a mistake. Condsider double quotes.
+It is probably a mistake. Consider double quotes.
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test1712
+++ b/tests/data/test1712
@@ -30,6 +30,9 @@ Funny-head: yesyes
 <server>
 http
 </server>
+<setenv>
+COLUMNS=300
+</setenv>
 <name>
 config file with argument using single quotes
 </name>

--- a/tests/data/test1712
+++ b/tests/data/test1712
@@ -57,8 +57,7 @@ Content-Type: application/x-www-form-urlencoded
 'arg-with-quote'
 </protocol>
 <stderr mode="warn">
-Warning: %LOGDIR/config:1 Option 'data' uses argument with leading single quote.%SP
-It is probably a mistake. Consider double quotes.
+Warning: %LOGDIR/config:1 Option 'data' uses argument with leading single quote. It is probably a mistake. Consider double quotes.
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test1712
+++ b/tests/data/test1712
@@ -31,7 +31,7 @@ Funny-head: yesyes
 http
 </server>
 <setenv>
-COLUMNS=300
+COLUMNS=10000
 </setenv>
 <name>
 config file with argument using single quotes

--- a/tests/data/test1712
+++ b/tests/data/test1712
@@ -55,7 +55,7 @@ Content-Type: application/x-www-form-urlencoded
 </protocol>
 <stderr mode="warn">
 Warning: %LOGDIR/config:1 Option 'data' uses argument with leading single quote.%SP
-It is probably a mistake. Consider double quotes.
+It is probably a mistake. Condsider double quotes.
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test433
+++ b/tests/data/test433
@@ -32,7 +32,7 @@ XDG_CONFIG_HOME=%PWD/%LOGDIR
 HOME
 CURL_HOME
 # set the terminal wide to avoid word wrap in the message
-COLUMNS=300
+COLUMNS=10000
 </setenv>
 <name>
 Verify XDG_CONFIG_HOME use to find curlrc

--- a/tests/data/test459
+++ b/tests/data/test459
@@ -30,6 +30,9 @@ Funny-head: yesyes
 <server>
 http
 </server>
+<setenv>
+COLUMNS=10000
+</setenv>
 <name>
 config file with argument using whitespace missing quotes
 </name>
@@ -54,8 +57,7 @@ Content-Type: application/x-www-form-urlencoded
 arg
 </protocol>
 <stderr mode="warn">
-Warning: %LOGDIR/config:1 Option 'data' uses argument with unquoted whitespace.%SP
-Warning: This may cause side-effects. Consider double quotes.
+Warning: %LOGDIR/config:1 Option 'data' uses argument with unquoted whitespace. This may cause side-effects. Consider double quotes.
 </stderr>
 </verify>
 </testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1372,8 +1372,8 @@ sub singletest_check {
                 s/\r//;
                 s/\n/ /;
             }
-            my $v = join(@validstderr, "");
-            my $a = join(@actual, "");
+            my $v = join("", @validstderr);
+            my $a = join("", @actual);
             @validstderr = $v;
             @actual = $a;
         }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1361,6 +1361,8 @@ sub singletest_check {
             normalize_text(\@validstderr);
             normalize_text(\@actual);
         }
+printf "Bv:|%s|\n", join("", @validstderr);
+printf "Ba:|%s|\n", join("", @actual);
         if($filemode && ($filemode eq "warn")) {
             for(@validstderr) {
                 s/Warning: //;
@@ -1372,11 +1374,17 @@ sub singletest_check {
                 s/\r//;
                 s/\n/ /;
             }
-            my $v = join("", @validstderr);
-            my $a = join("", @actual);
+            my $v = join(@validstderr, "");
+            my $a = join(@actual, "");
             @validstderr = $v;
             @actual = $a;
+            #my $v = join(@validstderr, "");
+            #my $a = join(@actual, "");
+            #@validstderr = $v;
+            #@actual = $a;
         }
+printf "Av:|%s|\n", join("", @validstderr);
+printf "Aa:|%s|\n", join("", @actual);
 
         if($hash{'nonewline'}) {
             # Yes, we must cut off the final newline from the final line

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1361,8 +1361,6 @@ sub singletest_check {
             normalize_text(\@validstderr);
             normalize_text(\@actual);
         }
-printf "Bv:|%s|\n", join("", @validstderr);
-printf "Ba:|%s|\n", join("", @actual);
         if($filemode && ($filemode eq "warn")) {
             for(@validstderr) {
                 s/Warning: //;
@@ -1374,17 +1372,7 @@ printf "Ba:|%s|\n", join("", @actual);
                 s/\r//;
                 s/\n/ /;
             }
-            my $v = join(@validstderr, "");
-            my $a = join(@actual, "");
-            @validstderr = $v;
-            @actual = $a;
-            #my $v = join(@validstderr, "");
-            #my $a = join(@actual, "");
-            #@validstderr = $v;
-            #@actual = $a;
         }
-printf "Av:|%s|\n", join("", @validstderr);
-printf "Aa:|%s|\n", join("", @actual);
 
         if($hash{'nonewline'}) {
             # Yes, we must cut off the final newline from the final line


### PR DESCRIPTION
Fix test 1712 to pass curl C by setting `COLUMNS` to the highest 
accepted value, and adjust expected results. To avoid envs with varying
lengths of `LOGDIR` affect the outcome.

Apply the same fix to test 459, though it wasn't affected in curl CI.

Also sync up test 433 `COLUMNS` value with these two tests for
consistency.

Ref: #22381
Follow-up to 8e3a2a64d103a46508e17cde76595993de96ea6c #20666
