### PR TITLE
GHA: work around Homebrew `ca-certificates` install error

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,6 +80,7 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev \
             libnghttp2-dev libldap-dev libkrb5-dev libgnutls28-dev libwolfssl-dev
+          /home/linuxbrew/.linuxbrew/bin/brew install ca-certificates || true
           /home/linuxbrew/.linuxbrew/bin/brew install c-ares gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,6 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_AUTO_UPDATE: '1'
 
 jobs:
   gha_python:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,7 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_AUTO_UPDATE: '1'
 
 jobs:
   gha_python:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,7 @@ env:
   CURL_CI: github
   CURL_TEST_MIN: 1660
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_AUTO_UPDATE: '1'
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   AWSLC_VERSION: 5.1.0
   # renovate: datasource=github-tags depName=google/boringssl versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,6 @@ env:
   CURL_CI: github
   CURL_TEST_MIN: 1660
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_AUTO_UPDATE: '1'
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   AWSLC_VERSION: 5.1.0
   # renovate: datasource=github-tags depName=google/boringssl versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -481,6 +481,7 @@ jobs:
             ${INSTALL_PACKAGES} \
             ${MATRIX_INSTALL_PACKAGES}
           if [ -n "${INSTALL_PACKAGES_BREW}" ]; then
+            /home/linuxbrew/.linuxbrew/bin/brew install ca-certificates || true
             /home/linuxbrew/.linuxbrew/bin/brew install ${INSTALL_PACKAGES_BREW}
           fi
 


### PR DESCRIPTION
Working around:
```
==> Installing libngtcp2 dependency: ca-certificates
==> Pouring ca-certificates--2026-07-16.all.bottle.1.tar.gz
Warning: The post-install step did not complete successfully
[...]
Error: Process completed with exit code 1.
```

Refs:
https://github.com/Homebrew/homebrew-core/pull/295934
https://github.com/Homebrew/brew/pull/23357

Bug: https://github.com/curl/curl/pull/22437#issuecomment-5124151490

---

- [x] try something new first. [FAIL]
