### PR TITLE
Support AWS-LC as shared library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AC_SUBST(VERSIONNUM)
 
 dnl
 dnl initialize all the info variables
-         curl_ssl_msg="no       (--with-{openssl,gnutls,mbedtls,wolfssl,schannel,amissl,rustls} )"
+         curl_ssl_msg="no       (--with-{openssl,gnutls,mbedtls,wolfssl,schannel,amissl,rustls,aws-lc} )"
          curl_ssh_msg="no       (--with-{libssh,libssh2})"
         curl_zlib_msg="no       (--with-zlib)"
       curl_brotli_msg="no       (--with-brotli)"
@@ -265,6 +265,17 @@ AS_HELP_STRING([--with-openssl=PATH],[Where to look for OpenSSL, PATH points
   OPT_OPENSSL=$withval
   if test "x$withval" != "xno"; then
     TLSCHOICE="${TLSCHOICE:+$TLSCHOICE, }OpenSSL"
+  fi
+])
+
+AC_ARG_WITH(aws-lc,
+AS_HELP_STRING([--with-aws-lc=PATH],[Where to look for AWS-LC, PATH points
+  to the SSL installation (default: /usr/local/ssl); when possible, set
+  the PKG_CONFIG_PATH environment variable instead of using this option]),
+[
+  OPT_AWS_LC=$withval
+  if test "x$withval" != "xno"; then
+    TLSCHOICE="${TLSCHOICE:+$TLSCHOICE, }AWS-LC"
   fi
 ])
 
@@ -527,6 +538,7 @@ Select from these:
   --with-gnutls
   --with-mbedtls
   --with-openssl (also works for AWS-LC, BoringSSL and LibreSSL)
+  --with-aws-lc (for AWS-LC as a shared library)
   --with-rustls
   --with-schannel
   --with-wolfssl
@@ -2135,6 +2147,7 @@ esac
 CURL_WITH_SCHANNEL
 CURL_WITH_AMISSL
 CURL_WITH_OPENSSL
+CURL_WITH_AWS_LC
 CURL_WITH_GNUTLS
 CURL_WITH_MBEDTLS
 CURL_WITH_WOLFSSL
@@ -2151,10 +2164,10 @@ if test "$curl_cv_native_windows" = "yes"; then
   LIBS="-lbcrypt $LIBS"
 fi
 
-case "x$SSL_DISABLED$OPENSSL_ENABLED$GNUTLS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$RUSTLS_ENABLED" in
+case "x$SSL_DISABLED$OPENSSL_ENABLED$GNUTLS_ENABLED$MBEDTLS_ENABLED$WOLFSSL_ENABLED$SCHANNEL_ENABLED$RUSTLS_ENABLED$AWS_LC_ENABLED" in
   x)
     AC_MSG_ERROR([TLS not detected, cannot build with HTTPS, FTPS, NTLM and more.
-Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schannel, --with-amissl or --with-rustls to address this.])
+Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schannel, --with-amissl, --with-rustls, or --with-aws-lc to address this.])
     ;;
   x1)
     dnl one SSL backend is enabled
@@ -2166,7 +2179,7 @@ Use --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schann
     ;;
   xD*)
     AC_MSG_ERROR([--without-ssl has been set together with an explicit option to use an SSL library
-(e.g. --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schannel, --with-amissl, --with-rustls).
+(e.g. --with-openssl, --with-gnutls, --with-wolfssl, --with-mbedtls, --with-schannel, --with-amissl, --with-rustls, --with-aws-lc).
 Since these are conflicting parameters, verify which is the desired one and drop the other.])
     ;;
   *)
@@ -2826,6 +2839,8 @@ AS_HELP_STRING([--disable-versioned-symbols], [Disable versioned symbols in shar
         versioned_symbols_flavor="MULTISSL_"
       elif test "$OPENSSL_ENABLED" = "1"; then
         versioned_symbols_flavor="OPENSSL_"
+      elif test "$AWS_LC_ENABLED" = "1"; then
+        versioned_symbols_flavor="AWS_LC_"
       elif test "$MBEDTLS_ENABLED" = "1"; then
         versioned_symbols_flavor="MBEDTLS_"
       elif test "$WOLFSSL_ENABLED" = "1"; then
@@ -3480,6 +3495,65 @@ if test "$USE_NGTCP2" = "1" && test "$OPENSSL_ENABLED" = "1" &&
       dnl To avoid link errors, we do not allow --with-ngtcp2 without
       dnl a pkgconfig file
       AC_MSG_ERROR([--with-ngtcp2 was specified but could not find ngtcp2_crypto_ossl pkg-config file.])
+    fi
+  fi
+fi
+
+if test "$USE_NGTCP2" = "1" && test "$AWS_LC_ENABLED" = "1"; then
+
+  dnl backup the pre-ngtcp2_crypto_aws_lc variables
+  CLEANLDFLAGS="$LDFLAGS"
+  CLEANLDFLAGSPC="$LDFLAGSPC"
+  CLEANCPPFLAGS="$CPPFLAGS"
+  CLEANLIBS="$LIBS"
+
+  CURL_CHECK_PKGCONFIG(libngtcp2_crypto_aws_lc, $want_tcp2_path, 1)
+
+  if test "$PKGCONFIG" != "no"; then
+    LIB_NGTCP2_CRYPTO_AWS_LC=`CURL_EXPORT_PCDIR([$want_tcp2_path], 1)
+      $PKGCONFIG --libs-only-l libngtcp2_crypto_aws_lc`
+    AC_MSG_NOTICE([-l is $LIB_NGTCP2_CRYPTO_AWS_LC])
+
+    CPP_NGTCP2_CRYPTO_AWS_LC=`CURL_EXPORT_PCDIR([$want_tcp2_path], 1)
+      $PKGCONFIG --cflags-only-I libngtcp2_crypto_aws_lc`
+    AC_MSG_NOTICE([-I is $CPP_NGTCP2_CRYPTO_AWS_LC])
+
+    LD_NGTCP2_CRYPTO_AWS_LC=`CURL_EXPORT_PCDIR([$want_tcp2_path], 1)
+      $PKGCONFIG --libs-only-L libngtcp2_crypto_aws_lc`
+    AC_MSG_NOTICE([-L is $LD_NGTCP2_CRYPTO_AWS_LC])
+
+    LDFLAGS="$LDFLAGS $LD_NGTCP2_CRYPTO_AWS_LC"
+    LDFLAGSPC="$LDFLAGSPC $LD_NGTCP2_CRYPTO_AWS_LC"
+    CPPFLAGS="$CPPFLAGS $CPP_NGTCP2_CRYPTO_AWS_LC"
+    LIBS="$LIB_NGTCP2_CRYPTO_AWS_LC $LIBS"
+
+    if test "$cross_compiling" != "yes"; then
+      DIR_NGTCP2_CRYPTO_AWS_LC=`echo $LD_NGTCP2_CRYPTO_AWS_LC | $SED -e 's/^-L//'`
+    fi
+    AC_CHECK_LIB(ngtcp2_crypto_aws_lc, ngtcp2_crypto_recv_client_initial_cb,
+      [
+        AC_CHECK_HEADERS(ngtcp2/ngtcp2_crypto.h,
+          USE_NGTCP2=1
+          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_NGTCP2_CRYPTO_AWS_LC"
+          export CURL_LIBRARY_PATH
+          AC_MSG_NOTICE([Added $DIR_NGTCP2_CRYPTO_AWS_LC to CURL_LIBRARY_PATH])
+          LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE libngtcp2_crypto_aws_lc"
+          AC_DEFINE(AWS_LC_QUIC_API2, 1, [AWS-LC with new QUIC API])
+        )
+      ],
+        dnl not found, revert back to clean variables
+        LDFLAGS=$CLEANLDFLAGS
+        LDFLAGSPC=$CLEANLDFLAGSPC
+        CPPFLAGS=$CLEANCPPFLAGS
+        LIBS=$CLEANLIBS
+    )
+
+  else
+    dnl no ngtcp2_crypto_aws_lc pkg-config found, deal with it
+    if test "$want_tcp2" != "default"; then
+      dnl To avoid link errors, we do not allow --with-ngtcp2 without
+      dnl a pkgconfig file
+      AC_MSG_ERROR([--with-ngtcp2 was specified but could not find ngtcp2_crypto_aws_lc pkg-config file.])
     fi
   fi
 fi
@@ -5015,6 +5089,7 @@ if test "$want_ech" != "no"; then
   ECH_ENABLED_OPENSSL=0
   ECH_ENABLED_WOLFSSL=0
   ECH_ENABLED_RUSTLS=0
+  ECH_ENABLED_AWS_LC=0
   ECH_SUPPORT=''
 
   dnl check for OpenSSL equivalent
@@ -5022,6 +5097,11 @@ if test "$want_ech" != "no"; then
     AC_CHECK_FUNCS(SSL_set1_ech_config_list,
       ECH_SUPPORT="$ECH_SUPPORT OpenSSL"
       ECH_ENABLED_OPENSSL=1)
+  fi
+  if test "$AWS_LC_ENABLED" = "1"; then
+    AC_CHECK_FUNCS(SSL_set1_ech_config_list,
+      ECH_SUPPORT="$ECH_SUPPORT AWS-LC"
+      ECH_ENABLED_AWS_LC=1)
   fi
   if test "$WOLFSSL_ENABLED" = "1"; then
     AC_CHECK_FUNCS(wolfSSL_CTX_GenerateEchConfig,
@@ -5035,6 +5115,7 @@ if test "$want_ech" != "no"; then
 
   dnl now deal with whatever we found
   if test "$ECH_ENABLED_OPENSSL" = "1" ||
+     test "$ECH_ENABLED_AWS_LC" = "1" ||
      test "$ECH_ENABLED_WOLFSSL" = "1" ||
      test "$ECH_ENABLED_RUSTLS" = "1"; then
     AC_DEFINE(USE_ECH, 1, [if ECH support is available])
@@ -5326,6 +5407,7 @@ dnl if not explicitly turned off, HTTPS-proxy comes with some TLS backends
 if test "$CURL_DISABLE_HTTP" != "1"; then
   if test "$https_proxy" != "no"; then
     if test "$OPENSSL_ENABLED" = "1" ||
+       test "$AWS_LC_ENABLED" = "1" ||
        test "$GNUTLS_ENABLED" = "1" ||
        test "$RUSTLS_ENABLED" = "1" ||
        test "$SCHANNEL_ENABLED" = "1" ||

--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -29,7 +29,12 @@
 
 #ifdef USE_OPENSSL
 #include <openssl/err.h>
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
+#if defined(USE_AWS_LC)
+/* AWS-LC can be used from newer ngtcp2 that has explicit support, or through
+ * the boringssl support.
+ */
+#include <ngtcp2/ngtcp2_crypto_aws_lc.h>
+#elif defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 #include <ngtcp2/ngtcp2_crypto_boringssl.h>
 #elif defined(OPENSSL_QUIC_API2)
 #include <ngtcp2/ngtcp2_crypto_ossl.h>
@@ -821,7 +826,13 @@ static CURLcode cf_ngtcp2_tls_ctx_setup(struct Curl_cfilter *cf,
   struct curl_tls_ctx *ctx = user_data;
 
 #ifdef USE_OPENSSL
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
+#ifdef USE_AWS_LC
+  if(ngtcp2_crypto_aws_lc_configure_client_context(ctx->ossl.ssl_ctx)
+     != 0) {
+    failf(data, "ngtcp2_crypto_aws_lc_configure_client_context failed");
+    return CURLE_FAILED_INIT;
+  }
+#elif defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
   if(ngtcp2_crypto_boringssl_configure_client_context(ctx->ossl.ssl_ctx)
      != 0) {
     failf(data, "ngtcp2_crypto_boringssl_configure_client_context failed");

--- a/lib/vquic/cf-ngtcp2-cmn.h
+++ b/lib/vquic/cf-ngtcp2-cmn.h
@@ -32,7 +32,10 @@
 
 #ifdef USE_OPENSSL
 #include <openssl/err.h>
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
+#if defined(USE_AWS_LC)
+/* AWS-LC through explicit support, or through older boringssl */
+#include <ngtcp2/ngtcp2_crypto_aws_lc.h>
+#elif defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 #include <ngtcp2/ngtcp2_crypto_boringssl.h>
 #elif defined(OPENSSL_QUIC_API2)
 #include <ngtcp2/ngtcp2_crypto_ossl.h>

--- a/m4/curl-aws-lc.m4
+++ b/m4/curl-aws-lc.m4
@@ -1,0 +1,320 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+#***************************************************************************
+
+dnl File version for 'aclocal' use. Keep it a single number.
+dnl serial 5
+
+dnl **********************************************************************
+dnl Check for AWS-LC libraries and headers
+dnl **********************************************************************
+
+AC_DEFUN([CURL_WITH_AWS_LC], [
+if test "x$OPT_AWS_LC" != "xno"; then
+  ssl_msg=
+
+  dnl backup the pre-detection variables
+  CLEANLDFLAGS="$LDFLAGS"
+  CLEANLDFLAGSPC="$LDFLAGSPC"
+  CLEANCPPFLAGS="$CPPFLAGS"
+  CLEANLIBS="$LIBS"
+
+  dnl This is for MSYS/MinGW
+  case $host in
+    *-*-msys* | *-*-mingw*)
+      AC_MSG_CHECKING([for gdi32])
+      my_ac_save_LIBS=$LIBS
+      LIBS="-lgdi32 $LIBS"
+      AC_LINK_IFELSE([ AC_LANG_PROGRAM([[
+        #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+        #endif
+        #include <windef.h>
+        #include <wingdi.h>
+        ]],
+        [[
+          GdiFlush();
+        ]])],
+        [ dnl worked!
+        AC_MSG_RESULT([yes])],
+        [ dnl failed, restore LIBS
+        LIBS=$my_ac_save_LIBS
+        AC_MSG_RESULT(no)]
+        )
+      ;;
+  esac
+
+  case "$OPT_AWS_LC" in
+    yes)
+      dnl --with-aws-lc (without path) used
+      PKGTEST="yes"
+      PREFIX_AWS_LC=
+      ;;
+    *)
+      dnl check the given --with-aws-lc spot
+      PKGTEST="no"
+      PREFIX_AWS_LC=$OPT_AWS_LC
+
+      dnl Try pkg-config even when cross-compiling.  Since we
+      dnl specify PKG_CONFIG_LIBDIR we are only looking where
+      dnl the user told us to look
+      AWS_LC_PCDIR="$OPT_AWS_LC/lib/pkgconfig"
+      if test -f "$AWS_LC_PCDIR/aws-lc.pc"; then
+        AC_MSG_NOTICE([PKG_CONFIG_LIBDIR is set to "$AWS_LC_PCDIR"])
+        PKGTEST="yes"
+      fi
+
+      if test "$PKGTEST" != "yes"; then
+        dnl try lib64 instead
+        AWS_LC_PCDIR="$OPT_AWS_LC/lib64/pkgconfig"
+        if test -f "$AWS_LC_PCDIR/aws-lc.pc"; then
+          AC_MSG_NOTICE([PKG_CONFIG_LIBDIR is set to "$AWS_LC_PCDIR"])
+          PKGTEST="yes"
+        fi
+      fi
+
+      if test "$PKGTEST" != "yes" &&
+         test ! -f "$PREFIX_AWS_LC/include/aws-lc/openssl/ssl.h"; then
+        AC_MSG_ERROR([$PREFIX_AWS_LC is a bad --with-aws-lc prefix!])
+      fi
+
+      dnl in case pkg-config comes up empty, use what we got
+      dnl via --with-aws-lc
+      LIB_AWS_LC="$PREFIX_AWS_LC/lib$libsuff"
+      if test "$PREFIX_AWS_LC" != "/usr"; then
+        SSL_LDFLAGS="-L$LIB_AWS_LC"
+        SSL_CPPFLAGS="-I$PREFIX_AWS_LC/include/aws-lc"
+      fi
+      ;;
+  esac
+
+  if test "$PKGTEST" = "yes"; then
+
+    CURL_CHECK_PKGCONFIG(aws-lc, [$AWS_LC_PCDIR])
+
+    if test "$PKGCONFIG" != "no"; then
+      SSL_LIBS=`CURL_EXPORT_PCDIR([$AWS_LC_PCDIR])
+        $PKGCONFIG --libs-only-l --libs-only-other aws-lc 2>/dev/null`
+
+      SSL_LDFLAGS=`CURL_EXPORT_PCDIR([$AWS_LC_PCDIR])
+        $PKGCONFIG --libs-only-L aws-lc 2>/dev/null`
+
+      SSL_CPPFLAGS=`CURL_EXPORT_PCDIR([$AWS_LC_PCDIR])
+        $PKGCONFIG --cflags-only-I aws-lc 2>/dev/null`
+
+      AC_MSG_NOTICE([pkg-config: SSL_LIBS: "$SSL_LIBS"])
+      AC_MSG_NOTICE([pkg-config: SSL_LDFLAGS: "$SSL_LDFLAGS"])
+      AC_MSG_NOTICE([pkg-config: SSL_CPPFLAGS: "$SSL_CPPFLAGS"])
+
+      LIB_AWS_LC=`echo $SSL_LDFLAGS | sed -e 's/^-L//'`
+
+      dnl use the values pkg-config reported.  This is here
+      dnl instead of below with CPPFLAGS and LDFLAGS because we only
+      dnl learn about this via pkg-config.  If we only have
+      dnl the argument to --with-openssl we do not know what
+      dnl additional libs may be necessary.  Hope that we
+      dnl do not need any.
+      LIBS="$SSL_LIBS $LIBS"
+    fi
+  fi
+
+  dnl finally, set flags to use SSL
+  CPPFLAGS="$CPPFLAGS $SSL_CPPFLAGS"
+  LDFLAGS="$LDFLAGS $SSL_LDFLAGS"
+  LDFLAGSPC="$LDFLAGSPC $SSL_LDFLAGS"
+
+  AC_CHECK_LIB(crypto-awslc, HMAC_Update,[
+    HAVECRYPTO_AWSLC="yes"
+    LIBS="-lcrypto-awslc $LIBS"
+    ],[
+    if test -n "$LIB_AWS_LC"; then
+      LDFLAGS="$CLEANLDFLAGS -L$LIB_AWS_LC"
+      LDFLAGSPC="$CLEANLDFLAGSPC -L$LIB_AWS_LC"
+    fi
+    if test "$PKGCONFIG" = "no" && test -n "$PREFIX_AWS_LC"; then
+      dnl only set this if pkg-config was not used
+      CPPFLAGS="$CLEANCPPFLAGS -I$PREFIX_AWS_LC/include/aws-lc"
+    fi
+    dnl Linking previously failed, try extra paths from --with-aws-lc or
+    dnl pkg-config.  Use a different function name to avoid reusing the earlier
+    dnl cached result.
+    AC_CHECK_LIB(crypto-awslc, HMAC_Init_ex,[
+      HAVECRYPTO_AWSLC="yes"
+      LIBS="-lcrypto-awslc $LIBS"], [
+
+      dnl still no, but what about with -ldl?
+      AC_MSG_CHECKING([AWS-LC linking with -ldl])
+      LIBS="-lcrypto-awslc $CLEANLIBS -ldl"
+      AC_LINK_IFELSE([ AC_LANG_PROGRAM([[
+        #include <openssl/err.h>
+      ]], [[
+        ERR_clear_error();
+      ]]) ],
+      [
+        AC_MSG_RESULT(yes)
+        HAVECRYPTO_AWSLC="yes"
+      ],
+      [
+        AC_MSG_RESULT(no)
+        dnl ok, so what about both -ldl and -lpthread?
+        dnl This may be necessary for static libraries.
+
+        AC_MSG_CHECKING([AWS-LC linking with -ldl and -lpthread])
+        LIBS="-lcrypto-awslc $CLEANLIBS -ldl -lpthread"
+        AC_LINK_IFELSE([
+          AC_LANG_PROGRAM([[
+          #include <openssl/err.h>
+        ]], [[
+          ERR_clear_error();
+        ]])],
+        [
+          AC_MSG_RESULT(yes)
+          HAVECRYPTO_AWSLC="yes"
+        ],
+        [
+          AC_MSG_RESULT(no)
+          LDFLAGS="$CLEANLDFLAGS"
+          LDFLAGSPC="$CLEANLDFLAGSPC"
+          CPPFLAGS="$CLEANCPPFLAGS"
+          LIBS="$CLEANLIBS"
+        ])
+      ])
+    ])
+  ])
+
+  if test "$HAVECRYPTO_AWSLC" = "yes"; then
+    dnl This is only reasonable to do if crypto actually is there: check for
+    dnl SSL libs NOTE: it is important to do this AFTER the crypto lib
+
+    AC_CHECK_LIB(ssl-awslc, SSL_connect)
+
+    if test "$ac_cv_lib_ssl_awslc_SSL_connect" = "yes"; then
+      dnl Have the libraries--check for AWS-LC headers
+      AC_CHECK_HEADERS(openssl/rsa.h openssl/crypto.h openssl/pem.h openssl/ssl.h openssl/err.h,
+        ssl_msg="AWS-LC"
+        test "aws-lc" != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
+        AWS_LC_ENABLED=1
+        AC_DEFINE(USE_OPENSSL, 1, [if AWS-LC is in use, similar enough to OpenSSL codepaths])
+        AC_DEFINE(USE_AWS_LC, 1, [if AWS-LC is in use]))
+    fi
+
+    if test "$AWS_LC_ENABLED" != "1"; then
+      LIBS="$CLEANLIBS"
+      AC_MSG_ERROR([AWS-LC libs and/or directories were not found!])
+    fi
+  fi
+
+  if test "$AWS_LC_ENABLED" = "1"; then
+    dnl These can only exist if OpenSSL exists
+
+    AC_MSG_CHECKING([for AWS-LC])
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
+        #include <openssl/base.h>
+        ]],[[
+        #ifndef OPENSSL_IS_AWSLC
+        #error not AWS-LC
+        #endif
+      ]])
+    ],[
+      AC_MSG_RESULT([yes])
+      ssl_msg="AWS-LC"
+      OPENSSL_IS_AWSLC=1
+    ],[
+      AC_MSG_RESULT([no])
+    ])
+  fi
+
+  dnl is this OpenSSL (fork) providing the original QUIC API?
+  AC_CHECK_FUNCS([SSL_set_quic_use_legacy_codepoint], [QUIC_ENABLED=yes])
+  if test "$QUIC_ENABLED" = "yes"; then
+    AC_MSG_NOTICE([AWS-LC speaks QUIC API])
+  else
+    AC_CHECK_FUNCS([SSL_set_quic_tls_cbs], [QUIC_ENABLED=yes])
+    if test "$QUIC_ENABLED" = "yes"; then
+      AC_MSG_NOTICE([AWS-LC with QUIC APIv2])
+      OPENSSL_QUIC_API2=1
+    else
+      AC_MSG_NOTICE([AWS-LC version does not speak any known QUIC API])
+    fi
+  fi
+
+  if test "$AWS_LC_ENABLED" = "1"; then
+    if test -n "$LIB_AWS_LC"; then
+      dnl when the SSL shared libs were found in a path that the runtime
+      dnl linker does not search through, we need to add it to CURL_LIBRARY_PATH
+      dnl to prevent further configure tests to fail due to this
+      if test "$cross_compiling" != "yes"; then
+        CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$LIB_AWS_LC"
+        export CURL_LIBRARY_PATH
+        AC_MSG_NOTICE([Added $LIB_AWS_LC to CURL_LIBRARY_PATH])
+      fi
+    fi
+    check_for_ca_bundle=1
+    LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE aws-lc"
+  fi
+
+  if test "$AWS_LC_ENABLED" != "1"; then
+    AC_MSG_NOTICE([OPT_AWS_LC: $OPT_AWS_LC])
+    AC_MSG_NOTICE([AWS_LC_ENABLED: $AWS_LC_ENABLED])
+    AC_MSG_ERROR([--with-aws-lc was given but AWS-LC could not be detected])
+  fi
+
+  test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
+fi dnl AWS-LC not disabled
+
+if test "$AWS_LC_ENABLED" = "1"; then
+  dnl ---
+  dnl We check AWS-LC for DES support.
+  dnl ---
+  AC_MSG_CHECKING([for DES support in AWS-LC])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      #ifndef OPENSSL_SUPPRESS_DEPRECATED
+      #define OPENSSL_SUPPRESS_DEPRECATED
+      #endif
+      #include <openssl/des.h>
+    ]],[[
+      DES_ecb_encrypt(0, 0, 0, DES_ENCRYPT);
+    ]])
+  ],[
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(HAVE_DES_ECB_ENCRYPT, 1, [if you have the function DES_ecb_encrypt])
+    HAVE_DES_ECB_ENCRYPT=1
+  ],[
+    AC_MSG_RESULT([no])
+  ])
+
+  dnl ---
+  dnl Whether the AWS-LC configuration is loaded automatically
+  dnl ---
+  AC_ARG_ENABLE(aws-lc-auto-load-config,
+AS_HELP_STRING([--enable-aws-lc-auto-load-config],[Enable automatic loading of AWS-LC configuration])
+AS_HELP_STRING([--disable-aws-lc-auto-load-config],[Disable automatic loading of AWS-LC configuration]),
+  [ if test "x$enableval" = "xno"; then
+      AC_MSG_NOTICE([automatic loading of AWS-LC configuration disabled])
+      AC_DEFINE(CURL_DISABLE_AWS_LC_AUTO_LOAD_CONFIG, 1, [if the AWS-LC configuration is not loaded automatically])
+    fi
+  ])
+fi
+])


### PR DESCRIPTION
Since AWS-LC 5.2.0 it has supported building as a shared library with full symbol versioning etc designed to be suitable to ship in a Linux distribution as a shared library.
See: https://github.com/aws/aws-lc/releases/tag/v5.2.0

This moves curl to be able to build against the AWS-LC shared library while maintaining the ability to link statically.

The ngtcp2 code relies on a change to ngtcp2 which is currently up as a pull request and *NOT* yet upstream:
https://github.com/ngtcp2/ngtcp2/pull/2273

Only the autotools build system is currently modified as I want feedback on the approach of how all the defines work, and the ngtcp2 change is not yet upstream, so may not be ready/correct.

I have not tested any platform apart from Linux, nor have I tested the ability to continue to build with AWS-LC statically linked.

---

Feedback wanted/needed, and I'm not precious about having my PR merged vs someone else's who gets it done sooner.