### PR TITLE
pytest: update two H3 tests for nghttp3 1.18.0+

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -56,7 +56,7 @@ env:
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   WOLFSSL_VERSION: 5.9.2
   # renovate: datasource=github-tags depName=ngtcp2/nghttp3 versioning=semver registryUrl=https://github.com
-  NGHTTP3_VERSION: 1.17.0
+  NGHTTP3_VERSION: 1.18.0
   # renovate: datasource=github-tags depName=ngtcp2/ngtcp2 versioning=semver registryUrl=https://github.com
   NGTCP2_VERSION: 1.24.0
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -56,7 +56,7 @@ env:
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   WOLFSSL_VERSION: 5.9.2
   # renovate: datasource=github-tags depName=ngtcp2/nghttp3 versioning=semver registryUrl=https://github.com
-  NGHTTP3_VERSION: 1.18.0
+  NGHTTP3_VERSION: 1.17.0
   # renovate: datasource=github-tags depName=ngtcp2/ngtcp2 versioning=semver registryUrl=https://github.com
   NGTCP2_VERSION: 1.24.0
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -720,7 +720,7 @@ class TestDownload:
                 # h2 is unable to send such large headers (frame limits)
                 r.check_exit_code(55)
             elif proto == 'h3':
-                if url_junk <= 64 * 1024:
+                if url_junk <= 32 * 1024:
                     r.check_exit_code(0)
                     # nghttpx reports 431 Request Header Field too Large
                     r.check_response(http_status=431)

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -720,11 +720,11 @@ class TestDownload:
                 # h2 is unable to send such large headers (frame limits)
                 r.check_exit_code(55)
             elif proto == 'h3':
-                if url_junk <= 32 * 1024:
-                    r.check_exit_code(0)
-                    # nghttpx reports 431 Request Header Field too Large
+                # nghttpx reports 431 Request Header Field too Large
+                # or destroys the connection with internal error
+                # ERR_QPACK_HEADER_TOO_LARGE,
+                # depending on nghttp3 version and payload size
+                assert r.exit_code in (0, 56), f'expected exit code 0 or 56, '\
+                                               f'got {r.exit_code}\n{r.dump_logs()}'
+                if r.exit_code == 0:
                     r.check_response(http_status=431)
-                else:
-                    # nghttpx destroys the connection with internal error
-                    # ERR_QPACK_HEADER_TOO_LARGE
-                    r.check_exit_code(56)

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -105,8 +105,11 @@ class TestAuth:
             '--trace-config', 'http/2,http/3'
         ])
         # but apache either denies on length limit or gives a 400
-        r.check_exit_code(0)
-        assert r.stats[0]['http_code'] in [400, 431]
+        if proto == 'h3':
+            r.check_exit_code(56)
+        else:
+            r.check_exit_code(0)
+            assert r.stats[0]['http_code'] in [400, 431]
 
     # PUT data, basic auth with very large pw
     @pytest.mark.parametrize("proto", Env.http_mplx_protos())

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -92,7 +92,7 @@ class TestAuth:
     # PUT data, basic auth large pw
     @pytest.mark.parametrize("proto", Env.http_mplx_protos())
     def test_14_05_basic_large_pw(self, env: Env, httpd, nghttpx, proto):
-        if proto == 'h3' and not env.curl_uses_lib('ngtcp2'):
+        if proto == 'h3' and env.curl_uses_lib('quiche'):
             # See <https://github.com/cloudflare/quiche/issues/1573>
             pytest.skip("quiche has problems with large requests")
         # large enough that nghttp2 will submit

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -106,9 +106,12 @@ class TestAuth:
         ])
         # but apache either denies on length limit or gives a 400
         if proto == 'h3':
-            r.check_exit_code(56)
+            # depends on nghttp3 version
+            assert r.exit_code in (0, 56), f'expected exit code 0 or 56, '\
+                                           f'got {r.exit_code}\n{r.dump_logs()}'
         else:
             r.check_exit_code(0)
+        if r.exit_code == 0:
             assert r.stats[0]['http_code'] in [400, 431]
 
     # PUT data, basic auth with very large pw


### PR DESCRIPTION
Fixing:
```
FAILED ../../tests/http/test_02_download.py::TestDownload::test_02_36_looong_urls[65536-h3] -
  AssertionError: expected exit code 0, got 56
FAILED ../../tests/http/test_14_auth.py::TestAuth::test_14_05_basic_large_pw[h3] -
  AssertionError: expected exit code 0, got 56
```
Ref: https://github.com/curl/curl/actions/runs/30207198835/job/89807247058?pr=22400

Refs:
https://github.com/ngtcp2/nghttp3/pull/539
https://github.com/ngtcp2/nghttp3/commit/a5872645446cdc07e897fea33b61a3c665563da9

Bug: https://github.com/curl/curl/pull/22397#issuecomment-5084927935

---

https://github.com/curl/curl/pull/22402/files?w=1

Tested OK with nghttp3 1.17.0 also: https://github.com/curl/curl/actions/runs/30219011819/job/89838099489?pr=22402
