### PR TITLE
schannel: fix error check logic in `get_client_cert()` file reader

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -441,12 +441,13 @@ static CURLcode get_client_cert(struct Curl_cfilter *cf,
       if(fInCert) {
         long cert_tell = 0;
         bool continue_reading = fseek(fInCert, 0, SEEK_END) == 0;
-        if(continue_reading)
+        if(continue_reading) {
           cert_tell = ftell(fInCert);
-        if(cert_tell < 0)
-          continue_reading = FALSE;
-        else
-          certsize = (size_t)cert_tell;
+          if(cert_tell < 0)
+            continue_reading = FALSE;
+          else
+            certsize = (size_t)cert_tell;
+        }
         if(continue_reading)
           continue_reading = fseek(fInCert, 0, SEEK_SET) == 0;
         if(continue_reading && (certsize < CURL_MAX_INPUT_LENGTH))


### PR DESCRIPTION
Reported by GitHub Code Quality
Follow-up to 0fdf96512613574591f501d63fe49495ba40e1d5 #5193

---

https://github.com/curl/curl/pull/22415/files?w=1

"`ftell` returns `-1L` on error, but `cert_tell` is declared as `long`
and initialized to `0`. If `fseek` fails, `continue_reading` is set to
`FALSE` but `cert_tell` remains `0`, and on the next line `cert_tell <
0` would be false. More importantly, if `continue_reading` is false
after `fseek`, `ftell` is not called, but the check `if(cert_tell < 0)`
will still be evaluated. The check should be guarded: it should only be
reached if `continue_reading` is still true, otherwise the `certsize`
assignment on line 450 is skipped correctly but the negative check is
misleadingly evaluated. Consider restructuring so `ftell` is only
checked when `continue_reading` is true before calling it."
