### PR TITLE
servers: drop duplicate (and interacting) ctrl handlers on Windows, add exit message

### DIFF
--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -72,12 +72,15 @@ int main(int argc, const char **argv)
     logmsg("========> %s %s (%s pid: %ld) exits with signal (%d)",
            socket_type, entry_name,
            location_str, (long)our_getpid(), exit_signal);
+
+#ifndef _WIN32
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we
      * caught and let the old handler take care of it.
      */
     raise(exit_signal);
+#endif
   }
 
   if(serverlogfile)

--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -58,6 +58,9 @@ int main(int argc, const char **argv)
 
   result = entry_func(argc - 1, argv + 1);
 
+  if(serverlogfile && exit_msg)
+    logmsg("========> exit message: %s", exit_msg);
+
   if(got_exit_signal) {
     char port_str[11];
     const char *location_str = port_str;

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -148,6 +148,7 @@ static volatile int exit_signal = 0;
 #ifdef _WIN32
 static HANDLE exit_event = NULL;
 #endif
+static volatile const char *exit_msg = NULL;
 extern void install_signal_handlers(bool keep_sigalrm);
 extern void restore_signal_handlers(bool keep_sigalrm);
 #ifdef USE_UNIX_SOCKETS

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -429,8 +429,9 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  static const char msgT[] = "ctrl_event_handler(): handled\n";
-  static const char msgF[] = "ctrl_event_handler(): unhandled\n";
+  static const char msgU[] = "ctrl_event_handler(): unhandled\n";
+  static const char msgH[] = "ctrl_event_handler(): handled\n";
+  static const char msgF[] = "ctrl_event_handler(): failed to handle\n";
   HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
   DWORD dwWritten;
   BOOL handled = FALSE;
@@ -445,14 +446,16 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
   case CTRL_BREAK_EVENT:
     signum = SIGBREAK;
     break;
+  default:
+    WriteFile(out, msgU, CURL_CSTRLEN(msgU), &dwWritten, NULL);
+    return FALSE;
   }
-  if(signum)
-    handled = initiate_exit(signum);
-  if(handled)
-    WriteFile(out, msgT, CURL_CSTRLEN(msgT), &dwWritten, NULL);
-  else
+  if(!initiate_exit(signum)) {
     WriteFile(out, msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
-  return handled;
+    return FALSE;
+  }
+  WriteFile(out, msgH, CURL_CSTRLEN(msgH), &dwWritten, NULL);
+  return TRUE;
 }
 
 #ifndef CURL_WINDOWS_UWP

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -328,6 +328,8 @@ static HANDLE thread_main_window = NULL;
 static HWND hidden_main_window = NULL;
 #endif
 
+#ifndef _WIN32
+
 /* signal handler that is triggered to indicate that the program
  * should finish its execution in a controlled manner as soon as possible.
  * The first time this is called it sets got_exit_signal to 1 and
@@ -364,8 +366,6 @@ static void exit_signal_handler(int signum)
 #endif
   errno = old_errno;
 }
-
-#ifndef _WIN32
 
 /* vars used to keep around previous signal handlers */
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -429,12 +429,14 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  static const char msgU[] = "ctrl_event_handler(): unhandled\n";
-  static const char msgH[] = "ctrl_event_handler(): handled\n";
-  static const char msgF[] = "ctrl_event_handler(): failed to handle\n";
+  static const char func[] = "ctrl_event_handler(): ";
+  static const char msgU[] = "unhandled\n";
+  static const char msgH[] = "handled\n";
+  static const char msgF[] = "failed to handle\n";
   HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
   DWORD dwWritten;
   int signum = 0;
+  WriteFile(out, func, CURL_CSTRLEN(func), &dwWritten, NULL);
   switch(dwCtrlType) {
   case CTRL_C_EVENT:
     signum = SIGINT;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -409,15 +409,26 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
   int signum = 0;
   switch(dwCtrlType) {
   case CTRL_C_EVENT:
+    signum = SIGINT;
+    break;
   case CTRL_CLOSE_EVENT:
+    signum = SIGTERM;
+    break;
   case CTRL_BREAK_EVENT:
-    WriteFile(out, msgT, sizeof(msgT) - 1, &dwWritten, NULL);
-    if(exit_event)
-      (void)SetEvent(exit_event);
-    return TRUE;
+    signum = SIGBREAK;
+    break;
+  default:
+     WriteFile(out, msgF, sizeof(msgF) - 1, &dwWritten, NULL);
+     return FALSE;
   }
-  WriteFile(out, msgF, sizeof(msgF) - 1, &dwWritten, NULL);
-  return FALSE;
+  WriteFile(out, msgT, sizeof(msgT) - 1, &dwWritten, NULL);
+  if(got_exit_signal == 0) {
+    got_exit_signal = 1;
+    exit_signal = signum;
+  }
+  if(exit_event)
+    (void)SetEvent(exit_event);
+  return TRUE;
 }
 #endif /* !_WIN32 */
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -476,10 +476,14 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
 {
   if(hwnd == hidden_main_window) {
     switch(uMsg) {
-    case WM_CLOSE:
-      logmsg("main_window_proc: %u -> %d", uMsg, SIGTERM);
+    case WM_CLOSE: {
+      static const char str[] = "main_window_proc(): WM_CLOSE -> SIGTERM\n";
+      DWORD dwWritten;
+      WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
+                             &dwWritten, NULL);
       initiate_exit(SIGTERM);
       break;
+    }
     case WM_DESTROY:
       PostQuitMessage(0);
       break;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -427,8 +427,8 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  static const char msgT[] = "ctrl_event_handler(): return handled\n";
   static const char msgF[] = "ctrl_event_handler(): return unhandled\n";
+  static const char msgT[] = "ctrl_event_handler(): return handled\n";
   HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
   DWORD dwWritten;
   int signum = 0;
@@ -443,10 +443,10 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
     signum = SIGBREAK;
     break;
   default:
-     WriteFile(out, msgF, sizeof(msgF) - 1, &dwWritten, NULL);
+     WriteFile(out, msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
      return FALSE;
   }
-  WriteFile(out, msgT, sizeof(msgT) - 1, &dwWritten, NULL);
+  WriteFile(out, msgT, CURL_CSTRLEN(msgT), &dwWritten, NULL);
   initiate_exit(signum);
   return TRUE;
 }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -322,6 +322,18 @@ storerequest_cleanup:
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 }
 
+static void initiate_exit(int signum)  /* must remain signal-safe */
+{
+  if(got_exit_signal == 0) {
+    got_exit_signal = 1;
+    exit_signal = signum;
+  }
+#ifdef _WIN32
+  if(exit_event)
+    (void)SetEvent(exit_event);
+#endif
+}
+
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
 static DWORD thread_main_id = 0;
 static HANDLE thread_main_window = NULL;
@@ -353,10 +365,7 @@ static void exit_signal_handler(int signum)
 #if defined(CURL_HAVE_DIAG) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-  if(got_exit_signal == 0) {
-    got_exit_signal = 1;
-    exit_signal = signum;
-  }
+  initiate_exit(signum);
 #if !(defined(HAVE_SIGACTION) && defined(SA_RESTART))
   (void)signal(signum, exit_signal_handler);
 #endif
@@ -422,12 +431,7 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
      return FALSE;
   }
   WriteFile(out, msgT, sizeof(msgT) - 1, &dwWritten, NULL);
-  if(got_exit_signal == 0) {
-    got_exit_signal = 1;
-    exit_signal = signum;
-  }
-  if(exit_event)
-    (void)SetEvent(exit_event);
+  initiate_exit(signum);
   return TRUE;
 }
 #endif /* !_WIN32 */
@@ -443,19 +447,15 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
                                          WPARAM wParam, LPARAM lParam)
 {
-  int signum = 0;
   if(hwnd == hidden_main_window) {
     switch(uMsg) {
     case WM_CLOSE:
-      signum = SIGTERM;
+      logmsg("main_window_proc: %u -> %d", uMsg, SIGTERM);
+      initiate_exit(SIGTERM);
       break;
     case WM_DESTROY:
       PostQuitMessage(0);
       break;
-    }
-    if(signum) {
-      logmsg("main_window_proc: %u -> %d", uMsg, signum);
-      raise(signum);
     }
   }
   return DefWindowProc(hwnd, uMsg, wParam, lParam);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -447,14 +447,17 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
     signum = SIGBREAK;
     break;
   default:
-    WriteFile(out, exit_msg = msgU, CURL_CSTRLEN(msgU), &dwWritten, NULL);
+    exit_msg = msgU;
+    WriteFile(out, msgU, CURL_CSTRLEN(msgU), &dwWritten, NULL);
     return FALSE;
   }
   if(!initiate_exit(signum)) {
-    WriteFile(out, exit_msg = msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
+    exit_msg = msgF;
+    WriteFile(out, msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
     return FALSE;
   }
-  WriteFile(out, exit_msg = msgH, CURL_CSTRLEN(msgH), &dwWritten, NULL);
+  exit_msg = msgH;
+  WriteFile(out, msgH, CURL_CSTRLEN(msgH), &dwWritten, NULL);
   return TRUE;
 }
 
@@ -478,8 +481,8 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
     case WM_CLOSE: {
       static const char msg[] = "main_window_proc(): WM_CLOSE -> SIGTERM\n";
       DWORD dwWritten;
-      WriteFile(GetStdHandle(STD_ERROR_HANDLE),
-                             exit_msg = msg, CURL_CSTRLEN(msg),
+      exit_msg = msg;
+      WriteFile(GetStdHandle(STD_ERROR_HANDLE), msg, CURL_CSTRLEN(msg),
                              &dwWritten, NULL);
       initiate_exit(SIGTERM);
       break;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -322,16 +322,18 @@ storerequest_cleanup:
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 }
 
-static void initiate_exit(int signum)  /* must remain signal-safe */
+static bool initiate_exit(int signum)  /* must remain signal-safe */
 {
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
     exit_signal = signum;
   }
 #ifdef _WIN32
-  if(exit_event)
-    (void)SetEvent(exit_event);
+  if(!exit_event)
+    return FALSE;
+  (void)SetEvent(exit_event);
 #endif
+  return TRUE;
 }
 
 #ifndef _WIN32
@@ -379,7 +381,7 @@ static void exit_signal_handler(int signum)
 #if defined(CURL_HAVE_DIAG) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-  initiate_exit(signum);
+  (void)initiate_exit(signum);
 #if !(defined(HAVE_SIGACTION) && defined(SA_RESTART))
   (void)signal(signum, exit_signal_handler);
 #endif
@@ -427,10 +429,11 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  static const char msgF[] = "ctrl_event_handler(): return unhandled\n";
   static const char msgT[] = "ctrl_event_handler(): return handled\n";
+  static const char msgF[] = "ctrl_event_handler(): return unhandled\n";
   HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
   DWORD dwWritten;
+  BOOL handled = FALSE;
   int signum = 0;
   switch(dwCtrlType) {
   case CTRL_C_EVENT:
@@ -442,13 +445,14 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
   case CTRL_BREAK_EVENT:
     signum = SIGBREAK;
     break;
-  default:
-     WriteFile(out, msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
-     return FALSE;
   }
-  WriteFile(out, msgT, CURL_CSTRLEN(msgT), &dwWritten, NULL);
-  initiate_exit(signum);
-  return TRUE;
+  if(signum)
+    handled = initiate_exit(signum);
+  if(handled)
+    WriteFile(out, msgT, CURL_CSTRLEN(msgT), &dwWritten, NULL);
+  else
+    WriteFile(out, msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
+  return handled;
 }
 
 #ifndef CURL_WINDOWS_UWP

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -429,14 +429,12 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  static const char func[] = "ctrl_event_handler(): ";
-  static const char msgU[] = "unhandled\n";
-  static const char msgH[] = "handled\n";
-  static const char msgF[] = "failed to handle\n";
+  static const char msgU[] = "ctrl_event_handler(): unhandled\n";
+  static const char msgH[] = "ctrl_event_handler(): handled\n";
+  static const char msgF[] = "ctrl_event_handler(): failed to handle\n";
   HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
   DWORD dwWritten;
   int signum = 0;
-  WriteFile(out, func, CURL_CSTRLEN(func), &dwWritten, NULL);
   switch(dwCtrlType) {
   case CTRL_C_EVENT:
     signum = SIGINT;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -322,33 +322,6 @@ storerequest_cleanup:
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 }
 
-/* vars used to keep around previous signal handlers */
-
-typedef void (*SIGHANDLER_T)(int);
-
-#if defined(_MSC_VER) && (_MSC_VER <= 1700)
-/* Workaround for warning C4306:
-   'type cast' : conversion from 'int' to 'void (__cdecl *)(int)' */
-#undef SIG_ERR
-#define SIG_ERR  ((SIGHANDLER_T)(size_t)-1)
-#endif
-
-#ifdef SIGHUP
-static SIGHANDLER_T old_sighup_handler  = SIG_ERR;
-#endif
-#ifdef SIGPIPE
-static SIGHANDLER_T old_sigpipe_handler = SIG_ERR;
-#endif
-#ifdef SIGALRM
-static SIGHANDLER_T old_sigalrm_handler = SIG_ERR;
-#endif
-#ifdef SIGINT
-static SIGHANDLER_T old_sigint_handler  = SIG_ERR;
-#endif
-#ifdef SIGTERM
-static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
-#endif
-
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
 static DWORD thread_main_id = 0;
 static HANDLE thread_main_window = NULL;
@@ -392,7 +365,29 @@ static void exit_signal_handler(int signum)
   errno = old_errno;
 }
 
-#ifdef _WIN32
+#ifndef _WIN32
+
+/* vars used to keep around previous signal handlers */
+
+typedef void (*SIGHANDLER_T)(int);
+
+#ifdef SIGHUP
+static SIGHANDLER_T old_sighup_handler  = SIG_ERR;
+#endif
+#ifdef SIGPIPE
+static SIGHANDLER_T old_sigpipe_handler = SIG_ERR;
+#endif
+#ifdef SIGALRM
+static SIGHANDLER_T old_sigalrm_handler = SIG_ERR;
+#endif
+#ifdef SIGINT
+static SIGHANDLER_T old_sigint_handler  = SIG_ERR;
+#endif
+#ifdef SIGTERM
+static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
+#endif
+
+#else /* _WIN32 */
 /* CTRL event handler for Windows Console applications to simulate
  * SIGINT, SIGTERM and SIGBREAK on CTRL events and trigger signal handler.
  *
@@ -432,7 +427,7 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
   }
   return TRUE;
 }
-#endif
+#endif /* !_WIN32 */
 
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
 /* Window message handler for Windows applications to add support

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -402,15 +402,16 @@ static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  logmsg("ctrl_event_handler: %lu", dwCtrlType);
   switch(dwCtrlType) {
   case CTRL_C_EVENT:
   case CTRL_CLOSE_EVENT:
   case CTRL_BREAK_EVENT:
+    logmsg("ctrl_event_handler: returned handled");
     if(exit_event)
       (void)SetEvent(exit_event);
     return TRUE;
   }
+  logmsg("ctrl_event_handler: return unhandled");
   return FALSE;
 }
 #endif /* !_WIN32 */

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -402,16 +402,21 @@ static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
+  static const char msgT[] = "ctrl_event_handler(): return handled\n";
+  static const char msgF[] = "ctrl_event_handler(): return unhandled\n";
+  HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
+  DWORD dwWritten;
+  int signum = 0;
   switch(dwCtrlType) {
   case CTRL_C_EVENT:
   case CTRL_CLOSE_EVENT:
   case CTRL_BREAK_EVENT:
-    logmsg("ctrl_event_handler: returned handled");
+    WriteFile(out, msgT, sizeof(msgT) - 1, &dwWritten, NULL);
     if(exit_event)
       (void)SetEvent(exit_event);
     return TRUE;
   }
-  logmsg("ctrl_event_handler: return unhandled");
+  WriteFile(out, msgF, sizeof(msgF) - 1, &dwWritten, NULL);
   return FALSE;
 }
 #endif /* !_WIN32 */

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -370,18 +370,7 @@ static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
 static void exit_signal_handler(int signum)  /* stay signal-safe */
 {
   int old_errno = errno;
-  static const char msg[] = "exit_signal_handler(): triggered\n";
-  /* suppress warning seen in configurations where 'write()' has the attribute
-     'warn_unused_result', which is not silenced by casting to '(void)'. */
-#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result" /* GCC 4.5+ */
-#endif
-  (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
-#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-  exit_msg = msg;
+  exit_msg = "exit_signal_handler(): triggered";
   (void)initiate_exit(signum);
 #if !(defined(HAVE_SIGACTION) && defined(SA_RESTART))
   (void)signal(signum, exit_signal_handler);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -334,13 +334,27 @@ static void initiate_exit(int signum)  /* must remain signal-safe */
 #endif
 }
 
-#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
-static DWORD thread_main_id = 0;
-static HANDLE thread_main_window = NULL;
-static HWND hidden_main_window = NULL;
-#endif
-
 #ifndef _WIN32
+
+/* vars used to keep around previous signal handlers */
+
+typedef void (*SIGHANDLER_T)(int);
+
+#ifdef SIGHUP
+static SIGHANDLER_T old_sighup_handler  = SIG_ERR;
+#endif
+#ifdef SIGPIPE
+static SIGHANDLER_T old_sigpipe_handler = SIG_ERR;
+#endif
+#ifdef SIGALRM
+static SIGHANDLER_T old_sigalrm_handler = SIG_ERR;
+#endif
+#ifdef SIGINT
+static SIGHANDLER_T old_sigint_handler  = SIG_ERR;
+#endif
+#ifdef SIGTERM
+static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
+#endif
 
 /* signal handler that is triggered to indicate that the program
  * should finish its execution in a controlled manner as soon as possible.
@@ -372,27 +386,37 @@ static void exit_signal_handler(int signum)
   errno = old_errno;
 }
 
-/* vars used to keep around previous signal handlers */
+static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
+{
+#if defined(HAVE_SIGACTION) && defined(SA_RESTART)
+  struct sigaction sa, oldsa;
 
-typedef void (*SIGHANDLER_T)(int);
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = handler;
+  sigemptyset(&sa.sa_mask);
+  sigaddset(&sa.sa_mask, signum);
+  sa.sa_flags = norestart ? 0 : SA_RESTART;
 
-#ifdef SIGHUP
-static SIGHANDLER_T old_sighup_handler  = SIG_ERR;
+  if(sigaction(signum, &sa, &oldsa))
+    return SIG_ERR;
+
+  return oldsa.sa_handler;
+#else
+  SIGHANDLER_T oldhdlr = signal(signum, handler);
+
+#ifdef HAVE_SIGINTERRUPT
+  if(oldhdlr != SIG_ERR)
+    siginterrupt(signum, norestart);
+#else
+  (void)norestart;
 #endif
-#ifdef SIGPIPE
-static SIGHANDLER_T old_sigpipe_handler = SIG_ERR;
+
+  return oldhdlr;
 #endif
-#ifdef SIGALRM
-static SIGHANDLER_T old_sigalrm_handler = SIG_ERR;
-#endif
-#ifdef SIGINT
-static SIGHANDLER_T old_sigint_handler  = SIG_ERR;
-#endif
-#ifdef SIGTERM
-static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
-#endif
+}
 
 #else /* _WIN32 */
+
 /* CTRL event handler for Windows Console applications to simulate
  * SIGINT, SIGTERM and SIGBREAK on CTRL events and trigger signal handler.
  *
@@ -434,9 +458,12 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
   initiate_exit(signum);
   return TRUE;
 }
-#endif /* !_WIN32 */
 
-#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
+#ifndef CURL_WINDOWS_UWP
+static DWORD thread_main_id = 0;
+static HANDLE thread_main_window = NULL;
+static HWND hidden_main_window = NULL;
+
 /* Window message handler for Windows applications to add support
  * for graceful process termination via taskkill (without /f) which
  * sends WM_CLOSE to all Windows of a process (even hidden ones).
@@ -516,38 +543,8 @@ static DWORD WINAPI main_window_loop(void *lpParameter)
   hidden_main_window = NULL;
   return (DWORD)msg.wParam;
 }
-#endif
-
-#ifndef _WIN32
-static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
-{
-#if defined(HAVE_SIGACTION) && defined(SA_RESTART)
-  struct sigaction sa, oldsa;
-
-  memset(&sa, 0, sizeof(sa));
-  sa.sa_handler = handler;
-  sigemptyset(&sa.sa_mask);
-  sigaddset(&sa.sa_mask, signum);
-  sa.sa_flags = norestart ? 0 : SA_RESTART;
-
-  if(sigaction(signum, &sa, &oldsa))
-    return SIG_ERR;
-
-  return oldsa.sa_handler;
-#else
-  SIGHANDLER_T oldhdlr = signal(signum, handler);
-
-#ifdef HAVE_SIGINTERRUPT
-  if(oldhdlr != SIG_ERR)
-    siginterrupt(signum, norestart);
-#else
-  (void)norestart;
-#endif
-
-  return oldhdlr;
-#endif
-}
-#endif /* _WIN32 */
+#endif /* CURL_WINDOWS_UWP */
+#endif /* !_WIN32 */
 
 void install_signal_handlers(bool keep_sigalrm)
 {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -402,26 +402,16 @@ static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  int signum = 0;
   logmsg("ctrl_event_handler: %lu", dwCtrlType);
   switch(dwCtrlType) {
   case CTRL_C_EVENT:
-    signum = SIGINT;
-    break;
   case CTRL_CLOSE_EVENT:
-    signum = SIGTERM;
-    break;
   case CTRL_BREAK_EVENT:
-    signum = SIGBREAK;
-    break;
-  default:
-    return FALSE;
+    if(exit_event)
+      (void)SetEvent(exit_event);
+    return TRUE;
   }
-  if(signum) {
-    logmsg("ctrl_event_handler: %lu -> %d", dwCtrlType, signum);
-    raise(signum);
-  }
-  return TRUE;
+  return FALSE;
 }
 #endif /* !_WIN32 */
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -434,7 +434,6 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
   static const char msgF[] = "ctrl_event_handler(): failed to handle\n";
   HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
   DWORD dwWritten;
-  BOOL handled = FALSE;
   int signum = 0;
   switch(dwCtrlType) {
   case CTRL_C_EVENT:

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -553,12 +553,8 @@ void install_signal_handlers(bool keep_sigalrm)
 {
   char errbuf[STRERROR_LEN];
   (void)errbuf;
-#ifdef _WIN32
-  /* setup Windows exit event before any signal can trigger */
-  exit_event = CreateEvent(NULL, TRUE, FALSE, NULL);
-  if(!exit_event)
-    logmsg("cannot create exit event");
-#endif
+  (void)keep_sigalrm;
+#ifndef _WIN32
 #ifdef SIGHUP
   /* ignore SIGHUP signal */
   old_sighup_handler = set_signal(SIGHUP, SIG_IGN, 0);
@@ -581,8 +577,6 @@ void install_signal_handlers(bool keep_sigalrm)
       logmsg("cannot install SIGALRM handler: (%d) %s",
              errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
   }
-#else
-  (void)keep_sigalrm;
 #endif
 #ifdef SIGINT
   /* handle SIGINT signal with our exit_signal_handler */
@@ -598,7 +592,11 @@ void install_signal_handlers(bool keep_sigalrm)
     logmsg("cannot install SIGTERM handler: (%d) %s",
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 #endif
-#ifdef _WIN32
+#else /* _WIN32 */
+  /* setup Windows exit event before any signal can trigger */
+  exit_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+  if(!exit_event)
+    logmsg("cannot create exit event");
   if(!SetConsoleCtrlHandler(ctrl_event_handler, TRUE))
     logmsg("cannot install CTRL event handler");
 
@@ -608,11 +606,13 @@ void install_signal_handlers(bool keep_sigalrm)
   if(!thread_main_window || !thread_main_id)
     logmsg("cannot start main window loop");
 #endif
-#endif
+#endif /* !_WIN32 */
 }
 
 void restore_signal_handlers(bool keep_sigalrm)
 {
+  (void)keep_sigalrm;
+#ifndef _WIN32
 #ifdef SIGHUP
   if(old_sighup_handler != SIG_ERR)
     (void)set_signal(SIGHUP, old_sighup_handler, 0);
@@ -626,8 +626,6 @@ void restore_signal_handlers(bool keep_sigalrm)
     if(old_sigalrm_handler != SIG_ERR)
       (void)set_signal(SIGALRM, old_sigalrm_handler, 0);
   }
-#else
-  (void)keep_sigalrm;
 #endif
 #ifdef SIGINT
   if(old_sigint_handler != SIG_ERR)
@@ -637,7 +635,7 @@ void restore_signal_handlers(bool keep_sigalrm)
   if(old_sigterm_handler != SIG_ERR)
     (void)set_signal(SIGTERM, old_sigterm_handler, 0);
 #endif
-#ifdef _WIN32
+#else /* _WIN32 */
   (void)SetConsoleCtrlHandler(ctrl_event_handler, FALSE);
 #ifndef CURL_WINDOWS_UWP
   if(thread_main_window && thread_main_id) {
@@ -653,7 +651,7 @@ void restore_signal_handlers(bool keep_sigalrm)
 #endif
   if(exit_event && CloseHandle(exit_event))
     exit_event = NULL;
-#endif
+#endif /* !_WIN32 */
 }
 
 #ifdef USE_UNIX_SOCKETS

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -356,10 +356,6 @@ static void exit_signal_handler(int signum)
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
     exit_signal = signum;
-#ifdef _WIN32
-    if(exit_event)
-      (void)SetEvent(exit_event);
-#endif
   }
 #if !(defined(HAVE_SIGACTION) && defined(SA_RESTART))
   (void)signal(signum, exit_signal_handler);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -429,8 +429,8 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
-  static const char msgT[] = "ctrl_event_handler(): return handled\n";
-  static const char msgF[] = "ctrl_event_handler(): return unhandled\n";
+  static const char msgT[] = "ctrl_event_handler(): handled\n";
+  static const char msgF[] = "ctrl_event_handler(): unhandled\n";
   HANDLE out = GetStdHandle(STD_ERROR_HANDLE);
   DWORD dwWritten;
   BOOL handled = FALSE;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -371,7 +371,6 @@ static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
   static const char msg[] = "exit_signal_handler(): triggered\n";
-  exit_msg = msg;
   /* suppress warning seen in configurations where 'write()' has the attribute
      'warn_unused_result', which is not silenced by casting to '(void)'. */
 #if defined(CURL_HAVE_DIAG) && !defined(__clang__)
@@ -382,6 +381,7 @@ static void exit_signal_handler(int signum)
 #if defined(CURL_HAVE_DIAG) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
+  exit_msg = msg;
   (void)initiate_exit(signum);
 #if !(defined(HAVE_SIGACTION) && defined(SA_RESTART))
   (void)signal(signum, exit_signal_handler);
@@ -447,17 +447,17 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
     signum = SIGBREAK;
     break;
   default:
-    exit_msg = msgU;
     WriteFile(out, msgU, CURL_CSTRLEN(msgU), &dwWritten, NULL);
+    exit_msg = msgU;
     return FALSE;
   }
   if(!initiate_exit(signum)) {
-    exit_msg = msgF;
     WriteFile(out, msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
+    exit_msg = msgF;
     return FALSE;
   }
-  exit_msg = msgH;
   WriteFile(out, msgH, CURL_CSTRLEN(msgH), &dwWritten, NULL);
+  exit_msg = msgH;
   return TRUE;
 }
 
@@ -481,9 +481,9 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
     case WM_CLOSE: {
       static const char msg[] = "main_window_proc(): WM_CLOSE -> SIGTERM\n";
       DWORD dwWritten;
-      exit_msg = msg;
       WriteFile(GetStdHandle(STD_ERROR_HANDLE), msg, CURL_CSTRLEN(msg),
                              &dwWritten, NULL);
+      exit_msg = msg;
       initiate_exit(SIGTERM);
       break;
     }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -417,21 +417,13 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
 
 #else /* _WIN32 */
 
-/* CTRL event handler for Windows Console applications to simulate
- * SIGINT, SIGTERM and SIGBREAK on CTRL events and trigger signal handler.
+/* CTRL event handler for Windows Console applications to handle exit events.
  *
  * Background information from MSDN:
- * SIGINT is not supported for any Win32 application. When a CTRL+C
- * interrupt occurs, Win32 operating systems generate a new thread
- * to specifically handle that interrupt. This can cause a single-thread
+ * When a CTRL+C interrupt occurs, Win32 operating systems generate a new
+ * thread to specifically handle that interrupt. This can cause a single-thread
  * application, such as one in UNIX, to become multi-threaded and cause
  * unexpected behavior.
- * [...]
- * The SIGKILL and SIGTERM signals are not generated under Windows.
- * They are included for ANSI compatibility. Therefore, you can set
- * signal handlers for these signals by using signal, and you can also
- * explicitly generate these signals by calling raise. Source:
- * https://learn.microsoft.com/cpp/c-runtime-library/reference/signal
  */
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -371,6 +371,7 @@ static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
   static const char msg[] = "exit_signal_handler(): triggered\n";
+  exit_msg = msg;
   /* suppress warning seen in configurations where 'write()' has the attribute
      'warn_unused_result', which is not silenced by casting to '(void)'. */
 #if defined(CURL_HAVE_DIAG) && !defined(__clang__)
@@ -446,14 +447,14 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
     signum = SIGBREAK;
     break;
   default:
-    WriteFile(out, msgU, CURL_CSTRLEN(msgU), &dwWritten, NULL);
+    WriteFile(out, exit_msg = msgU, CURL_CSTRLEN(msgU), &dwWritten, NULL);
     return FALSE;
   }
   if(!initiate_exit(signum)) {
-    WriteFile(out, msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
+    WriteFile(out, exit_msg = msgF, CURL_CSTRLEN(msgF), &dwWritten, NULL);
     return FALSE;
   }
-  WriteFile(out, msgH, CURL_CSTRLEN(msgH), &dwWritten, NULL);
+  WriteFile(out, exit_msg = msgH, CURL_CSTRLEN(msgH), &dwWritten, NULL);
   return TRUE;
 }
 
@@ -475,9 +476,10 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
   if(hwnd == hidden_main_window) {
     switch(uMsg) {
     case WM_CLOSE: {
-      static const char str[] = "main_window_proc(): WM_CLOSE -> SIGTERM\n";
+      static const char msg[] = "main_window_proc(): WM_CLOSE -> SIGTERM\n";
       DWORD dwWritten;
-      WriteFile(GetStdHandle(STD_ERROR_HANDLE), str, CURL_CSTRLEN(str),
+      WriteFile(GetStdHandle(STD_ERROR_HANDLE),
+                             exit_msg = msg, CURL_CSTRLEN(msg),
                              &dwWritten, NULL);
       initiate_exit(SIGTERM);
       break;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -348,9 +348,6 @@ static SIGHANDLER_T old_sigint_handler  = SIG_ERR;
 #ifdef SIGTERM
 static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
 #endif
-#ifdef _WIN32
-static SIGHANDLER_T old_sigbreak_handler = SIG_ERR;
-#endif
 
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
 static DWORD thread_main_id = 0;
@@ -602,11 +599,6 @@ void install_signal_handlers(bool keep_sigalrm)
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 #endif
 #ifdef _WIN32
-  /* handle SIGBREAK signal with our exit_signal_handler */
-  old_sigbreak_handler = set_signal(SIGBREAK, exit_signal_handler, 1);
-  if(old_sigbreak_handler == SIG_ERR)
-    logmsg("cannot install SIGBREAK handler: (%d) %s",
-           errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
   if(!SetConsoleCtrlHandler(ctrl_event_handler, TRUE))
     logmsg("cannot install CTRL event handler");
 
@@ -646,8 +638,6 @@ void restore_signal_handlers(bool keep_sigalrm)
     (void)set_signal(SIGTERM, old_sigterm_handler, 0);
 #endif
 #ifdef _WIN32
-  if(old_sigbreak_handler != SIG_ERR)
-    (void)set_signal(SIGBREAK, old_sigbreak_handler, 0);
   (void)SetConsoleCtrlHandler(ctrl_event_handler, FALSE);
 #ifndef CURL_WINDOWS_UWP
   if(thread_main_window && thread_main_id) {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -520,6 +520,7 @@ static DWORD WINAPI main_window_loop(void *lpParameter)
 }
 #endif
 
+#ifndef _WIN32
 static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
 {
 #if defined(HAVE_SIGACTION) && defined(SA_RESTART)
@@ -548,6 +549,7 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
   return oldhdlr;
 #endif
 }
+#endif /* _WIN32 */
 
 void install_signal_handlers(bool keep_sigalrm)
 {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -322,7 +322,7 @@ storerequest_cleanup:
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 }
 
-static bool initiate_exit(int signum)  /* must remain signal-safe */
+static bool initiate_exit(int signum)  /* stay signal-safe */
 {
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
@@ -367,7 +367,7 @@ static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
  * the POSIX specification:
  *   https://pubs.opengroup.org/onlinepubs/009695399/functions/xsh_chap02_04.html#tag_02_04_03
  */
-static void exit_signal_handler(int signum)
+static void exit_signal_handler(int signum)  /* stay signal-safe */
 {
   int old_errno = errno;
   static const char msg[] = "exit_signal_handler(): triggered\n";
@@ -428,7 +428,7 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler, int norestart)
  * application, such as one in UNIX, to become multi-threaded and cause
  * unexpected behavior.
  */
-static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
+static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)  /* stay signal-safe */
 {
   static const char msgU[] = "ctrl_event_handler(): unhandled\n";
   static const char msgH[] = "ctrl_event_handler(): handled\n";


### PR DESCRIPTION
On Windows, the init code calls `SetConsoleCtrlHandler()`, and before
this patch also set handlers for all Unixy signals. Of these, `SIGBREAK`
(used on Windows-only), `SIGINT`, `SIGABRT` and `SIGTERM` were also
setting up a `SetConsoleCtrlHandler()`, in addition to the call made 
directly. (The rest, `SIGHUP`, `SIGPIPE`, `SIGALRM` are either missing
the macros, or ignored by `signal()` on Windows.)

As per WINE sources, `SetConsolCtrlHandler(<h>, TRUE)` calls are
additive, which means the test server set up two console ctrl handlers.

Then the ctrl handler set directly (`ctrl_event_handler()`), was
triggering the other signal handler via `raise()`, for the 'initiate
exit' logic, which in turn triggered exiting a wait within `select_ws()`
and other loops. The Windows window handler also made use of the
`SIGTERM` event to initiate exit via `raise()` and the second signal
handler.

To simplify, de-duplicate the ctrl handlers by dropping `signal()` calls
and keeping the direct Win32 call with `ctrl_event_handler()` doing all
the signal handling on Windows. Break out the 'initiate exit' logic into
a function and call it from both Unix and Windows signal/ctrl/window
handlers. Also drop calling `raise()` on exit, because it's a no-op 
without a `signal()` pair.

Also:
- drop logging the actual ctrl type number, replace with just logging 
  whether we handled the event, in `ctrl_event_handler()`. To avoid
  using non-signal-safe functions (e.g. `fprintf()`) from the handler.
- also replace `logmsg()` with `WriteFile()` to prevent regressions.
  Ref: #22045
- replace `logmsg()` with `WriteFile()` in `main_window_proc()`.
- fix to forward ctrl handling to the OS in the rare case of failed
  `exit_event` initialization on startup. To swap a possible hang
  (within `WaitForMultipleObjectsEx()`) with an ungraceful shutdown.
- add support for an 'exit message' string, set by signal/ctrl handlers,
  and log it on app exit. To avoid the need to deal with logging within
  the handlers, yet have a static trace message about the event.
  Complementing the already logged signal number.
- drop stderr trace message from `exit_signal_handler()` in favor of an
  exit message. runtests triggers it frequantly, which added much noise
  to stderr. As a bonus, this also allows dropping the compiler warning
  suppression.
  Reported-by: Stefan Eissing
  Bug: https://github.com/curl/curl/pull/22487#issuecomment-5204092974
  Follow-up to 3aae64e4fbee7c1fa408c54df18d3f631781c283 #22507

Refs:
https://learn.microsoft.com/windows/console/setconsolectrlhandler
https://learn.microsoft.com/windows/console/registering-a-control-handler-function
https://learn.microsoft.com/cpp/c-runtime-library/reference/raise
https://learn.microsoft.com/cpp/c-runtime-library/reference/signal
https://gitlab.winehq.org/wine/wine/-/blob/wine-11.14/dlls/kernelbase/console.c#L1517-1526
https://github.com/huangqinjin/ucrt/blob/d6e817a4cc90f6f1fe54f8a0aa4af4fff0bb647d/misc/signal.cpp#L286-L348

Follow-up to fe28fcf04cdfe7c6e1ab4499a33f9b8479839f14 7dc8a981fa043b9dbbae3a632229b74dcd868bd7 0e058776c02cf8ddc753a36f9cde98cc87899d51 #5260

---

- [x] figure out/test/double-check how the `WM_CLOSE` codepath works.
  It should work now like it did before, but without going through a raise/catch custom SIGTERM
  cycle, and instead doing the same job directly. I suppose this should be enough without doing any
  explicit things, such as generating a CTRL_BREAK_EVENT with `GenerateConsoleCtrlEvent()`,
  or some other things from the window handler?
  → Works fine in local tests, above tricks not needed. The closing `raise(SIGTERM)` is rundant, no-op.
- [x] to relay messages from handlers, they may assign it to a string buffer which can be logged on exit from the main thread. (the signal number is already relayed this way). Perhaps centralize this instead of repeating for each server.
- [x] with this completed, and `signal()` use limited to non-Windows, it
  becomes an option to drop legacy `signal()` support in favor of `sigaction()` + `SA_RESTART`,
  to simplify the source, and drop detection from the build systems.
  Not so fast, libcurl code also uses `signal()`, making the benefits minimal. [SKIP]
- [x] perhaps also to revise if the guard for each macro use is still necessary? [AFAICS, the actual signals are implementation-dependent, and not specified by POSIX, so better keep them.]
- [x] after this, we may give another change to reindtroduce graceful taskkills in runtests.
   OR, if we don't bother, the window handler code can be dropped.
  The graceful shutdown is indeed better because server.exe cleans up after
  itself, deletes PID file and so on. → [contemplating options at #22496]
