### PR TITLE
lib: update mentions of the legacy "sessionhandle"

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3130,7 +3130,7 @@ void Curl_multi_will_close(struct Curl_easy *data, curl_socket_t s)
  * timeout to use (skip the already expired ones) and add this node back to
  * the splay tree again.
  *
- * The splay tree only has each sessionhandle as a single node and the nearest
+ * The splay tree only has each Curl_easy as a single node and the nearest
  * timeout is used to sort it on.
  */
 static CURLMcode add_next_timeout(const struct curltime *pnow,

--- a/lib/url.c
+++ b/lib/url.c
@@ -196,7 +196,7 @@ static void up_free(struct Curl_easy *data)
 
 /*
  * This is the internal function curl_easy_cleanup() calls. This should
- * cleanup and free all resources associated with this sessionhandle.
+ * cleanup and free all resources associated with this Curl_easy.
  *
  * We ignore SIGPIPE when this is called from curl_easy_cleanup.
  */
@@ -454,7 +454,7 @@ static void easy_meta_freeentry(void *p)
 /**
  * Curl_open()
  *
- * @param curl is a pointer to a sessionhandle pointer that gets set by this
+ * @param curl is a pointer to a Curl_easy pointer that gets set by this
  * function.
  * @return CURLcode
  */


### PR DESCRIPTION
It is now "Curl_easy"
