### PR TITLE
mbedtls: enforce verifyhost when verifypeer is disabled

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -453,9 +453,11 @@ static int mbed_verify_cb(void *ptr, mbedtls_x509_crt *crt,
       mbed_extract_certinfo(data, crt);
   }
 
+  /* `verifypeer` and `verifyhost` are independent, so clear the flags of a
+     disabled check only. The name mismatch belongs to `verifyhost`. */
   if(!conn_config->verifypeer)
-    *flags = 0;
-  else if(!conn_config->verifyhost)
+    *flags &= MBEDTLS_X509_BADCERT_CN_MISMATCH;
+  if(!conn_config->verifyhost)
     *flags &= ~MBEDTLS_X509_BADCERT_CN_MISMATCH;
 
   if(*flags) {

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -255,6 +255,7 @@ test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 test2093 test2094 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
 test2108 test2109 test2110 test2113 test2114 test2115 test2116 test2117 \
+test2118 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 test2208 \

--- a/tests/data/test2118
+++ b/tests/data/test2118
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP GET
+PEM certificate
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<features>
+SSL
+local-http
+</features>
+<server>
+https test-localhost.nn.pem
+</server>
+<tool>
+lib%TESTNUMBER
+</tool>
+<name>
+VERIFYHOST with VERIFYPEER disabled rejects a mismatching certificate
+</name>
+<command>
+https://localhost:%HTTPSPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+60
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test2118
+++ b/tests/data/test2118
@@ -17,6 +17,8 @@ PEM certificate
 <features>
 SSL
 local-http
+!wolfssl
+!rustls
 </features>
 <server>
 https test-localhost.nn.pem

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -117,7 +117,7 @@ TESTS_C = \
   lib1955.c lib1956.c lib1957.c lib1958.c lib1959.c lib1960.c \
   lib1964.c lib1965.c           lib1967.c                     lib1970.c \
   lib1971.c lib1972.c lib1973.c lib1974.c lib1975.c lib1977.c lib1978.c \
-  lib2023.c lib2032.c lib2082.c \
+  lib2023.c lib2032.c lib2082.c lib2118.c \
   lib2301.c lib2302.c lib2304.c           lib2306.c lib2308.c lib2309.c \
   lib2402.c           lib2404.c lib2405.c \
   lib2412.c           lib2414.c \

--- a/tests/libtest/lib2118.c
+++ b/tests/libtest/lib2118.c
@@ -46,9 +46,9 @@ static CURLcode test_lib2118(const char *URL)
 
   easy_setopt(curl, CURLOPT_URL, URL);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-  easy_setopt(curl, CURLOPT_IPRESOLVE, (long)CURL_IPRESOLVE_V4);
+  easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
   easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-  easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+  easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
 
   result = curl_easy_perform(curl);
 

--- a/tests/libtest/lib2118.c
+++ b/tests/libtest/lib2118.c
@@ -1,0 +1,60 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+/* CURLOPT_SSL_VERIFYHOST is independent of CURLOPT_SSL_VERIFYPEER, so a
+   certificate issued for another name must be rejected even when the peer is
+   not verified. The server presents a certificate for "localhost.nn". */
+
+static CURLcode test_lib2118(const char *URL)
+{
+  CURLcode result;
+  CURL *curl;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    curl_mfprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    curl_mfprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_IPRESOLVE, (long)CURL_IPRESOLVE_V4);
+  easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+  easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+
+  result = curl_easy_perform(curl);
+
+test_cleanup:
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return result;
+}


### PR DESCRIPTION
Repro: `CURLOPT_SSL_VERIFYPEER` 0 together with `CURLOPT_SSL_VERIFYHOST` 2, against a server holding a certificate issued for a different name. Expected `CURLE_PEER_FAILED_VERIFICATION`, got `CURLE_OK`.

Cause: `mbed_verify_cb()` clears the whole flag bitmask when peer verification is off, so `MBEDTLS_X509_BADCERT_CN_MISMATCH` goes with it. Nothing else in the backend looks at the name, so `verifyhost` has no effect on that path. The comment above `mbedtls_ssl_conf_authmode()` already says only the flags of a disabled check should be cleared.

Fix: clear the flags of the disabled check only, so a name mismatch survives a disabled peer verification. OpenSSL, GnuTLS, wolfSSL and Schannel all keep the two options independent already, Schannel with an explicit branch for exactly this combination.

Added libtest 2118, which reuses the `localhost.nn` certificate from test 312. It fails on mbedTLS without the change and passes with it; unaffected on the other backends.