### PR TITLE
curl_setup: asking for DEBUGBUILD undefs NDEBUG

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1072,6 +1072,11 @@ typedef unsigned int curl_bit;
  */
 #undef DEBUGASSERT
 #ifdef DEBUGBUILD
+
+#ifdef NDEBUG
+#error "a debug build with NDEBUG defined is a mixed message. Make a decision."
+#endif
+
 #ifdef CURL_DEBUGASSERT
 /* External assertion handler for custom integrations */
 #define DEBUGASSERT(x) CURL_DEBUGASSERT(x)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,6 +28,11 @@
 #define CURL_NO_OLDIES
 #endif
 
+/* DEBUGBUILD overrides NDEBUG enable assert. #22481 */
+#if defined(DEBUGBUILD) && defined(NDEBUG)
+#undef NDEBUG
+#endif
+
 /* Set default _WIN32_WINNT */
 #ifdef __MINGW32__
 #include <_mingw.h>
@@ -1072,10 +1077,6 @@ typedef unsigned int curl_bit;
  */
 #undef DEBUGASSERT
 #ifdef DEBUGBUILD
-
-#ifdef NDEBUG
-#error "a debug build with NDEBUG defined is a mixed message. Make a decision."
-#endif
 
 #ifdef CURL_DEBUGASSERT
 /* External assertion handler for custom integrations */


### PR DESCRIPTION
A debug build enables DEBUGASSERT(), but the NDEBUG define actively disables asserts.

Ref: #22481

Discussion item.