### PR TITLE
h3-proxy: fix NULL deref when non-:status header arrives before :status

### DIFF
--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -431,6 +431,9 @@ static int cb_h3_proxy_recv_header(nghttp3_conn *conn, int64_t stream_id,
     pctx->tunnel.resp = resp;
   }
   else {
+    if(!pctx->tunnel.resp) {
+      return NGHTTP3_ERR_CALLBACK_FAILURE;
+    }
     /* store as an HTTP1-style header */
     CURL_TRC_CF(data, cf, "[%" PRId64 "] header: %.*s: %.*s", stream_id,
                 (int)h3name.len, h3name.base, (int)h3val.len, h3val.base);


### PR DESCRIPTION
cb_h3_proxy_recv_header() only allocates pctx->tunnel.resp when it sees the :status pseudo-header. Any other header field is stored via pctx->tunnel.resp->headers without checking that resp was actually set, so a header arriving before :status (or a response with no :status at all) crashes with a NULL dereference.

Add a check for pctx->tunnel.resp before use, same as the non-proxy cb_h3_recv_header already does for its stream pointer.

Found via a libFuzzer harness driving curl's H3-proxy callbacks directly.