### PR TITLE
doh: fail early upon a read error

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -1226,6 +1226,10 @@ CURLcode Curl_doh_take_result(struct Curl_easy *data,
     de_init(&de);
     for(slot = 0; slot < DOH_SLOT_COUNT; slot++) {
       struct doh_response *p = &dohp->probe_resp[slot];
+      if(p->result) {
+        result = p->result;
+        goto error;
+      }
       if(!p->dnstype)
         continue;
       rc[slot] = doh_resp_decode(curlx_dyn_uptr(&p->body),


### PR DESCRIPTION
Instead of keep on parsing (which shall eventually fail though).

This also improves the error message. E.g. with a DoH service that returns too much payload (e.g. >3000 bytes, see also DYN_DOH_RESPONSE) curl before this change would report:

```
$ ./src/curl -v https://example.com/ --doh-insecure --doh-url 127.0.0.1
* Could not resolve host: example.com
* Could not resolve: example.com:443
* closing connection #0
curl: (6) Could not resolve host: example.com
```

and after this change:
```
$ ./src/curl -v https://example.com/ --doh-insecure --doh-url 127.0.0.1
* Error 23 resolving example.com:443
* closing connection #0
curl: (23) Error 23 resolving example.com:443
```

Fixes #22477

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
