### PR TITLE
harden: add bounds check before memcpy in smb.c

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -23,6 +23,7 @@
  *
  ***************************************************************************/
 #include "curl_setup.h"
+#include <stddef.h>  /* for offsetof() */
 #include "urldata.h"
 
 #if defined(CURL_ENABLE_SMB) && defined(USE_CURL_NTLM_CORE)
@@ -936,7 +937,8 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
 
   switch(smbc->state) {
   case SMB_NEGOTIATE:
-    if((smbc->got < sizeof(*nrsp) + sizeof(smbc->challenge) - 1) ||
+    if((smbc->got < offsetof(struct smb_negotiate_response, bytes) +
+                    sizeof(smbc->challenge)) ||
        h->status) {
       CURL_TRC_M(data, "SMB: negotiation failed");
       connclose(conn);


### PR DESCRIPTION
## Summary
Harden input handling in `lib/smb.c` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/smb.c:940` |
| **Assessment** | Defensive hardening |

**Description**: The bounds check for SMB negotiate response at line 944 uses sizeof(struct) which includes a flexible array member, potentially allowing the memcpy at line 952 to read beyond the actual received data if struct padding differs from expected.

## Threat Model Context

This is a containerized service - vulnerabilities may be exploitable depending on network exposure.

## Changes
- `lib/smb.c`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `lib/smb.c:585`, `lib/smb.c:649`, `lib/smb.c:702`, `lib/smb.c:704`, `lib/smb.c:954`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
