### PR TITLE
build: fix HTTPSIG option for unsupported TLS backends

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -316,7 +316,7 @@ jobs:
           - name: '!ssl !http !smtp !imap'
             image: ubuntu-26.04-arm
             tflags: '--min=500'
-            configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity
+            configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity --enable-httpsig
 
           - name: 'clang-tidy'
             image: ubuntu-26.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -341,7 +341,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=/home/linuxbrew/.linuxbrew/opt/openssl@4
               -DCURL_USE_WOLFSSL=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_RUSTLS=ON
               -DCURL_USE_GSASL=ON
-              -DUSE_ECH=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON
+              -DUSE_ECH=ON -DCURL_USE_GSSAPI=ON -DUSE_SSLS_EXPORT=ON -DCURL_DISABLE_HTTPSIG=OFF
               -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=/usr/bin/clang-tidy-22
 
           - name: 'clang-tidy H3 c-ares !examples'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -235,7 +235,7 @@ jobs:
 
           - name: '!ssl libssh2 AppleIDN'
             compiler: clang
-            generate: -DENABLE_DEBUG=ON -DCURL_USE_LIBSSH2=ON -DUSE_APPLE_IDN=ON -DCURL_ENABLE_SSL=OFF -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF
+            generate: -DENABLE_DEBUG=ON -DCURL_USE_LIBSSH2=ON -DUSE_APPLE_IDN=ON -DCURL_ENABLE_SSL=OFF -DCURL_BROTLI=OFF -DCURL_ZSTD=OFF -DCURL_DISABLE_HTTPSIG=OFF
             tflags: '--min=1630'
 
           - name: 'OpenSSL libssh c-ares'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -345,7 +345,7 @@ jobs:
             compiler: clang
             install: brotli wolfssl zstd
             install_steps: pytest
-            generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON
+            generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON -DCURL_ENABLE_NTLM=ON -DCURL_DISABLE_HTTPSIG=OFF
 
           - name: 'mbedTLS !ldap brotli zstd MultiSSL AppleIDN'
             compiler: llvm@18

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -313,7 +313,7 @@ jobs:
           #   install: 'mingw-w64-ucrt-x86_64-libssh2' }
           - { name: 'schannel dev debug', type: 'Debug', cppflags: '-DCURL_SCHANNEL_DEV_DEBUG', image: 'windows-2025',
               build: 'cmake'    , sys: 'mingw64'   , env: 'x86_64'       , tflags: 'skiprun',
-              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DCURL_USE_WOLFSSL=ON -DENABLE_UNICODE=ON -DCMAKE_VERBOSE_MAKEFILE=ON',
+              config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DCURL_USE_WOLFSSL=ON -DENABLE_UNICODE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCURL_DISABLE_HTTPSIG=OFF',
               install: 'mingw-w64-x86_64-libssh2 mingw-w64-x86_64-wolfssl' }
           - { name: 'MultiSSL R', type: 'Release',
               build: 'cmake'    , sys: 'mingw32'   , env: 'i686'         , tflags: 'skiprun',
@@ -686,6 +686,7 @@ jobs:
               -DCURL_DROP_UNUSED=ON \
               -DCURL_WERROR=ON \
               -DUSE_LIBIDN2=OFF \
+              -DCURL_DISABLE_HTTPSIG=OFF \
               ${MATRIX_CONFIG}
           done
           if [ -d bld_chkprefill ] && ! diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1106,6 +1106,11 @@ if(USE_ECH)
   endif()
 endif()
 
+if(NOT CURL_DISABLE_HTTPSIG AND (NOT USE_OPENSSL AND NOT USE_WOLFSSL))
+  message(WARNING "HTTPSIG requires OpenSSL or wolfSSL. HTTPSIG support disabled.")
+  set(CURL_DISABLE_HTTPSIG ON)
+endif()
+
 option(USE_SSLS_EXPORT "Enable SSL session import/export (experimental)" OFF)
 if(USE_SSLS_EXPORT)
   if(_ssl_enabled)

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -79,6 +79,7 @@ if [ -n "${CMAKE_GENERATOR:-}" ]; then
       -DCURL_STATIC_CRT=ON \
       -DCURL_DROP_UNUSED=ON \
       -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBPSL=OFF \
+      -DCURL_DISABLE_HTTPSIG=OFF \
       ${CMAKE_GENERATE:-} \
       ${options} \
       || { cat _bld/CMakeFiles/CMake* 2>/dev/null; false; }

--- a/configure.ac
+++ b/configure.ac
@@ -4599,7 +4599,6 @@ AS_HELP_STRING([--disable-httpsig],[Disable HTTP Message Signatures support (exp
 [ case "$enableval" in
   no)
     AC_MSG_RESULT(no)
-    AC_DEFINE(CURL_DISABLE_HTTPSIG, 1, [to disable HTTP Message Signatures support])
     want_httpsig="no"
     ;;
   *)
@@ -4608,9 +4607,17 @@ AS_HELP_STRING([--disable-httpsig],[Disable HTTP Message Signatures support (exp
     ;;
   esac ],
     AC_MSG_RESULT(no)
-    AC_DEFINE(CURL_DISABLE_HTTPSIG, 1, [to disable HTTP Message Signatures support])
     want_httpsig="no"
 )
+
+if test "$want_httpsig" = "yes"; then
+  if test "$OPENSSL_ENABLED" = "1" || test "$WOLFSSL_ENABLED" = "1"; then
+    AC_MSG_WARN([HTTPSIG requires OpenSSL or wolfSSL. HTTPSIG support disabled.])
+  else
+    AC_DEFINE(CURL_DISABLE_HTTPSIG, 1, [to disable HTTP Message Signatures support])
+    want_httpsig="no"
+  fi
+fi
 
 dnl ************************************************************
 dnl disable NTLM support

--- a/configure.ac
+++ b/configure.ac
@@ -4610,7 +4610,7 @@ AS_HELP_STRING([--disable-httpsig],[Disable HTTP Message Signatures support (exp
     want_httpsig="no"
 )
 
-if test "$want_httpsig" = "yes" && test "$OPENSSL_ENABLED" != "1" && test "$WOLFSSL_ENABLED" = "1"; then
+if test "$want_httpsig" = "yes" && test "$OPENSSL_ENABLED" != "1" && test "$WOLFSSL_ENABLED" != "1"; then
   AC_MSG_WARN([HTTPSIG requires OpenSSL or wolfSSL. HTTPSIG support disabled.])
   want_httpsig="no"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -4610,13 +4610,12 @@ AS_HELP_STRING([--disable-httpsig],[Disable HTTP Message Signatures support (exp
     want_httpsig="no"
 )
 
-if test "$want_httpsig" = "yes"; then
-  if test "$OPENSSL_ENABLED" = "1" || test "$WOLFSSL_ENABLED" = "1"; then
-    AC_MSG_WARN([HTTPSIG requires OpenSSL or wolfSSL. HTTPSIG support disabled.])
-  else
-    AC_DEFINE(CURL_DISABLE_HTTPSIG, 1, [to disable HTTP Message Signatures support])
-    want_httpsig="no"
-  fi
+if test "$want_httpsig" = "yes" && test "$OPENSSL_ENABLED" != "1" && test "$WOLFSSL_ENABLED" = "1"; then
+  AC_MSG_WARN([HTTPSIG requires OpenSSL or wolfSSL. HTTPSIG support disabled.])
+  want_httpsig="no"
+fi
+if test "$want_httpsig" != "yes"; then
+  AC_DEFINE(CURL_DISABLE_HTTPSIG, 1, [to disable HTTP Message Signatures support])
 fi
 
 dnl ************************************************************


### PR DESCRIPTION
Show a warning and force-disable HTTPSIG when the TLS backend is not
OpenSSL or wolfSSL. Before this patch this resulted in a mismatched
feature list in configure and `curl -V`.

Also enable HTTPSIG in more CI jobs to cover unsupported ones, Windows 
compilers, clang-tidy, cmake.

Follow-up to a55731050e8c3dbea0b96205cf916443118f6acb #22386 #21239
Cherry-picked from #22437
