### PR TITLE
fopen: avoid truncating before temp rename

### DIFF
--- a/lib/curl_fopen.c
+++ b/lib/curl_fopen.c
@@ -95,13 +95,13 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   *tempname = NULL;
 
 #ifndef _WIN32
-  *fh = curlx_fopen(filename, FOPEN_WRITETEXT);
-  if(!*fh)
+  if(curlx_stat(filename, &sb) == -1 || !S_ISREG(sb.st_mode)) {
+    /* a non-regular file, fallback to direct fopen() */
+    *fh = curlx_fopen(filename, FOPEN_WRITETEXT);
+    if(*fh)
+      return CURLE_OK;
     goto fail;
-  if(curlx_fstat(fileno(*fh), &sb) == -1 || !S_ISREG(sb.st_mode)) {
-    return CURLE_OK;
   }
-  curlx_fclose(*fh);
 #ifdef HAVE_GETEUID
   /* If the existing file is not owned by the user, do not inherit
    * its permissions at the temp file created below. The permissions

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -288,7 +288,7 @@ test3223 test3224 test3225 test3226 test3227 test3228 test3229 \
 \
 test3300 test3301 test3302 test3303 test3304 test3305 test3306 \
 \
-test3400 test3401 \
+test3400 test3401 test3402 \
 \
 test4000 test4001 \
 \

--- a/tests/data/test3402
+++ b/tests/data/test3402
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+fopen
+</keywords>
+</info>
+
+<client>
+<features>
+unittest
+</features>
+<name>
+Curl_fopen keeps existing destinations intact until rename
+</name>
+</client>
+
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -51,4 +51,4 @@ TESTS_C = \
   unit3211.c unit3212.c unit3213.c unit3214.c            unit3216.c unit3219.c \
   unit3227.c \
   unit3300.c unit3301.c unit3302.c unit3303.c unit3304.c unit3306.c \
-  unit3400.c
+  unit3400.c unit3402.c

--- a/tests/unit/unit3402.c
+++ b/tests/unit/unit3402.c
@@ -1,0 +1,142 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "unitcheck.h"
+#include "curl_fopen.h"
+
+#ifndef _WIN32
+static char filename[512];
+static char linkname[512];
+static char targetname[512];
+
+static void cleanup_file(const char *path)
+{
+  if(path)
+    unlink(path);
+}
+
+static CURLcode t3402_setup(void)
+{
+  long pid = (long)getpid();
+
+  curl_msnprintf(filename, sizeof(filename), "unit3402-file-%ld.tmp", pid);
+  curl_msnprintf(linkname, sizeof(linkname), "unit3402-link-%ld.tmp", pid);
+  curl_msnprintf(targetname, sizeof(targetname), "unit3402-target-%ld.tmp",
+                 pid);
+
+  cleanup_file(filename);
+  cleanup_file(linkname);
+  cleanup_file(targetname);
+
+  return CURLE_OK;
+}
+
+static void t3402_stop(void)
+{
+  cleanup_file(filename);
+  cleanup_file(linkname);
+  cleanup_file(targetname);
+}
+
+static bool write_text(const char *path, const char *text)
+{
+  FILE *fp = curlx_fopen(path, "wb");
+  if(!fp)
+    return FALSE;
+  if(fputs(text, fp) < 0) {
+    curlx_fclose(fp);
+    return FALSE;
+  }
+  return !curlx_fclose(fp);
+}
+
+static bool read_text(const char *path, char *buf, size_t buflen)
+{
+  FILE *fp = curlx_fopen(path, "rb");
+  size_t nread;
+
+  if(!fp)
+    return FALSE;
+  nread = fread(buf, 1, buflen - 1, fp);
+  if(ferror(fp)) {
+    curlx_fclose(fp);
+    return FALSE;
+  }
+  buf[nread] = '\0';
+  return !curlx_fclose(fp);
+}
+
+static void write_replacement(const char *path, FILE *fp, char *tempname)
+{
+  fputs("replacement\n", fp);
+  curlx_fclose(fp);
+  fail_unless(curlx_rename(tempname, path) == 0, "rename failed");
+  curlx_free(tempname);
+}
+#endif
+
+static CURLcode test_unit3402(const char *arg)
+{
+#ifndef _WIN32
+  UNITTEST_BEGIN(t3402_setup())
+
+  CURLcode result;
+  FILE *fp = NULL;
+  char *tempname = NULL;
+  char buf[64];
+
+  abort_unless(write_text(filename, "original\n"), "create file failed");
+  result = Curl_fopen(NULL, filename, &fp, &tempname);
+  abort_unless(result == CURLE_OK, "Curl_fopen failed");
+  abort_unless(fp && tempname, "expected temp file for existing file");
+  abort_unless(read_text(filename, buf, sizeof(buf)), "read file failed");
+  fail_unless(!strcmp(buf, "original\n"), "destination was truncated");
+  write_replacement(filename, fp, tempname);
+  abort_unless(read_text(filename, buf, sizeof(buf)), "read replaced failed");
+  fail_unless(!strcmp(buf, "replacement\n"), "replacement failed");
+
+  abort_unless(write_text(targetname, "symlink target\n"),
+               "create symlink target failed");
+  abort_unless(symlink(targetname, linkname) == 0, "symlink failed");
+  result = Curl_fopen(NULL, linkname, &fp, &tempname);
+  abort_unless(result == CURLE_OK, "Curl_fopen symlink failed");
+  abort_unless(fp && tempname, "expected temp file for symlink");
+  abort_unless(read_text(targetname, buf, sizeof(buf)),
+               "read symlink target failed");
+  fail_unless(!strcmp(buf, "symlink target\n"),
+              "symlink target was truncated");
+  write_replacement(linkname, fp, tempname);
+  abort_unless(read_text(linkname, buf, sizeof(buf)), "read link failed");
+  fail_unless(!strcmp(buf, "replacement\n"), "link replacement failed");
+  abort_unless(read_text(targetname, buf, sizeof(buf)),
+               "read original symlink target failed");
+  fail_unless(!strcmp(buf, "symlink target\n"),
+              "original symlink target changed");
+
+  UNITTEST_END(t3402_stop())
+#else
+  UNITTEST_BEGIN_SIMPLE
+  UNITTEST_END_SIMPLE
+#endif
+}


### PR DESCRIPTION
### Checklist

- [ ] I've run `make test` to see all new and existing tests pass
- [x] I've run `make checksrc` to ensure the code style is valid
- [x] I've read the contribution guidelines
- [ ] I've updated the documentation if necessary
- [x] I've added or updated relevant tests

### Motivation and Context

Resolves #21610.

`Curl_fopen()` opened the destination path for writing before deciding whether it should use a temporary replacement file. On Unix-like builds this could truncate an existing destination immediately, and it could also follow a symlink and truncate the symlink target before the later temp-file rename replaced the link path. The helper now stats the destination first and only falls back to direct `fopen()` for missing or non-regular paths, restoring the invariant that existing regular destinations are not touched until the temp file is renamed into place.

### Description

This moves the Unix-side destination inspection in `Curl_fopen()` back before the write-open. Existing regular files, including regular files reached through symlinks, go through the existing temp-file replacement path without first truncating the destination. The new unit test covers both an existing regular file and a symlink target, and verifies that their contents remain intact until the caller renames the temp file.

### Testing Steps

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_USE_LIBPSL=OFF -DBUILD_EXAMPLES=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF` passed.
- `cmake --build build --parallel 4` passed.
- `cmake --build build --target units --parallel 4 && ./build/tests/unit/units unit3402` passed.
- As a regression check, the same `unit3402` test failed against the old eager-open behavior with `destination was truncated` and `symlink target was truncated` assertions.
- `cmake --build build --target curl --parallel 4` passed.
- `perl scripts/checksrc-all.pl` passed.
- `git diff --check` passed.

Blockers: I did not run the full `make test` suite because this checkout was built with CMake and only the needed `units` target/test binary was built locally; invoking `tests/runtests.pl` directly could not find the full generated test helper set. The targeted unit was run directly from the built CMake unit binary.
