### PR TITLE
cd2nroff: fix backslashes for 4-space indent lines

### DIFF
--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -203,11 +203,8 @@ my %knowntls = (
 sub quoted {
     my ($d) = @_;
 
-    # convert single backslashes to doubles
-    $d =~ s/\\/\\\\/g;
-    # lines starting with a period needs it escaped
-    $d =~ s/^\./\\&./;
-
+    # lines starting with a period or apostrophe need it escaped
+    $d =~ s/^([.'])/\\&$1/;
     return $d;
 }
 

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -200,6 +200,17 @@ my %knowntls = (
     'none' => 1,
     );
 
+sub quoted {
+    my ($d) = @_;
+
+    # convert single backslashes to doubles
+    $d =~ s/\\/\\\\/g;
+    # lines starting with a period needs it escaped
+    $d =~ s/^\./\\&./;
+
+    return $d;
+}
+
 sub single {
     my @seealso;
     my @proto;
@@ -391,7 +402,8 @@ sub single {
             if($quote == 4) {
                 # remove the indentation
                 if($d =~ /^    (.*)/) {
-                    push @desc, "$1\n";
+                    $d = quoted($1);
+                    push @desc, "$d\n";
                     next;
                 }
                 else {
@@ -407,10 +419,7 @@ sub single {
                 push @desc, ".fi\n";
                 next;
             }
-            # convert single backslashes to doubles
-            $d =~ s/\\/\\\\/g;
-            # lines starting with a period needs it escaped
-            $d =~ s/^\./\\&./;
+            $d = quoted($d);
             push @desc, $d;
             next;
         }

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -406,22 +406,23 @@ sub single {
                     push @desc, "$d\n";
                     next;
                 }
-                else {
+                # end of quote
+                $quote = 0;
+                push @desc, ".fi\n";
+
+                # fall-through
+            }
+            else {
+                if(/^~~~/) {
                     # end of quote
                     $quote = 0;
                     push @desc, ".fi\n";
                     next;
                 }
-            }
-            if(/^~~~/) {
-                # end of quote
-                $quote = 0;
-                push @desc, ".fi\n";
+                $d = quoted($d);
+                push @desc, $d;
                 next;
             }
-            $d = quoted($d);
-            push @desc, $d;
-            next;
         }
 
         # remove single line HTML comments

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -203,6 +203,9 @@ my %knowntls = (
 sub quoted {
     my ($d) = @_;
 
+    # in verbatim/quoted blocks, make backslashes literal
+    $d =~ s/\\/\\\\/g;
+
     # lines starting with a period or apostrophe need it escaped
     $d =~ s/^([.'])/\\&$1/;
     return $d;

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -518,7 +518,8 @@ sub single {
             $quote = 4;
             push @desc, "\n" if($blankline && !$header);
             $header = 0;
-            push @desc, ".nf\n$1\n";
+            my $d = quoted($1);
+            push @desc, ".nf\n$d\n";
         }
         elsif(/^[ \t]*\n/) {
             # count and ignore blank lines


### PR DESCRIPTION
They were previously only properly escaped for ~~~ quotes. Spotted for the CURLOPT_HTTPSIG_KEY man page.
