### PR TITLE
tests: add httpsig tests using redirects

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -672,10 +672,17 @@ static CURLcode output_auth_headers(struct Curl_easy *data,
 #endif
 #ifndef CURL_DISABLE_HTTPSIG
   if((authstatus->picked == CURLAUTH_HTTPSIG) && !proxy) {
-    auth = "HTTPSIG";
-    result = Curl_output_httpsig(data);
-    if(result)
-      return result;
+    /* HTTPSIG uses its own configured key material rather than
+       data->state.creds. Do not let unrelated credentials from a
+       redirected URL bypass the cross-host auth boundary. */
+    if(Curl_auth_allowed_to_host(data)) {
+      auth = "HTTPSIG";
+      result = Curl_output_httpsig(data);
+      if(result)
+        return result;
+    }
+    else
+      authstatus->done = TRUE;
   }
   else
 #endif

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -295,7 +295,7 @@ test4000 test4001 \
 test5000 test5001 test5002 test5003 test5004 test5005 test5006 test5007 \
 test5008 test5009 test5010 test5011 test5012 test5013 test5014 test5015 \
 test5016 test5017 test5018 test5019 test5020 test5021 test5022 test5023 \
-test5024
+test5024 test5025
 
 EXTRA_DIST = $(TESTCASES) DISABLED data-xml1 \
 data1461.txt data1463.txt  \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -294,7 +294,8 @@ test4000 test4001 \
 \
 test5000 test5001 test5002 test5003 test5004 test5005 test5006 test5007 \
 test5008 test5009 test5010 test5011 test5012 test5013 test5014 test5015 \
-test5016 test5017 test5018 test5019 test5020 test5021 test5022
+test5016 test5017 test5018 test5019 test5020 test5021 test5022 test5023 \
+test5024
 
 EXTRA_DIST = $(TESTCASES) DISABLED data-xml1 \
 data1461.txt data1463.txt  \

--- a/tests/data/test5023
+++ b/tests/data/test5023
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+httpsig
+RFC9421
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 OK
+Content-Length: 0
+Location: http://example.org:9000/%TESTNUMBER0002
+
+</data>
+<data2 crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data2>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+Debug
+httpsig
+</features>
+<name>
+HTTP Message Signature with cross-origin redirect
+</name>
+<command>
+"http://example.com:8000/%TESTNUMBER/resource?action=read" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT --connect-to example.org:9000:%HOSTIP:%HTTPPORT --location
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER/resource?action=read HTTP/1.1
+Host: example.com:8000
+Signature-Input: sig1=("@method" "@authority" "@path" "@query");created=0;keyid="my-key-1";alg="ed25519"
+Signature: sig1=:faTRQjDfWWm39STQkXyafoAp6ee2FCPh2KMefXOB51WAvoOdc6/Uwp9LW4zNWI7r+ivTKY7oSDb5kqcPJ/aSAQ==:
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: example.org:9000
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test5024
+++ b/tests/data/test5024
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+httpsig
+RFC9421
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 OK
+Content-Length: 0
+Location: /%TESTNUMBER0002
+
+</data>
+<data2 crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data2>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+Debug
+httpsig
+</features>
+<name>
+HTTP Message Signature with same-origin redirect
+</name>
+<command>
+"http://example.com:8000/%TESTNUMBER/resource?action=read" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT --location
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER/resource?action=read HTTP/1.1
+Host: example.com:8000
+Signature-Input: sig1=("@method" "@authority" "@path" "@query");created=0;keyid="my-key-1";alg="ed25519"
+Signature: sig1=:pxRrwEySHVgwXOI93y5KxKytfoXU6leQpC7i82Uodh8+oI7ycqCogD4PUU1p0RUAzoqeT2RHVWIN7Qg3k4A9DQ==:
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: example.com:8000
+Signature-Input: sig1=("@method" "@authority" "@path");created=0;keyid="my-key-1";alg="ed25519"
+Signature: sig1=:QVx0WyxuyHqb3j0YihCLaWYdZOySKoIezj6FmTzsJprSqgm6yUsFbcWek4r6pALF1/jKGwNB1Rbyv3DE/pn/BA==:
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test5025
+++ b/tests/data/test5025
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+httpsig
+RFC9421
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 OK
+Content-Length: 0
+Location: http://bob:alice@example.org:9000/%TESTNUMBER0002
+
+</data>
+<data2 crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data2>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+Debug
+httpsig
+</features>
+<name>
+HTTP Message Signature with cross-origin + user auth redirect
+</name>
+<command>
+"http://example.com:8000/%TESTNUMBER/resource?action=read" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT --connect-to example.org:9000:%HOSTIP:%HTTPPORT --location
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER/resource?action=read HTTP/1.1
+Host: example.com:8000
+Signature-Input: sig1=("@method" "@authority" "@path" "@query");created=0;keyid="my-key-1";alg="ed25519"
+Signature: sig1=:OUXXFiQlk/CEUksEkxvuivcFqWxL3xoPIZhB9FKTrx4MbhQqCRYMT0CQCUA9wCeRGkzmpGComBk5oPwKZr+MDg==:
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: example.org:9000
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
5023 - cross-origin (thus not done for the second request) 5024 - same-origin
