### PR TITLE
DEPRECATE.md: HTTP/2 Server Push gets removed in March 2027

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -53,7 +53,7 @@ This protocol feature has been deprecated in specifications, by major browsers,
 and in server implementations. It was never supported by the curl command line
 tool, only by libcurl.
 
-We estimate that very few libcurl users still use this feature.
+We estimate that barely any libcurl users still use this feature.
 
 HTTP/2 Server Push gets removed in March 2027.
 

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -47,6 +47,16 @@ future curl versions when built without TLS support. For example Digest.
 
 Local crypto gets removed in October 2026.
 
+## HTTP/2 Server Push
+
+This protocol feature has been deprecated in specifications, by major browsers,
+and in server implementations. It was never supported by the curl command line
+tool, only by libcurl.
+
+We estimate that very few libcurl users still use this feature.
+
+HTTP/2 Server Push gets removed in March 2027.
+
 ## Past removals
 
 - axTLS (removed in 7.63.0)


### PR DESCRIPTION
URL: https://curl.se/mail/lib-2026-08/0003.html
