### PR TITLE
servers: fix to avoid a non-signal-safe call in signal handler

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -403,7 +403,7 @@ static void exit_signal_handler(int signum)
       (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
       str = serverlogfile;
       while(*str)
-        (void)write(STDERR_FILENO, *str++, 1);
+        (void)write(STDERR_FILENO, str++, 1);
       (void)write(STDERR_FILENO, "\n", 1);
     }
   }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -399,8 +399,11 @@ static void exit_signal_handler(int signum)
     }
     else {
       static const char msg[] = "exit_signal_handler: failed opening ";
+      const char *str;
       (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
-      (void)write(STDERR_FILENO, serverlogfile, strlen(serverlogfile));
+      str = serverlogfile;
+      while(*str)
+        (void)write(STDERR_FILENO, *str++, 1);
       (void)write(STDERR_FILENO, "\n", 1);
     }
   }


### PR DESCRIPTION
`strlen()` is only guaranteed to be signal-safe since POSIX.1-2008.

Ref: https://pubs.opengroup.org/onlinepubs/009695399/functions/xsh_chap02_04.html#tag_02_04_03

Reported by Copilot
Bug: https://github.com/curl/curl/pull/22487#pullrequestreview-4863961494
Follow-up to e95f509c66abdd88ae02e3243cdc217f19c4a330 #16852

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
