### PR TITLE
curl_gssapi: document/update feature availability

### DIFF
--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -510,7 +510,7 @@ OM_uint32 Curl_gss_init_sec_context(struct Curl_easy *data,
     req_flags |= GSS_C_MUTUAL_FLAG;
 
   if(data->set.gssapi_delegation & CURLGSSAPI_DELEGATION_POLICY_FLAG) {
-#ifdef GSS_C_DELEG_POLICY_FLAG  /* MIT Kerberos 1.8+ (2010-03-02), Apple GSS,
+#ifdef GSS_C_DELEG_POLICY_FLAG  /* MIT Kerberos 1.7+ (2009-06-02), Apple GSS,
                                    missing from GNU GSS */
     req_flags |= GSS_C_DELEG_POLICY_FLAG;
 #else

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -435,7 +435,7 @@ static OM_uint32 stub_gss_indicate_mechs(
   return GSS_S_COMPLETE;
 }
 
-#ifdef HAVE_GSS_SET_NEG_MECHS  /* MIT Kerberos 1.9+ (2010-12-22),
+#ifdef HAVE_GSS_SET_NEG_MECHS  /* MIT Kerberos 1.8+ (2010-03-02),
                                   missing from Apple GSS, GNU GSS */
 static OM_uint32 stub_gss_set_neg_mechs(
   OM_uint32 *min,

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -511,7 +511,7 @@ OM_uint32 Curl_gss_init_sec_context(struct Curl_easy *data,
 
   if(data->set.gssapi_delegation & CURLGSSAPI_DELEGATION_POLICY_FLAG) {
 #ifdef GSS_C_DELEG_POLICY_FLAG  /* MIT Kerberos 1.8+ (2010-03-02), Apple GSS,
-                                   missing from GNU GSS (as of 1.0.4) */
+                                   missing from GNU GSS */
     req_flags |= GSS_C_DELEG_POLICY_FLAG;
 #else
     infof(data, "WARNING: support for CURLGSSAPI_DELEGATION_POLICY_FLAG not "

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -436,8 +436,7 @@ static OM_uint32 stub_gss_indicate_mechs(
 }
 
 #ifdef HAVE_GSS_SET_NEG_MECHS  /* MIT Kerberos 1.9+ (2010-12-22),
-                                  missing from Heimdal (as of 7.8.0),
-                                  Apple GSS, GNU GSS (as of 1.0.4) */
+                                  missing from Apple GSS, GNU GSS */
 static OM_uint32 stub_gss_set_neg_mechs(
   OM_uint32 *min,
   gss_cred_id_t cred_handle,
@@ -511,8 +510,7 @@ OM_uint32 Curl_gss_init_sec_context(struct Curl_easy *data,
     req_flags |= GSS_C_MUTUAL_FLAG;
 
   if(data->set.gssapi_delegation & CURLGSSAPI_DELEGATION_POLICY_FLAG) {
-#ifdef GSS_C_DELEG_POLICY_FLAG  /* MIT Kerberos 1.8+ (2010-03-02),
-                                   Heimdal 1.3.0+ (2009-11-15), Apple GSS,
+#ifdef GSS_C_DELEG_POLICY_FLAG  /* MIT Kerberos 1.8+ (2010-03-02), Apple GSS,
                                    missing from GNU GSS (as of 1.0.4) */
     req_flags |= GSS_C_DELEG_POLICY_FLAG;
 #else

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -435,7 +435,9 @@ static OM_uint32 stub_gss_indicate_mechs(
   return GSS_S_COMPLETE;
 }
 
-#ifdef HAVE_GSS_SET_NEG_MECHS
+#ifdef HAVE_GSS_SET_NEG_MECHS  /* MIT Kerberos 1.9+ (2010-12-22),
+                                  missing from Heimdal (as of 7.8.0),
+                                  Apple GSS, GNU GSS (as of 1.0.4) */
 static OM_uint32 stub_gss_set_neg_mechs(
   OM_uint32 *min,
   gss_cred_id_t cred_handle,
@@ -509,7 +511,9 @@ OM_uint32 Curl_gss_init_sec_context(struct Curl_easy *data,
     req_flags |= GSS_C_MUTUAL_FLAG;
 
   if(data->set.gssapi_delegation & CURLGSSAPI_DELEGATION_POLICY_FLAG) {
-#ifdef GSS_C_DELEG_POLICY_FLAG  /* MIT Kerberos 1.8+, missing from GNU GSS */
+#ifdef GSS_C_DELEG_POLICY_FLAG  /* MIT Kerberos 1.8+ (2010-03-02),
+                                   Heimdal 1.3.0+ (2009-11-15), Apple GSS,
+                                   missing from GNU GSS (as of 1.0.4) */
     req_flags |= GSS_C_DELEG_POLICY_FLAG;
 #else
     infof(data, "WARNING: support for CURLGSSAPI_DELEGATION_POLICY_FLAG not "


### PR DESCRIPTION
- update `GSS_C_DELEG_POLICY_FLAG` comment to include Apple GSS, add
  date, and amend MIT Kerberos version to 1.7+ (was: 1.8+)
  Ref: https://github.com/krb5/krb5/commit/45875a4d7bbd6bb8a943572d84fef5ca2bb18291
  Ref: https://github.com/apple-oss-distributions/Heimdal/commit/1635de38a813f6e1dd3f8fd270683187ad4f02be

- document `HAVE_GSS_SET_NEG_MECHS`/`gss_set_neg_mechs()`.
  Ref: https://github.com/krb5/krb5/commit/079eed2cf749702f75ddc385cf943fbab931f9d8
  It's also committed to Heimdal, but not present in a release
  as of 7.8.0 (current latest).
  Ref: https://github.com/heimdal/heimdal/commit/735039dbdc3aa58d06afdefd214efe3f5e421244

Follow-up to a8881e5e1d2e22d4b085d45ab6c8ce1df251d602 #21315 #22410
Follow-up to d169ad68faa5ed5ba2375e7502307a6262466d88 #22052

---

By my estimate Apple forked Heimdal somewhere around 1.4.0 and 1.5.1
https://github.com/heimdal/heimdal/commit/49b471f1a2e0c2bfd19fa48fb2fbcb156de39674,
that is around 2011-09, and before 2012-02-03:
https://github.com/apple-oss-distributions/Heimdal/commit/673e1a1a5939d00754e9ec370a3ebed101e56f9d
