### PR TITLE
DEPENDENCIES.md: document minimum nettle version: 3.4.1 (2018-12-04)

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -35,6 +35,7 @@ We aim to support these or later versions:
 - libssh2       1.9.0 (2019-06-20)
 - mbedTLS       3.2.0 (2022-07-11)
 - MIT Kerberos  1.3 (2003-07-31)
+- nettle        3.4.1 (2018-12-04)
 - nghttp2       1.15.0 (2016-09-25)
 - nghttp3       1.0.0 (2023-10-15)
 - ngtcp2        1.0.0 (2023-10-15), with OpenSSL 3.5.0+: 1.12.0 (2025-04-16)


### PR DESCRIPTION
It comes as a transitive requirement by the minimum GnuTLS version.
Because libcurl uses nettle directly (in GnuTLS builds), I figure it is 
useful to document explicitly.

Refs:
https://github.com/gnutls/gnutls/commit/4353ea025ae032887f3e8cf5aadace25662c6b35
https://github.com/curl/curl/pull/22456#discussion_r3695417678
https://github.com/gnutls/nettle/releases/tag/nettle_3.4.1_release_20181204
