### PR TITLE
vquic: silence `-Wmissing-field-initializers` for nghttp3/ngtcp2 callback tables

### DIFF
--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -546,6 +546,10 @@ static int cb_recv_rx_key(ngtcp2_conn *tconn, ngtcp2_encryption_level level,
   return 0;
 }
 
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 static ngtcp2_callbacks ng_callbacks = {
   ngtcp2_crypto_client_initial_cb,
   NULL, /* recv_client_initial */
@@ -600,6 +604,9 @@ static ngtcp2_callbacks ng_callbacks = {
   NULL, /* recv_stop_sending */
 #endif
 };
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic pop
+#endif
 
 #if defined(_MSC_VER) && defined(_DLL)
 #pragma warning(pop)

--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -601,6 +601,10 @@ static nghttp3_ssize cb_h3_tunnel_read_data(nghttp3_conn *conn,
   return (nghttp3_ssize)nvecs;
 }
 
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 static nghttp3_callbacks ngh3_proxy_callbacks = {
   cb_h3_proxy_acked_req_body, /* acked_stream_data */
   cb_h3_proxy_stream_close,
@@ -629,6 +633,9 @@ static nghttp3_callbacks ngh3_proxy_callbacks = {
   NULL, /* stream_close2 */
 #endif
 };
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic pop
+#endif
 
 static CURLcode cf_ngtcp2_proxy_h3_init(struct Curl_cfilter *cf,
                                         struct Curl_easy *data,

--- a/lib/vquic/cf-ngtcp2.c
+++ b/lib/vquic/cf-ngtcp2.c
@@ -386,6 +386,10 @@ static int cb_h3_reset_stream(nghttp3_conn *conn, int64_t stream_id,
   return 0;
 }
 
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 static nghttp3_callbacks ngh3_callbacks = {
   cb_h3_acked_req_body, /* acked_stream_data */
   cb_h3_stream_close,
@@ -414,6 +418,9 @@ static nghttp3_callbacks ngh3_callbacks = {
   NULL, /* stream_close2 */
 #endif
 };
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic pop
+#endif
 
 static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
                                struct Curl_easy *data,


### PR DESCRIPTION
To avoid a breakage in CI and curl-for-win builds on upstream updates
extending the callback lists. Each such breakage needed patching curl,
rolling these patches into curl-for-win, and doing it in near real-time,
to keep CI and builds working (and still causing some red CI jobs).

Bring calmness here by suppressing the warnings and allowing time to
extend the callback tables as/if needed and at a convenient moment.

---

Also explored the option to dynamically setup the the callbacks, but
the libraries need a static callback table before nghttp3 v1.11.0+ and
ngctp2 v1.14.0+ which made this unnecessarily complex.

nghttp3 1.18.0 causing two pytests to fail.
Possibly due to https://github.com/ngtcp2/nghttp3/pull/539. → PR #22402
