### PR TITLE
build: replace `assert()` with `DEBUGASSERT()`, where missing

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -283,7 +283,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
      * does not seem to like a msg_control of length 0. */
     memset(msg_ctrl, 0, sizeof(msg_ctrl));
     msg.msg_control = msg_ctrl;
-    assert(sizeof(msg_ctrl) >= CMSG_SPACE(sizeof(int)));
+    DEBUGASSERT(sizeof(msg_ctrl) >= CMSG_SPACE(sizeof(int)));
     msg.msg_controllen = CMSG_SPACE(sizeof(int));
     cm = CMSG_FIRSTHDR(&msg);
     cm->cmsg_level = SOL_UDP;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -799,10 +799,10 @@ curl_socket_t win32_stdin_read_thread(void)
   static curl_socket_t socket_r = CURL_SOCKET_BAD;
 
   if(socket_r != CURL_SOCKET_BAD) {
-    assert(stdin_thread);
+    DEBUGASSERT(stdin_thread);
     return socket_r;
   }
-  assert(!stdin_thread);
+  DEBUGASSERT(!stdin_thread);
 
   do {
     curl_socklen_t socksize = 0;
@@ -944,7 +944,7 @@ err:
     return CURL_SOCKET_BAD;
   }
 
-  assert(socket_r != CURL_SOCKET_BAD);
+  DEBUGASSERT(socket_r != CURL_SOCKET_BAD);
   return socket_r;
 }
 #endif /* USE_WINSOCK */


### PR DESCRIPTION
Follow-up to 9a2663322c330ff11275abafd612e9c99407a94a #17572
Follow-up to c96f982166fbc671b77f84a1730e9b6d11357e8f #10451
