### PR TITLE
dnsd: fix bounds check in `read_https_alpn_part()`

### DIFF
--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -570,7 +570,7 @@ static int read_https_alpn_part(struct blob *b, struct Curl_str *str)
     if(str->str[i] == ',')
       break;
   }
-  if(i > 256)
+  if(i >= 256)
     return 1;
   if(blob_add(b, (uint8_t)i) || blob_addchars(b, str->str, i))
     return 1;


### PR DESCRIPTION
"The check `i > 256` permits `i == 256` to pass through. When `i` is
then cast to `uint8_t` in `blob_add(b, (uint8_t)i)`, the value wraps to
0, silently encoding a zero-length ALPN entry instead of rejecting it.
The condition should be `i > 255` (or equivalently `i >= 256`) to
correctly reject any length that does not fit in a single byte."

Reported by GitHub Code Quality

Follow-up to 86f1e5b3f6c90e453368fdf23c366c1d4a8c953b #21299

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
