### PR TITLE
gitignore: maintenance updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,6 @@ test-driver
 stamp-h*
 scripts/_curl
 scripts/curl.fish
-curl_fuzzer
-curl_fuzzer_seed_corpus.zip
-libstandaloneengine.a
 tests/string
 tests/config
 tests/ech-log/

--- a/docs/cmdline-opts/.gitignore
+++ b/docs/cmdline-opts/.gitignore
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: curl
 
 curl.txt
+asciipage.tmp.*

--- a/docs/cmdline-opts/.gitignore
+++ b/docs/cmdline-opts/.gitignore
@@ -4,3 +4,4 @@
 
 curl.txt
 asciipage.tmp.*
+manpage.tmp.*

--- a/docs/cmdline-opts/.gitignore
+++ b/docs/cmdline-opts/.gitignore
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: curl
 
 curl.txt
-asciipage.tmp.*


### PR DESCRIPTION
- docs/cmdline-opts/.gitignore: also ignore `manpage.tmp.*`.
  Follow-up to a55731050e8c3dbea0b96205cf916443118f6acb #22386 #21239

- ./.gitignore: drop obsolete entries.
  Follow-up to 4f38db1d28a971f938400f558e968fdffb9233a0 #1923
