### PR TITLE
tool_getparam: clear the --httpsig-key argument

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -173,7 +173,7 @@ static const struct LongShort aliases[] = {
 #ifndef CURL_DISABLE_HTTPSIG
   {"httpsig-algo",               ARG_STRG, ' ', C_HTTPSIG_ALGORITHM},
   {"httpsig-headers",            ARG_STRG, ' ', C_HTTPSIG_HEADERS},
-  {"httpsig-key",                ARG_FILE, ' ', C_HTTPSIG_KEY},
+  {"httpsig-key",                ARG_FILE|ARG_CLEAR, ' ', C_HTTPSIG_KEY},
   {"httpsig-keyid",              ARG_STRG, ' ', C_HTTPSIG_KEYID},
 #endif
   {"ignore-content-length",      ARG_BOOL, ' ', C_IGNORE_CONTENT_LENGTH},


### PR DESCRIPTION
To hide it somewhat from process listings.
