### PR TITLE
scorecard: fix `max_upload` init value in `ul_parallel()`

### DIFF
--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -542,7 +542,7 @@ class ScoreRunner:
         samples = []
         errors = []
         profiles = []
-        max_parallel = self._download_parallel if self._download_parallel > 0 else count
+        max_parallel = self._upload_parallel if self._upload_parallel > 0 else count
         url = f'{url}?id=[0-{count - 1}]'
         self.info('parallel...')
         for _ in range(nsamples):


### PR DESCRIPTION
"In `ul_parallel`, `max_parallel` is computed using
`self._download_parallel` instead of `self._upload_parallel`. This
causes the upload parallelism to incorrectly follow the download
parallel setting. It should use `self._upload_parallel` to be consistent
with how `uploads()` computes `max_parallel`."

Reported by GitHub Code Quality

Follow-up to 30ef79ed937ca0fc7592ff73d162398773c6a5aa #17295
