### PR TITLE
Add URL parsing descriptive error message for url parts

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2213,7 +2213,7 @@ out:
   return result;
 }
 
-static const char* url_part_get_str(CURLUPart part)
+static const char *url_part_get_str(CURLUPart part)
 {
   switch(part) {
     default: return "url";
@@ -2229,7 +2229,7 @@ static const char* url_part_get_str(CURLUPart part)
   }
 }
 
-static char* extract_url_part_val(struct Curl_URL_Fail* uf,
+static char *extract_url_part_val(struct Curl_URL_Fail *uf,
                                   CURLUPart part)
 {
   switch(part) {
@@ -2255,10 +2255,10 @@ static char* extract_url_part_val(struct Curl_URL_Fail* uf,
       return uf->url;
   }
 }
-static void rejected_url_err_msg(struct Curl_easy* data,
-                                 CURLU* uh, CURLUcode uc)
+static void rejected_url_err_msg(struct Curl_easy *data,
+                                 CURLU *uh, CURLUcode uc)
 {
-  struct Curl_URL_Fail* uf = uh->fail_curl_url;
+  struct Curl_URL_Fail *uf = uh->fail_curl_url;
   CURLUPart highlight_part;
 
   if(!uf) {
@@ -2287,7 +2287,7 @@ static void rejected_url_err_msg(struct Curl_easy* data,
   /* Append the parsed/failed parsed parts of the url */
   for(CURLUPart part = CURLUPART_URL; part <= CURLUPART_FRAGMENT; part++) {
     const char *val = NULL;
-    val = (const char*)extract_url_part_val(uf, part);
+    val = (const char *)extract_url_part_val(uf, part);
 
     /* Only append if it is not an empty string
      */
@@ -2354,7 +2354,7 @@ static CURLcode url_set_data_origin_and_creds(struct Curl_easy *data)
                         CURLU_DISALLOW_USER : 0) |
                        (data->set.path_as_is ? CURLU_PATH_AS_IS : 0)));
     if(uc) {
-      /* Displays a well formatted error message with parsing details*/
+      /* Displays a well formatted error message with parsing details */
       rejected_url_err_msg(data, uh, uc);
       result = Curl_uc_to_curlcode(uc);
       goto out;

--- a/lib/url.c
+++ b/lib/url.c
@@ -2213,6 +2213,95 @@ out:
   return result;
 }
 
+static const char* url_part_get_str(CURLUPart part)
+{
+  switch(part) {
+    default: return "url";
+    case CURLUPART_SCHEME: return "scheme";
+    case CURLUPART_USER: return "user";
+    case CURLUPART_PASSWORD: return "password";
+    case CURLUPART_HOST: return "host";
+    case CURLUPART_PORT: return "port";
+    case CURLUPART_PATH: return "path";
+    case CURLUPART_QUERY: return "query";
+    case CURLUPART_FRAGMENT: return "fragment";
+    case CURLUPART_OPTIONS: return "options";
+  }
+}
+
+static char* extract_url_part_val(struct Curl_URL_Fail* uf,
+                                  CURLUPart part)
+{
+  switch(part) {
+    case CURLUPART_SCHEME:
+      return uf->scheme;
+    case CURLUPART_USER:
+      return uf->user;
+    case CURLUPART_PASSWORD:
+      return uf->password;
+    case CURLUPART_OPTIONS:
+      return uf->options;
+    case CURLUPART_HOST:
+      return uf->host;
+    case CURLUPART_PORT:
+      return uf->portnumstr;
+    case CURLUPART_PATH:
+      return uf->path;
+    case CURLUPART_QUERY:
+      return uf->query;
+    case CURLUPART_FRAGMENT:
+      return uf->fragment;
+    default:
+      return uf->url;
+  }
+}
+static void rejected_url_err_msg(struct Curl_easy* data,
+                                 CURLU* uh, CURLUcode uc)
+{
+  struct Curl_URL_Fail* uf = uh->fail_curl_url;
+  CURLUPart highlight_part;
+
+  if(!uf) {
+    failf(data, "URL rejected: %s", curl_url_strerror(uc));
+    return;
+  }
+
+  highlight_part = uf->last_failed_part;
+
+#define HIGHLIGHT(P, TARGET_P) (P == TARGET_P ? " <--": "")
+
+  if(!data->set.verbose) {
+    /* URL rejected : {Err}, got {part} : '{part_value}' */
+    failf(data, "URL rejected: %s, %s %s : %s%s%s",
+          curl_url_strerror(uc),
+          "got",
+          url_part_get_str(highlight_part),
+          "\'",
+          extract_url_part_val(uf, highlight_part),
+          "\'");
+    return;
+  }
+
+  failf(data, "URL rejected: %s", curl_url_strerror(uc));
+
+  /* Append the parsed/failed parsed parts of the url */
+  for(CURLUPart part = CURLUPART_URL; part <= CURLUPART_FRAGMENT; part++) {
+    const char *val = NULL;
+    val = (const char*)extract_url_part_val(uf, part);
+
+    /* Only append if it is not an empty string
+     */
+    if(val) {
+      infof(data,
+            "%-8s: %s%s",
+            url_part_get_str(part),
+            val,
+            HIGHLIGHT(part, highlight_part));
+    }
+
+  }
+}
+
 static CURLcode url_set_data_origin_and_creds(struct Curl_easy *data)
 {
   CURLcode result = CURLE_OK;
@@ -2265,7 +2354,8 @@ static CURLcode url_set_data_origin_and_creds(struct Curl_easy *data)
                         CURLU_DISALLOW_USER : 0) |
                        (data->set.path_as_is ? CURLU_PATH_AS_IS : 0)));
     if(uc) {
-      failf(data, "URL rejected: %s", curl_url_strerror(uc));
+      /* Displays a well formatted error message with parsing details*/
+      rejected_url_err_msg(data, uh, uc);
       result = Curl_uc_to_curlcode(uc);
       goto out;
     }

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -26,7 +26,27 @@
 #include "curl_setup.h"
 #include <curl/urlapi.h>
 
+#define CURLUPART_NONE ((CURLUPart) - 1)
+#define EMPTY_URL_PART "(EMPTY)"
+
+/* Container for intermediary errors of parsing Curl_URL */
+struct Curl_URL_Fail {
+  char* url;
+  char* scheme;
+  char* user;
+  char* password;
+  char* options;
+  char* host;
+  char* path;
+  char* zoneid;
+  char* portnumstr;
+  char* query;
+  char* fragment;
+  CURLUPart last_failed_part;
+};
+
 /* Internal representation of CURLU. Point to URL-encoded strings. */
+
 struct Curl_URL {
   char *scheme;
   char *user;
@@ -37,6 +57,7 @@ struct Curl_URL {
   char *path;
   char *query;
   char *fragment;
+  struct Curl_URL_Fail *fail_curl_url; /* Tracks failed parsing of Curl_URL parts*/
   uint16_t portnum; /* the numerical port if present */
   BIT(port_present);    /* to support missing port */
   BIT(query_present);    /* to support blank */

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -31,17 +31,17 @@
 
 /* Container for intermediary errors of parsing Curl_URL */
 struct Curl_URL_Fail {
-  char* url;
-  char* scheme;
-  char* user;
-  char* password;
-  char* options;
-  char* host;
-  char* path;
-  char* zoneid;
-  char* portnumstr;
-  char* query;
-  char* fragment;
+  char *url;
+  char *scheme;
+  char *user;
+  char *password;
+  char *options;
+  char *host;
+  char *path;
+  char *zoneid;
+  char *portnumstr;
+  char *query;
+  char *fragment;
   CURLUPart last_failed_part;
 };
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -82,6 +82,141 @@ static void free_urlhandle(struct Curl_URL *u)
   curlx_free(u->fragment);
 }
 
+/* Copies the valid parsed fields only*/
+static void curl_url_fail_cpy_curlurl(struct Curl_URL_Fail *fail_url,
+                                      CURLU* url)
+{
+  if(!fail_url || !url)
+    return;
+
+  if(!fail_url->scheme && url->scheme) {
+    fail_url->scheme = url->scheme;
+    url->scheme = NULL;
+  }
+  if(!fail_url->user && url->user) {
+    fail_url->user = url->user;
+    url->user = NULL;
+  }
+  if(!fail_url->password && url->password) {
+    fail_url->password = url->password;
+    url->password = NULL;
+  }
+  if(!fail_url->host && url->host) {
+    fail_url->host = url->host;
+    url->host = NULL;
+  }
+  if(!fail_url->portnumstr && url->port_present) {
+    fail_url->portnumstr = curl_maprintf("%u", url->portnum);
+  }
+  if(!fail_url->path && url->path) {
+    fail_url->path = url->path;
+    url->path = NULL;
+  }
+  if(!fail_url->query && url->query) {
+    fail_url->query = url->query;
+    url->query = NULL;
+  }
+  if(!fail_url->fragment && url->fragment) {
+    fail_url->fragment = url->fragment;
+    url->fragment = NULL;
+  }
+}
+
+/*
+ * curl_url_fail_cleanup() frees the Curl_URL_Fail struct and
+ * related resources used for the URL failure tracking.
+ */
+static void curl_url_fail_cleanup(struct Curl_URL_Fail* fail_url)
+{
+  if(!fail_url)
+    return;
+
+  curlx_free(fail_url->url);
+  curlx_free(fail_url->scheme);
+  curlx_free(fail_url->host);
+  curlx_free(fail_url->user);
+  curlx_free(fail_url->password);
+  curlx_free(fail_url->path);
+  curlx_free(fail_url->query);
+  curlx_free(fail_url->fragment);
+  curlx_free(fail_url->options);
+  curlx_free(fail_url->zoneid);
+
+  curlx_free(fail_url);
+}
+
+/*
+ * curl_url_fail() creates a new struct Curl_URL_Fail and
+ * returns a pointer to it.
+ * Must be freed with curl_url_fail_cleanup().
+ */
+static struct Curl_URL_Fail *curl_url_fail(void)
+{
+  struct Curl_URL_Fail *url_fail = calloc(1, sizeof(struct Curl_URL_Fail));
+  return url_fail;
+}
+
+/*
+ * curl_url_fail_set() sets a specific part of the URL failure tracking
+ * in a struct Curl_URL_Fail.
+ * The function lazily initializes the struct to
+ * save memory and avoid leaks in case of a successful url parsing.
+ * Passing NULL or Empty string defaults to the EMPTY_URL_PART
+ */
+static void curl_url_fail_set(struct Curl_URL_Fail **fail_url,
+                       CURLUPart what, const char *part)
+{
+  if(what == CURLUPART_NONE)
+    return;
+
+  /* Initializes on the first failed parsing occurrence */
+  if(!*fail_url)
+    *fail_url = curl_url_fail();
+
+  struct Curl_URL_Fail* uf = *fail_url;
+  uf->last_failed_part = what;
+
+  if (!part || !*part)
+    part = EMPTY_URL_PART;
+
+  switch(what) {
+    case CURLUPART_SCHEME:
+      uf->scheme = curlx_strdup(part);
+      break;
+    case CURLUPART_USER:
+      uf->user = curlx_strdup(part);
+      break;
+    case CURLUPART_PASSWORD:
+      uf->password = curlx_strdup(part);
+      break;
+    case CURLUPART_HOST:
+      uf->host = curlx_strdup(part);
+      break;
+    case CURLUPART_PORT:
+      uf->portnumstr = curlx_strdup(part);
+      break;
+    case CURLUPART_PATH:
+      uf->path = curlx_strdup(part);
+      break;
+    case CURLUPART_QUERY:
+      uf->query = curlx_strdup(part);
+      break;
+    case CURLUPART_OPTIONS:
+      uf->options = curlx_strdup(part);
+      break;
+    case CURLUPART_ZONEID:
+      uf->zoneid = curlx_strdup(part);
+      break;
+    case CURLUPART_FRAGMENT:
+      uf->fragment = curlx_strdup(part);
+      break;
+
+    default:
+      uf->url = curlx_strdup(part);
+      break;
+  }
+}
+
 /*
  * Find the separator at the end of the hostname, or the '?' in cases like
  * http://www.example.com?id=2380
@@ -317,6 +452,7 @@ UNITTEST CURLUcode parse_hostname_login(struct Curl_URL *u,
   if(userp) {
     if(flags & CURLU_DISALLOW_USER) {
       /* Option DISALLOW_USER is set and URL contains username. */
+      curl_url_fail_set(&u->fail_curl_url, CURLUPART_USER, userp);
       ures = CURLUE_USER_NOT_ALLOWED;
       goto out;
     }
@@ -370,8 +506,11 @@ UNITTEST CURLUcode parse_port(struct Curl_URL *u, struct dynbuf *host,
     portptr++;
     /* this is a RFC2732-style specified IP-address */
     if(*portptr) {
-      if(*portptr != ':')
+      if(*portptr != ':') {
+        curl_url_fail_set(&u->fail_curl_url, CURLUPART_HOST, hostname);
+        curl_url_fail_set(&u->fail_curl_url, CURLUPART_PORT, portptr);
         return CURLUE_BAD_PORT_NUMBER;
+      }
     }
     else
       portptr = NULL;
@@ -391,12 +530,25 @@ UNITTEST CURLUcode parse_port(struct Curl_URL *u, struct dynbuf *host,
        a scheme not work! */
     curlx_dyn_setlen(host, keep);
     portptr++;
-    if(!*portptr)
-      return has_scheme ? CURLUE_OK : CURLUE_BAD_PORT_NUMBER;
 
-    if(curlx_str_number(&portptr, &port, 0xffff) || *portptr)
+
+    if(!*portptr) {
+      CURLUcode ures = has_scheme ? CURLUE_OK : CURLUE_BAD_PORT_NUMBER;
+      if(ures) {
+        curl_url_fail_set(&u->fail_curl_url, CURLUPART_HOST, hostname);
+        curl_url_fail_set(&u->fail_curl_url, CURLUPART_PORT, portptr);
+      }
+      return ures;
+    }
+
+    char* temp_portptr = curlx_strdup(portptr);
+    if(curlx_str_number(&portptr, &port, 0xffff) || *portptr) {
+      curl_url_fail_set(&u->fail_curl_url, CURLUPART_HOST, hostname);
+      curl_url_fail_set(&u->fail_curl_url, CURLUPART_PORT, temp_portptr);
       return CURLUE_BAD_PORT_NUMBER;
+    }
 
+    curlx_free(temp_portptr);
     u->portnum = (uint16_t)port;
     u->port_present = TRUE;
   }
@@ -418,6 +570,7 @@ UNITTEST CURLUcode ipv6_parse(struct Curl_URL *u, char *hostname,
   DEBUGASSERT(*hostname == '[');
   if(hlen < 4) /* '[::]' is the shortest possible valid string */
     return CURLUE_BAD_IPV6;
+
   hostname++;
   hlen -= 2;
 
@@ -673,8 +826,10 @@ static CURLUcode parse_authority(struct Curl_URL *u,
     uc = CURLUE_NO_HOST;
   else
     uc = urldecode_host(host);
-  if(uc)
+  if(uc) {
+    curl_url_fail_set(&u->fail_curl_url, CURLUPART_HOST, curlx_dyn_ptr(host));
     return uc;
+  }
 
   switch(ipv4_normalize(host)) {
   case HOST_IPV4:
@@ -692,6 +847,9 @@ static CURLUcode parse_authority(struct Curl_URL *u,
     uc = CURLUE_BAD_HOSTNAME; /* Bad IPv4 address even */
     break;
   }
+
+  if(uc && uc != CURLUE_OUT_OF_MEMORY)
+    curl_url_fail_set(&u->fail_curl_url, CURLUPART_HOST, curlx_dyn_ptr(host));
 
   return uc;
 }
@@ -874,10 +1032,11 @@ UNITTEST CURLUcode parse_file(const char *url, size_t urllen, CURLU *u,
 
   *pathp = NULL;
   *pathlenp = 0;
-  if(urllen <= 6)
+  if(urllen <= 6) {
     /* file:/ is not enough to actually be a complete file: URL */
+    curl_url_fail_set(&u->fail_curl_url, CURLUPART_PATH, url);
     return CURLUE_BAD_FILE_URL;
-
+  }
   /* path has been allocated large enough to hold this */
   path = &url[5];
   pathlen = urllen - 5;
@@ -885,9 +1044,10 @@ UNITTEST CURLUcode parse_file(const char *url, size_t urllen, CURLU *u,
   /* RFC 8089: file-hier-part = ( "//" auth-path ) / local-path, where
      local-path also starts with a "/". So reject anything that does not
      start with at least one "/" */
-  if(path[0] != '/')
+  if(path[0] != '/') {
+    curl_url_fail_set(&u->fail_curl_url, CURLUPART_PATH, path);
     return CURLUE_BAD_FILE_URL;
-
+  }
   /* Extra handling URLs with an authority component (i.e. that start with
    * "file://")
    *
@@ -921,10 +1081,12 @@ UNITTEST CURLUcode parse_file(const char *url, size_t urllen, CURLU *u,
          checkprefix("127.0.0.1/", ptr)) {
         ptr += 9; /* now points to the slash after the host */
       }
-      else
+      else {
         /* Invalid file://hostname/, expected localhost or 127.0.0.1 or
            none */
+        curl_url_fail_set(&u->fail_curl_url, CURLUPART_HOST, ptr);
         return CURLUE_BAD_FILE_URL;
+      }
     }
 
     path = ptr;
@@ -937,6 +1099,7 @@ UNITTEST CURLUcode parse_file(const char *url, size_t urllen, CURLU *u,
   if(('/' == path[0] && STARTS_WITH_URL_DRIVE_PREFIX(&path[1])) ||
      STARTS_WITH_URL_DRIVE_PREFIX(path)) {
     /* File drive letters are only accepted in MS-DOS/Windows */
+    curl_url_fail_set(&u->fail_curl_url, CURLUPART_PATH, path);
     return CURLUE_BAD_FILE_URL;
   }
 #else
@@ -966,12 +1129,18 @@ static CURLUcode parse_scheme(const char *url, CURLU *u, char *schemebuf,
   if(schemelen) {
     int num_slashes = 0;
     const char *p = &url[schemelen + 1];
-    if(!Curl_get_scheme(schemebuf) && !(flags & CURLU_NON_SUPPORT_SCHEME))
+    if(!Curl_get_scheme(schemebuf) && !(flags & CURLU_NON_SUPPORT_SCHEME)) {
+      curl_url_fail_set(&u->fail_curl_url, CURLUPART_SCHEME, schemebuf);
       return CURLUE_UNSUPPORTED_SCHEME;
+    }
 
-    if(!ISSLASH(*p))
+
+    if(!ISSLASH(*p)) {
+      curl_url_fail_set(&u->fail_curl_url, CURLUPART_SCHEME, schemebuf);
       /* less than one */
       return CURLUE_BAD_SLASHES;
+    }
+
     if((flags & CURLU_NO_AUTHORITY)) {
       while(ISSLASH(*p) && (num_slashes < 2)) {
         p++;
@@ -983,8 +1152,10 @@ static CURLUcode parse_scheme(const char *url, CURLU *u, char *schemebuf,
         p++;
         num_slashes++;
       }
-      if(num_slashes > 3)
+      if(num_slashes > 3) {
+        curl_url_fail_set(&u->fail_curl_url, CURLUPART_SCHEME, schemebuf);
         return CURLUE_BAD_SLASHES;
+      }
     }
 
     schemep = schemebuf;
@@ -993,8 +1164,11 @@ static CURLUcode parse_scheme(const char *url, CURLU *u, char *schemebuf,
   else {
     /* no scheme! */
 
-    if(!(flags & (CURLU_DEFAULT_SCHEME | CURLU_GUESS_SCHEME)))
+    if(!(flags & (CURLU_DEFAULT_SCHEME | CURLU_GUESS_SCHEME))) {
+      curl_url_fail_set(&u->fail_curl_url, CURLUPART_SCHEME, schemebuf);
       return CURLUE_BAD_SCHEME;
+    }
+
 
     if(flags & CURLU_DEFAULT_SCHEME)
       schemep = DEFAULT_SCHEME;
@@ -1004,6 +1178,7 @@ static CURLUcode parse_scheme(const char *url, CURLU *u, char *schemebuf,
      */
     *hostpp = url;
   }
+
 
   if(schemep) {
     u->scheme = curlx_strdup(schemep);
@@ -1153,8 +1328,10 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
   curlx_dyn_init(&host, CURL_MAX_INPUT_LENGTH);
 
   ures = Curl_junkscan(url, &urllen, !!(flags & CURLU_ALLOW_SPACE));
-  if(ures)
+  if(ures) {
+    curl_url_fail_set(&u->fail_curl_url, CURLUPART_URL, url);
     goto fail;
+  }
 
   schemelen = Curl_is_absolute_url(url, schemebuf, sizeof(schemebuf),
                                    flags & (CURLU_GUESS_SCHEME |
@@ -1219,6 +1396,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
   }
 fail:
   curlx_dyn_free(&host);
+  curl_url_fail_cpy_curlurl(u->fail_curl_url, u);
   free_urlhandle(u);
   return ures;
 }
@@ -1236,6 +1414,11 @@ static CURLUcode parseurl_and_replace(const char *url, CURLU *u,
   if(!ures) {
     free_urlhandle(u);
     *u = tmpurl;
+  }
+  else {
+    /* Transfer Curl_URL_Fail element */
+    curl_url_fail_cleanup(u->fail_curl_url);
+    u->fail_curl_url = tmpurl.fail_curl_url;
   }
   return ures;
 }
@@ -1319,6 +1502,8 @@ static CURLUcode redirect_url(const char *base, const char *relurl,
   return uc;
 }
 
+
+
 /*
  */
 CURLU *curl_url(void)
@@ -1330,6 +1515,8 @@ void curl_url_cleanup(CURLU *u)
 {
   if(u) {
     free_urlhandle(u);
+    if(u->fail_curl_url)
+      curl_url_fail_cleanup(u->fail_curl_url);
     curlx_free(u);
   }
 }
@@ -1725,9 +1912,11 @@ static CURLUcode set_url_port(CURLU *u, const char *provided_port)
   if(!ISDIGIT(provided_port[0]))
     /* not a number */
     return CURLUE_BAD_PORT_NUMBER;
+
   if(curlx_str_number(&provided_port, &port, 0xffff) || *provided_port)
     /* weirdly provided number, not good! */
     return CURLUE_BAD_PORT_NUMBER;
+
   u->portnum = (uint16_t)port;
   u->port_present = TRUE;
   return CURLUE_OK;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -170,13 +170,16 @@ static void curl_url_fail_set(struct Curl_URL_Fail **fail_url,
     return;
 
   /* Initializes on the first failed parsing occurrence */
-  if(!*fail_url)
+  if(!*fail_url) {
     *fail_url = curl_url_fail();
+    if(!*fail_url)
+      return;
+  }
 
   struct Curl_URL_Fail* uf = *fail_url;
   uf->last_failed_part = what;
 
-  if (!part || !*part)
+  if(!part || !*part)
     part = EMPTY_URL_PART;
 
   switch(what) {

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -82,7 +82,7 @@ static void free_urlhandle(struct Curl_URL *u)
   curlx_free(u->fragment);
 }
 
-/* Copies the valid parsed fields only*/
+/* Copies the valid parsed fields only */
 static void curl_url_fail_cpy_curlurl(struct Curl_URL_Fail *fail_url,
                                       CURLU* url)
 {
@@ -126,7 +126,7 @@ static void curl_url_fail_cpy_curlurl(struct Curl_URL_Fail *fail_url,
  * curl_url_fail_cleanup() frees the Curl_URL_Fail struct and
  * related resources used for the URL failure tracking.
  */
-static void curl_url_fail_cleanup(struct Curl_URL_Fail* fail_url)
+static void curl_url_fail_cleanup(struct Curl_URL_Fail *fail_url)
 {
   if(!fail_url)
     return;
@@ -152,7 +152,7 @@ static void curl_url_fail_cleanup(struct Curl_URL_Fail* fail_url)
  */
 static struct Curl_URL_Fail *curl_url_fail(void)
 {
-  struct Curl_URL_Fail *url_fail = calloc(1, sizeof(struct Curl_URL_Fail));
+  struct Curl_URL_Fail *url_fail = curlx_calloc(1, sizeof(struct Curl_URL_Fail));
   return url_fail;
 }
 
@@ -166,17 +166,17 @@ static struct Curl_URL_Fail *curl_url_fail(void)
 static void curl_url_fail_set(struct Curl_URL_Fail **fail_url,
                        CURLUPart what, const char *part)
 {
+  struct Curl_URL_Fail *uf;
   if(what == CURLUPART_NONE)
     return;
 
   /* Initializes on the first failed parsing occurrence */
-  if(!*fail_url) {
+  if(!*fail_url)
     *fail_url = curl_url_fail();
-    if(!*fail_url)
-      return;
-  }
+  if(!*fail_url)
+    return;
 
-  struct Curl_URL_Fail* uf = *fail_url;
+  uf = *fail_url;
   uf->last_failed_part = what;
 
   if(!part || !*part)
@@ -496,6 +496,7 @@ UNITTEST CURLUcode parse_port(struct Curl_URL *u, struct dynbuf *host,
                               bool has_scheme)
 {
   const char *portptr;
+  const char *portptr_start;
   const char *hostname = curlx_dyn_ptr(host);
   /*
    * Find the end of an IPv6 address on the ']' ending bracket.
@@ -544,14 +545,13 @@ UNITTEST CURLUcode parse_port(struct Curl_URL *u, struct dynbuf *host,
       return ures;
     }
 
-    char* temp_portptr = curlx_strdup(portptr);
+    portptr_start = portptr;
     if(curlx_str_number(&portptr, &port, 0xffff) || *portptr) {
       curl_url_fail_set(&u->fail_curl_url, CURLUPART_HOST, hostname);
-      curl_url_fail_set(&u->fail_curl_url, CURLUPART_PORT, temp_portptr);
+      curl_url_fail_set(&u->fail_curl_url, CURLUPART_PORT, portptr_start);
       return CURLUE_BAD_PORT_NUMBER;
     }
 
-    curlx_free(temp_portptr);
     u->portnum = (uint16_t)port;
     u->port_present = TRUE;
   }


### PR DESCRIPTION
Added feat. to display url parts causing the `URL rejected` error for better insight on the url parsing process.

```
$ curl 'http://localhost:1111\\test'
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535, got port : '1111\test'
$ curl -v 'http://localhost:1111\\test'
* URL rejected: Port number was not a decimal number between 0 and 65535
* scheme  : http
* host    : localhost
* port    : 1111\test <--
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
$ curl 'http:\\localhost:1111'
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535, got port : '\localhost:1111'
$ curl -v 'http:\\localhost:1111'
* URL rejected: Port number was not a decimal number between 0 and 65535
* host    : http
* port    : \localhost:1111 <--
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
$ curl 'http:\\localhost'
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535, got port : '\localhost'
$ curl -v 'http:\\localhost'
* URL rejected: Port number was not a decimal number between 0 and 65535
* host    : http
* port    : \localhost <--
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
$ curl --disallow-username-in-url 'http://user:password@localhost'
curl: (67) URL rejected: Credentials was passed in the URL when prohibited, got user : 'user'
$ curl -v --disallow-username-in-url 'http://user:password@localhost'
* URL rejected: Credentials was passed in the URL when prohibited
* scheme  : http
* user    : user <--
curl: (67) URL rejected: Credentials was passed in the URL when prohibited
$ curl 'file://badhost/path'
curl: (3) URL rejected: Bad file:// URL, got host : 'badhost/path'
$ curl -v 'file://badhost/path'
* URL rejected: Bad file:// URL
* host    : badhost/path <--
curl: (3) URL rejected: Bad file:// URL
```
The approach was creation a struct mirroring `Curl_URL` aka `CURLU` called `Curl_URL_Failed`.
A pointer of this struct was added to `CURLU` struct, to avoid any parameter modification across the functions using `CURLU`.
It is also lazily initialized to avoid any friction with the core logic in case of a correct parsing process.
The display has two views , depending on the verbose flag :
- non-verbose:
```
URL rejected : [ERR], got [part] : '[part_value]'
```
- verbose (non-empty fields are displayed, correctly parsed and incorrectly parsed ones :
```
schema : (SCHEMA)
user : (USER)
...
port : (PORT) 
[Last modified field in failure] : (VALUE) <--
```

Suggestive solution for https://github.com/curl/curl/issues/22337