### PR TITLE
GHA: set `HOMEBREW_NO_INSTALL_CLEANUP=1` where brew is used

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -31,6 +31,7 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
 
 jobs:
   checksrc:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,7 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
 
 jobs:
   gha_python:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -38,6 +38,7 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
 
 jobs:
   check-linux:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -22,6 +22,7 @@ permissions: {}
 env:
   CURL_TEST_MIN: 1500
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
   MAKEFLAGS: -j 5
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,7 @@ env:
   CURL_CI: github
   CURL_TEST_MIN: 1660
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   AWSLC_VERSION: 5.1.0
   # renovate: datasource=github-tags depName=google/boringssl versioning=semver registryUrl=https://github.com

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,6 +46,7 @@ env:
   CURL_CI: github
   CURL_TEST_MIN: 1750
   DO_NOT_TRACK: '1'
+  HOMEBREW_NO_INSTALL_CLEANUP: '1'
   MAKEFLAGS: -j 4
   LDFLAGS: -w  # suppress 'object file was built for newer macOS version than being linked' warnings
 


### PR DESCRIPTION
To save work unnecessary in CI context, and to reduce log noise.

Cherry-picked from #22437

---

- [x] this may be unnecessary in normal runs. No, it _does_ actually avoid unnecessary work and log noise, and also a message recommending to enable it for this purpose (it's not saving significant time in this particular example though):
   Before: https://github.com/curl/curl/actions/runs/30522192805/job/90804900165
   After: https://github.com/curl/curl/actions/runs/30522192805/job/90804900165
   
```
==> Installing libngtcp2 dependency: openssl@3
==> Pouring openssl@3--3.6.3.x86_64_linux.bottle.1.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/openssl@3/3.6.3: 7,643 files, 42.7MB
==> Installing libngtcp2
==> Pouring libngtcp2--1.25.0.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libngtcp2/1.25.0: 23 files, 1.7MB
==> Running `brew cleanup libngtcp2`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Pouring libnghttp3--1.18.0.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libnghttp3/1.18.0: 20 files, 743.0KB
==> Running `brew cleanup libnghttp3`...
==> Pouring c-ares--1.34.8.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/c-ares/1.34.8: 176 files, 1.4MB
==> Running `brew cleanup c-ares`...
```

```
==> Installing libngtcp2 dependency: openssl@3
==> Pouring openssl@3--3.6.3.x86_64_linux.bottle.1.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/openssl@3/3.6.3: 7,643 files, 42.7MB
==> Installing libngtcp2
==> Pouring libngtcp2--1.25.0.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libngtcp2/1.25.0: 23 files, 1.7MB
==> Pouring libnghttp3--1.18.0.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libnghttp3/1.18.0: 20 files, 743.0KB
==> Pouring c-ares--1.34.8.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/c-ares/1.34.8: 176 files, 1.4MB
``` 
