### PR TITLE
servers: drop complex and redundant signal handler output

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -367,17 +367,20 @@ static HWND hidden_main_window = NULL;
  * the POSIX specification:
  *   https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html
  */
-/* suppress warnings seen in configurations where 'write()' has the attribute
-   'warn_unused_result', which is not silenced by casting to '(void)'. */
-#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result" /* GCC 4.5+ */
-#endif
 static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
   static const char msg[] = "exit_signal_handler(): triggered\n";
+  /* suppress warnings seen in configurations where 'write()' has the attribute
+     'warn_unused_result', which is not silenced by casting to '(void)'. */
+#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result" /* GCC 4.5+ */
+#endif
   (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
+#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
     exit_signal = signum;
@@ -391,9 +394,6 @@ static void exit_signal_handler(int signum)
 #endif
   errno = old_errno;
 }
-#if defined(CURL_HAVE_DIAG) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 #ifdef _WIN32
 /* CTRL event handler for Windows Console applications to simulate

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -366,8 +366,6 @@ static HWND hidden_main_window = NULL;
  * Only call signal-safe functions from the signal handler, as required by
  * the POSIX specification:
  *   https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html
- * Hence, do not call 'logmsg()', and instead use 'open/write/close' to
- * log errors.
  */
 /* suppress warnings seen in configurations where 'write()' has the attribute
    'warn_unused_result', which is not silenced by casting to '(void)'. */
@@ -378,35 +376,6 @@ static HWND hidden_main_window = NULL;
 static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
-  if(!serverlogfile) {
-    static const char msg[] = "exit_signal_handler: serverlogfile not set\n";
-    (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
-  }
-  else {
-    int fd = -1;
-#ifdef _WIN32
-    if(!_sopen_s(&fd, serverlogfile, _O_WRONLY | _O_CREAT | _O_APPEND,
-                 _SH_DENYNO, _S_IREAD | _S_IWRITE) &&
-       fd != -1) {
-#else
-    /* !checksrc! disable BANNEDFUNC 1 */
-    fd = open(serverlogfile, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
-    if(fd != -1) {
-#endif
-      static const char msg[] = "exit_signal_handler: called\n";
-      (void)write(fd, msg, CURL_CSTRLEN(msg));
-      curlx_close(fd);
-    }
-    else {
-      static const char msg[] = "exit_signal_handler: failed opening ";
-      const char *str;
-      (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
-      str = serverlogfile;
-      while(*str)
-        (void)write(STDERR_FILENO, str++, 1);
-      (void)write(STDERR_FILENO, "\n", 1);
-    }
-  }
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
     exit_signal = signum;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -365,7 +365,7 @@ static HWND hidden_main_window = NULL;
  *
  * Only call signal-safe functions from the signal handler, as required by
  * the POSIX specification:
- *   https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html
+ *   https://pubs.opengroup.org/onlinepubs/009695399/functions/xsh_chap02_04.html#tag_02_04_03
  */
 static void exit_signal_handler(int signum)
 {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -376,6 +376,8 @@ static HWND hidden_main_window = NULL;
 static void exit_signal_handler(int signum)
 {
   int old_errno = errno;
+  static const char msg[] = "exit_signal_handler(): triggered\n";
+  (void)write(STDERR_FILENO, msg, CURL_CSTRLEN(msg));
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
     exit_signal = signum;


### PR DESCRIPTION
In year 2020 the Unixy signal handler received a `logmsg()` call to log
the signal number, but at the same time it already saved it to a global
variable and logged it on exit, meaning this extra `logmsg()` was
redundant. Because `logmsg()` is not signal-safe, this call was replaced
in 2025 with signal-safe logging, but without the signal number, while
also adding complexity, spent on trying to open the log file and handle
errors. All for nothing, because the signal number was logged all along.

This patch removes all this, and simplifies it to a single, signal-safe
`write()` to STDERR to say that the signal handler triggered. This is
also non-critical, but may help debugging.

Also: point the POSIX documentation to the 2004 revision, which has a
shorter list of safe functions. (was: 2018)

Follow-up to e95f509c66abdd88ae02e3243cdc217f19c4a330 #16852
Follow-up to 9869f6dc5af85caf2e0fd4c56713a7f2049ecfff #5218

---

- [x] drop the `write()` call too? it needs warning suppression. Or shorten
the suppression to `(void)!write()` again, maybe for a single line it's better.
→ [FUTURE PR maybe]
