### PR TITLE
curl_easy_setopt access from langs without va_arg support

### DIFF
--- a/include/curl/easy.h
+++ b/include/curl/easy.h
@@ -40,6 +40,7 @@ struct curl_blob {
 
 CURL_EXTERN CURL *curl_easy_init(void);
 CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...);
+CURL_EXTERN CURLcode curl_easy_setopt_ffi(CURL *curl, CURLoption option, void* value);
 CURL_EXTERN CURLcode curl_easy_perform(CURL *curl);
 CURL_EXTERN void curl_easy_cleanup(CURL *curl);
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2932,3 +2932,16 @@ CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...)
   CURL_EAPI_LEAVE(&guard);
   return result;
 }
+
+/*
+ * curl_easy_setopt_ffi() wraps curl_easy_setopt, so that curl_easy_setopt
+ * be accessed, from languages other than C/C++, via dlsym. Languages
+ * that don't have variadic parameter support yet.
+ *
+ * We assume that any parameters sent, are held in integer parameters.
+ * So: Pointers, ints, bools only. No float or vectors passed.
+ */
+CURLcode curl_easy_setopt_ffi(CURL *curl, CURLoption option, void* value)
+{
+  return curl_easy_setopt(curl, option, value);
+}


### PR DESCRIPTION
I want to use curl from a language that I am creating, accessed via dlopen/dlsym.

curl is unusuable for me, because of it's variadic params, which my my lang's VM can't handle.

So I added a one-line function to wrap curl_easy_setopt with normal params.

I've found multiple non C/C++ languages having issues with variadics. Including: https://github.com/oven-sh/bun/issues/12389 https://akrabat.com/wrapping-variadic-functions-for-use-in-swift/ https://crtschin.com/posts/wait-this-isnt-haskell . I'm sure other languages have had similar issues.

Adding a 1 line wrapper function in curl itself, is much much easier than writing/testing ASM for 6 combinations  (Mac+Linux+Win) * (ARM64+x86) of platforms.

Thanks for the help and accepting it, if you do. You will make my life sooo much easier. I would love to use curl!