### PR TITLE
configure: clarify --enable-debug option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ if(CYGWIN OR CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "G
   list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")  # Apply to all feature checks
 endif()
 
-option(ENABLE_DEBUG "Enable curl debug features (for developing curl itself)" OFF)
+option(ENABLE_DEBUG "Enable curl debug features (for developing curl)" OFF)
 if(ENABLE_DEBUG)
   message(WARNING "This curl build is Debug-enabled and insecure, do not use in production.")
 endif()

--- a/configure.ac
+++ b/configure.ac
@@ -5619,6 +5619,10 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   Features:         ${SUPPORT_FEATURES}
 ])
 
+if test "$want_debug" = "yes"; then
+  AC_MSG_WARN([This curl build is Debug-enabled and insecure, do not use in production.])
+fi
+
 if test -n "$experimental"; then
   for a in $experimental; do
     AC_MSG_WARN([$a is enabled but marked EXPERIMENTAL. Use with caution!])

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -146,8 +146,8 @@ Building statically is not for the faint of heart.
 
 ## Debug
 
-If you are a curl developer and use gcc, you might want to enable more debug
-options with the `--enable-debug` option.
+If you are a curl developer and use gcc, you might want to enable curl debug
+features (for developing curl) with the `--enable-debug` option.
 
 curl can be built to use a whole range of libraries to provide various useful
 services, and configure tries to auto-detect a decent default. If you want to

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -113,8 +113,8 @@ AC_DEFUN([CURL_CHECK_OPTION_DEBUG], [
   AC_MSG_CHECKING([whether to enable debug build options])
   OPT_DEBUG_BUILD="default"
   AC_ARG_ENABLE(debug,
-AS_HELP_STRING([--enable-debug],[Enable debug build options])
-AS_HELP_STRING([--disable-debug],[Disable debug build options]),
+AS_HELP_STRING([--enable-debug],[Enable curl debug features (for developing curl)])
+AS_HELP_STRING([--disable-debug],[Disable curl debug features]),
   OPT_DEBUG_BUILD=$enableval)
   case "$OPT_DEBUG_BUILD" in
     no)


### PR DESCRIPTION
- Change --enable-debug help text to say it is for developing curl.

- Warn when --enable-debug is used.

This change copies the help text and warning from cmake ENABLE_DEBUG. Also, it shortens the "for debugging curl itself" to just say "for debugging curl".

Now it looks like this:
~~~
  --enable-debug          Enable curl debug features (for developing curl)
  --disable-debug         Disable curl debug features
~~~
Ref: https://github.com/curl/curl/issues/22481#issuecomment-5207220359

Reported-by: Viktor Szakats

Closes #xxxx

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
