### PR TITLE
h2: bootstrap max streams from multi handle if in use

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2412,7 +2412,9 @@ static CURLcode cf_h2_ctx_open(struct Curl_cfilter *cf,
     failf(data, "Could not initialize nghttp2");
     goto out;
   }
-  ctx->max_concurrent_streams = DEFAULT_MAX_CONCURRENT_STREAMS;
+  ctx->max_concurrent_streams = data->multi ?
+    Curl_multi_max_concurrent_streams(data->multi) :
+    DEFAULT_MAX_CONCURRENT_STREAMS;
 
   if(ctx->via_h1_upgrade) {
     /* HTTP/1.1 Upgrade issued. H2 Settings have already been submitted


### PR DESCRIPTION
From the description of `CURLMOPT_MAX_CONCURRENT_STREAMS` introduced in #3806 I'd expect the initial no. of concurrent streams CURL can send over one connection before a `SETTINGS` frame from the server is received would be tunable, but it isn't. For HTTP/2, it just bootstraps the value sent in curl's `SETTINGS` frame - but that applies to the server `PUSH` direction.

For my application, the situation improved a bit with #6852 but when the application goes from idle state (no connections) to having to process a sudden request peak (say thousands within few milliseconds), curl quickly spawns as many connections as allowed with `CURLMOPT_MAX_TOTAL_CONNECTIONS` (tens of connections; `PIPEWAIT` is set on each handle so each fills up to currently hard-coded 100 `ctx->max_concurrent_streams` before the next one is created) even though the server would've been perfectly OK with those thousands of open streams over one connection, just didn't manage to get a `SETTINGS` frame to curl in time.

Would this be an acceptable change?

If users don't set `CURLMOPT_MAX_CONCURRENT_STREAMS`, the default from `multi->max_concurrent_streams` is exactly the same (100) as the `DEFAULT_MAX_CONCURRENT_STREAMS`, so no change in behavior. If they do set it - with a different aim than mine - the comment from #6852 still applies:

> The server can always reject new streams anyway if we go above what it accepts.