### PR TITLE
runtests: allow comments in `setenv` section, merge sections in test433

### DIFF
--- a/tests/data/test433
+++ b/tests/data/test433
@@ -31,14 +31,12 @@ http
 XDG_CONFIG_HOME=%PWD/%LOGDIR
 HOME
 CURL_HOME
+# set the terminal wide to avoid word wrap in the message
+COLUMNS=300
 </setenv>
 <name>
 Verify XDG_CONFIG_HOME use to find curlrc
 </name>
-# set the terminal wide to avoid word wrap in the message
-<setenv>
-COLUMNS=300
-</setenv>
 <command option="no-q">
 %HOSTIP:%HTTPPORT/%TESTNUMBER --no-progress-meter
 </command>

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -665,7 +665,7 @@ sub singletest_setenv {
     my @setenv = getpart("client", "setenv");
     foreach my $s (@setenv) {
         chomp $s;
-        if($s =~ /([^=]*)(.*)/) {
+        if($s !~ /^#/ && $s =~ /([^=]*)(.*)/) {
             my ($var, $content) = ($1, $2);
             # remember current setting, to restore it once test runs
             $oldenv{$var} = $ENV{$var} ? $ENV{$var} : 'notset';


### PR DESCRIPTION
---

Comments were silently allowed before this patch, but internally they
were handled as env deletion commands, which just failed or did not
do harm. I figure it's better to allow explicitly and not pass to OS.
