### PR TITLE
servers: de-duplicate shutdown signal/logging code

### DIFF
--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -1082,18 +1082,6 @@ dnsd_cleanup:
 
   restore_signal_handlers(FALSE);
 
-  if(got_exit_signal) {
-    logmsg("========> %s dnsd (port: %d pid: %ld) exits with signal (%d)",
-           socket_type, (int)server_port, (long)our_getpid(), exit_signal);
-    /*
-     * To properly set the return status of the process we
-     * must raise the same signal SIGINT or SIGTERM that we
-     * caught and let the old handler take care of it.
-     */
-    raise(exit_signal);
-  }
-
-  logmsg("========> dnsd quits");
   return result;
 }
 #else

--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -59,7 +59,16 @@ int main(int argc, const char **argv)
   result = entry_func(argc - 1, argv + 1);
 
   if(got_exit_signal) {
-    logmsg("========> %s %s (port: %d pid: %ld) exits with signal (%d)",
+    char port_str[11];
+    const char *location_str = port_str;
+    snprintf(port_str, sizeof(port_str), "port %hu", server_port);
+
+#ifdef USE_UNIX_SOCKETS
+    if(socket_domain == AF_UNIX)
+      location_str = server_unix_socket;
+#endif
+
+    logmsg("========> %s %s (%s pid: %ld) exits with signal (%d)",
            socket_type, entry_name + CURL_CSTRLEN("test_"),
            location_str, (long)our_getpid(), exit_signal);
     /*

--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -69,7 +69,7 @@ int main(int argc, const char **argv)
 #endif
 
     logmsg("========> %s %s (%s pid: %ld) exits with signal (%d)",
-           socket_type, entry_name + CURL_CSTRLEN("test_"),
+           socket_type, entry_name,
            location_str, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
@@ -79,7 +79,7 @@ int main(int argc, const char **argv)
     raise(exit_signal);
   }
 
-  logmsg("========> %s quits", entry_name + CURL_CSTRLEN("test_"));
+  logmsg("========> %s quits", entry_name);
 
   return result;
 }

--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -65,7 +65,8 @@ int main(int argc, const char **argv)
 
 #ifdef USE_UNIX_SOCKETS
     if(socket_domain == AF_UNIX)
-      location_str = server_unix_socket;
+      location_str = server_unix_socket ? server_unix_socket
+                                        : "<unix socket not set>";
 #endif
 
     logmsg("========> %s %s (%s pid: %ld) exits with signal (%d)",
@@ -79,7 +80,8 @@ int main(int argc, const char **argv)
     raise(exit_signal);
   }
 
-  logmsg("========> %s quits", entry_name);
+  if(serverlogfile)
+    logmsg("========> %s quits", entry_name);
 
   return result;
 }

--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -29,6 +29,7 @@ int main(int argc, const char **argv)
 {
   entry_func_t entry_func;
   const char *entry_name;
+  int result;
   size_t tmp;
 
   if(argc < 2) {
@@ -55,5 +56,21 @@ int main(int argc, const char **argv)
     return 2;
 #endif
 
-  return entry_func(argc - 1, argv + 1);
+  result = entry_func(argc - 1, argv + 1);
+
+  if(got_exit_signal) {
+    logmsg("========> %s %s (port: %d pid: %ld) exits with signal (%d)",
+           socket_type, entry_name + CURL_CSTRLEN("test_"),
+           location_str, (long)our_getpid(), exit_signal);
+    /*
+     * To properly set the return status of the process we
+     * must raise the same signal SIGINT or SIGTERM that we
+     * caught and let the old handler take care of it.
+     */
+    raise(exit_signal);
+  }
+
+  logmsg("========> %s quits", entry_name + CURL_CSTRLEN("test_"));
+
+  return result;
 }

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -168,6 +168,9 @@ static int serverlogslocked;
 static const char *configfile = NULL;
 static const char *logdir = "log";
 static char loglockfile[256];
+#ifdef USE_UNIX_SOCKETS
+static const char *server_unix_socket = NULL;
+#endif
 static uint16_t server_port = 0;
 static const char *socket_type = "IPv4";
 static int socket_domain = AF_INET;

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -168,9 +168,7 @@ static int serverlogslocked;
 static const char *configfile = NULL;
 static const char *logdir = "log";
 static char loglockfile[256];
-#ifdef USE_UNIX_SOCKETS
 static const char *server_unix_socket = NULL;
-#endif
 static uint16_t server_port = 0;
 static const char *socket_type = "IPv4";
 static int socket_domain = AF_INET;

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -910,16 +910,5 @@ mqttd_cleanup:
 
   restore_signal_handlers(FALSE);
 
-  if(got_exit_signal) {
-    logmsg("============> mqttd exits with signal (%d)", exit_signal);
-    /*
-     * To properly set the return status of the process we
-     * must raise the same signal SIGINT or SIGTERM that we
-     * caught and let the old handler take care of it.
-     */
-    raise(exit_signal);
-  }
-
-  logmsg("============> mqttd quits");
   return 0;
 }

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1278,17 +1278,5 @@ server_cleanup:
 
   restore_signal_handlers(FALSE);
 
-  if(got_exit_signal) {
-    logmsg("========> %s rtspd (port: %d pid: %ld) exits with signal (%d)",
-           socket_type, (int)server_port, (long)our_getpid(), exit_signal);
-    /*
-     * To properly set the return status of the process we
-     * must raise the same signal SIGINT or SIGTERM that we
-     * caught and let the old handler take care of it.
-     */
-    raise(exit_signal);
-  }
-
-  logmsg("========> rtspd quits");
   return 0;
 }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1386,16 +1386,5 @@ sockfilt_cleanup:
 
   restore_signal_handlers(FALSE);
 
-  if(got_exit_signal) {
-    logmsg("============> sockfilt exits with signal (%d)", exit_signal);
-    /*
-     * To properly set the return status of the process we
-     * must raise the same signal SIGINT or SIGTERM that we
-     * caught and let the old handler take care of it.
-     */
-    raise(exit_signal);
-  }
-
-  logmsg("============> sockfilt quits");
   return 0;
 }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -922,16 +922,5 @@ socks5_cleanup:
 
   restore_signal_handlers(FALSE);
 
-  if(got_exit_signal) {
-    logmsg("============> socksd exits with signal (%d)", exit_signal);
-    /*
-     * To properly set the return status of the process we
-     * must raise the same signal SIGINT or SIGTERM that we
-     * caught and let the old handler take care of it.
-     */
-    raise(exit_signal);
-  }
-
-  logmsg("============> socksd quits");
   return 0;
 }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -728,8 +728,6 @@ static int test_socksd(int argc, const char *argv[])
   bool juggle_again;
   char errbuf[STRERROR_LEN];
   int arg = 1;
-
-  const char *unix_socket = NULL;
 #ifdef USE_UNIX_SOCKETS
   bool unlink_socket = FALSE;
 #endif
@@ -808,11 +806,11 @@ static int test_socksd(int argc, const char *argv[])
       if(argc > arg) {
 #ifdef USE_UNIX_SOCKETS
         struct sockaddr_un sau;
-        unix_socket = argv[arg];
-        if(strlen(unix_socket) >= sizeof(sau.sun_path)) {
+        server_unix_socket = argv[arg];
+        if(strlen(server_unix_socket) >= sizeof(sau.sun_path)) {
           fprintf(stderr,
                   "socksd: socket path must be shorter than %u chars: %s\n",
-                  (unsigned int)sizeof(sau.sun_path), unix_socket);
+                  (unsigned int)sizeof(sau.sun_path), server_unix_socket);
           return 0;
         }
         socket_type = "unix";
@@ -865,7 +863,7 @@ static int test_socksd(int argc, const char *argv[])
 
   {
     /* passive daemon style */
-    sock = sockdaemon(sock, &server_port, unix_socket, FALSE);
+    sock = sockdaemon(sock, &server_port, server_unix_socket, FALSE);
     if(sock == CURL_SOCKET_BAD) {
       goto socks5_cleanup;
     }
@@ -879,7 +877,7 @@ static int test_socksd(int argc, const char *argv[])
 
 #ifdef USE_UNIX_SOCKETS
   if(socket_domain == AF_UNIX)
-    logmsg("Listening on Unix socket %s", unix_socket);
+    logmsg("Listening on Unix socket %s", server_unix_socket);
   else
 #endif
   logmsg("Listening on port %hu", server_port);
@@ -909,9 +907,9 @@ socks5_cleanup:
     sclose(sock);
 
 #ifdef USE_UNIX_SOCKETS
-  if(unlink_socket && socket_domain == AF_UNIX && unix_socket &&
-     unlink(unix_socket))
-    logmsg("unlink(%s): %d (%s)", unix_socket,
+  if(unlink_socket && socket_domain == AF_UNIX && server_unix_socket &&
+     unlink(server_unix_socket))
+    logmsg("unlink(%s): %d (%s)", server_unix_socket,
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 #endif
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2415,17 +2415,5 @@ sws_cleanup:
 
   restore_signal_handlers(FALSE);
 
-  if(got_exit_signal) {
-    logmsg("========> %s sws (%s pid: %ld) exits with signal (%d)",
-           socket_type, location_str, (long)our_getpid(), exit_signal);
-    /*
-     * To properly set the return status of the process we
-     * must raise the same signal SIGINT or SIGTERM that we
-     * caught and let the old handler take care of it.
-     */
-    raise(exit_signal);
-  }
-
-  logmsg("========> sws quits");
   return 0;
 }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1920,7 +1920,6 @@ static int test_sws(int argc, const char *argv[])
   int wroteportfile = 0;
   int flag;
 #ifdef USE_UNIX_SOCKETS
-  const char *unix_socket = NULL;
   bool unlink_socket = FALSE;
 #endif
   struct sws_httprequest *req = NULL;
@@ -2006,16 +2005,16 @@ static int test_sws(int argc, const char *argv[])
       arg++;
       if(argc > arg) {
 #ifdef USE_UNIX_SOCKETS
-        unix_socket = argv[arg];
-        if(strlen(unix_socket) >= sizeof(me.sau.sun_path)) {
+        server_unix_socket = argv[arg];
+        if(strlen(server_unix_socket) >= sizeof(me.sau.sun_path)) {
           fprintf(stderr,
                   "sws: socket path must be shorter than %u chars: %s\n",
-                  (unsigned int)sizeof(me.sau.sun_path), unix_socket);
+                  (unsigned int)sizeof(me.sau.sun_path), server_unix_socket);
           return 0;
         }
         socket_type = "unix";
         socket_domain = AF_UNIX;
-        location_str = unix_socket;
+        location_str = server_unix_socket;
 #endif
         arg++;
       }
@@ -2144,14 +2143,14 @@ static int test_sws(int argc, const char *argv[])
 #endif /* USE_IPV6 */
 #ifdef USE_UNIX_SOCKETS
   case AF_UNIX:
-    rc = bind_unix_socket(sock, unix_socket, &me.sau);
+    rc = bind_unix_socket(sock, server_unix_socket, &me.sau);
 #endif /* USE_UNIX_SOCKETS */
   }
   if(rc) {
     sockerr = SOCKERRNO;
 #ifdef USE_UNIX_SOCKETS
     if(socket_domain == AF_UNIX)
-      logmsg("Error binding socket on path %s (%d) %s", unix_socket,
+      logmsg("Error binding socket on path %s (%d) %s", server_unix_socket,
              sockerr, curlx_strerror(sockerr, errbuf, sizeof(errbuf)));
     else
 #endif
@@ -2392,9 +2391,9 @@ sws_cleanup:
     sclose(sock);
 
 #ifdef USE_UNIX_SOCKETS
-  if(unlink_socket && socket_domain == AF_UNIX && unix_socket &&
-     unlink(unix_socket))
-    logmsg("unlink(%s): %d (%s)", unix_socket,
+  if(unlink_socket && socket_domain == AF_UNIX && server_unix_socket &&
+     unlink(server_unix_socket))
+    logmsg("unlink(%s): %d (%s)", server_unix_socket,
            errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
 #endif
 

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1317,17 +1317,5 @@ tftpd_cleanup:
 
   restore_signal_handlers(TRUE);
 
-  if(got_exit_signal) {
-    logmsg("========> %s tftpd (port: %d pid: %ld) exits with signal (%d)",
-           socket_type, (int)server_port, (long)our_getpid(), exit_signal);
-    /*
-     * To properly set the return status of the process we
-     * must raise the same signal SIGINT or SIGTERM that we
-     * caught and let the old handler take care of it.
-     */
-    raise(exit_signal);
-  }
-
-  logmsg("========> tftpd quits");
   return result;
 }


### PR DESCRIPTION
To share more common code between servers, and to log the same set of 
information for all of them.

Also:
- move server unix socket to global variable.

Follow-up to d1eca3861c9cf8f3cd03274ce0db3c500bd246ae #22501
Follow-up to 1637bbc9ced4213b902703b9223273ab2dcd2c6e #22498
