### PR TITLE
tidy-up: minor code fixes and improvements

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -921,7 +921,7 @@ static CURLcode schannel_connect_step1(struct Curl_cfilter *cf,
 
     /* The first four bytes is an unsigned int indicating number
        of bytes of data in the rest of the buffer. */
-    extension_len = (unsigned int *)(void *)(&alpn_buffer[cur]);
+    extension_len = (unsigned int *)(void *)&alpn_buffer[cur];
     cur += (int)sizeof(unsigned int);
 
     /* The next four bytes are an indicator that this buffer contains
@@ -932,7 +932,7 @@ static CURLcode schannel_connect_step1(struct Curl_cfilter *cf,
 
     /* The next two bytes is an unsigned short indicating the number
        of bytes used to list the preferred protocols. */
-    list_len = (unsigned short *)(void *)(&alpn_buffer[cur]);
+    list_len = (unsigned short *)(void *)&alpn_buffer[cur];
     cur += (int)sizeof(unsigned short);
 
     list_start_index = cur;

--- a/projects/OS400/os400sys.c
+++ b/projects/OS400/os400sys.c
@@ -28,8 +28,6 @@
 #include <curl/curl.h>
 #include "config-os400.h"  /* Not curl_setup.h: we only need some defines. */
 
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/un.h>
 
 #include <stdlib.h>

--- a/scripts/cmakeopts.sh
+++ b/scripts/cmakeopts.sh
@@ -11,7 +11,7 @@ cd -- "$(dirname "$0")"/..
 
 anyerr=0
 while read -r opt; do
-  if ! grep -q -F "^- \`$opt\`: " docs/INSTALL-CMAKE.md; then
+  if ! grep -q -F -- "- \`$opt\`: " docs/INSTALL-CMAKE.md; then
     echo "CMake option missing from documentation: '$opt'"
     anyerr=1
   fi

--- a/scripts/cmakeopts.sh
+++ b/scripts/cmakeopts.sh
@@ -11,7 +11,7 @@ cd -- "$(dirname "$0")"/..
 
 anyerr=0
 while read -r opt; do
-  if ! grep -q -F -- "- \`$opt\`: " docs/INSTALL-CMAKE.md; then
+  if ! grep -q -F "^- \`$opt\`: " docs/INSTALL-CMAKE.md; then
     echo "CMake option missing from documentation: '$opt'"
     anyerr=1
   fi

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -718,7 +718,7 @@ class TestDownload:
                 # or destroys the connection with internal error
                 # ERR_QPACK_HEADER_TOO_LARGE,
                 # depending on nghttp3 version and payload size
-                assert r.exit_code in (0, 56), f'expected exit code 0 or 56, '\
+                assert r.exit_code in [0, 56], f'expected exit code 0 or 56, '\
                                                f'got {r.exit_code}\n{r.dump_logs()}'
                 if r.exit_code == 0:
                     r.check_response(http_status=431)

--- a/tests/http/test_21_resolve.py
+++ b/tests/http/test_21_resolve.py
@@ -298,7 +298,7 @@ class TestResolve:
             '--connect-timeout', '1'
         ])
         # should fail with CURLE_OPERATION_TIMEOUT or COULDNT_CONNECT
-        assert r.exit_code in (7, 28), f'{r.dump_logs()}'
+        assert r.exit_code in [7, 28], f'{r.dump_logs()}'
         af_unspec_resolves = [
             line for line in r.trace_lines
             if re.match(r'.* \[DNS] re-queueing query .+ for AF_UNSPEC resolve', line)

--- a/tests/libtest/lib1549.c
+++ b/tests/libtest/lib1549.c
@@ -55,7 +55,7 @@ static CURLcode test_lib1549(const char *URL)
     result = curl_easy_getinfo(curl, CURLINFO_COOKIELIST, &cookies);
     if(!result && cookies) {
       /* a linked list of cookies in cookie file format */
-      struct curl_slist *each = cookies;
+      const struct curl_slist *each = cookies;
       while(each) {
         curl_mprintf("%s\n", each->data);
         each = each->next;

--- a/tests/libtest/lib1582.c
+++ b/tests/libtest/lib1582.c
@@ -43,7 +43,7 @@ static CURLcode test_lib1582(const char *URL)
   easy_setopt(curl, CURLOPT_HEADER, 1L);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   easy_setopt(curl, CURLOPT_URL, URL);
-  easy_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_NEGOTIATE);
+  easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);
   easy_setopt(curl, CURLOPT_USERPWD, ":");
   easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
   easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -38,7 +38,7 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
 
   /* Enumerate each certificate in the chain */
   for(cert = 0; cert < cert_info->num_of_certs; cert++) {
-    struct curl_slist *slist = cert_info->certinfo[cert];
+    const struct curl_slist *slist = cert_info->certinfo[cert];
     const char *issuer = NULL;
     const char *subject = NULL;
 

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -197,7 +197,7 @@ static CURLcode test_lib3207(const char *URL)
       result = ctx[i].result;
     }
     else {
-      struct curl_slist *item = ctx[i].contents;
+      const struct curl_slist *item = ctx[i].contents;
       while(item) {
         curl_mprintf("%s", item->data);
         item = item->next;

--- a/tests/libtest/lib5000.c
+++ b/tests/libtest/lib5000.c
@@ -42,7 +42,7 @@ static CURLcode test_lib5000(const char *URL)
   }
 
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-  easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, (long)CURLHTTPSIG_ED25519);
+  easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, CURLHTTPSIG_ED25519);
   easy_setopt(curl, CURLOPT_HTTPSIG_KEY,
               "9f8362f87a484a954e6e740c5b4c0e84"
               "229139a20aa8ab56ff66586f6a7d29c5");

--- a/tests/libtest/lib5004.c
+++ b/tests/libtest/lib5004.c
@@ -49,7 +49,7 @@ static CURLcode test_lib5004(const char *URL)
   }
 
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-  easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, (long)CURLHTTPSIG_ED25519);
+  easy_setopt(curl, CURLOPT_HTTPSIG_ALGORITHM, CURLHTTPSIG_ED25519);
   easy_setopt(curl, CURLOPT_HTTPSIG_KEY,
               "9f8362f87a484a954e6e740c5b4c0e84"
               "229139a20aa8ab56ff66586f6a7d29c5");

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -92,7 +92,7 @@ static CURLcode test_lib650(const char *URL)
   formrc = curl_formadd(&formpost,
                         &lastptr,
                         CURLFORM_PTRNAME, testname,
-                        CURLFORM_NAMELENGTH, (long)(sizeof(testname) - 2),
+                        CURLFORM_NAMELENGTH, (long)CURL_CSTRLEN(testname) - 1,
                         CURLFORM_ARRAY, formarray,
                         CURLFORM_FILENAME, "remotefile.txt",
                         CURLFORM_END);


### PR DESCRIPTION
- schannel: drop redundant parentheses.
- os400sys: drop redundant includes.
  Follow-up to ebc5212dacd3db8f5315b5a2d676415848e936d5 #22374
- pytest: replace `()` with `[]` to match rest of tests.
- libtests: constify some local pointers.
- libtests: drop redundant `(long)` casts.
- lib650: use `CURL_CSTRLEN()`.
  Follow-up to 59dc2bbe07c3b5889e0b380e5fa384d338d9d24e #22424
