### PR TITLE
tidy-up: comments, messages, formatting

### DIFF
--- a/README
+++ b/README
@@ -41,7 +41,7 @@ GIT
 
   git clone https://github.com/curl/curl
 
-  (you get a directory named curl created, filled with the source code)
+  (you get a directory named curl, filled with the source code)
 
 SECURITY PROBLEMS
 

--- a/README
+++ b/README
@@ -41,7 +41,7 @@ GIT
 
   git clone https://github.com/curl/curl
 
-  (you will get a directory named curl created, filled with the source code)
+  (you get a directory named curl created, filled with the source code)
 
 SECURITY PROBLEMS
 

--- a/configure.ac
+++ b/configure.ac
@@ -2153,7 +2153,7 @@ fi
 
 case "x$SSL_DISABLED$OPENSSL_ENABLED$GNUTLS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$RUSTLS_ENABLED" in
   x)
-    AC_MSG_ERROR([TLS not detected, you will not be able to use HTTPS, FTPS, NTLM and more.
+    AC_MSG_ERROR([TLS not detected, disabling HTTPS, FTPS, NTLM and more.
 Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schannel, --with-amissl or --with-rustls to address this.])
     ;;
   x1)

--- a/configure.ac
+++ b/configure.ac
@@ -4571,16 +4571,16 @@ AS_HELP_STRING([--disable-negotiate-auth],[Disable negotiate authentication]),
 )
 
 dnl ************************************************************
-dnl disable aws
+dnl disable aws-sigv4
 dnl
-AC_MSG_CHECKING([whether to enable aws sig methods])
+AC_MSG_CHECKING([whether to enable aws-sigv4 methods])
 AC_ARG_ENABLE(aws,
-AS_HELP_STRING([--enable-aws],[Enable AWS sig support (default)])
-AS_HELP_STRING([--disable-aws],[Disable AWS sig support]),
+AS_HELP_STRING([--enable-aws],[Enable aws-sigv4 support (default)])
+AS_HELP_STRING([--disable-aws],[Disable aws-sigv4 support]),
 [ case "$enableval" in
   no)
     AC_MSG_RESULT(no)
-    AC_DEFINE(CURL_DISABLE_AWS, 1, [to disable AWS sig support])
+    AC_DEFINE(CURL_DISABLE_AWS, 1, [to disable aws-sigv4 support])
     ;;
   *)
     AC_MSG_RESULT(yes)

--- a/configure.ac
+++ b/configure.ac
@@ -2153,7 +2153,7 @@ fi
 
 case "x$SSL_DISABLED$OPENSSL_ENABLED$GNUTLS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$RUSTLS_ENABLED" in
   x)
-    AC_MSG_ERROR([TLS not detected, disabling HTTPS, FTPS, NTLM and more.
+    AC_MSG_ERROR([TLS not detected, cannot build with HTTPS, FTPS, NTLM and more.
 Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schannel, --with-amissl or --with-rustls to address this.])
     ;;
   x1)

--- a/docs/libcurl/opts/CURLOPT_HTTPSIG_ALGORITHM.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPSIG_ALGORITHM.md
@@ -68,8 +68,7 @@ int main(void)
 
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/api");
-    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM,
-                     CURLHTTPSIG_ED25519);
+    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, CURLHTTPSIG_ED25519);
     curl_easy_setopt(curl, CURLOPT_HTTPSIG_KEY,
                      "9f8362f87a484a954e6e740c5b4c0e84"
                      "229139a20aa8ab56ff66586f6a7d29c5");

--- a/docs/libcurl/opts/CURLOPT_HTTPSIG_HEADERS.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPSIG_HEADERS.md
@@ -84,8 +84,7 @@ int main(void)
     headers = curl_slist_append(headers, "User-Agent: MyApp/1.0");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/api");
-    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM,
-                     CURLHTTPSIG_ED25519);
+    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, CURLHTTPSIG_ED25519);
     curl_easy_setopt(curl, CURLOPT_HTTPSIG_KEY,
                      "9f8362f87a484a954e6e740c5b4c0e84"
                      "229139a20aa8ab56ff66586f6a7d29c5");

--- a/docs/libcurl/opts/CURLOPT_HTTPSIG_KEY.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPSIG_KEY.md
@@ -69,8 +69,7 @@ int main(void)
 
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/api");
-    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM,
-                     CURLHTTPSIG_ED25519);
+    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, CURLHTTPSIG_ED25519);
     curl_easy_setopt(curl, CURLOPT_HTTPSIG_KEY,
                      "9f8362f87a484a954e6e740c5b4c0e84"
                      "229139a20aa8ab56ff66586f6a7d29c5");

--- a/docs/libcurl/opts/CURLOPT_HTTPSIG_KEYID.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPSIG_KEYID.md
@@ -55,8 +55,7 @@ int main(void)
 
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/api");
-    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM,
-                     CURLHTTPSIG_ED25519);
+    curl_easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, CURLHTTPSIG_ED25519);
     curl_easy_setopt(curl, CURLOPT_HTTPSIG_KEY,
                      "9f8362f87a484a954e6e740c5b4c0e84"
                      "229139a20aa8ab56ff66586f6a7d29c5");

--- a/lib/curl_ed25519.c
+++ b/lib/curl_ed25519.c
@@ -147,8 +147,12 @@ CURLcode Curl_ed25519_sign(const unsigned char *key, size_t keylen,
                            const unsigned char *msg, size_t msglen,
                            unsigned char *sig, size_t *siglen)
 {
-  (void)key; (void)keylen; (void)msg; (void)msglen;
-  (void)sig; (void)siglen;
+  (void)key;
+  (void)keylen;
+  (void)msg;
+  (void)msglen;
+  (void)sig;
+  (void)siglen;
   return CURLE_NOT_BUILT_IN;
 }
 
@@ -160,8 +164,12 @@ CURLcode Curl_ed25519_sign(const unsigned char *key, size_t keylen,
                            const unsigned char *msg, size_t msglen,
                            unsigned char *sig, size_t *siglen)
 {
-  (void)key; (void)keylen; (void)msg; (void)msglen;
-  (void)sig; (void)siglen;
+  (void)key;
+  (void)keylen;
+  (void)msg;
+  (void)msglen;
+  (void)sig;
+  (void)siglen;
   return CURLE_NOT_BUILT_IN;
 }
 

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -437,10 +437,9 @@ static OM_uint32 stub_gss_indicate_mechs(
 
 #ifdef HAVE_GSS_SET_NEG_MECHS  /* MIT Kerberos 1.8+ (2010-03-02),
                                   missing from Apple GSS, GNU GSS */
-static OM_uint32 stub_gss_set_neg_mechs(
-  OM_uint32 *min,
-  gss_cred_id_t cred_handle,
-  const gss_OID_set mech_set)
+static OM_uint32 stub_gss_set_neg_mechs(OM_uint32 *min,
+                                        gss_cred_id_t cred_handle,
+                                        const gss_OID_set mech_set)
 {
   struct stub_gss_cred_id_t_desc *cred;
   size_t i;

--- a/lib/curlx/base64.c
+++ b/lib/curlx/base64.c
@@ -149,7 +149,7 @@ CURLcode curlx_base64_decode(const char *src,
     pos += 3 - padding;
   }
 
-  /* Null-terminate */
+  /* null-terminate */
   *pos = '\0';
 
   /* Return the decoded data */
@@ -213,7 +213,7 @@ static CURLcode base64_encode(const char *table64,
     }
   }
 
-  /* Null-terminate */
+  /* null-terminate */
   *output = '\0';
 
   /* Return the pointer to the new data (allocated memory) */

--- a/lib/curlx/strdup.c
+++ b/lib/curlx/strdup.c
@@ -108,14 +108,14 @@ void curlx_memzero_low(void *buf, size_t size)
 }
 #endif
 
-/* Free 'buf' after zeroing its content. */
+/* Fill 'buf' with zeroes. */
 void curlx_memzero(void *buf, size_t size)
 {
   if(buf)
     curlx_memzero_low(buf, size);
 }
 
-/* Free 'buf' after zeroing its content, where 'buf' is null-terminated. */
+/* Fill 'buf' with zeroes, where 'buf' is null-terminated. */
 void curlx_strzero(void *buf)
 {
   if(buf)

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -196,7 +196,7 @@ void curl_free(void *p)
  * Curl_hexencode()
  *
  * Converts binary input to lowercase hex-encoded ASCII output.
- * Null-terminated.
+ * null-terminated.
  */
 void Curl_hexencode(const unsigned char *src, size_t len, /* input length */
                     unsigned char *out, size_t olen) /* output buffer size */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3794,7 +3794,7 @@ static CURLcode ftp_done_check_partial(struct Curl_easy *data,
        (data->state.infilesize != -1) && /* upload with known size */
        ((!data->set.crlf && !data->state.prefer_ascii && /* no conversion */
          (data->state.infilesize != data->req.writebytecount)) ||
-        ((data->set.crlf || data->state.prefer_ascii) && /* maybe crlf conv */
+        ((data->set.crlf || data->state.prefer_ascii) && /* maybe CRLF conv */
          (data->state.infilesize > data->req.writebytecount))
        )) {
       failf(data, "Uploaded unaligned file size (%" FMT_OFF_T

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1407,7 +1407,7 @@ static const struct SASLproto saslpop3 = {
   pop3_continue_auth,   /* Send authentication continuation */
   pop3_cancel_auth,     /* Send authentication cancellation */
   pop3_get_message,     /* Get SASL response message */
-  255 - 8,              /* Max line len - strlen("AUTH ") - 1 space - crlf */
+  255 - 8,              /* Max line len - strlen("AUTH ") - 1 space - CRLF */
   '*',                  /* Code received when continuation is expected */
   '+',                  /* Code to receive upon authentication success */
   SASL_AUTH_DEFAULT,    /* Default mechanisms */

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1128,7 +1128,7 @@ static CURLcode do_init_reader_stack(struct Curl_easy *data,
 
   data->req.reader.stack = r;
   clen = r->crt->total_length(data, r);
-  /* if we do not have 0 length init, and crlf conversion is wanted,
+  /* if we do not have 0 length init, and CRLF conversion is wanted,
    * add the reader for it */
   if(clen && (data->set.crlf
 #ifdef CURL_PREFER_LF_LINEENDS

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1657,7 +1657,7 @@ static const struct SASLproto saslsmtp = {
   smtp_continue_auth,   /* Send authentication continuation */
   smtp_cancel_auth,     /* Cancel authentication */
   smtp_get_message,     /* Get SASL response message */
-  512 - 8,              /* Max line len - strlen("AUTH ") - 1 space - crlf */
+  512 - 8,              /* Max line len - strlen("AUTH ") - 1 space - CRLF */
   334,                  /* Code received when continuation is expected */
   235,                  /* Code to receive upon authentication success */
   SASL_AUTH_DEFAULT,    /* Default mechanisms */

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -341,7 +341,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   /* NTLM type-2 message structure:
 
           Index  Description            Content
-            0    NTLMSSP Signature      Null-terminated ASCII "NTLMSSP"
+            0    NTLMSSP Signature      null-terminated ASCII "NTLMSSP"
                                         (0x4e544c4d53535000)
             8    NTLM Message Type      long (0x02000000)
            12    Target Name            security buffer
@@ -430,7 +430,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   /* NTLM type-1 message structure:
 
        Index  Description            Content
-         0    NTLMSSP Signature      Null-terminated ASCII "NTLMSSP"
+         0    NTLMSSP Signature      null-terminated ASCII "NTLMSSP"
                                      (0x4e544c4d53535000)
          8    NTLM Message Type      long (0x01000000)
         12    Flags                  long
@@ -549,13 +549,13 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   /* NTLM type-3 message structure:
 
           Index  Description            Content
-            0    NTLMSSP Signature      Null-terminated ASCII "NTLMSSP"
+            0    NTLMSSP Signature      null-terminated ASCII "NTLMSSP"
                                         (0x4e544c4d53535000)
             8    NTLM Message Type      long (0x03000000)
            12    LM/LMv2 Response       security buffer
            20    NTLM/NTLMv2 Response   security buffer
            28    Target Name            security buffer
-           36    username              security buffer
+           36    username               security buffer
            44    Workstation Name       security buffer
           (52)   Session Key            security buffer (*)
           (60)   Flags                  long (*)

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -555,7 +555,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
            12    LM/LMv2 Response       security buffer
            20    NTLM/NTLMv2 Response   security buffer
            28    Target Name            security buffer
-           36    username               security buffer
+           36    Username               security buffer
            44    Workstation Name       security buffer
           (52)   Session Key            security buffer (*)
           (60)   Flags                  long (*)

--- a/projects/OS400/os400sys.c
+++ b/projects/OS400/os400sys.c
@@ -1035,4 +1035,4 @@ int Curl_os400_inflateEnd(z_streamp strm)
   return ret;
 }
 
-#endif
+#endif /* HAVE_LIBZ */

--- a/projects/vms/curl_crtl_init.c
+++ b/projects/vms/curl_crtl_init.c
@@ -126,7 +126,7 @@ static int sys_trnlnm(const char *logname, char *value, int value_len)
 
   if($VMS_STATUS_SUCCESS(status)) {
 
-    /* Null-terminate and return the string */
+    /* null-terminate and return the string */
     /*--------------------------------------*/
     value[result] = '\0';
   }

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -710,8 +710,8 @@ struct win_thread_data {
   /* This is the listen socket for the thread. It is closed after the first
      connection. */
   curl_socket_t socket_l;
-  /* This is the random number which the background thread will use to verify
-   * the peer. */
+  /* This is the random number which the background thread uses to verify
+     the peer. */
   uint64_t expected_auth_val;
 };
 

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -2575,7 +2575,7 @@ sub PASV_ftp {
     }
 
     logmsg "Client has been notified that DATA conn ".
-           "will be accepted on port $pasvport\n";
+           "is accepted on port $pasvport\n";
 
     if($nodataconn) {
         my $str = nodataconn_str();
@@ -2765,7 +2765,7 @@ sub datasockf_state {
     }
     elsif($state eq 'PASSIVE_NODATACONN') {
         # Data sockfilter bound port without listening,
-        # client will not be able to establish data connection.
+        # client is not able to establish data connection.
         $datasockf_state = $state;
         $datasockf_mode = 'passive';
         $datasockf_runs = 'yes';

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -2575,7 +2575,7 @@ sub PASV_ftp {
     }
 
     logmsg "Client has been notified that upcoming DATA connection ".
-           "is accepted on port $pasvport\n";
+           "is awaited on port $pasvport\n";
 
     if($nodataconn) {
         my $str = nodataconn_str();
@@ -2765,7 +2765,7 @@ sub datasockf_state {
     }
     elsif($state eq 'PASSIVE_NODATACONN') {
         # Data sockfilter bound port without listening,
-        # client is not able to establish data connection.
+        # client is unable to establish data connection.
         $datasockf_state = $state;
         $datasockf_mode = 'passive';
         $datasockf_runs = 'yes';

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -2574,7 +2574,7 @@ sub PASV_ftp {
         sendcontrol sprintf("229 Entering Passive Mode (|||%d|)\r\n", $pasvport);
     }
 
-    logmsg "Client has been notified that DATA conn ".
+    logmsg "Client has been notified that upcoming DATA connection ".
            "is accepted on port $pasvport\n";
 
     if($nodataconn) {

--- a/tests/negtelnetserver.py
+++ b/tests/negtelnetserver.py
@@ -126,7 +126,7 @@ class Negotiator:
         """
         buffer = bytearray()
 
-        # If we keep receiving negotiation sequences, we will not fill the buffer.
+        # If we keep receiving negotiation sequences, we do not fill the buffer.
         # Keep looping while we can, and until we have something to give back
         # to the caller.
         while len(buffer) == 0:

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -186,7 +186,7 @@ static struct bf bfs[2];
 static int nextone;     /* index of next buffer to use */
 static int current;     /* index of buffer in use */
 
-                           /* control flags for crlf conversions */
+                           /* control flags for CRLF conversions */
 static int newline = 0;    /* fillbuf: in middle of newline expansion */
 static int prevchar = -1;  /* putbuf: previous char (cr check) */
 
@@ -296,7 +296,7 @@ static void nak(int error)
  */
 static struct tftphdr *rw_init(int x)
 {
-  newline = 0;                    /* init crlf flag */
+  newline = 0;                    /* init CRLF flag */
   prevchar = -1;
   bfs[0].counter = BF_ALLOC;      /* pass out the first buffer */
   current = 0;


### PR DESCRIPTION
- 'null-terminate', sync casing.          
- add an `#endif` comment.               
- avoid a few instances of 'will'.       
- configure: 'aws' → 'aws-sigv4', where missing.
- unfold/fold lines.                     
- update memzero/strzero comments.       
- uppercase 'CRLF'.
