### PR TITLE
tests: fix cert comparison with old cryptography

### DIFF
--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -693,7 +693,7 @@ class ScoreRunner:
                 'os': self.env.curl_os(),
                 'server': self.server_descr,
                 'samples': nsamples,
-                'date': f'{datetime.datetime.now(tz=datetime.timezone.utc).isoformat()}',
+                'date': f'{datetime.datetime.now(datetime.timezone.utc).isoformat()}',
             }
         }
         if self._limit_rate:

--- a/tests/http/testenv/certs.py
+++ b/tests/http/testenv/certs.py
@@ -344,17 +344,15 @@ class CertStore:
             cert = self.load_pem_cert(cert_file)
             pkey = self.load_pem_pkey(pkey_file)
             try:
-                now = datetime.now(tz=timezone.utc)
-                if check_valid and \
-                    ((cert.not_valid_after_utc < now) or
-                     (cert.not_valid_before_utc > now)):
-                    return None
-            except AttributeError:  # older python
-                now = datetime.now(timezone.utc)
-                if check_valid and \
-                        ((cert.not_valid_after < now) or
-                         (cert.not_valid_before > now)):
-                    return None
+                before = cert.not_valid_before_utc
+                after = cert.not_valid_after_utc
+            except AttributeError:  # cryptography < 42.0.0
+                # the timestamps are already returned in UTC, just missing the time zone
+                before = cert.not_valid_before.replace(tzinfo=timezone.utc)
+                after = cert.not_valid_after.replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
+            if check_valid and ((after < now) or (before > now)):
+                return None
             creds = Credentials(name=name, cert=cert, pkey=pkey, issuer=issuer)
             creds.set_store(self)
             creds.set_files(cert_file, pkey_file, comb_file)


### PR DESCRIPTION
The fallback path for cryptography < 42 was broken by commit e13362c2
that caused a comparison between offset-naive and offset-aware
datetimes.

Pointed out by Codex Security
Closes #22426


<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->