### PR TITLE
servers: drop re-registering the signal handler on modern systems

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -415,7 +415,9 @@ static void exit_signal_handler(int signum)
       (void)SetEvent(exit_event);
 #endif
   }
+#if !(defined(HAVE_SIGACTION) && defined(SA_RESTART))
   (void)signal(signum, exit_signal_handler);
+#endif
   errno = old_errno;
 }
 #if defined(CURL_HAVE_DIAG) && !defined(__clang__)


### PR DESCRIPTION
Before this patch modern systems used `sigaction()` and `SA_RESTART` to
install signal handlers, but the signal handler function itself still
made a call to the legacy `signal()` function to re-register itself
before returning.

Re-registering the handler is not necessary with `sigaction()`. It's
also undesired to use the legacy API when the modern one is available.

Fix by guarding off this call in builds that support the modern API.

Follow-up to 3fb6e5a01001b8c7dfdc33a89041178aac381a27 #6529
Follow-up to 18cbb4d7d645016d1a9c0ee772c724d8c41db3bd
