### PR TITLE
tidy-up: use `CURL_CSTRLEN()` macro on more static strings

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -433,7 +433,7 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
         return result;
 
       result = Curl_client_write(data, CLIENTWRITE_HEADER,
-                                 accept_ranges, sizeof(accept_ranges) - 1);
+                                 accept_ranges, CURL_CSTRLEN(accept_ranges));
       if(result != CURLE_OK)
         return result;
     }

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -878,9 +878,9 @@ static bool out_string(void *userp,
 
   if(!str) {
     /* Write null string if there is space. */
-    if(prec == -1 || prec >= (int)sizeof(nilstr) - 1) {
+    if(prec == -1 || prec >= (int)CURL_CSTRLEN(nilstr)) {
       str = nilstr;
-      len = sizeof(nilstr) - 1;
+      len = CURL_CSTRLEN(nilstr);
       /* Disable quotes around (nil) */
       flags &= ~(unsigned int)FLAGS_ALT;
     }
@@ -939,7 +939,7 @@ static bool out_pointer(void *userp,
     int width = p->width;
     int flags = p->flags;
 
-    width -= (int)(sizeof(nilstr) - 1);
+    width -= (int)CURL_CSTRLEN(nilstr);
     if(flags & FLAGS_LEFT)
       while(width-- > 0)
         OUTCHAR(' ');

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -208,7 +208,7 @@ CURLcode Curl_rand_alnum(struct Curl_easy *data, unsigned char *rnd,
                          size_t num)
 {
   CURLcode result = CURLE_OK;
-  const unsigned int alnumspace = sizeof(alnum) - 1;
+  const unsigned int alnumspace = CURL_CSTRLEN(alnum);
   unsigned int r;
   DEBUGASSERT(num > 1);
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -268,7 +268,7 @@ static uint16_t mbed_cipher_suite_walk_str(const char **str, const char **end)
   static const char ecjpake_suite[] = "TLS_ECJPAKE_WITH_AES_128_CCM_8";
 
   if(!id) {
-    if((len == sizeof(ecjpake_suite) - 1) &&
+    if((len == CURL_CSTRLEN(ecjpake_suite)) &&
        curl_strnequal(ecjpake_suite, *str, len))
       id = MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8;
   }

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -693,7 +693,7 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
       written = swrite(sock, streamthis, CURL_CSTRLEN(streamthis));
       if(got_exit_signal)
         return -1;
-      if(written != (ssize_t)CURL_CSTRLEN(streamthis))) {
+      if(written != (ssize_t)CURL_CSTRLEN(streamthis)) {
         logmsg("Stopped streaming");
         break;
       }

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -690,10 +690,10 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
   case RCMD_STREAM: {
     static const char streamthis[] = "a string to stream 01234567890\n";
     for(;;) {
-      written = swrite(sock, streamthis, sizeof(streamthis) - 1);
+      written = swrite(sock, streamthis, CURL_CSTRLEN(streamthis));
       if(got_exit_signal)
         return -1;
-      if(written != (ssize_t)(sizeof(streamthis) - 1)) {
+      if(written != (ssize_t)CURL_CSTRLEN(streamthis))) {
         logmsg("Stopped streaming");
         break;
       }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -380,7 +380,7 @@ static void exit_signal_handler(int signum)
   int old_errno = errno;
   if(!serverlogfile) {
     static const char msg[] = "exit_signal_handler: serverlogfile not set\n";
-    (void)write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
   }
   else {
     int fd = -1;
@@ -394,12 +394,12 @@ static void exit_signal_handler(int signum)
     if(fd != -1) {
 #endif
       static const char msg[] = "exit_signal_handler: called\n";
-      (void)write(fd, msg, sizeof(msg) - 1);
+      (void)write(fd, msg, CURL_CSTRLEN(msg));
       curlx_close(fd);
     }
     else {
       static const char msg[] = "exit_signal_handler: failed opening ";
-      (void)write(STDERR_FILENO, msg, sizeof(msg) - 1);
+      (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
       (void)write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
       (void)write(STDERR_FILENO, "\n", 1);
     }


### PR DESCRIPTION
Follow-up to e1450d8fdaf05f27ec75eb15df303fe931755a59 #22406
