### PR TITLE
servers: sync server port global variable across servers, make port variables `uint16_t`

### DIFF
--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -778,7 +778,6 @@ static int test_dnsd(int argc, const char **argv)
   srvr_sockaddr_union_t me;
   ssize_t n = 0;
   int arg = 1;
-  uint16_t port = 9123; /* UDP */
   curl_socket_t sock = CURL_SOCKET_BAD;
   int flag;
   int rc;
@@ -790,6 +789,7 @@ static int test_dnsd(int argc, const char **argv)
   pidname = ".dnsd.pid";
   serverlogfile = "log/dnsd.log";
   serverlogslocked = 0;
+  server_port = 9123; /* UDP */
 
   while(argc > arg) {
     const char *opt;
@@ -845,7 +845,7 @@ static int test_dnsd(int argc, const char **argv)
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          port = (uint16_t)num;
+          server_port = (uint16_t)num;
         arg++;
       }
     }
@@ -899,7 +899,7 @@ static int test_dnsd(int argc, const char **argv)
     memset(&me.sa6, 0, sizeof(me.sa6));
     me.sa6.sin6_family = AF_INET6;
     me.sa6.sin6_addr = in6addr_any;
-    me.sa6.sin6_port = htons(port);
+    me.sa6.sin6_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa6));
   }
   else
@@ -908,18 +908,18 @@ static int test_dnsd(int argc, const char **argv)
     memset(&me.sa4, 0, sizeof(me.sa4));
     me.sa4.sin_family = AF_INET;
     me.sa4.sin_addr.s_addr = INADDR_ANY;
-    me.sa4.sin_port = htons(port);
+    me.sa4.sin_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa4));
   }
   if(rc) {
     sockerr = SOCKERRNO;
-    logmsg("Error binding socket on port %hu (%d) %s", port,
+    logmsg("Error binding socket on port %hu (%d) %s", server_port,
            sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto dnsd_cleanup;
   }
 
-  if(!port) {
+  if(!server_port) {
     /* The system was supposed to choose a port number, figure out which
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
@@ -941,17 +941,17 @@ static int test_dnsd(int argc, const char **argv)
     }
     switch(localaddr.sa.sa_family) {
     case AF_INET:
-      port = ntohs(localaddr.sa4.sin_port);
+      server_port = ntohs(localaddr.sa4.sin_port);
       break;
 #ifdef USE_IPV6
     case AF_INET6:
-      port = ntohs(localaddr.sa6.sin6_port);
+      server_port = ntohs(localaddr.sa6.sin6_port);
       break;
 #endif
     default:
       break;
     }
-    if(!port) {
+    if(!server_port) {
       /* Real failure, listener port shall not be zero beyond this point. */
       logmsg("Apparently getsockname() succeeded, with listener port zero.");
       logmsg("A valid reason for this failure is a binary built without");
@@ -969,14 +969,14 @@ static int test_dnsd(int argc, const char **argv)
   }
 
   if(portname) {
-    dnsd_wroteportfile = write_portfile(portname, port);
+    dnsd_wroteportfile = write_portfile(portname, server_port);
     if(!dnsd_wroteportfile) {
       result = 1;
       goto dnsd_cleanup;
     }
   }
 
-  logmsg("Running %s version on port UDP/%d", socket_type, (int)port);
+  logmsg("Running %s version on port UDP/%d", socket_type, (int)server_port);
   curlx_nonblock(sock, TRUE);
 
   for(;;) {
@@ -1084,7 +1084,7 @@ dnsd_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s dnsd (port: %d pid: %ld) exits with signal (%d)",
-           socket_type, (int)port, (long)our_getpid(), exit_signal);
+           socket_type, (int)server_port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -168,7 +168,7 @@ static int serverlogslocked;
 static const char *configfile = NULL;
 static const char *logdir = "log";
 static char loglockfile[256];
-static unsigned short server_port = 0;
+static uint16_t server_port = 0;
 static const char *socket_type = "IPv4";
 static int socket_domain = AF_INET;
 

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -155,7 +155,7 @@ extern int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
                             struct sockaddr_un *sau);
 #endif
 extern curl_socket_t sockdaemon(curl_socket_t sock,
-                                unsigned short *listenport,
+                                uint16_t *listenport,
                                 const char *unix_socket,
                                 bool bind_only);
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -832,7 +832,7 @@ static int test_mqttd(int argc, const char *argv[])
           fprintf(stderr, "mqttd: invalid --port argument (%s)\n", argv[arg]);
           return 0;
         }
-        server_port = (unsigned short)num;
+        server_port = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -952,7 +952,6 @@ static int test_rtspd(int argc, const char *argv[])
   int wrotepidfile = 0;
   int wroteportfile = 0;
   int flag;
-  unsigned short port = 8999;
   struct rtspd_httprequest req;
   int rc;
   int sockerr;
@@ -964,6 +963,7 @@ static int test_rtspd(int argc, const char *argv[])
   pidname = ".rtsp.pid";
   serverlogfile = "log/rtspd.log";
   serverlogslocked = 0;
+  server_port = 8999;
 
   while(argc > arg) {
     const char *opt;
@@ -1016,7 +1016,7 @@ static int test_rtspd(int argc, const char *argv[])
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          port = (unsigned short)num;
+          server_port = (unsigned short)num;
         arg++;
       }
     }
@@ -1074,7 +1074,7 @@ static int test_rtspd(int argc, const char *argv[])
     memset(&me.sa6, 0, sizeof(me.sa6));
     me.sa6.sin6_family = AF_INET6;
     me.sa6.sin6_addr = in6addr_any;
-    me.sa6.sin6_port = htons(port);
+    me.sa6.sin6_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa6));
   }
   else
@@ -1083,17 +1083,17 @@ static int test_rtspd(int argc, const char *argv[])
     memset(&me.sa4, 0, sizeof(me.sa4));
     me.sa4.sin_family = AF_INET;
     me.sa4.sin_addr.s_addr = INADDR_ANY;
-    me.sa4.sin_port = htons(port);
+    me.sa4.sin_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa4));
   }
   if(rc) {
     sockerr = SOCKERRNO;
-    logmsg("Error binding socket on port %hu (%d) %s", port,
+    logmsg("Error binding socket on port %hu (%d) %s", server_port,
            sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto server_cleanup;
   }
 
-  if(!port) {
+  if(!server_port) {
     /* The system was supposed to choose a port number, figure out which
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
@@ -1114,17 +1114,17 @@ static int test_rtspd(int argc, const char *argv[])
     }
     switch(localaddr.sa.sa_family) {
     case AF_INET:
-      port = ntohs(localaddr.sa4.sin_port);
+      server_port = ntohs(localaddr.sa4.sin_port);
       break;
 #ifdef USE_IPV6
     case AF_INET6:
-      port = ntohs(localaddr.sa6.sin6_port);
+      server_port = ntohs(localaddr.sa6.sin6_port);
       break;
 #endif
     default:
       break;
     }
-    if(!port) {
+    if(!server_port) {
       /* Real failure, listener port shall not be zero beyond this point. */
       logmsg("Apparently getsockname() succeeded, with listener port zero.");
       logmsg("A valid reason for this failure is a binary built without");
@@ -1134,7 +1134,7 @@ static int test_rtspd(int argc, const char *argv[])
       goto server_cleanup;
     }
   }
-  logmsg("Running %s version on port %d", socket_type, (int)port);
+  logmsg("Running %s version on port %d", socket_type, (int)server_port);
 
   /* start accepting connections */
   if(listen(sock, 5)) {
@@ -1154,7 +1154,7 @@ static int test_rtspd(int argc, const char *argv[])
     goto server_cleanup;
 
   if(portname) {
-    wroteportfile = write_portfile(portname, port);
+    wroteportfile = write_portfile(portname, server_port);
     if(!wroteportfile)
       goto server_cleanup;
   }
@@ -1280,7 +1280,7 @@ server_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s rtspd (port: %d pid: %ld) exits with signal (%d)",
-           socket_type, (int)port, (long)our_getpid(), exit_signal);
+           socket_type, (int)server_port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1016,7 +1016,7 @@ static int test_rtspd(int argc, const char *argv[])
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          server_port = (unsigned short)num;
+          server_port = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1235,7 +1235,7 @@ static int test_sockfilt(int argc, const char *argv[])
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          server_port = (unsigned short)num;
+          server_port = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -90,8 +90,8 @@
 
 static bool verbose = FALSE;
 static bool s_bind_only = FALSE;
-static unsigned short server_connectport = 0; /* if non-zero,
-                                                 we activate this mode */
+static uint16_t server_connectport = 0; /* if non-zero,
+                                           we activate this mode */
 
 enum sockmode {
   PASSIVE_LISTEN,    /* as a server waiting for connections */
@@ -1250,7 +1250,7 @@ static int test_sockfilt(int argc, const char *argv[])
                   argv[arg]);
           return 0;
         }
-        server_connectport = (unsigned short)num;
+        server_connectport = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -210,7 +210,7 @@ static void socksd_getconfig(void)
 #define SOCKS4_DSTPORT 2
 
 /* connect to a given IPv4 address, not the one asked for */
-static curl_socket_t socksconnect(unsigned short connectport,
+static curl_socket_t socksconnect(uint16_t connectport,
                                   const char *connectaddr)
 {
   srvr_sockaddr_union_t me;
@@ -252,8 +252,8 @@ static curl_socket_t socks4(curl_socket_t fd,
     return CURL_SOCKET_BAD;
   }
   if(!s_config.port)
-    s4port = (unsigned short)((buffer[SOCKS4_DSTPORT] << 8) |
-                              (buffer[SOCKS4_DSTPORT + 1]));
+    s4port = (uint16_t)((buffer[SOCKS4_DSTPORT] << 8) |
+                        (buffer[SOCKS4_DSTPORT + 1]));
   else
     s4port = s_config.port;
 
@@ -297,9 +297,9 @@ static curl_socket_t sockit(curl_socket_t fd)
   unsigned char type;
   unsigned char rep = 0;
   const unsigned char *address;
-  unsigned short socksport;
+  uint16_t socksport;
   curl_socket_t connfd = CURL_SOCKET_BAD;
-  unsigned short s5port;
+  uint16_t s5port;
 
   socksd_getconfig();
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -57,7 +57,7 @@
 /* based on sockfilt.c */
 
 static const char *backendaddr = "127.0.0.1";
-static unsigned short backendport = 0; /* default is use client's */
+static uint16_t backendport = 0; /* default is use client's */
 
 struct socksd_configurable {
   unsigned char version; /* initial version byte in the request must match
@@ -149,7 +149,7 @@ static void socksd_getconfig(void)
         else if(!strcmp(key, "backendport")) {
           pval = value;
           if(!curlx_str_number(&pval, &num, 0xffff)) {
-            s_config.port = (unsigned short)num;
+            s_config.port = (uint16_t)num;
             logmsg("backendport [%d] set", s_config.port);
           }
         }
@@ -777,7 +777,7 @@ static int test_socksd(int argc, const char *argv[])
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          backendport = (unsigned short)num;
+          backendport = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -68,7 +68,7 @@ struct socksd_configurable {
   unsigned char responsemethod;
   unsigned char reqcmd;
   unsigned char connectrep;
-  unsigned short port; /* backend port */
+  uint16_t port; /* backend port */
   char addr[32]; /* backend IPv4 numerical */
   char user[256];
   char password[256];
@@ -241,7 +241,7 @@ static curl_socket_t socks4(curl_socket_t fd,
   unsigned char response[256 + 16];
   curl_socket_t connfd;
   unsigned char cd;
-  unsigned short s4port;
+  uint16_t s4port;
 
   if(buffer[SOCKS4_CD] != 1) {
     logmsg("SOCKS4 CD is not 1: %d", buffer[SOCKS4_CD]);
@@ -500,7 +500,7 @@ static curl_socket_t sockit(curl_socket_t fd)
 
   if(!s_config.port) {
     const unsigned char *portp = &buffer[SOCKS5_DSTADDR + len];
-    s5port = (unsigned short)((portp[0] << 8) | (portp[1]));
+    s5port = (uint16_t)((portp[0] << 8) | (portp[1]));
   }
   else
     s5port = s_config.port;

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -826,7 +826,7 @@ static int test_socksd(int argc, const char *argv[])
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          server_port = (unsigned short)num;
+          server_port = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2028,7 +2028,7 @@ static int test_sws(int argc, const char *argv[])
           fprintf(stderr, "sws: invalid --port argument (%s)\n", argv[arg]);
           return 0;
         }
-        server_port = (unsigned short)num;
+        server_port = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1919,7 +1919,6 @@ static int test_sws(int argc, const char *argv[])
   int wrotepidfile = 0;
   int wroteportfile = 0;
   int flag;
-  unsigned short port = 8999;
 #ifdef USE_UNIX_SOCKETS
   const char *unix_socket = NULL;
   bool unlink_socket = FALSE;
@@ -1942,6 +1941,7 @@ static int test_sws(int argc, const char *argv[])
   portname = ".http.port";
   serverlogfile = "log/sws.log";
   serverlogslocked = 0;
+  server_port = 8999;
 
   while(argc > arg) {
     const char *opt;
@@ -2028,7 +2028,7 @@ static int test_sws(int argc, const char *argv[])
           fprintf(stderr, "sws: invalid --port argument (%s)\n", argv[arg]);
           return 0;
         }
-        port = (unsigned short)num;
+        server_port = (unsigned short)num;
         arg++;
       }
     }
@@ -2130,7 +2130,7 @@ static int test_sws(int argc, const char *argv[])
     memset(&me.sa4, 0, sizeof(me.sa4));
     me.sa4.sin_family = AF_INET;
     me.sa4.sin_addr.s_addr = INADDR_ANY;
-    me.sa4.sin_port = htons(port);
+    me.sa4.sin_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa4));
     break;
 #ifdef USE_IPV6
@@ -2138,7 +2138,7 @@ static int test_sws(int argc, const char *argv[])
     memset(&me.sa6, 0, sizeof(me.sa6));
     me.sa6.sin6_family = AF_INET6;
     me.sa6.sin6_addr = in6addr_any;
-    me.sa6.sin6_port = htons(port);
+    me.sa6.sin6_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa6));
     break;
 #endif /* USE_IPV6 */
@@ -2155,12 +2155,12 @@ static int test_sws(int argc, const char *argv[])
              sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     else
 #endif
-      logmsg("Error binding socket on port %hu (%d) %s", port,
+      logmsg("Error binding socket on port %hu (%d) %s", server_port,
              sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     goto sws_cleanup;
   }
 
-  if(!port) {
+  if(!server_port) {
     /* The system was supposed to choose a port number, figure out which
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
@@ -2181,17 +2181,17 @@ static int test_sws(int argc, const char *argv[])
     }
     switch(localaddr.sa.sa_family) {
     case AF_INET:
-      port = ntohs(localaddr.sa4.sin_port);
+      server_port = ntohs(localaddr.sa4.sin_port);
       break;
 #ifdef USE_IPV6
     case AF_INET6:
-      port = ntohs(localaddr.sa6.sin6_port);
+      server_port = ntohs(localaddr.sa6.sin6_port);
       break;
 #endif
     default:
       break;
     }
-    if(!port) {
+    if(!server_port) {
       /* Real failure, listener port shall not be zero beyond this point. */
       logmsg("Apparently getsockname() succeeded, with listener port zero.");
       logmsg("A valid reason for this failure is a binary built without");
@@ -2204,7 +2204,7 @@ static int test_sws(int argc, const char *argv[])
 #ifdef USE_UNIX_SOCKETS
   if(socket_domain != AF_UNIX)
 #endif
-    snprintf(port_str, sizeof(port_str), "port %hu", port);
+    snprintf(port_str, sizeof(port_str), "port %hu", server_port);
 
   logmsg("Running %s %s version on %s",
          protocol_type, socket_type, location_str);
@@ -2231,7 +2231,7 @@ static int test_sws(int argc, const char *argv[])
   if(!wrotepidfile)
     goto sws_cleanup;
 
-  wroteportfile = write_portfile(portname, port);
+  wroteportfile = write_portfile(portname, server_port);
   if(!wroteportfile)
     goto sws_cleanup;
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1355,7 +1355,7 @@ success:
 static void http_connect(curl_socket_t *infdp,
                          curl_socket_t rootfd,
                          const char *ipaddr,
-                         unsigned short ipport,
+                         uint16_t ipport,
                          int keepalive_secs)
 {
   curl_socket_t serverfd[2] = { CURL_SOCKET_BAD, CURL_SOCKET_BAD };

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1193,7 +1193,7 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
   return fail ? -1 : 1;
 }
 
-static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
+static curl_socket_t connect_to(const char *ipaddr, uint16_t port)
 {
   srvr_sockaddr_union_t serveraddr;
   curl_socket_t serverfd;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -53,7 +53,7 @@ static bool sws_prevbounce = FALSE; /* instructs the server to override the
 struct sws_httprequest {
   char reqbuf[2 * 1024 * 1024]; /* buffer area for the incoming request */
   bool connect_request; /* if a CONNECT */
-  unsigned short connect_port; /* the port number CONNECT used */
+  uint16_t connect_port; /* the port number CONNECT used */
   size_t checkindex; /* where to start checking of the request */
   size_t offset;     /* size of the incoming request */
   long testno;       /* test number found in the request */
@@ -487,9 +487,9 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
                (num <= 0) || (num > 65535))
               logmsg("Invalid CONNECT port received");
             else
-              req->connect_port = (unsigned short)num;
+              req->connect_port = (uint16_t)num;
           }
-          logmsg("Port number: %d, test case number: %ld",
+          logmsg("Port number: %hu, test case number: %ld",
                  req->connect_port, req->testno);
         }
       }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1009,7 +1009,6 @@ static int test_tftpd(int argc, const char **argv)
   struct tftphdr *tp;
   ssize_t n = 0;
   int arg = 1;
-  unsigned short port = 8999; /* UDP */
   curl_socket_t sock = CURL_SOCKET_BAD;
   int flag;
   int rc;
@@ -1025,6 +1024,7 @@ static int test_tftpd(int argc, const char **argv)
   pidname = ".tftpd.pid";
   serverlogfile = "log/tftpd.log";
   serverlogslocked = 0;
+  server_port = 8999; /* UDP */
 
   while(argc > arg) {
     const char *opt;
@@ -1076,7 +1076,7 @@ static int test_tftpd(int argc, const char **argv)
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          port = (unsigned short)num;
+          server_port = (unsigned short)num;
         arg++;
       }
     }
@@ -1136,7 +1136,7 @@ static int test_tftpd(int argc, const char **argv)
     memset(&me.sa6, 0, sizeof(me.sa6));
     me.sa6.sin6_family = AF_INET6;
     me.sa6.sin6_addr = in6addr_any;
-    me.sa6.sin6_port = htons(port);
+    me.sa6.sin6_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa6));
   }
   else
@@ -1145,18 +1145,18 @@ static int test_tftpd(int argc, const char **argv)
     memset(&me.sa4, 0, sizeof(me.sa4));
     me.sa4.sin_family = AF_INET;
     me.sa4.sin_addr.s_addr = INADDR_ANY;
-    me.sa4.sin_port = htons(port);
+    me.sa4.sin_port = htons(server_port);
     rc = bind(sock, &me.sa, sizeof(me.sa4));
   }
   if(rc) {
     sockerr = SOCKERRNO;
-    logmsg("Error binding socket on port %hu (%d) %s", port,
+    logmsg("Error binding socket on port %hu (%d) %s", server_port,
            sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     result = 1;
     goto tftpd_cleanup;
   }
 
-  if(!port) {
+  if(!server_port) {
     /* The system was supposed to choose a port number, figure out which
        port we actually got and update the listener port value with it. */
     curl_socklen_t la_size;
@@ -1177,17 +1177,17 @@ static int test_tftpd(int argc, const char **argv)
     }
     switch(localaddr.sa.sa_family) {
     case AF_INET:
-      port = ntohs(localaddr.sa4.sin_port);
+      server_port = ntohs(localaddr.sa4.sin_port);
       break;
 #ifdef USE_IPV6
     case AF_INET6:
-      port = ntohs(localaddr.sa6.sin6_port);
+      server_port = ntohs(localaddr.sa6.sin6_port);
       break;
 #endif
     default:
       break;
     }
-    if(!port) {
+    if(!server_port) {
       /* Real failure, listener port shall not be zero beyond this point. */
       logmsg("Apparently getsockname() succeeded, with listener port zero.");
       logmsg("A valid reason for this failure is a binary built without");
@@ -1205,14 +1205,14 @@ static int test_tftpd(int argc, const char **argv)
   }
 
   if(portname) {
-    tftpd_wroteportfile = write_portfile(portname, port);
+    tftpd_wroteportfile = write_portfile(portname, server_port);
     if(!tftpd_wroteportfile) {
       result = 1;
       goto tftpd_cleanup;
     }
   }
 
-  logmsg("Running %s version on port UDP/%d", socket_type, (int)port);
+  logmsg("Running %s version on port UDP/%d", socket_type, (int)server_port);
 
   for(;;) {
     fromlen = sizeof(from);
@@ -1319,7 +1319,7 @@ tftpd_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s tftpd (port: %d pid: %ld) exits with signal (%d)",
-           socket_type, (int)port, (long)our_getpid(), exit_signal);
+           socket_type, (int)server_port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1076,7 +1076,7 @@ static int test_tftpd(int argc, const char **argv)
       if(argc > arg) {
         opt = argv[arg];
         if(!curlx_str_number(&opt, &num, 0xffff))
-          server_port = (unsigned short)num;
+          server_port = (uint16_t)num;
         arg++;
       }
     }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -768,7 +768,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
 #endif
 
 curl_socket_t sockdaemon(curl_socket_t sock,
-                         int16_t *listenport,
+                         uint16_t *listenport,
                          const char *unix_socket,
                          bool bind_only)
 {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -768,7 +768,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
 #endif
 
 curl_socket_t sockdaemon(curl_socket_t sock,
-                         unsigned short *listenport,
+                         int16_t *listenport,
                          const char *unix_socket,
                          bool bind_only)
 {


### PR DESCRIPTION
Follow-up to 1637bbc9ced4213b902703b9223273ab2dcd2c6e #22498