### PR TITLE
GHA/windows: re-enable taskkill in torture jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -514,7 +514,6 @@ jobs:
             fi
             if [[ "${TFLAGS}" = *'-t'* ]]; then
               TFLAGS+=' !2300'  # Leaks memory and file handle via tool_doswin.c / win32_stdin_read_thread()
-              export CURL_TEST_NO_TASKKILL=1  # experiment to see if it reduces flaky failures
             fi
             if [[ "${MATRIX_INSTALL} " = *'-libssh '* && \
                   "${MATRIX_ENV}" = *'x86_64'* ]]; then


### PR DESCRIPTION
Torture jobs are arguably the most flaky nowadays. Make a blind try to
see if re-enabling taskkill makes an observable improvement for torture.

Follow-up to 208b87744e8ce326e2569c2efd735da43ce74a0b #21039
Follow-up to f450f3801b6b9dff0ea280f5fb4bf28203f7b313 #19897
Follow-up to 2701ac6a4d16a62130dad05be1c484903b8545c7 #19421
