### PR TITLE
typecheck-gcc: allow passing `char[]` as callback data

### DIFF
--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -608,7 +608,7 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
  * == or whatsoever.
  */
 
-/* XXX: should evaluate to true if expr is a pointer */
+/* XXX: should evaluate to true if expr is a pointer or a char[] array */
 #define curlcheck_any_ptr(expr)                                         \
   (sizeof(expr) == sizeof(void *) ||                                    \
    __builtin_types_compatible_p(__typeof__(expr), char[]))
@@ -678,7 +678,7 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
   (__builtin_types_compatible_p(__typeof__(expr), curl_off_t))
 
 /* evaluates to true if expr is abuffer suitable for CURLOPT_ERRORBUFFER */
-/* XXX: also check size of an char[] array? */
+/* XXX: also check size of a char[] array? */
 #define curlcheck_error_buffer(expr)                                    \
   (curlcheck_NULL(expr) ||                                              \
    __builtin_types_compatible_p(__typeof__(expr), char *) ||            \

--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -610,7 +610,8 @@ CURLWARNING(Wcurl_easy_getinfo_err_curl_off_t,
 
 /* XXX: should evaluate to true if expr is a pointer */
 #define curlcheck_any_ptr(expr)                                         \
-  (sizeof(expr) == sizeof(void *))
+  (sizeof(expr) == sizeof(void *) ||                                    \
+   __builtin_types_compatible_p(__typeof__(expr), char[]))
 
 /* evaluates to true if expr is NULL */
 /* XXX: must not evaluate expr, so this check is not accurate */


### PR DESCRIPTION
E.g. `TEST_DATA_STRING` in test 655.

Cherry-picked from #22406

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
