### PR TITLE
imap: stream large SEARCH responses instead of buffering whole

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1215,6 +1215,30 @@ static bool is_custom_fetch_listing(struct IMAP *imap)
   return FALSE;
 }
 
+/*
+ * imap_stream_resp()
+ *
+ * Tells the pingpong layer that a very long untagged response line should be
+ * streamed to the download body rather than buffered whole. This applies to
+ * the SEARCH response, which lists every matching message number on a single
+ * line and can be arbitrarily long on a large mailbox. Custom requests (e.g.
+ * "-X SEARCH ..." or "-X UID SEARCH ...") run in the LIST state and have their
+ * untagged response written to the body the same way, so those are streamed
+ * too - except custom FETCH listings, whose data is delivered differently.
+ */
+static bool imap_stream_resp(struct Curl_easy *data, struct connectdata *conn)
+{
+  struct imap_conn *imapc = Curl_conn_meta_get(conn, CURL_META_IMAP_CONN);
+  struct IMAP *imap = Curl_meta_get(data, CURL_META_IMAP_EASY);
+  if(!imapc)
+    return FALSE;
+  if(imapc->state == IMAP_SEARCH)
+    return TRUE;
+  if(imapc->state == IMAP_LIST && imap && !is_custom_fetch_listing(imap))
+    return TRUE;
+  return FALSE;
+}
+
 /* For LIST and SEARCH responses */
 static CURLcode imap_state_listsearch_resp(struct Curl_easy *data,
                                            struct imap_conn *imapc,
@@ -2284,6 +2308,7 @@ static CURLcode imap_setup_connection(struct Curl_easy *data,
 
   pp = &imapc->pp;
   PINGPONG_SETUP(pp, imap_pp_statemachine, imap_endofresp);
+  pp->stream_resp = imap_stream_resp;
 
   /* Set the default preferred authentication type and mechanism */
   imapc->preftype = IMAP_TYPE_ANY;

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1218,23 +1218,41 @@ static bool is_custom_fetch_listing(struct IMAP *imap)
 /*
  * imap_stream_resp()
  *
- * Tells the pingpong layer that a very long untagged response line should be
- * streamed to the download body rather than buffered whole. This applies to
- * the SEARCH response, which lists every matching message number on a single
- * line and can be arbitrarily long on a large mailbox. Custom requests (e.g.
- * "-X SEARCH ..." or "-X UID SEARCH ...") run in the LIST state and have their
- * untagged response written to the body the same way, so those are streamed
- * too - except custom FETCH listings, whose data is delivered differently.
+ * Tells the pingpong layer whether the incomplete response line buffered so
+ * far should be streamed to the download body as it arrives rather than
+ * buffered whole. This is done for the untagged SEARCH response, which lists
+ * every matching message number on a single line and can be arbitrarily long
+ * on a large mailbox. It applies to the SEARCH state and to custom "SEARCH"
+ * and "UID SEARCH" requests, which run in the LIST state and have their
+ * untagged response written to the body the same way. Any other line, such as
+ * the tagged completion response, is left to be buffered and parsed as usual.
  */
-static bool imap_stream_resp(struct Curl_easy *data, struct connectdata *conn)
+static bool imap_stream_resp(struct Curl_easy *data, struct connectdata *conn,
+                             const char *line, size_t len)
 {
   struct imap_conn *imapc = Curl_conn_meta_get(conn, CURL_META_IMAP_CONN);
   struct IMAP *imap = Curl_meta_get(data, CURL_META_IMAP_EASY);
-  if(!imapc)
+
+  if(!imapc || !imap)
     return FALSE;
-  if(imapc->state == IMAP_SEARCH)
+
+  if(imapc->state == IMAP_LIST) {
+    if(!imap->custom)
+      return FALSE;
+    if(!curl_strequal(imap->custom, "SEARCH") &&
+       !(curl_strequal(imap->custom, "UID") && imap->custom_params &&
+         curl_strnequal(imap->custom_params, " SEARCH ", 8)))
+      return FALSE;
+  }
+  else if(imapc->state != IMAP_SEARCH)
+    return FALSE;
+
+  /* Only an untagged "* SEARCH ..." (or "* ESEARCH ..." when RETURN options
+     were used) line is streamed. It is not decided until enough of the line
+     has arrived to tell. */
+  if(len >= 9 && !memcmp(line, "* SEARCH ", 9))
     return TRUE;
-  if(imapc->state == IMAP_LIST && imap && !is_custom_fetch_listing(imap))
+  if(len >= 10 && !memcmp(line, "* ESEARCH ", 10))
     return TRUE;
   return FALSE;
 }

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -39,14 +39,6 @@
 #include "select.h"
 #include "progress.h"
 
-/* When streaming, a response line is flushed after every append once it has
-   grown past PP_STREAM_FLUSH bytes, and a single append adds at most
-   PP_READBUF_SIZE bytes, so the receive buffer always stays clear of its
-   DYN_PINGPPONG_CMD limit. */
-#if (PP_STREAM_FLUSH + PP_READBUF_SIZE) >= DYN_PINGPPONG_CMD
-#error "PP_STREAM_FLUSH too close to the pingpong receive buffer limit"
-#endif
-
 timediff_t Curl_pp_state_timeleft_ms(struct Curl_easy *data,
                                      struct pingpong *pp)
 {
@@ -252,7 +244,7 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
   struct connectdata *conn = data->conn;
   CURLcode result = CURLE_OK;
   size_t gotbytes;
-  char buffer[PP_READBUF_SIZE];
+  char buffer[900];
 
   *code = 0; /* 0 for errors or not done */
   *size = 0;
@@ -297,14 +289,15 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
       size_t buflen = curlx_dyn_len(&pp->recvbuf);
       const char *nl = memchr(line, '\n', buflen);
 
-      /* Stream a very long response line to the download body instead of
-         buffering it whole, when the protocol opts in (e.g. IMAP SEARCH on a
-         large mailbox). This keeps memory bounded no matter how long the line
-         is. Once started (pp->streaming) keep going until the terminating
-         newline arrives, at which point the line is complete. */
+      /* When an incomplete response line is buffered and the protocol opts
+         in for it (e.g. an IMAP SEARCH reply, which can be arbitrarily long),
+         stream its content to the download body as it arrives instead of
+         buffering the whole line. This keeps memory bounded no matter how
+         long the line is. Once started (pp->streaming) keep going until the
+         terminating newline arrives, at which point the line is complete. */
       if(pp->streaming ||
-         (!nl && buflen >= PP_STREAM_FLUSH &&
-          pp->stream_resp && pp->stream_resp(data, conn))) {
+         (!nl && pp->stream_resp &&
+          pp->stream_resp(data, conn, line, buflen))) {
         size_t chunk = nl ? (size_t)(nl - line + 1) : buflen;
         if(chunk) {
           if(memchr(line, 0, chunk)) {

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -286,7 +286,40 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
 
     do {
       const char *line = curlx_dyn_ptr(&pp->recvbuf);
-      const char *nl = memchr(line, '\n', curlx_dyn_len(&pp->recvbuf));
+      size_t buflen = curlx_dyn_len(&pp->recvbuf);
+      const char *nl = memchr(line, '\n', buflen);
+
+      /* Stream a very long response line to the download body instead of
+         buffering it whole, when the protocol opts in (e.g. IMAP SEARCH on a
+         large mailbox). This keeps memory bounded no matter how long the line
+         is. Once started (pp->streaming) keep going until the terminating
+         newline arrives, at which point the line is complete. */
+      if(pp->streaming ||
+         (!nl && buflen >= PP_STREAM_FLUSH &&
+          pp->stream_resp && pp->stream_resp(data, conn))) {
+        size_t chunk = nl ? (size_t)(nl - line + 1) : buflen;
+        if(chunk) {
+          result = Curl_client_write(data, CLIENTWRITE_BODY, line, chunk);
+          if(result)
+            return result;
+        }
+        if(nl) {
+          /* the streamed line is now complete */
+          pp->streaming = FALSE;
+          if(buflen > chunk)
+            /* keep whatever follows (e.g. the tagged response line) */
+            curlx_dyn_tail(&pp->recvbuf, buflen - chunk);
+          else
+            curlx_dyn_reset(&pp->recvbuf);
+          continue; /* re-scan any remaining buffered data */
+        }
+        /* still no newline: everything so far is streamed, wait for more */
+        pp->streaming = TRUE;
+        pp->overflow = 0;
+        curlx_dyn_reset(&pp->recvbuf);
+        break;
+      }
+
       if(nl) {
         /* a newline is CRLF in pp-talk, so the CR is ignored as
            the line is not really terminated until the LF comes */

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -39,6 +39,14 @@
 #include "select.h"
 #include "progress.h"
 
+/* When streaming, a response line is flushed after every append once it has
+   grown past PP_STREAM_FLUSH bytes, and a single append adds at most
+   PP_READBUF_SIZE bytes, so the receive buffer always stays clear of its
+   DYN_PINGPPONG_CMD limit. */
+#if (PP_STREAM_FLUSH + PP_READBUF_SIZE) >= DYN_PINGPPONG_CMD
+#error "PP_STREAM_FLUSH too close to the pingpong receive buffer limit"
+#endif
+
 timediff_t Curl_pp_state_timeleft_ms(struct Curl_easy *data,
                                      struct pingpong *pp)
 {
@@ -244,7 +252,7 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
   struct connectdata *conn = data->conn;
   CURLcode result = CURLE_OK;
   size_t gotbytes;
-  char buffer[900];
+  char buffer[PP_READBUF_SIZE];
 
   *code = 0; /* 0 for errors or not done */
   *size = 0;
@@ -299,6 +307,16 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
           pp->stream_resp && pp->stream_resp(data, conn))) {
         size_t chunk = nl ? (size_t)(nl - line + 1) : buflen;
         if(chunk) {
+          if(memchr(line, 0, chunk)) {
+            failf(data, "Nul byte in server response line");
+            return CURLE_WEIRD_SERVER_REPLY;
+          }
+          /* mirror the chunk to the debug and header channels the same way a
+             complete line is passed on below, in pieces */
+          Curl_debug(data, CURLINFO_HEADER_IN, line, chunk);
+          result = Curl_client_write(data, CLIENTWRITE_INFO, line, chunk);
+          if(result)
+            return result;
           result = Curl_client_write(data, CLIENTWRITE_BODY, line, chunk);
           if(result)
             return result;

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -86,8 +86,16 @@ struct pingpong {
    the download body instead of being buffered as one whole line. This keeps
    memory bounded for very large single-line responses (e.g. IMAP SEARCH on a
    big mailbox) that would otherwise hit the receive buffer limit and fail with
-   CURLE_TOO_LARGE. */
+   CURLE_TOO_LARGE. The exact value is a policy choice: it must be larger than
+   any legitimate line that should not be streamed, while leaving at least
+   PP_READBUF_SIZE bytes of headroom to the receive buffer limit (enforced at
+   build time in pingpong.c). */
 #define PP_STREAM_FLUSH          (32 * 1024)
+
+/* Size of the local read chunk in Curl_pp_readresp(). A single read can grow
+   the receive buffer by at most this many bytes past PP_STREAM_FLUSH before
+   the flush check runs again. */
+#define PP_READBUF_SIZE          900
 
 #define PINGPONG_SETUP(pp, s, e) \
   do {                           \

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -64,7 +64,14 @@ struct pingpong {
   CURLcode (*statemachine)(struct Curl_easy *data, struct connectdata *conn);
   bool (*endofresp)(struct Curl_easy *data, struct connectdata *conn,
                     const char *ptr, size_t len, int *code);
+  /* Optional. When a single response line grows past PP_STREAM_FLUSH bytes
+     without a terminating newline, this is called to ask the protocol whether
+     the partial line content should be streamed to the download body (as for a
+     large IMAP "* SEARCH ..." reply that lists all matching message numbers on
+     one line). Returns TRUE to stream, keeping the receive buffer bounded. */
+  bool (*stream_resp)(struct Curl_easy *data, struct connectdata *conn);
   BIT(initialized);
+  BIT(streaming);     /* streaming a long response line to the body */
   BIT(pending_resp);  /* set TRUE when a server response is pending or in
                          progress, and is cleared once the last response is
                          read */
@@ -73,6 +80,14 @@ struct pingpong {
 /* Default pingpong response timeout in milliseconds, unless a transfer
  * has CURLOPT_SERVER_RESPONSE_TIMEOUT(_MS) set. */
 #define PINGPONG_TIMEOUT_MS      (60 * 1000)
+
+/* When a response line exceeds this many bytes without a terminating newline
+   and the protocol opts in via pp->stream_resp(), its content is streamed to
+   the download body instead of being buffered as one whole line. This keeps
+   memory bounded for very large single-line responses (e.g. IMAP SEARCH on a
+   big mailbox) that would otherwise hit the receive buffer limit and fail with
+   CURLE_TOO_LARGE. */
+#define PP_STREAM_FLUSH          (32 * 1024)
 
 #define PINGPONG_SETUP(pp, s, e) \
   do {                           \

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -64,12 +64,15 @@ struct pingpong {
   CURLcode (*statemachine)(struct Curl_easy *data, struct connectdata *conn);
   bool (*endofresp)(struct Curl_easy *data, struct connectdata *conn,
                     const char *ptr, size_t len, int *code);
-  /* Optional. When a single response line grows past PP_STREAM_FLUSH bytes
-     without a terminating newline, this is called to ask the protocol whether
-     the partial line content should be streamed to the download body (as for a
-     large IMAP "* SEARCH ..." reply that lists all matching message numbers on
-     one line). Returns TRUE to stream, keeping the receive buffer bounded. */
-  bool (*stream_resp)(struct Curl_easy *data, struct connectdata *conn);
+  /* Optional. Called with the incomplete response line buffered so far (no
+     terminating newline yet) to ask the protocol whether its content should be
+     streamed to the download body as it arrives instead of being buffered
+     whole (as for an IMAP "* SEARCH ..." reply that lists all matching message
+     numbers on one line, which can be arbitrarily long). Returns TRUE to
+     stream, keeping the receive buffer bounded no matter how long the line
+     gets. Once streaming starts, the rest of the line is streamed too. */
+  bool (*stream_resp)(struct Curl_easy *data, struct connectdata *conn,
+                      const char *line, size_t len);
   BIT(initialized);
   BIT(streaming);     /* streaming a long response line to the body */
   BIT(pending_resp);  /* set TRUE when a server response is pending or in
@@ -80,22 +83,6 @@ struct pingpong {
 /* Default pingpong response timeout in milliseconds, unless a transfer
  * has CURLOPT_SERVER_RESPONSE_TIMEOUT(_MS) set. */
 #define PINGPONG_TIMEOUT_MS      (60 * 1000)
-
-/* When a response line exceeds this many bytes without a terminating newline
-   and the protocol opts in via pp->stream_resp(), its content is streamed to
-   the download body instead of being buffered as one whole line. This keeps
-   memory bounded for very large single-line responses (e.g. IMAP SEARCH on a
-   big mailbox) that would otherwise hit the receive buffer limit and fail with
-   CURLE_TOO_LARGE. The exact value is a policy choice: it must be larger than
-   any legitimate line that should not be streamed, while leaving at least
-   PP_READBUF_SIZE bytes of headroom to the receive buffer limit (enforced at
-   build time in pingpong.c). */
-#define PP_STREAM_FLUSH          (32 * 1024)
-
-/* Size of the local read chunk in Curl_pp_readresp(). A single read can grow
-   the receive buffer by at most this many bytes past PP_STREAM_FLUSH before
-   the flush check runs again. */
-#define PP_READBUF_SIZE          900
 
 #define PINGPONG_SETUP(pp, s, e) \
   do {                           \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -221,7 +221,7 @@ test1653 test1654 test1655 test1656 test1657 test1658 test1659 test1660 \
 test1661 test1662 test1663 test1664 test1665 test1666 test1667 test1668 \
 test1669 test1670 test1671 test1672 test1673 test1674 test1675 test1676 \
 test1677 test1678          test1680 test1681 test1682 test1683 test1684 \
-test1685 test1686 \
+test1685 test1686 test1687 test1688 \
 \
 test1700          test1702 test1703 test1704 test1705 test1706 test1707 \
 test1708 test1709 test1710 test1711 test1712 test1713 test1714 test1715 \

--- a/tests/data/test1687
+++ b/tests/data/test1687
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+SEARCH
+huge response
+</keywords>
+</info>
+
+# Server-side
+<reply>
+# a single ~70000 bytes response line, larger than the 64 KB pingpong
+# receive buffer limit, so it only works when streamed to the body
+<data crlf="yes" nocheck="yes">
+* SEARCH 1%repeat[7000 x %20123456789]%
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+imap
+</server>
+<name>
+IMAP SEARCH with excessively large response line
+</name>
+<command>
+imap://%HOSTIP:%IMAPPORT/%TESTNUMBER?ALL -u user:secret
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+A001 CAPABILITY
+A002 LOGIN user secret
+A003 SELECT %TESTNUMBER
+A004 SEARCH ALL
+A005 LOGOUT
+</protocol>
+<stdout crlf="yes">
+* SEARCH 1%repeat[7000 x %20123456789]%
+</stdout>
+</verify>
+</testcase>

--- a/tests/data/test1688
+++ b/tests/data/test1688
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+SEARCH
+huge response
+</keywords>
+</info>
+
+# Server-side
+<reply>
+# a single ~70000 bytes response line, larger than the 64 KB pingpong
+# receive buffer limit, so it only works when streamed to the body
+<data crlf="yes" nocheck="yes">
+* SEARCH 1%repeat[7000 x %20123456789]%
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+imap
+</server>
+<name>
+IMAP custom SEARCH with excessively large response line
+</name>
+<command>
+imap://%HOSTIP:%IMAPPORT/%TESTNUMBER -u user:secret -X 'SEARCH ALL'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+A001 CAPABILITY
+A002 LOGIN user secret
+A003 SELECT %TESTNUMBER
+A004 SEARCH ALL
+A005 LOGOUT
+</protocol>
+<stdout crlf="yes">
+* SEARCH 1%repeat[7000 x %20123456789]%
+</stdout>
+</verify>
+</testcase>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -454,20 +454,34 @@ sub getreplydata {
     return @data;
 }
 
-sub sockfilt {
+# Send data in DATA blocks of at most 16 KB each, so that a payload of any
+# size can be passed on regardless of the sockfilt buffer size and of the
+# 4 hex digit block length limit
+sub sockfiltblocks {
+    my ($fh, @data) = @_;
     my $l;
-    foreach $l (@_) {
-        printf SFWRITE "DATA\n%04x\n", length($l);
-        print SFWRITE $l;
+    foreach $l (@data) {
+        my $len = length($l);
+        my $off = 0;
+        if(!$len) {
+            printf $fh "DATA\n0000\n";
+            next;
+        }
+        while($off < $len) {
+            my $chunk = substr($l, $off, 16384);
+            printf $fh "DATA\n%04x\n", length($chunk);
+            print $fh $chunk;
+            $off += length($chunk);
+        }
     }
 }
 
+sub sockfilt {
+    sockfiltblocks(\*SFWRITE, @_);
+}
+
 sub sockfiltsecondary {
-    my $l;
-    foreach $l (@_) {
-        printf DWRITE "DATA\n%04x\n", length($l);
-        print DWRITE $l;
-    }
+    sockfiltblocks(\*DWRITE, @_);
 }
 
 #**********************************************************************

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -354,13 +354,16 @@ static void lograw(const unsigned char *buffer, ssize_t len)
 /*
  * handle the DATA command
  * maxlen is the available space in buffer (input)
- * *buffer_len is the amount of data in the buffer (output)
+ * sockfd is the socket to relay the data to, or CURL_SOCKET_BAD to discard
+ * A block larger than maxlen is read and relayed in maxlen sized pieces, so
+ * that a block up to the protocol maximum is supported with a small buffer.
  */
 static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
-                            ssize_t *buffer_len)
+                            curl_socket_t sockfd)
 {
   curl_off_t value;
   const char *endp;
+  ssize_t remaining;
 
   if(!read_stdin(buffer, 5))
     return FALSE;
@@ -372,18 +375,32 @@ static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
     logmsg("Failed to decode buffer size");
     return FALSE;
   }
-  *buffer_len = (ssize_t)value;
-  if(*buffer_len > maxlen) {
-    logmsg("Buffer size (%zd bytes) too small for data size error "
-           "(%zd bytes)", maxlen, *buffer_len);
-    return FALSE;
+  remaining = (ssize_t)value;
+  logmsg("> %zd bytes data, server => client", remaining);
+
+  while(remaining) {
+    ssize_t chunk = (remaining > maxlen) ? maxlen : remaining;
+    ssize_t nwritten = 0;
+
+    if(!read_stdin(buffer, chunk))
+      return FALSE;
+
+    lograw(buffer, chunk);
+    remaining -= chunk;
+
+    while((sockfd != CURL_SOCKET_BAD) && (nwritten < chunk)) {
+      ssize_t nsent = swrite(sockfd, buffer + nwritten, chunk - nwritten);
+      if(nsent <= 0) {
+        logmsg("Not all data was sent. Bytes to send: %zd sent: %zd",
+               chunk, nwritten);
+        /* discard the rest of the block but keep reading it, to stay in
+           sync with the stdin stream */
+        sockfd = CURL_SOCKET_BAD;
+        break;
+      }
+      nwritten += nsent;
+    }
   }
-  logmsg("> %zd bytes data, server => client", *buffer_len);
-
-  if(!read_stdin(buffer, *buffer_len))
-    return FALSE;
-
-  lograw(buffer, *buffer_len);
 
   return TRUE;
 }
@@ -870,7 +887,6 @@ static bool disc_handshake(void)
 
   do {
     unsigned char buffer[BUFFER_SIZE];
-    ssize_t buffer_len;
     if(!read_stdin(buffer, 5))
       return FALSE;
     logmsg("Received %c%c%c%c (on stdin)",
@@ -888,7 +904,7 @@ static bool disc_handshake(void)
     else if(!memcmp("DATA", buffer, 4)) {
       /* We must read more data to stay in sync */
       logmsg("Throwing away data bytes");
-      if(!read_data_block(buffer, sizeof(buffer), &buffer_len))
+      if(!read_data_block(buffer, sizeof(buffer), CURL_SOCKET_BAD))
         return FALSE;
     }
     else if(!memcmp("QUIT", buffer, 4)) {
@@ -1072,24 +1088,18 @@ static bool juggle(curl_socket_t *sockfdp,
     }
     else if(!memcmp("DATA", buffer, 4)) {
       /* data IN => data OUT */
-      if(!read_data_block(buffer, sizeof(buffer), &buffer_len))
-        return FALSE;
-
-      if(buffer_len < 0)
-        return FALSE;
-
       if(*mode == PASSIVE_LISTEN) {
+        /* consume the block to stay in sync */
+        if(!read_data_block(buffer, sizeof(buffer), CURL_SOCKET_BAD))
+          return FALSE;
         logmsg("*** We are disconnected!");
         if(!disc_handshake())
           return FALSE;
       }
       else {
-        /* send away on the socket */
-        ssize_t bytes_written = swrite(sockfd, buffer, buffer_len);
-        if(bytes_written != buffer_len) {
-          logmsg("Not all data was sent. Bytes to send: %zd sent: %zd",
-                 buffer_len, bytes_written);
-        }
+        /* send away on the socket while reading it */
+        if(!read_data_block(buffer, sizeof(buffer), sockfd))
+          return FALSE;
       }
     }
     else if(!memcmp("DISC", buffer, 4)) {


### PR DESCRIPTION
### Summary

Fixes an IMAP `SEARCH` on a large mailbox failing with `CURLE_TOO_LARGE` and delivering zero bytes. A SEARCH reply is a single untagged line listing every matching message number, so on a big mailbox that one line can exceed the pingpong receive buffer (`DYN_PINGPPONG_CMD`, 64 KB). Once a line crosses the cap, `dyn_nappend()` aborts the transfer.

Closes #22435

### Approach

Stream an over-long response line to the download body as it arrives, and only finalize it at the terminating CRLF, instead of requiring the whole line in the receive buffer first. Memory stays bounded (the receive buffer is unchanged at 64 KB) regardless of how long the response line is.

- `lib/pingpong.{c,h}`: when a response line grows past `PP_STREAM_FLUSH` (32 KB) without a newline and the protocol opts in via a new optional `pp->stream_resp()` callback, the partial content is written to the body and the buffer reset; a `pp->streaming` flag carries this across reads until the newline completes the line. Protocols that don't set the callback are unaffected.

- `lib/imap.c`: opt in for the SEARCH state and for custom `-X SEARCH` / `-X "UID SEARCH"` (which run in the LIST state), while excluding custom FETCH listings, whose untagged data is delivered by a different path.

### Before / after

Against a real Dovecot server (2.3.21) with 20000 messages (SEARCH line =108904 bytes), same 64 KB receive buffer:

| build | `SEARCH ALL` | result |
| --- | --- | --- |
| before | `exit 100 (CURLE_TOO_LARGE)` | 0 bytes |
| after  | `exit 0` | full line delivered (108904 bytes) |

Standard `?ALL` and custom `-X "SEARCH ALL"` produce byte-identical output after the change.

### Testing

- Existing IMAP test suite (tests 800-899): 76/76 OK with the change.
- Manual reproduction + verification against Dovecot 2.3.21 (20000 messages) for
  both the standard and custom SEARCH paths.
- `scripts/checksrc.pl` clean on the changed files.

### Known gap / question for reviewers

I could not add a `tests/data/testNNNN` regression test the usual way: the test server relays through `sockfilt`, which breaks ("broken pipe", surfaces as error 56) on a single response line of this size before curl's buffer limit is even reached. I'd appreciate guidance on how you'd like this covered — one option is a test whose SEARCH line sits just above the 32 KB streaming threshold (rather than 100 KB+), if that stays within what sockfilt can relay.

### Alternative considered

A smaller change simply raises the receive-buffer ceiling for the receive side (separate cap from the send side). That works but only moves the wall and costs more peak memory; streaming removes the ceiling entirely with bounded memory, so I went with streaming. Happy to switch to the simpler cap bump, or to a different threshold, if you prefer.

### Not in this PR

The `docs/KNOWN_BUGS.md` entry "IMAP `SEARCH ALL` truncated response" (under "Email protocols") describes this as a fixed-length truncation in `pingpong.c`, which appears stale (there is no fixed-length truncation there anymore; the current behavior is the hard failure this PR fixes). Can update it separately once the behavior here is agreed.
