### PR TITLE
curl_ed25519: drop unused wolfSSL random generator

### DIFF
--- a/lib/curl_ed25519.c
+++ b/lib/curl_ed25519.c
@@ -94,7 +94,6 @@ CURLcode Curl_ed25519_sign(const unsigned char *key, size_t keylen,
                            unsigned char *sig, size_t *siglen)
 {
   int ret;
-  WC_RNG rng;
   ed25519_key edkey;
   word32 outlen;
   unsigned char pubkey[ED25519_PUB_KEY_SIZE];
@@ -102,15 +101,9 @@ CURLcode Curl_ed25519_sign(const unsigned char *key, size_t keylen,
   if(keylen != ED25519_KEY_SIZE)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
-  ret = wc_InitRng(&rng);
+  ret = wc_ed25519_init(&edkey);
   if(ret)
     return CURLE_AUTH_ERROR;
-
-  ret = wc_ed25519_init(&edkey);
-  if(ret) {
-    wc_FreeRng(&rng);
-    return CURLE_AUTH_ERROR;
-  }
 
   ret = wc_ed25519_import_private_only(key, ED25519_KEY_SIZE, &edkey);
   if(ret)
@@ -132,12 +125,10 @@ CURLcode Curl_ed25519_sign(const unsigned char *key, size_t keylen,
 
   *siglen = (size_t)outlen;
   wc_ed25519_free(&edkey);
-  wc_FreeRng(&rng);
   return CURLE_OK;
 
 fail:
   wc_ed25519_free(&edkey);
-  wc_FreeRng(&rng);
   return CURLE_AUTH_ERROR;
 }
 


### PR DESCRIPTION
Follow-up to a55731050e8c3dbea0b96205cf916443118f6acb #22386 #21239