### PR TITLE
test557: test curl_mv*printf() functions

### DIFF
--- a/tests/data/test557
+++ b/tests/data/test557
@@ -35,6 +35,8 @@ All curl_mprintf() curl_off_t tests OK!
 All curl_mprintf() strings tests OK!
 All float strings tests OK!
 All curl_mprintf() octal and hexadecimal tests OK!
+testing a string and -443 is super fun and 9876543
+All v-functions test OK!
 </stdout>
 </verify>
 

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1284,7 +1284,7 @@ static int var557(int expected_len, const char *format, ...)
   va_start(arg, format);
   len = curl_mvsnprintf(buffer, sizeof(buffer), format, arg);
   if(len != expected_len) {
-    curl_mfprintf(stderr, "curl_mvprintf: expected length %d but got %d\n",
+    curl_mfprintf(stderr, "curl_mvsnprintf: expected length %d but got %d\n",
                   expected_len, len);
     goto error;
   }
@@ -1294,7 +1294,7 @@ static int var557(int expected_len, const char *format, ...)
   /* no buffer size, but we know it fits */
   len = curl_mvsprintf(buffer, format, arg);
   if(len != expected_len) {
-    curl_mfprintf(stderr, "curl_mvprintf: expected length %d but got %d\n",
+    curl_mfprintf(stderr, "curl_mvsprintf: expected length %d but got %d\n",
                   expected_len, len);
     goto error;
   }
@@ -1305,7 +1305,7 @@ static int var557(int expected_len, const char *format, ...)
   len = ptr ? (int)strlen(ptr) : 0;
   curl_free(ptr);
   if(len != expected_len) {
-    curl_mfprintf(stderr, "curl_mvprintf: expected length %d but got %d\n",
+    curl_mfprintf(stderr, "curl_mvaprintf: expected length %d but got %d\n",
                   expected_len, len);
     goto error;
   }

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1237,6 +1237,88 @@ static int test_return_codes(void)
   return 0;
 }
 
+/*
+  Basic verification of the vararg versions of the printf functions:
+
+  - curl_mvfprintf
+  - curl_mvprintf
+  - curl_mvsnprintf
+  - curl_mvsprintf
+  - curl_mvaprintf
+ */
+static int var557(int expected_len, const char *format, ...)
+{
+  va_list arg;
+  int len;
+  int errors = 1;
+  char buffer[80];
+  char *ptr;
+  va_start(arg, format);
+
+  len = curl_mvfprintf(stderr, format, arg);
+  if(len != expected_len) {
+    curl_mfprintf(stderr, "curl_mvfprintf: expected length %d but got %d\n",
+                  expected_len, len);
+    goto error;
+  }
+
+  va_end(arg);
+  va_start(arg, format);
+  /* this unfortunately writes to stdout but we can't prevent it */
+  len = curl_mvprintf(format, arg);
+  if(len != expected_len) {
+    curl_mfprintf(stderr, "curl_mvprintf: expected length %d but got %d\n",
+                  expected_len, len);
+    goto error;
+  }
+
+  va_end(arg);
+  va_start(arg, format);
+  len = curl_mvsnprintf(buffer, sizeof(buffer), format, arg);
+  if(len != expected_len) {
+    curl_mfprintf(stderr, "curl_mvprintf: expected length %d but got %d\n",
+                  expected_len, len);
+    goto error;
+  }
+
+  va_end(arg);
+  va_start(arg, format);
+  /* no buffer size, but we know it fits */
+  len = curl_mvsprintf(buffer, format, arg);
+  if(len != expected_len) {
+    curl_mfprintf(stderr, "curl_mvprintf: expected length %d but got %d\n",
+                  expected_len, len);
+    goto error;
+  }
+
+  va_end(arg);
+  va_start(arg, format);
+  ptr = curl_mvaprintf(format, arg);
+  len = ptr ? (int)strlen(ptr) : 0;
+  curl_free(ptr);
+  if(len != expected_len) {
+    curl_mfprintf(stderr, "curl_mvprintf: expected length %d but got %d\n",
+                  expected_len, len);
+    goto error;
+  }
+
+  errors = 0; /* success */
+error:
+  va_end(arg);
+  if(!errors)
+    curl_mprintf("All v-functions test OK!\n");
+  else
+    curl_mprintf("The v-functions test failed!\n");
+  return errors;
+}
+
+static int test_vversions(void)
+{
+  int rc = var557(51, "testing %s and %d is %s and %ld\n",
+                  "a string", -443, "super fun", (long)9876543);
+  return rc;
+}
+
 static CURLcode test_lib557(const char *URL)
 {
   int errors = 0;
@@ -1263,6 +1345,7 @@ static CURLcode test_lib557(const char *URL)
   errors += test_float_formatting();
   errors += test_oct_hex_formatting();
   errors += test_return_codes();
+  errors += test_vversions();
 
   if(errors)
     return TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1246,6 +1246,10 @@ static int test_return_codes(void)
   - curl_mvsprintf
   - curl_mvaprintf
  */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
 static int var557(int expected_len, const char *format, ...)
 {
   va_list arg;
@@ -1311,6 +1315,9 @@ error:
     curl_mprintf("The v-functions test failed!\n");
   return errors;
 }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 static int test_vversions(void)
 {

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1250,6 +1250,10 @@ static int test_return_codes(void)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
 #endif
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
 static int var557(int expected_len, const char *format, ...)
 {
   va_list arg;
@@ -1317,6 +1321,9 @@ error:
 }
 #ifdef __clang__
 #pragma clang diagnostic pop
+#endif
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic pop
 #endif
 
 static int test_vversions(void)


### PR DESCRIPTION
These functions were previously untested in the test suite. This is just a set of basic invokes to make sure they work. The core of these functions is identical and is tested already.

  - curl_mvfprintf
  - curl_mvprintf
  - curl_mvsnprintf
  - curl_mvsprintf
  - curl_mvaprintf
 