### PR TITLE
tests: keep test names shorter than 70 columns

### DIFF
--- a/tests/data/test1062
+++ b/tests/data/test1062
@@ -26,7 +26,7 @@ REPLY CWD %repeat[218 x 250-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 ftp
 </server>
 <name>
-FTP with excessively long server command response lines, boundary condition
+FTP excessively long server command response lines, boundary condition
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER

--- a/tests/data/test1088
+++ b/tests/data/test1088
@@ -75,7 +75,7 @@ contents
 http
 </server>
 <name>
-HTTP, proxy with --anyauth and Location: to new host using location-trusted
+HTTP, proxy with --anyauth and Location: using location-trusted
 </name>
 <command>
 http://first.host.it.is/we/want/that/page/%TESTNUMBER1000 -x %HOSTIP:%HTTPPORT --user iam:myself --location-trusted --anyauth

--- a/tests/data/test1113
+++ b/tests/data/test1113
@@ -26,7 +26,7 @@ ftp
 lib574
 </tool>
 <name>
-FTP wildcard download - changed fnmatch, 2x perform (DOS LIST response)
+FTP wildcard download - changed fnmatch, 2x perform (DOS LIST)
 </name>
 <command>
 "ftp://%HOSTIP:%FTPPORT/fully_simulated/DOS/*.txt"

--- a/tests/data/test1133
+++ b/tests/data/test1133
@@ -27,7 +27,7 @@ Mime
 http
 </server>
 <name>
-HTTP RFC1867-type formposting with filename/data contains ',', ';', '"'
+HTTP formpost with filename/data containing ',', ';', '"'
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER

--- a/tests/data/test1177
+++ b/tests/data/test1177
@@ -11,7 +11,7 @@ documentation
 # Client-side
 <client>
 <name>
-Verify that feature names and CURL_VERSION_* in lib and docs are in sync
+Verify feature names and CURL_VERSION_* in lib and docs in sync
 </name>
 
 <command type="perl">

--- a/tests/data/test1253
+++ b/tests/data/test1253
@@ -28,7 +28,7 @@ foo
 http
 </server>
 <name>
---proxy, override NO_PROXY by --noproxy and access target URL through proxy
+--proxy, override NO_PROXY by --noproxy and access URL through proxy
 </name>
 <setenv>
 NO_PROXY=example.com

--- a/tests/data/test1255
+++ b/tests/data/test1255
@@ -29,7 +29,7 @@ foo
 http
 </server>
 <name>
-http_proxy, override NO_PROXY by --noproxy and access target URL directly
+http_proxy, override NO_PROXY by --noproxy and access URL directly
 </name>
 <setenv>
 http_proxy=http://%HOSTIP:%HTTPPORT

--- a/tests/data/test1315
+++ b/tests/data/test1315
@@ -30,7 +30,7 @@ Mime
 http
 </server>
 <name>
-HTTP RFC1867-type formposting - -F with three files, one with explicit type
+HTTP -F with three files, one with explicit type
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F name=value -F 'file=@%LOGDIR/test%TESTNUMBER.txt,%LOGDIR/test%TESTNUMBER.txt;type=magic/content,%LOGDIR/test%TESTNUMBER.txt'

--- a/tests/data/test1479
+++ b/tests/data/test1479
@@ -30,7 +30,7 @@ Data
 http
 </server>
 <name>
-HTTP/1.1 response followed by an HTTP/0.9 response over the same connection
+HTTP/1.1 response followed by HTTP/0.9 response over same connection
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002

--- a/tests/data/test1557
+++ b/tests/data/test1557
@@ -16,7 +16,7 @@ lib%TESTNUMBER
 </tool>
 
 <name>
-Remove easy handle in pending connections does not leave dangling entry
+Remove easy handle in pending connections, no dangling entry
 </name>
 <command>
 hostname.invalid

--- a/tests/data/test1616
+++ b/tests/data/test1616
@@ -13,7 +13,7 @@ uint_hash
 unittest
 </features>
 <name>
-Internal uint_hash create/add/destroy testing, exercising clean functions
+uint_hash create/add/destroy testing, exercising clean functions
 </name>
 </client>
 </testcase>

--- a/tests/data/test162
+++ b/tests/data/test162
@@ -35,7 +35,7 @@ proxy
 http
 </server>
 <name>
-HTTP GET asking for --proxy-ntlm when some other authentication is required
+HTTP GET --proxy-ntlm when some other authentication is required
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER --proxy http://%HOSTIP:%HTTPPORT --proxy-user foo:bar --proxy-ntlm --fail

--- a/tests/data/test1641
+++ b/tests/data/test1641
@@ -33,7 +33,7 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 http
 </server>
 <name>
-HTTP GET with -J, a redirect and Content-Disposition in the second response
+HTTP GET -J, a redirect and Content-Disposition in the second response
 </name>
 <command option="no-output,no-include">
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -L -O --output-dir %LOGDIR

--- a/tests/data/test1642
+++ b/tests/data/test1642
@@ -32,7 +32,7 @@ Content-Type: text/html
 http
 </server>
 <name>
-HTTP GET with -J, redirect, no Content-Disposition use the Location: name
+HTTP GET -J, redirect, no Content-Disposition use the Location: name
 </name>
 <command option="no-output,no-include">
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -L -O --output-dir %LOGDIR

--- a/tests/data/test1677
+++ b/tests/data/test1677
@@ -45,7 +45,7 @@ random data in first chunk
 http
 </server>
 <name>
-HTTP POST response with both Transfer-Encoding chunked and Content-Length 0
+HTTP POST response with both chunked and zero Content-Length
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -d "testdata"

--- a/tests/data/test2010
+++ b/tests/data/test2010
@@ -35,7 +35,7 @@ http
 https
 </server>
 <name>
-proxy credentials via options for two proxies, redirect from http to https
+proxy creds via options for two proxies, redir from http to https
 </name>
 
 <setenv>

--- a/tests/data/test2039
+++ b/tests/data/test2039
@@ -31,7 +31,7 @@ dr-xr-xr-x   5 0        1            512 Oct  1  1997 usr
 ftp
 </server>
 <name>
-FTP (optional .netrc with 'default' override; no user/pass) dir list PASV
+FTP optional .netrc with 'default' override; no user/pass, dir list
 </name>
 <command>
 --netrc-optional --netrc-file %LOGDIR/netrc%TESTNUMBER ftp://%HOSTIP:%FTPPORT/

--- a/tests/data/test2052
+++ b/tests/data/test2052
@@ -27,7 +27,7 @@ OK
 http
 </server>
 <name>
---connect-to: do not mix connections with and without a "connect to host"
+--connect-to: do not mix connections with and w/o a "connect to host"
 </name>
 
 <command>

--- a/tests/data/test2054
+++ b/tests/data/test2054
@@ -26,7 +26,7 @@ OK
 http
 </server>
 <name>
-Connect to specific host: use the first "connect-to" string that matches
+Connect to specific host: use the first "connect-to" string
 </name>
 
 <command>

--- a/tests/data/test2055
+++ b/tests/data/test2055
@@ -48,7 +48,7 @@ http-proxy
 socks5
 </server>
 <name>
---connect-to via SOCKS proxy and HTTP proxy (tunnel mode automatically)
+--connect-to via SOCKS proxy and HTTP proxy (tunnel mode auto)
 </name>
 <features>
 proxy

--- a/tests/data/test2059
+++ b/tests/data/test2059
@@ -70,7 +70,7 @@ proxy
 digest
 </features>
 <name>
-HTTP Digest with PUT, resumed upload, modified method, SHA-256 and userhash
+HTTP Digest PUT, resumed upload, modified method, SHA-256 and userhash
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u auser:apasswd --digest -T %LOGDIR/%TESTNUMBER -x  http://%HOSTIP:%HTTPPORT -C 2 -X GET

--- a/tests/data/test2067
+++ b/tests/data/test2067
@@ -55,7 +55,7 @@ crypto
 digest
 </features>
 <name>
-HTTP POST --digest with SHA256 and user-specified Content-Length header
+HTTP POST --digest with SHA256 and user-specified Content-Length
 </name>
 # This test is to ensure 'Content-Length: 0' is sent while negotiating auth
 # even when there is a user-specified Content-Length header.

--- a/tests/data/test2072
+++ b/tests/data/test2072
@@ -22,7 +22,7 @@ moo
 file
 </server>
 <name>
-file:// with Unix path resolution behavior for the case of extra slashes
+file:// with Unix path for the case of extra slashes
 </name>
 <command option="no-include">
 file:////%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt

--- a/tests/data/test2087
+++ b/tests/data/test2087
@@ -32,7 +32,7 @@ local-http
 https test-localhost.pem
 </server>
 <name>
-simple HTTPS GET with base64-sha256 public key pinning (Schannel variant)
+simple HTTPS GET with base64-sha256 public key pinning (Schannel)
 </name>
 <setenv>
 # This test is pointless if we are not using the Schannel backend

--- a/tests/data/test2113
+++ b/tests/data/test2113
@@ -61,7 +61,7 @@ contents
 http
 </server>
 <name>
-HTTP custom Authorization: with whitespace before colon and redirect to new host
+Authorization: with whitespace before colon and redir to new host
 </name>
 <command>
 http://first.host.it.is/we/want/that/page/%TESTNUMBER -x %HOSTIP:%HTTPPORT -H "Authorization : s3cr3t" --proxy-user testing:this --location

--- a/tests/data/test2311
+++ b/tests/data/test2311
@@ -26,7 +26,7 @@ This server says moo
 http
 </server>
 <name>
-Cookie from file: control octet rejected, prefixes matched case sensitively
+Cookie from file: control octet rejected, prefixes case sensitive
 </name>
 <command>
 http://example.fake/%TESTNUMBER -b %LOGDIR/injar%TESTNUMBER -x %HOSTIP:%HTTPPORT

--- a/tests/data/test234
+++ b/tests/data/test234
@@ -63,7 +63,7 @@ contents
 http
 </server>
 <name>
-HTTP, proxy, site+proxy auth and Location: to new host location-trusted
+HTTP, proxy, site+proxy auth and Location: --location-trusted
 </name>
 <command>
 http://first.host.it.is/we/want/that/page/%TESTNUMBER -x %HOSTIP:%HTTPPORT --user iam:myself --proxy-user testing:this --location-trusted

--- a/tests/data/test258
+++ b/tests/data/test258
@@ -64,7 +64,7 @@ proxy
 digest
 </features>
 <name>
-HTTP POST multipart without Expect: header using proxy anyauth (Digest)
+HTTP multipart POST without Expect: using proxy anyauth (Digest)
 </name>
 <command>
 -x http://%HOSTIP:%HTTPPORT http://remotehost:54321/we/want/%TESTNUMBER -F name=daniel -F tool=curl -F file=@%LOGDIR/test%TESTNUMBER.txt -H "Expect:" -U uuuser:pppassword --proxy-anyauth

--- a/tests/data/test3002
+++ b/tests/data/test3002
@@ -16,7 +16,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP multiple and invalid (first) --mail-rcpt and --mail-rcpt-allowfails
+SMTP invalid (first) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin crlf="yes">
 From: different

--- a/tests/data/test3003
+++ b/tests/data/test3003
@@ -16,7 +16,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP multiple and invalid (last) --mail-rcpt and --mail-rcpt-allowfails
+SMTP invalid (last) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin crlf="yes">
 From: different

--- a/tests/data/test3004
+++ b/tests/data/test3004
@@ -16,7 +16,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP multiple and invalid (middle) --mail-rcpt and --mail-rcpt-allowfails
+SMTP invalid (middle) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin crlf="yes">
 From: different

--- a/tests/data/test3005
+++ b/tests/data/test3005
@@ -16,7 +16,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP multiple invalid (all but one) --mail-rcpt and --mail-rcpt-allowfails
+SMTP invalid (all but one) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin crlf="yes">
 From: different

--- a/tests/data/test3006
+++ b/tests/data/test3006
@@ -16,7 +16,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP with multiple invalid (all) --mail-rcpt and --mail-rcpt-allowfails
+SMTP invalid (all) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin crlf="yes">
 From: different

--- a/tests/data/test3023
+++ b/tests/data/test3023
@@ -31,7 +31,7 @@ local-http
 https test-localhost-san-first.pem
 </server>
 <name>
-HTTPS localhost, first subaltname matches, CN does not match (Schannel)
+HTTPS localhost, first SAN matches, CN does not match (Schannel)
 </name>
 <setenv>
 # This test is pointless if we are not using the Schannel backend

--- a/tests/data/test316
+++ b/tests/data/test316
@@ -46,7 +46,7 @@ brotli
 http
 </server>
 <name>
-HTTP GET brotli compressed content of size more than CURL_MAX_WRITE_SIZE
+HTTP brotli compressed content of size more than CURL_MAX_WRITE_SIZE
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER --compressed

--- a/tests/data/test3302
+++ b/tests/data/test3302
@@ -13,7 +13,7 @@ CURLOPT_GSSAPI_DELEGATION
 unittest
 </features>
 <name>
-CURLOPT_GSSAPI_DELEGATION stores flags in data->set on GSS-API and SSPI builds
+CURLOPT_GSSAPI_DELEGATION stores flags in data->set
 </name>
 </client>
 </testcase>

--- a/tests/data/test3303
+++ b/tests/data/test3303
@@ -14,7 +14,7 @@ mTLS
 unittest
 </features>
 <name>
-conn-reuse match distinguishes mTLS key, cert_type, key_type and key_passwd fields
+conn-reuse distinguishes mTLS key, cert_type, key_type and key_passwd
 </name>
 </client>
 </testcase>

--- a/tests/data/test3304
+++ b/tests/data/test3304
@@ -14,7 +14,7 @@ mTLS
 unittest
 </features>
 <name>
-TLS session cache peer key discriminates on mTLS key, key_type and cert_type fields
+TLS session cache peer key uses mTLS key, key_type and cert_type
 </name>
 </client>
 </testcase>

--- a/tests/data/test345
+++ b/tests/data/test345
@@ -30,7 +30,7 @@ Funny-head: yesyes
 http
 </server>
 <name>
-Both --etag-compare and -save store new Etag using one pre-existing file
+Both --etag-compare and -save store new Etag in pre-existing file
 </name>
 <file name="%LOGDIR/etag%TESTNUMBER">
 "21025-dc7-39462498"

--- a/tests/data/test467
+++ b/tests/data/test467
@@ -9,7 +9,7 @@ cmdline
 # Client-side
 <client>
 <name>
-use a bad short option letter that does not exist (after one does exist)
+non-existing short option letter (after one that exists)
 </name>
 
 # the second option is outside the normal accepted range

--- a/tests/data/test485
+++ b/tests/data/test485
@@ -14,7 +14,7 @@ etag
 # Client-side
 <client>
 <name>
-Use --etag-compare and -save with more than one URL, URLs specified first
+--etag-compare and -save with more than one URL, URLs specified first
 </name>
 <command>
 http://example.com/%TESTNUMBER http://example.net/fooo --etag-save %LOGDIR/etag%TESTNUMBER

--- a/tests/data/test5000
+++ b/tests/data/test5000
@@ -32,7 +32,7 @@ httpsig
 </features>
 
 <name>
-HTTP RFC 9421 Message Signatures: basic GET with Ed25519
+httpsig: basic GET with Ed25519
 </name>
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test5001
+++ b/tests/data/test5001
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: CLI GET with query
+httpsig: CLI GET with query
 </name>
 <command>
 "http://example.com:8000/%TESTNUMBER/resource?action=read" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT

--- a/tests/data/test5002
+++ b/tests/data/test5002
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: CLI GET with HMAC-SHA256
+httpsig: CLI GET with HMAC-SHA256
 </name>
 <command>
 "http://example.com:7000/%TESTNUMBER/resource" --httpsig-algo "hmac-sha256" --httpsig-key @%SRCDIR/data/data-httpsig-hmac-sha256.key --httpsig-keyid "shared-key-1" --connect-to example.com:7000:%HOSTIP:%HTTPPORT

--- a/tests/data/test5003
+++ b/tests/data/test5003
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: custom --httpsig-headers
+httpsig: custom --httpsig-headers
 </name>
 <command>
 "http://example.com:6000/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --httpsig-headers "method authority" --connect-to example.com:6000:%HOSTIP:%HTTPPORT

--- a/tests/data/test5004
+++ b/tests/data/test5004
@@ -33,7 +33,7 @@ httpsig
 </features>
 
 <name>
-HTTP RFC 9421 B.2.6: Ed25519 POST with headers (RFC test vector)
+httpsig: Ed25519 POST with headers (RFC test vector)
 </name>
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test5005
+++ b/tests/data/test5005
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: sign with a regular HTTP header
+httpsig: sign with a regular HTTP header
 </name>
 <command>
 "http://example.com:5000/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --httpsig-headers "method authority content-type:" -H "Content-Type: application/json" --connect-to example.com:5000:%HOSTIP:%HTTPPORT

--- a/tests/data/test5006
+++ b/tests/data/test5006
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: component name lowercasing
+httpsig: component name lowercasing
 </name>
 <command>
 "http://example.com:5100/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --httpsig-headers "method Content-Type:" -H "Content-Type: text/plain" --connect-to example.com:5100:%HOSTIP:%HTTPPORT

--- a/tests/data/test5007
+++ b/tests/data/test5007
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: POST method
+httpsig: POST method
 </name>
 <command>
 "http://example.com:5200/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" -d "postbody" --connect-to example.com:5200:%HOSTIP:%HTTPPORT

--- a/tests/data/test5008
+++ b/tests/data/test5008
@@ -30,7 +30,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: error - missing --httpsig-key
+httpsig: error - missing --httpsig-key
 </name>
 <command>
 "http://example.com/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-keyid "my-key" --connect-to example.com::%HOSTIP:%HTTPPORT

--- a/tests/data/test5009
+++ b/tests/data/test5009
@@ -30,7 +30,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: error - unsupported algorithm
+httpsig: error - unsupported algorithm
 </name>
 <command>
 "http://example.com/%TESTNUMBER/resource" --httpsig-algo "rsa-pss-sha512" --httpsig-key %SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key" --connect-to example.com::%HOSTIP:%HTTPPORT

--- a/tests/data/test5010
+++ b/tests/data/test5010
@@ -30,7 +30,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: error - non-existent key file
+httpsig: error - non-existent key file
 </name>
 <command>
 "http://example.com/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @/nonexistent/key.hex --httpsig-keyid "my-key" --connect-to example.com::%HOSTIP:%HTTPPORT

--- a/tests/data/test5011
+++ b/tests/data/test5011
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: query string with special characters
+httpsig: query string with special characters
 </name>
 <command>
 "http://example.com:5300/%TESTNUMBER/resource?name=me%AMPnoval%AMPaim=b%25ad" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --connect-to example.com:5300:%HOSTIP:%HTTPPORT

--- a/tests/data/test5012
+++ b/tests/data/test5012
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: default port omitted from @authority
+httpsig: default port omitted from @authority
 </name>
 <command>
 "http://example.com/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --connect-to example.com::%HOSTIP:%HTTPPORT

--- a/tests/data/test5013
+++ b/tests/data/test5013
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: non-default port in @authority
+httpsig: non-default port in @authority
 </name>
 <command>
 "http://example.com:9000/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --connect-to example.com:9000:%HOSTIP:%HTTPPORT

--- a/tests/data/test5014
+++ b/tests/data/test5014
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: @query explicitly requested, no query in URL
+httpsig: @query explicitly requested, no query in URL
 </name>
 <command>
 "http://example.com:5400/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --httpsig-headers "method authority query" --connect-to example.com:5400:%HOSTIP:%HTTPPORT

--- a/tests/data/test5015
+++ b/tests/data/test5015
@@ -34,7 +34,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: POST with HMAC-SHA256
+httpsig: POST with HMAC-SHA256
 </name>
 <command>
 "http://example.com:5500/%TESTNUMBER/resource" --httpsig-algo "hmac-sha256" --httpsig-key @%SRCDIR/data/data-httpsig-hmac-sha256.key --httpsig-keyid "shared-key-1" -d "postbody" --connect-to example.com:5500:%HOSTIP:%HTTPPORT

--- a/tests/data/test5016
+++ b/tests/data/test5016
@@ -34,7 +34,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: HMAC-SHA256 with custom headers
+httpsig: HMAC-SHA256 with custom headers
 </name>
 <command>
 "http://example.com:5600/%TESTNUMBER/resource" --httpsig-algo "hmac-sha256" --httpsig-key @%SRCDIR/data/data-httpsig-hmac-sha256.key --httpsig-keyid "shared-key-1" --httpsig-headers "method authority content-type:" -H "Content-Type: application/json" --connect-to example.com:5600:%HOSTIP:%HTTPPORT

--- a/tests/data/test5017
+++ b/tests/data/test5017
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: user-supplied Signature header skips signing
+httpsig: user-supplied Signature header skips signing
 </name>
 <command>
 "http://example.com:5700/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key %SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" -H "Signature: preexisting" -H "Signature-Input: preexisting" --connect-to example.com:5700:%HOSTIP:%HTTPPORT

--- a/tests/data/test5018
+++ b/tests/data/test5018
@@ -36,7 +36,7 @@ httpsig
 putdata
 </file>
 <name>
-HTTP RFC 9421 Message Signatures: PUT upload
+httpsig: PUT upload
 </name>
 <command>
 "http://example.com:5800/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" -T log/upload5018 --connect-to example.com:5800:%HOSTIP:%HTTPPORT

--- a/tests/data/test5019
+++ b/tests/data/test5019
@@ -30,7 +30,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: error - duplicate component
+httpsig: error - duplicate component
 </name>
 <command>
 "http://example.com/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key %SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key" --httpsig-headers "method method" --connect-to example.com::%HOSTIP:%HTTPPORT

--- a/tests/data/test5020
+++ b/tests/data/test5020
@@ -30,7 +30,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: error - rejects legacy '@' component syntax
+httpsig: error - rejects legacy '@' component syntax
 </name>
 <command>
 "http://example.com/%TESTNUMBER/resource" --httpsig-algo "ed25519" --httpsig-key %SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key" --httpsig-headers "@method authority" --connect-to example.com::%HOSTIP:%HTTPPORT

--- a/tests/data/test5021
+++ b/tests/data/test5021
@@ -32,7 +32,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: default algorithm (ed25519) when --httpsig-algo omitted
+httpsig: default algorithm (ed25519) when --httpsig-algo omitted
 </name>
 <command>
 "http://example.com:6100/%TESTNUMBER/resource" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "test-key-ed25519" --connect-to example.com:6100:%HOSTIP:%HTTPPORT

--- a/tests/data/test5022
+++ b/tests/data/test5022
@@ -33,7 +33,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP RFC 9421 Message Signatures: pass key directly
+httpsig: pass key directly
 </name>
 <command>
 "http://example.com:8000/5001/resource?action=read" --httpsig-algo "ed25519" --variable key@%SRCDIR/data/data-httpsig-ed25519.key --expand-httpsig-key '{{key:trim}}' --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT

--- a/tests/data/test5023
+++ b/tests/data/test5023
@@ -39,7 +39,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP Message Signature with cross-origin redirect
+httpsig: cross-origin redirect
 </name>
 <command>
 "http://example.com:8000/%TESTNUMBER/resource?action=read" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT --connect-to example.org:9000:%HOSTIP:%HTTPPORT --location

--- a/tests/data/test5024
+++ b/tests/data/test5024
@@ -39,7 +39,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP Message Signature with same-origin redirect
+httpsig: same-origin redirect
 </name>
 <command>
 "http://example.com:8000/%TESTNUMBER/resource?action=read" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT --location

--- a/tests/data/test5025
+++ b/tests/data/test5025
@@ -39,7 +39,7 @@ Debug
 httpsig
 </features>
 <name>
-HTTP Message Signature with cross-origin + user auth redirect
+httpsig: cross-origin + user auth redirect
 </name>
 <command>
 "http://example.com:8000/%TESTNUMBER/resource?action=read" --httpsig-algo "ed25519" --httpsig-key @%SRCDIR/data/data-httpsig-ed25519.key --httpsig-keyid "my-key-1" --connect-to example.com:8000:%HOSTIP:%HTTPPORT --connect-to example.org:9000:%HOSTIP:%HTTPPORT --location

--- a/tests/data/test529
+++ b/tests/data/test529
@@ -24,7 +24,7 @@ ftp
 lib525
 </tool>
 <name>
-FTP PORT upload using multi interface (weird cleanup function sequence)
+FTP PORT upload using multi interface (weird cleanup function seq)
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER %LOGDIR/upload%TESTNUMBER

--- a/tests/data/test546
+++ b/tests/data/test546
@@ -36,7 +36,7 @@ ftp
 lib533
 </tool>
 <name>
-FTP RETR a non-existing file then a found one using the multi interface
+FTP RETR non-existing file then a found one using multi
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER

--- a/tests/data/test550
+++ b/tests/data/test550
@@ -37,7 +37,7 @@ proxy
 lib549
 </tool>
 <name>
-FTP RETR over proxy with CURLOPT_PROXY_TRANSFER_MODE and ASCII transfer
+FTP RETR over proxy with CURLOPT_PROXY_TRANSFER_MODE using ASCII
 </name>
 # first URL then proxy
 <command>

--- a/tests/data/test565
+++ b/tests/data/test565
@@ -68,7 +68,7 @@ lib510
 </tool>
 
 <name>
-send HTTP POST using read callback, chunked transfer-encoding and Digest
+HTTP POST using read callback, chunked transfer-encoding and Digest
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER

--- a/tests/data/test574
+++ b/tests/data/test574
@@ -22,7 +22,7 @@ ftp
 lib%TESTNUMBER
 </tool>
 <name>
-FTP wildcard download - changed fnmatch, 2x perform (Unix LIST response)
+FTP wildcard download - changed fnmatch, 2x perform (Unix LIST)
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/fully_simulated/UNIX/*.txt

--- a/tests/data/test73
+++ b/tests/data/test73
@@ -27,7 +27,7 @@ boo
 http
 </server>
 <name>
-HTTP, receive cookies when using custom Host:, domain using only two dots
+HTTP cookies when using custom Host:, domain using only two dots
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -c %LOGDIR/jar%TESTNUMBER.txt -H "Host: host.NOT_DISCLOSED.se"

--- a/tests/data/test739
+++ b/tests/data/test739
@@ -19,7 +19,7 @@ ipfs
 http
 </server>
 <name>
-IPNS path and query args for gateway and IPFS URL (malformed gateway URL)
+IPNS path and query args for gw and IPFS URL (malformed gw URL)
 </name>
 <command>
 --ipfs-gateway "http://%HOSTIP:%HTTPPORT/some/path?biz=baz" "ipns://fancy.tld/a/b?foo=bar%AMPaaa=bbb"

--- a/tests/data/test845
+++ b/tests/data/test845
@@ -27,7 +27,7 @@ REPLY AQ== A002 NO Authentication failed
 imap
 </server>
 <name>
-IMAP OAuth 2.0 (OAUTHBEARER) failure as continuation with initial response
+IMAP OAuth failure as continuation with initial response
 </name>
 <command>
 'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER/;MAILINDEX=1' -u user --oauth2-bearer mF_9.B5f-4.1JqM

--- a/tests/data/test890
+++ b/tests/data/test890
@@ -28,7 +28,7 @@ REPLY AQ== -ERR Authentication failed
 pop3
 </server>
 <name>
-POP3 OAuth 2.0 (OAUTHBEARER) failure as continuation with initial response
+POP3 OAuth failure as continuation with initial response
 </name>
 <command>
 pop3://%HOSTIP:%POP3PORT/%TESTNUMBER -u user --oauth2-bearer mF_9.B5f-4.1JqM --sasl-ir

--- a/tests/data/test91
+++ b/tests/data/test91
@@ -82,7 +82,7 @@ SSL
 http
 </server>
 <name>
-HTTP with NTLM/Negotiate/Basic, anyauth and user with domain, with size 0
+HTTP NTLM/Negotiate/Basic, anyauth and user with domain, with size 0
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER --anyauth -u mydomain\\myself:secret

--- a/tests/data/test949
+++ b/tests/data/test949
@@ -27,7 +27,7 @@ REPLY AQ== 535 Username and Password not accepted. Learn more at\r\n535 http://s
 smtp
 </server>
 <name>
-SMTP OAuth 2.0 (OAUTHBEARER) failure as continuation with initial response
+SMTP OAuth failure as continuation with initial response
 </name>
 <stdin crlf="yes">
 mail body

--- a/tests/data/test956
+++ b/tests/data/test956
@@ -23,7 +23,7 @@ codeset-utf8
 LC_ALL=C.UTF-8
 </setenv>
 <name>
-SMTP without SMTPUTF8 support - UTF-8 based recipient (local part only)
+SMTP without SMTPUTF8 support - UTF-8 based recipient (local part)
 </name>
 <stdin crlf="yes">
 From: different

--- a/tests/data/test958
+++ b/tests/data/test958
@@ -24,7 +24,7 @@ codeset-utf8
 LC_ALL=C.UTF-8
 </setenv>
 <name>
-SMTP external VRFY without SMTPUTF8 - UTF-8 recipient (local part only)
+SMTP external VRFY without SMTPUTF8 - UTF-8 recipient (local part)
 </name>
 <command>
 smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt Anv%hex[%c3%a4]hex%ndaren@example.com

--- a/tests/data/test964
+++ b/tests/data/test964
@@ -26,7 +26,7 @@ codeset-utf8
 LC_ALL=C.UTF-8
 </setenv>
 <name>
-SMTP external VRFY without SMTPUTF8 (IDN) - UTF-8 recipient (host part)
+SMTP external VRFY w/o SMTPUTF8 (IDN) - UTF-8 recipient (host part)
 </name>
 <command>
 smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt user@%hex[%c3%a5%c3%a4%c3%b6]hex%.se

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -967,6 +967,11 @@ sub citest_starttest {
     my $testname = (getpart("client", "name"))[0];
     chomp $testname;
 
+    if(length($testname) > 70) {
+        logmsg "ERROR: test $testnum has a too long name, wider than 70 columns\n";
+        return 1;
+    }
+
     # create test result in CI services
     if(azure_check_environment() && $AZURE_RUN_ID) {
         $AZURE_RESULT_ID = azure_create_test_result($ACURL, $AZURE_RUN_ID, $testnum, $testname);
@@ -974,6 +979,7 @@ sub citest_starttest {
     elsif(appveyor_check_environment()) {
         appveyor_create_test_result($ACURL, $testnum, $testname);
     }
+    return 0;
 }
 
 # Submit the test case result with the CI runner
@@ -2002,7 +2008,9 @@ sub singletest {
 
         ###################################################################
         # Register the test case with the CI environment
-        citest_starttest($testnum);
+        if(citest_starttest($testnum)) {
+            return (-1, 0);
+        }
 
         if(runnerac_test_preprocess($runnerid, $testnum)) {
             logmsg "ERROR: runner $runnerid seems to have died\n";

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -967,9 +967,12 @@ sub citest_starttest {
     my $testname = (getpart("client", "name"))[0];
     chomp $testname;
 
-    if(length($testname) > 70) {
-        logmsg "ERROR: test $testnum has a too long name, wider than 70 columns\n";
-        return 1;
+    my $maxlen = 70;
+    my $namelen = length($testname);
+    if($namelen > $maxlen) {
+        logmsg sprintf("ERROR: test %d name is %d characters (max %d): %s\n",
+                       $testnum, $namelen, $maxlen, $testname);
+        exit 1;
     }
 
     # create test result in CI services

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1218,7 +1218,7 @@ sub singletest_count {
     }
 
     # At this point we have committed to run this test
-    logmsg sprintf("test %04d...", $testnum) if(!$automakestyle);
+    logmsg sprintf("test %04d ", $testnum) if(!$automakestyle);
 
     # name of the test
     my $testname = (getpart("client", "name"))[0];


### PR DESCRIPTION
- makes test names less complicated

- makes them less likely to wrap lines when using narrow terminals

- runtests now returns error for the test if the name is longer
