### PR TITLE
tests: convert unit tests into libtests

### DIFF
--- a/tests/data/test1396
+++ b/tests/data/test1396
@@ -2,7 +2,6 @@
 <testcase>
 <info>
 <keywords>
-unittest
 curl_easy_escape
 curl_easy_unescape
 </keywords>
@@ -10,9 +9,9 @@ curl_easy_unescape
 
 # Client-side
 <client>
-<features>
-unittest
-</features>
+<tool>
+lib%TESTNUMBER
+</tool>
 <name>
 curl_easy_escape and curl_easy_unescape
 </name>

--- a/tests/data/test1398
+++ b/tests/data/test1398
@@ -2,18 +2,17 @@
 <testcase>
 <info>
 <keywords>
-unittest
 curl_msnprintf
 </keywords>
 </info>
 
 # Client-side
 <client>
-<features>
-unittest
-</features>
+<tool>
+lib%TESTNUMBER
+</tool>
 <name>
-curl_msnprintf unit tests
+curl_msnprintf tests
 </name>
 </client>
 

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -89,7 +89,7 @@ TESTS_C = \
   lib766.c \
   lib1156.c \
   lib1301.c                                                   lib1308.c \
-  lib1398.c \
+  lib1396.c           lib1398.c \
   lib1485.c \
   lib1500.c lib1501.c lib1502.c                               lib1506.c \
   lib1507.c lib1508.c lib1509.c lib1510.c lib1511.c lib1512.c lib1513.c \

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -89,6 +89,7 @@ TESTS_C = \
   lib766.c \
   lib1156.c \
   lib1301.c                                                   lib1308.c \
+  lib1398.c \
   lib1485.c \
   lib1500.c lib1501.c lib1502.c                               lib1506.c \
   lib1507.c lib1508.c lib1509.c lib1510.c lib1511.c lib1512.c lib1513.c \

--- a/tests/libtest/lib1396.c
+++ b/tests/libtest/lib1396.c
@@ -37,7 +37,7 @@ static void t1396_stop(CURL *easy)
   curl_global_cleanup();
 }
 
-static CURLcode test_unit1396(const char *arg)
+static CURLcode test_lib1396(const char *arg)
 {
   CURL *easy;
 

--- a/tests/libtest/lib1398.c
+++ b/tests/libtest/lib1398.c
@@ -28,7 +28,7 @@
 #pragma GCC diagnostic ignored "-Wformat"
 #endif
 
-static CURLcode test_unit1398(const char *arg)
+static CURLcode test_lib1398(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
 

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -33,7 +33,7 @@ TESTS_C = \
   unit1300.c            unit1302.c unit1303.c unit1304.c unit1305.c \
   unit1307.c            unit1309.c \
   unit1323.c unit1330.c \
-  unit1395.c unit1396.c unit1397.c            unit1399.c \
+  unit1395.c            unit1397.c            unit1399.c \
   unit1600.c unit1601.c unit1602.c unit1603.c            unit1605.c unit1606.c \
   unit1607.c unit1608.c unit1609.c unit1610.c unit1611.c unit1612.c unit1614.c \
   unit1615.c unit1616.c                                  unit1620.c \

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -33,7 +33,7 @@ TESTS_C = \
   unit1300.c            unit1302.c unit1303.c unit1304.c unit1305.c \
   unit1307.c            unit1309.c \
   unit1323.c unit1330.c \
-  unit1395.c unit1396.c unit1397.c unit1398.c unit1399.c \
+  unit1395.c unit1396.c unit1397.c            unit1399.c \
   unit1600.c unit1601.c unit1602.c unit1603.c            unit1605.c unit1606.c \
   unit1607.c unit1608.c unit1609.c unit1610.c unit1611.c unit1612.c unit1614.c \
   unit1615.c unit1616.c                                  unit1620.c \


### PR DESCRIPTION
These use only public libcurl functions and should therefore be libtests
