### PR TITLE
servers: sync socket type global variables

### DIFF
--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -831,7 +831,7 @@ static int test_dnsd(int argc, const char **argv)
     else if(!strcmp("--ipv4", argv[arg])) {
 #ifdef USE_IPV6
       socket_type = "IPv4";
-      use_ipv6 = FALSE;
+      socket_domain = AF_INET;
 #endif
       arg++;
     }

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -830,14 +830,14 @@ static int test_dnsd(int argc, const char **argv)
     }
     else if(!strcmp("--ipv4", argv[arg])) {
 #ifdef USE_IPV6
-      ipv_inuse = "IPv4";
+      socket_type = "IPv4";
       use_ipv6 = FALSE;
 #endif
       arg++;
     }
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
-      ipv_inuse = "IPv6";
+      socket_type = "IPv6";
       use_ipv6 = TRUE;
 #endif
       arg++;
@@ -868,7 +868,7 @@ static int test_dnsd(int argc, const char **argv)
   }
 
   snprintf(loglockfile, sizeof(loglockfile), "%s/%s/dnsd-%s.lock",
-           logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
+           logdir, SERVERLOGS_LOCKDIR, socket_type);
 
 #ifdef USE_IPV6
   if(!use_ipv6)
@@ -980,7 +980,7 @@ static int test_dnsd(int argc, const char **argv)
     }
   }
 
-  logmsg("Running %s version on port UDP/%d", ipv_inuse, (int)port);
+  logmsg("Running %s version on port UDP/%d", socket_type, (int)port);
   curlx_nonblock(sock, TRUE);
 
   for(;;) {
@@ -1089,7 +1089,7 @@ dnsd_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s dnsd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, (long)our_getpid(), exit_signal);
+           socket_type, (int)port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -838,7 +838,7 @@ static int test_dnsd(int argc, const char **argv)
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
       socket_type = "IPv6";
-      use_ipv6 = TRUE;
+      socket_domain = AF_INET6;
 #endif
       arg++;
     }

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -829,10 +829,8 @@ static int test_dnsd(int argc, const char **argv)
         logdir = argv[arg++];
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-#ifdef USE_IPV6
       socket_type = "IPv4";
       socket_domain = AF_INET;
-#endif
       arg++;
     }
     else if(!strcmp("--ipv6", argv[arg])) {
@@ -871,13 +869,11 @@ static int test_dnsd(int argc, const char **argv)
            logdir, SERVERLOGS_LOCKDIR, socket_type);
 
 #ifdef USE_IPV6
-  if(socket_domain != AF_INET6)
+  if(socket_domain == AF_INET6)
+    sock = socket(AF_INET6, SOCK_DGRAM, 0);
+  else
 #endif
     sock = socket(AF_INET, SOCK_DGRAM, 0);
-#ifdef USE_IPV6
-  else
-    sock = socket(AF_INET6, SOCK_DGRAM, 0);
-#endif
 
   if(sock == CURL_SOCKET_BAD) {
     sockerr = SOCKERRNO;
@@ -897,23 +893,22 @@ static int test_dnsd(int argc, const char **argv)
   }
 
 #ifdef USE_IPV6
-  if(socket_domain != AF_INET6) {
-#endif
-    memset(&me.sa4, 0, sizeof(me.sa4));
-    me.sa4.sin_family = AF_INET;
-    me.sa4.sin_addr.s_addr = INADDR_ANY;
-    me.sa4.sin_port = htons(port);
-    rc = bind(sock, &me.sa, sizeof(me.sa4));
-#ifdef USE_IPV6
-  }
-  else {
+  if(socket_domain == AF_INET6) {
     memset(&me.sa6, 0, sizeof(me.sa6));
     me.sa6.sin6_family = AF_INET6;
     me.sa6.sin6_addr = in6addr_any;
     me.sa6.sin6_port = htons(port);
     rc = bind(sock, &me.sa, sizeof(me.sa6));
   }
-#endif /* USE_IPV6 */
+  else
+#endif
+  {
+    memset(&me.sa4, 0, sizeof(me.sa4));
+    me.sa4.sin_family = AF_INET;
+    me.sa4.sin_addr.s_addr = INADDR_ANY;
+    me.sa4.sin_port = htons(port);
+    rc = bind(sock, &me.sa, sizeof(me.sa4));
+  }
   if(rc) {
     sockerr = SOCKERRNO;
     logmsg("Error binding socket on port %hu (%d) %s", port,
@@ -929,13 +924,12 @@ static int test_dnsd(int argc, const char **argv)
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6)
+    if(socket_domain == AF_INET6)
+      la_size = sizeof(localaddr.sa6);
+    else
 #endif
       la_size = sizeof(localaddr.sa4);
-#ifdef USE_IPV6
-    else
-      la_size = sizeof(localaddr.sa6);
-#endif
+
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",
@@ -994,13 +988,11 @@ static int test_dnsd(int argc, const char **argv)
     timediff_t timeout_ms = 0;
     fromlen = sizeof(from);
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6)
+    if(socket_domain == AF_INET6)
+      fromlen = sizeof(from.sa6);
+    else
 #endif
       fromlen = sizeof(from.sa4);
-#ifdef USE_IPV6
-    else
-      fromlen = sizeof(from.sa6);
-#endif
 
     timeout_ms = send_resp_queue(sock);
 

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -871,7 +871,7 @@ static int test_dnsd(int argc, const char **argv)
            logdir, SERVERLOGS_LOCKDIR, socket_type);
 
 #ifdef USE_IPV6
-  if(!use_ipv6)
+  if(socket_domain != AF_INET6)
 #endif
     sock = socket(AF_INET, SOCK_DGRAM, 0);
 #ifdef USE_IPV6
@@ -897,7 +897,7 @@ static int test_dnsd(int argc, const char **argv)
   }
 
 #ifdef USE_IPV6
-  if(!use_ipv6) {
+  if(socket_domain != AF_INET6) {
 #endif
     memset(&me.sa4, 0, sizeof(me.sa4));
     me.sa4.sin_family = AF_INET;
@@ -929,7 +929,7 @@ static int test_dnsd(int argc, const char **argv)
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(!use_ipv6)
+    if(socket_domain != AF_INET6)
 #endif
       la_size = sizeof(localaddr.sa4);
 #ifdef USE_IPV6
@@ -994,7 +994,7 @@ static int test_dnsd(int argc, const char **argv)
     timediff_t timeout_ms = 0;
     fromlen = sizeof(from);
 #ifdef USE_IPV6
-    if(!use_ipv6)
+    if(socket_domain != AF_INET6)
 #endif
       fromlen = sizeof(from.sa4);
 #ifdef USE_IPV6

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -168,9 +168,6 @@ static int serverlogslocked;
 static const char *configfile = NULL;
 static const char *logdir = "log";
 static char loglockfile[256];
-#ifdef USE_IPV6
-static bool use_ipv6 = FALSE;
-#endif
 static unsigned short server_port = 0;
 static const char *socket_type = "IPv4";
 static int socket_domain = AF_INET;

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -171,7 +171,6 @@ static char loglockfile[256];
 #ifdef USE_IPV6
 static bool use_ipv6 = FALSE;
 #endif
-static const char *ipv_inuse = "IPv4";
 static unsigned short server_port = 0;
 static const char *socket_type = "IPv4";
 static int socket_domain = AF_INET;

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -814,14 +814,14 @@ static int test_mqttd(int argc, const char *argv[])
     }
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
-      socket_domain = AF_INET6;
       socket_type = "IPv6";
+      socket_domain = AF_INET6;
 #endif
       arg++;
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-      socket_domain = AF_INET;
       socket_type = "IPv4";
+      socket_domain = AF_INET;
       arg++;
     }
     else if(!strcmp("--port", argv[arg])) {

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -820,11 +820,8 @@ static int test_mqttd(int argc, const char *argv[])
       arg++;
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-      /* for completeness, we support this option as well */
-#ifdef USE_IPV6
       socket_domain = AF_INET;
       socket_type = "IPv4";
-#endif
       arg++;
     }
     else if(!strcmp("--port", argv[arg])) {

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -815,7 +815,7 @@ static int test_mqttd(int argc, const char *argv[])
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
       socket_domain = AF_INET6;
-      ipv_inuse = "IPv6";
+      socket_type = "IPv6";
 #endif
       arg++;
     }
@@ -823,7 +823,7 @@ static int test_mqttd(int argc, const char *argv[])
       /* for completeness, we support this option as well */
 #ifdef USE_IPV6
       socket_domain = AF_INET;
-      ipv_inuse = "IPv4";
+      socket_type = "IPv4";
 #endif
       arg++;
     }
@@ -855,7 +855,7 @@ static int test_mqttd(int argc, const char *argv[])
   }
 
   snprintf(loglockfile, sizeof(loglockfile), "%s/%s/mqtt-%s.lock",
-           logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
+           logdir, SERVERLOGS_LOCKDIR, socket_type);
 
   CURL_BINMODE(stdin);
   CURL_BINMODE(stdout);
@@ -881,7 +881,7 @@ static int test_mqttd(int argc, const char *argv[])
     msgsock = CURL_SOCKET_BAD; /* no stream socket yet */
   }
 
-  logmsg("Running %s version", ipv_inuse);
+  logmsg("Running %s version", socket_type);
   logmsg("Listening on port %hu", server_port);
 
   wrotepidfile = write_pidfile(pidname);

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -61,7 +61,6 @@ static int test_resolve(int argc, const char *argv[])
 #endif
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-      /* for completeness, we support this option as well */
       socket_type = "IPv4";
       socket_domain = AF_INET;
       arg++;

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -84,7 +84,7 @@ static int test_resolve(int argc, const char *argv[])
   }
 
 #ifdef CURLRES_IPV6
-  if(use_ipv6) {
+  if(socket_domain == AF_INET6) {
     /* Check that the system has IPv6 enabled before checking the resolver */
     curl_socket_t s = socket(PF_INET6, SOCK_DGRAM, 0);
     if(s == CURL_SOCKET_BAD)

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -63,9 +63,7 @@ static int test_resolve(int argc, const char *argv[])
     else if(!strcmp("--ipv4", argv[arg])) {
       /* for completeness, we support this option as well */
       socket_type = "IPv4";
-#ifdef CURLRES_IPV6
-      use_ipv6 = FALSE;
-#endif
+      socket_domain = AF_INET;
       arg++;
     }
     else {

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -52,7 +52,7 @@ static int test_resolve(int argc, const char *argv[])
     }
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef CURLRES_IPV6
-      ipv_inuse = "IPv6";
+      socket_type = "IPv6";
       use_ipv6 = TRUE;
       arg++;
 #else
@@ -62,7 +62,7 @@ static int test_resolve(int argc, const char *argv[])
     }
     else if(!strcmp("--ipv4", argv[arg])) {
       /* for completeness, we support this option as well */
-      ipv_inuse = "IPv4";
+      socket_type = "IPv4";
 #ifdef CURLRES_IPV6
       use_ipv6 = FALSE;
 #endif
@@ -123,7 +123,7 @@ static int test_resolve(int argc, const char *argv[])
 #endif
 
   if(rc)
-    printf("Resolving %s '%s' did not work\n", ipv_inuse, host);
+    printf("Resolving %s '%s' did not work\n", socket_type, host);
 
   return !!rc;
 }

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -53,7 +53,7 @@ static int test_resolve(int argc, const char *argv[])
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef CURLRES_IPV6
       socket_type = "IPv6";
-      use_ipv6 = TRUE;
+      socket_domain = AF_INET6;
       arg++;
 #else
       puts("IPv6 support has been disabled in this program");

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -101,7 +101,7 @@ static int test_resolve(int argc, const char *argv[])
     struct addrinfo hints;
 
     memset(&hints, 0, sizeof(hints));
-    hints.ai_family = use_ipv6 ? PF_INET6 : PF_INET;
+    hints.ai_family = socket_domain;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_flags = 0;
     rc = getaddrinfo(host, "80", &hints, &ai);

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1050,7 +1050,7 @@ static int test_rtspd(int argc, const char *argv[])
   install_signal_handlers(FALSE);
 
 #ifdef USE_IPV6
-  if(!use_ipv6)
+  if(socket_domain != AF_INET6)
 #endif
     sock = socket(AF_INET, SOCK_STREAM, 0);
 #ifdef USE_IPV6
@@ -1074,7 +1074,7 @@ static int test_rtspd(int argc, const char *argv[])
   }
 
 #ifdef USE_IPV6
-  if(!use_ipv6) {
+  if(socket_domain != AF_INET6) {
 #endif
     memset(&me.sa4, 0, sizeof(me.sa4));
     me.sa4.sin_family = AF_INET;
@@ -1105,7 +1105,7 @@ static int test_rtspd(int argc, const char *argv[])
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(!use_ipv6)
+    if(socket_domain != AF_INET6)
 #endif
       la_size = sizeof(localaddr.sa4);
 #ifdef USE_IPV6

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1001,14 +1001,14 @@ static int test_rtspd(int argc, const char *argv[])
     }
     else if(!strcmp("--ipv4", argv[arg])) {
 #ifdef USE_IPV6
-      ipv_inuse = "IPv4";
+      socket_type = "IPv4";
       use_ipv6 = FALSE;
 #endif
       arg++;
     }
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
-      ipv_inuse = "IPv6";
+      socket_type = "IPv6";
       use_ipv6 = TRUE;
 #endif
       arg++;
@@ -1045,7 +1045,7 @@ static int test_rtspd(int argc, const char *argv[])
   }
 
   snprintf(loglockfile, sizeof(loglockfile), "%s/%s/rtsp-%s.lock",
-           logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
+           logdir, SERVERLOGS_LOCKDIR, socket_type);
 
   install_signal_handlers(FALSE);
 
@@ -1141,7 +1141,7 @@ static int test_rtspd(int argc, const char *argv[])
       goto server_cleanup;
     }
   }
-  logmsg("Running %s version on port %d", ipv_inuse, (int)port);
+  logmsg("Running %s version on port %d", socket_type, (int)port);
 
   /* start accepting connections */
   if(listen(sock, 5)) {
@@ -1287,7 +1287,7 @@ server_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s rtspd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, (long)our_getpid(), exit_signal);
+           socket_type, (int)port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1000,10 +1000,8 @@ static int test_rtspd(int argc, const char *argv[])
         logdir = argv[arg++];
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-#ifdef USE_IPV6
       socket_type = "IPv4";
-      use_ipv6 = FALSE;
-#endif
+      socket_domain = AF_INET;
       arg++;
     }
     else if(!strcmp("--ipv6", argv[arg])) {

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1048,13 +1048,11 @@ static int test_rtspd(int argc, const char *argv[])
   install_signal_handlers(FALSE);
 
 #ifdef USE_IPV6
-  if(socket_domain != AF_INET6)
+  if(socket_domain == AF_INET6)
+    sock = socket(AF_INET6, SOCK_STREAM, 0);
+  else
 #endif
     sock = socket(AF_INET, SOCK_STREAM, 0);
-#ifdef USE_IPV6
-  else
-    sock = socket(AF_INET6, SOCK_STREAM, 0);
-#endif
 
   if(sock == CURL_SOCKET_BAD) {
     sockerr = SOCKERRNO;
@@ -1072,23 +1070,22 @@ static int test_rtspd(int argc, const char *argv[])
   }
 
 #ifdef USE_IPV6
-  if(socket_domain != AF_INET6) {
-#endif
-    memset(&me.sa4, 0, sizeof(me.sa4));
-    me.sa4.sin_family = AF_INET;
-    me.sa4.sin_addr.s_addr = INADDR_ANY;
-    me.sa4.sin_port = htons(port);
-    rc = bind(sock, &me.sa, sizeof(me.sa4));
-#ifdef USE_IPV6
-  }
-  else {
+  if(socket_domain == AF_INET6) {
     memset(&me.sa6, 0, sizeof(me.sa6));
     me.sa6.sin6_family = AF_INET6;
     me.sa6.sin6_addr = in6addr_any;
     me.sa6.sin6_port = htons(port);
     rc = bind(sock, &me.sa, sizeof(me.sa6));
   }
-#endif /* USE_IPV6 */
+  else
+#endif
+  {
+    memset(&me.sa4, 0, sizeof(me.sa4));
+    me.sa4.sin_family = AF_INET;
+    me.sa4.sin_addr.s_addr = INADDR_ANY;
+    me.sa4.sin_port = htons(port);
+    rc = bind(sock, &me.sa, sizeof(me.sa4));
+  }
   if(rc) {
     sockerr = SOCKERRNO;
     logmsg("Error binding socket on port %hu (%d) %s", port,
@@ -1103,13 +1100,11 @@ static int test_rtspd(int argc, const char *argv[])
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6)
+    if(socket_domain == AF_INET6)
+      la_size = sizeof(localaddr.sa6);
+    else
 #endif
       la_size = sizeof(localaddr.sa4);
-#ifdef USE_IPV6
-    else
-      la_size = sizeof(localaddr.sa6);
-#endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1009,7 +1009,7 @@ static int test_rtspd(int argc, const char *argv[])
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
       socket_type = "IPv6";
-      use_ipv6 = TRUE;
+      socket_domain = AF_INET6;
 #endif
       arg++;
     }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1222,11 +1222,8 @@ static int test_sockfilt(int argc, const char *argv[])
       arg++;
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-      /* for completeness, we support this option as well */
-#ifdef USE_IPV6
       socket_domain = AF_INET;
       socket_type = "IPv4";
-#endif
       arg++;
     }
     else if(!strcmp("--bindonly", argv[arg])) {

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1057,7 +1057,7 @@ static bool juggle(curl_socket_t *sockfdp,
       /* Question asking us what PORT number we are listening to.
          Replies to PORT with "IPv[num]/[port]" */
       snprintf((char *)buffer, sizeof(buffer), "%s/%hu\n",
-               ipv_inuse, server_port);
+               socket_type, server_port);
       buffer_len = (ssize_t)strlen((const char *)buffer);
       snprintf(data, sizeof(data), "PORT\n%04x\n", (unsigned int)buffer_len);
       if(!write_stdout(data, 10))
@@ -1217,7 +1217,7 @@ static int test_sockfilt(int argc, const char *argv[])
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
       socket_domain = AF_INET6;
-      ipv_inuse = "IPv6";
+      socket_type = "IPv6";
 #endif
       arg++;
     }
@@ -1225,7 +1225,7 @@ static int test_sockfilt(int argc, const char *argv[])
       /* for completeness, we support this option as well */
 #ifdef USE_IPV6
       socket_domain = AF_INET;
-      ipv_inuse = "IPv4";
+      socket_type = "IPv4";
 #endif
       arg++;
     }
@@ -1348,7 +1348,7 @@ static int test_sockfilt(int argc, const char *argv[])
     msgsock = CURL_SOCKET_BAD; /* no stream socket yet */
   }
 
-  logmsg("Running %s version", ipv_inuse);
+  logmsg("Running %s version", socket_type);
 
   if(server_connectport)
     logmsg("Connected to port %hu", server_connectport);

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1216,14 +1216,14 @@ static int test_sockfilt(int argc, const char *argv[])
     }
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
-      socket_domain = AF_INET6;
       socket_type = "IPv6";
+      socket_domain = AF_INET6;
 #endif
       arg++;
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-      socket_domain = AF_INET;
       socket_type = "IPv4";
+      socket_domain = AF_INET;
       arg++;
     }
     else if(!strcmp("--bindonly", argv[arg])) {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -800,6 +800,7 @@ static int test_socksd(int argc, const char *argv[])
     }
     else if(!strcmp("--ipv4", argv[arg])) {
       socket_type = "IPv4";
+      socket_domain = AF_INET;
       arg++;
     }
     else if(!strcmp("--unix-socket", argv[arg])) {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -799,10 +799,7 @@ static int test_socksd(int argc, const char *argv[])
       arg++;
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-      /* for completeness, we support this option as well */
-#ifdef USE_IPV6
       socket_type = "IPv4";
-#endif
       arg++;
     }
     else if(!strcmp("--unix-socket", argv[arg])) {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -793,8 +793,8 @@ static int test_socksd(int argc, const char *argv[])
     }
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
-      socket_domain = AF_INET6;
       socket_type = "IPv6";
+      socket_domain = AF_INET6;
 #endif
       arg++;
     }
@@ -814,8 +814,8 @@ static int test_socksd(int argc, const char *argv[])
                   (unsigned int)sizeof(sau.sun_path), unix_socket);
           return 0;
         }
-        socket_domain = AF_UNIX;
         socket_type = "unix";
+        socket_domain = AF_UNIX;
 #endif
         arg++;
       }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2167,13 +2167,11 @@ static int test_sws(int argc, const char *argv[])
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6)
+    if(socket_domain == AF_INET6)
+      la_size = sizeof(localaddr.sa6);
+    else
 #endif
       la_size = sizeof(localaddr.sa4);
-#ifdef USE_IPV6
-    else
-      la_size = sizeof(localaddr.sa6);
-#endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1071,7 +1071,7 @@ static int test_tftpd(int argc, const char **argv)
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
       socket_type = "IPv6";
-      use_ipv6 = TRUE;
+      socket_domain = AF_INET6;
 #endif
       arg++;
     }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1063,14 +1063,14 @@ static int test_tftpd(int argc, const char **argv)
     }
     else if(!strcmp("--ipv4", argv[arg])) {
 #ifdef USE_IPV6
-      ipv_inuse = "IPv4";
+      socket_type = "IPv4";
       use_ipv6 = FALSE;
 #endif
       arg++;
     }
     else if(!strcmp("--ipv6", argv[arg])) {
 #ifdef USE_IPV6
-      ipv_inuse = "IPv6";
+      socket_type = "IPv6";
       use_ipv6 = TRUE;
 #endif
       arg++;
@@ -1107,7 +1107,7 @@ static int test_tftpd(int argc, const char **argv)
   }
 
   snprintf(loglockfile, sizeof(loglockfile), "%s/%s/tftp-%s.lock",
-           logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
+           logdir, SERVERLOGS_LOCKDIR, socket_type);
 
   install_signal_handlers(TRUE);
 
@@ -1221,7 +1221,7 @@ static int test_tftpd(int argc, const char **argv)
     }
   }
 
-  logmsg("Running %s version on port UDP/%d", ipv_inuse, (int)port);
+  logmsg("Running %s version on port UDP/%d", socket_type, (int)port);
 
   for(;;) {
     fromlen = sizeof(from);
@@ -1331,7 +1331,7 @@ tftpd_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s tftpd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, (long)our_getpid(), exit_signal);
+           socket_type, (int)port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -516,7 +516,7 @@ static int synchnet(curl_socket_t f /* socket to flush */)
     if(i) {
       j++;
 #ifdef USE_IPV6
-      if(!use_ipv6)
+      if(socket_domain != AF_INET6)
 #endif
         fromaddrlen = sizeof(fromaddr.sa4);
 #ifdef USE_IPV6
@@ -1112,7 +1112,7 @@ static int test_tftpd(int argc, const char **argv)
   install_signal_handlers(TRUE);
 
 #ifdef USE_IPV6
-  if(!use_ipv6)
+  if(socket_domain != AF_INET6)
 #endif
     sock = socket(AF_INET, SOCK_DGRAM, 0);
 #ifdef USE_IPV6
@@ -1138,7 +1138,7 @@ static int test_tftpd(int argc, const char **argv)
   }
 
 #ifdef USE_IPV6
-  if(!use_ipv6) {
+  if(socket_domain != AF_INET6) {
 #endif
     memset(&me.sa4, 0, sizeof(me.sa4));
     me.sa4.sin_family = AF_INET;
@@ -1170,7 +1170,7 @@ static int test_tftpd(int argc, const char **argv)
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(!use_ipv6)
+    if(socket_domain != AF_INET6)
 #endif
       la_size = sizeof(localaddr.sa4);
 #ifdef USE_IPV6
@@ -1226,7 +1226,7 @@ static int test_tftpd(int argc, const char **argv)
   for(;;) {
     fromlen = sizeof(from);
 #ifdef USE_IPV6
-    if(!use_ipv6)
+    if(socket_domain != AF_INET6)
 #endif
       fromlen = sizeof(from.sa4);
 #ifdef USE_IPV6
@@ -1247,7 +1247,7 @@ static int test_tftpd(int argc, const char **argv)
     serverlogslocked = 1;
 
 #ifdef USE_IPV6
-    if(!use_ipv6) {
+    if(socket_domain != AF_INET6) {
 #endif
       from.sa4.sin_family = AF_INET;
       peer = socket(AF_INET, SOCK_DGRAM, 0);

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1062,10 +1062,8 @@ static int test_tftpd(int argc, const char **argv)
         logdir = argv[arg++];
     }
     else if(!strcmp("--ipv4", argv[arg])) {
-#ifdef USE_IPV6
       socket_type = "IPv4";
-      use_ipv6 = FALSE;
-#endif
+      socket_domain = AF_INET;
       arg++;
     }
     else if(!strcmp("--ipv6", argv[arg])) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -516,13 +516,11 @@ static int synchnet(curl_socket_t f /* socket to flush */)
     if(i) {
       j++;
 #ifdef USE_IPV6
-      if(socket_domain != AF_INET6)
+      if(socket_domain == AF_INET6)
+        fromaddrlen = sizeof(fromaddr.sa6);
+      else
 #endif
         fromaddrlen = sizeof(fromaddr.sa4);
-#ifdef USE_IPV6
-      else
-        fromaddrlen = sizeof(fromaddr.sa6);
-#endif
       (void)recvfrom(f, rbuf, sizeof(rbuf), 0, &fromaddr.sa, &fromaddrlen);
     }
     else
@@ -1110,13 +1108,11 @@ static int test_tftpd(int argc, const char **argv)
   install_signal_handlers(TRUE);
 
 #ifdef USE_IPV6
-  if(socket_domain != AF_INET6)
+  if(socket_domain == AF_INET6)
+    sock = socket(AF_INET6, SOCK_DGRAM, 0);
+  else
 #endif
     sock = socket(AF_INET, SOCK_DGRAM, 0);
-#ifdef USE_IPV6
-  else
-    sock = socket(AF_INET6, SOCK_DGRAM, 0);
-#endif
 
   if(sock == CURL_SOCKET_BAD) {
     sockerr = SOCKERRNO;
@@ -1136,23 +1132,22 @@ static int test_tftpd(int argc, const char **argv)
   }
 
 #ifdef USE_IPV6
-  if(socket_domain != AF_INET6) {
-#endif
-    memset(&me.sa4, 0, sizeof(me.sa4));
-    me.sa4.sin_family = AF_INET;
-    me.sa4.sin_addr.s_addr = INADDR_ANY;
-    me.sa4.sin_port = htons(port);
-    rc = bind(sock, &me.sa, sizeof(me.sa4));
-#ifdef USE_IPV6
-  }
-  else {
+  if(socket_domain == AF_INET6) {
     memset(&me.sa6, 0, sizeof(me.sa6));
     me.sa6.sin6_family = AF_INET6;
     me.sa6.sin6_addr = in6addr_any;
     me.sa6.sin6_port = htons(port);
     rc = bind(sock, &me.sa, sizeof(me.sa6));
   }
-#endif /* USE_IPV6 */
+  else
+#endif
+  {
+    memset(&me.sa4, 0, sizeof(me.sa4));
+    me.sa4.sin_family = AF_INET;
+    me.sa4.sin_addr.s_addr = INADDR_ANY;
+    me.sa4.sin_port = htons(port);
+    rc = bind(sock, &me.sa, sizeof(me.sa4));
+  }
   if(rc) {
     sockerr = SOCKERRNO;
     logmsg("Error binding socket on port %hu (%d) %s", port,
@@ -1168,13 +1163,11 @@ static int test_tftpd(int argc, const char **argv)
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6)
+    if(socket_domain == AF_INET6)
+      la_size = sizeof(localaddr.sa6);
+    else
 #endif
       la_size = sizeof(localaddr.sa4);
-#ifdef USE_IPV6
-    else
-      la_size = sizeof(localaddr.sa6);
-#endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",
@@ -1224,13 +1217,11 @@ static int test_tftpd(int argc, const char **argv)
   for(;;) {
     fromlen = sizeof(from);
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6)
+    if(socket_domain == AF_INET6)
+      fromlen = sizeof(from.sa6);
+    else
 #endif
       fromlen = sizeof(from.sa4);
-#ifdef USE_IPV6
-    else
-      fromlen = sizeof(from.sa6);
-#endif
     n = (ssize_t)recvfrom(sock, &trsbuf.storage[0], sizeof(trsbuf.storage), 0,
                           &from.sa, &fromlen);
     if(got_exit_signal)
@@ -1245,23 +1236,7 @@ static int test_tftpd(int argc, const char **argv)
     serverlogslocked = 1;
 
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6) {
-#endif
-      from.sa4.sin_family = AF_INET;
-      peer = socket(AF_INET, SOCK_DGRAM, 0);
-      if(peer == CURL_SOCKET_BAD) {
-        logmsg("socket");
-        result = 2;
-        break;
-      }
-      if(connect(peer, &from.sa, sizeof(from.sa4)) < 0) {
-        logmsg("connect: fail");
-        result = 1;
-        break;
-      }
-#ifdef USE_IPV6
-    }
-    else {
+    if(socket_domain == AF_INET6) {
       from.sa6.sin6_family = AF_INET6;
       peer = socket(AF_INET6, SOCK_DGRAM, 0);
       if(peer == CURL_SOCKET_BAD) {
@@ -1275,7 +1250,22 @@ static int test_tftpd(int argc, const char **argv)
         break;
       }
     }
+    else
 #endif
+    {
+      from.sa4.sin_family = AF_INET;
+      peer = socket(AF_INET, SOCK_DGRAM, 0);
+      if(peer == CURL_SOCKET_BAD) {
+        logmsg("socket");
+        result = 2;
+        break;
+      }
+      if(connect(peer, &from.sa, sizeof(from.sa4)) < 0) {
+        logmsg("connect: fail");
+        result = 1;
+        break;
+      }
+    }
 
     maxtimeout = 5 * TIMEOUT;
 


### PR DESCRIPTION
Replace `ipv_inuse` and `use_ipv6` with `socket_type` and 
`socket_domain` (where missing) to avoid dupliicate globals with
overlapping purposes. The replacement variables also support Unix
sockets.

Also:
- simplify/reduce IPv6 guards.
- socksd: fix to reset `socket_domain` for `--ipv4` option.
