### PR TITLE
libcurl.pc: add the Link.ABI and Source tags

### DIFF
--- a/libcurl.pc.in
+++ b/libcurl.pc.in
@@ -33,9 +33,11 @@ Name: libcurl
 URL: https://curl.se/
 Description: Library to transfer files with HTTP, FTP, etc.
 Version: @CURLVERSION@
+Source: https://curl.se/download/curl-@CURLVERSION@.tar.gz
 Requires: @LIBCURL_PC_REQUIRES@
 Requires.private: @LIBCURL_PC_REQUIRES_PRIVATE@
 Libs: -L${libdir} -lcurl @LIBCURL_PC_LIBS@
 Libs.private: @LIBCURL_PC_LDFLAGS_PRIVATE@ @LIBCURL_PC_LIBS_PRIVATE@
 Cflags: -I${includedir} @LIBCURL_PC_CFLAGS@
 Cflags.private: @LIBCURL_PC_CFLAGS_PRIVATE@
+Link.ABI: c


### PR DESCRIPTION
Link.ABI is a feature of pkgconf 3.0 and indicates the ABI against which
a consumer must link the package. For libcurl, this is hard-coded as C.
Source is a URL from which to download the package tarball.

Closes #22519


<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->