### PR TITLE
build: require `!NDEBUG` for debug-enabled (aka development) builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -582,7 +582,7 @@ jobs:
             url: 'https://github.com/skeeto/w64devkit/releases/download/v2.8.0/w64devkit-x64-2.8.0.7z.exe'
             SHA256: 6252bf34fe2231a55ac7f03d482b36d2c7c58697990551bba508102cfb3f342e
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DENABLE_UNIX_SOCKETS=OFF -DCURL_GCC_ANALYZER=ON'
-            type: 'Release'
+            type: 'Debug'
           - name: 'schannel'  # mingw-w64 10.0
             sys: 'mingw64'
             dir: 'mingw64'
@@ -590,7 +590,7 @@ jobs:
             ver: '9.5.0'
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             SHA256: 41637132ea7dc36a7f86a1961eaa334c380b5a3423d36aecb481cabcd006e3fe
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCURL_DISABLE_VERBOSE_STRINGS=ON'
+            config: '-DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCURL_DISABLE_VERBOSE_STRINGS=ON'
             type: 'Release'
             tflags: 'skiprun'
           - name: 'schannel mbedtls U'  # mingw-w64 6.0
@@ -602,7 +602,7 @@ jobs:
             SHA256: 9dc08c9c2bdd5d8173f87791bed644f6e290624f739de474f117b590dfd8a721
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_MBEDTLS=ON -DCURL_TARGET_WINDOWS_VERSION=0x0600'
             install: mingw-w64-x86_64-mbedtls
-            type: 'Release'
+            type: 'Debug'
             tflags: 'skiprun'
           - name: 'schannel !unity'  # mingw-w64 5.0
             sys: 'mingw32'
@@ -611,7 +611,7 @@ jobs:
             ver: '6.4.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             SHA256: 12d2c62ad4527ec8a52275ea8485678dcbe20bec4716a3c7ba274f225d696085
-            config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
+            config: '-DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
             install: mingw-w64-i686-libssh
             type: 'Debug'
             tflags: 'skiprun'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -972,22 +972,6 @@ jobs:
               -DCURL_USE_SCHANNEL=ON
               -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
 
-          - name: 'schannel U Release'
-            install-vcpkg: 'zlib libssh2[core,zlib]'
-            arch: 'arm64'
-            env: 'clang-aarch64'
-            plat: 'windows'
-            type: 'Release'
-            image: 'windows-11-arm'
-            openssh: 'OpenSSH-Windows'
-            tflags: '--min=1720'
-            # leave SMB disabled to save 30-60 seconds by omitting prereqs,
-            # to counteract the slower test run step
-            config: >-
-              -DENABLE_DEBUG=ON
-              -DCURL_USE_SCHANNEL=ON
-              -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
-
       fail-fast: false
     steps:
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -299,13 +299,13 @@ jobs:
               build: 'cmake'    , sys: 'clangarm64', env: 'clang-aarch64', tflags: 'skiprun',
               config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_DROP_UNUSED=ON',
               install: 'mingw-w64-clang-aarch64-libssh2' }
-          - { name: 'openssl', type: 'Release', chkprefill: '_chkprefill',
+          - { name: 'openssl', type: 'Debug', chkprefill: '_chkprefill',
               build: 'cmake'    , sys: 'clang64'   , env: 'clang-x86_64' , tflags: 'skiprun',
               config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON  -DENABLE_UNICODE=OFF -DUSE_NGTCP2=ON -DUSE_PROXY_HTTP3=ON',
               install: 'mingw-w64-clang-x86_64-openssl mingw-w64-clang-x86_64-nghttp3 mingw-w64-clang-x86_64-ngtcp2 mingw-w64-clang-x86_64-libssh2' }
           - { name: 'openssl', type: 'Release', test: 'uwp',
               build: 'cmake'    , sys: 'ucrt64'    , env: 'ucrt-x86_64'  , tflags: 'skiprun',
-              config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_OPENSSL=ON',
+              config: '-DBUILD_SHARED_LIBS=ON  -DCURL_USE_OPENSSL=ON',
               install: 'mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-libssh2' }
           # { name: 'schannel', type: 'Release', test: 'uwp',
           #   build: 'autotools', sys: 'ucrt64'    , env: 'ucrt-x86_64'  , tflags: 'skiprun',

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -972,6 +972,22 @@ jobs:
               -DCURL_USE_SCHANNEL=ON
               -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
 
+          - name: 'schannel U Release'
+            install-vcpkg: 'zlib libssh2[core,zlib]'
+            arch: 'arm64'
+            env: 'clang-aarch64'
+            plat: 'windows'
+            type: 'Release'
+            image: 'windows-11-arm'
+            openssh: 'OpenSSH-Windows'
+            tflags: '--min=1720'
+            # leave SMB disabled to save 30-60 seconds by omitting prereqs,
+            # to counteract the slower test run step
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_SCHANNEL=ON
+              -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
+
       fail-fast: false
     steps:
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ endif()
 
 option(ENABLE_DEBUG "Enable curl debug features (for developing curl)" OFF)
 if(ENABLE_DEBUG)
-  if(CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE EQUAL "Debug")
+  if(CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     message(FATAL_ERROR "Debug-enabled (aka development mode) curl requires the Debug configuration")
   endif()
   message(WARNING "This curl build is Debug-enabled and insecure, do not use in production.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,9 @@ endif()
 
 option(ENABLE_DEBUG "Enable curl debug features (for developing curl)" OFF)
 if(ENABLE_DEBUG)
+  if(CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE EQUAL "Debug")
+    message(FATAL_ERROR "Debug-enabled (aka development mode) curl requires the Debug configuration")
+  endif()
   message(WARNING "This curl build is Debug-enabled and insecure, do not use in production.")
 endif()
 

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -222,6 +222,8 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `CURL_WERROR`:                            Turn compiler warnings into errors. Default: `OFF`
 - `ENABLE_CURL_MANUAL`:                     Build the man page for curl and enable its `-M`/`--manual` option. Default: `ON`
 - `ENABLE_DEBUG`:                           Enable curl debug features (for developing curl itself). Default: `OFF`
+                                            This also requires Debug configuration enabled/selected at the same time,
+                                            via `CMAKE_BUILD_TYPE=Debug`, or `--config Debug` for multi-config generators.
 - `IMPORT_LIB_SUFFIX`:                      Import library suffix. Default: `_imp` for MSVC-like toolchains, otherwise empty.
 - `LIBCURL_OUTPUT_NAME`:                    Basename of the curl library. Default: `libcurl`
 - `PICKY_COMPILER`:                         Enable picky compiler options. Default: `ON`

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1058,6 +1058,10 @@ typedef unsigned int curl_bit;
 
 #include "curl_ctype.h"
 
+#if defined(DEBUGBUILD) && defined(NDEBUG)
+#error "Debug-enabled builds cannot be combined with NDEBUG"
+#endif
+
 /*
  * Macro used to include code only in debug builds.
  */


### PR DESCRIPTION
To prevent creating a curl-development (aka debug-enabled, aka
`-DENABLE_DEBUG=ON`, `--enable-debug` or `DEBUGBUILD`) build without
`assert()`s. Since it may break expectations by missing to catch error
cases. Also to make it less likely to build an inherently insecure
development build by accident.

- in CMake, for non-Multi-Config builds, show this error unless Debug
  configuration is set at configure-time:
  ```
  CMake Error at CMakeLists.txt:263 (message):
    Debug-enabled (aka development mode) curl requires the Debug configuration
  ```
  Ref: https://github.com/curl/curl/actions/runs/31159065911/job/92805128331?pr=22513#step:6:56
  The other 3 predefined configs (`Release`, `RelWithDebInfo`,
  `MinSizeRel`) set `NDEBUG` automatically.

- or this message in other cases, e.g. when using CMake Multi-Config
  with non-Debug, e.g. `--config Release`, or passed `NDEBUG` manually
  with either build tools:
  ```
  curl_setup.h(1062): fatal error C1189: #error:
    "Debug-enabled builds cannot be combined with NDEBUG"
  ```
  Ref: https://github.com/curl/curl/actions/runs/31159628749/job/92807878479#step:9:28

Also:
- INSTALL-CMAKE.md: document.
- GHA/windows: adjust CI jobs to meet the above requirement, where
  missing.

Reported-by Stefan Eissing
Bug: https://github.com/curl/curl/pull/22484#discussion_r3730045572
Ref: ea984456804ab3ff1656a668fabdf734a32e379e #13592
Fixes #22481
Fixes #22484

---

- [x] adjust CI jobs not meeting this criteria.

Multi-Config tested OK (to fail by design) here: https://github.com/curl/curl/actions/runs/31159628749/job/92807878479?pr=22513
