### PR TITLE
urlapi: clear password buffer on error path

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -347,6 +347,7 @@ out:
   curlx_free(passwdp);
   curlx_free(optionsp);
   curlx_safefree(u->user);
+  curlx_strzero(u->password);
   curlx_safefree(u->password);
   curlx_safefree(u->options);
 


### PR DESCRIPTION
Reported by Copilot
Bug: https://github.com/curl/curl/pull/21637#pullrequestreview-4809702512
Follow-up to 112a8b5adf36c17e7816a8db701b3e7a22958e52 #21637
Follow-up to 7c34365ccea19949317878c7fcd5f7376e2e09f1 #21879

---

Missed a memfree that appeared after rebase on master.
