### PR TITLE
ldap: reject control characters in URL-decoded filter values

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -497,7 +497,6 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
   }
 
   Curl_pgrsReset(data);
-
   rc = ldap_search_s(server, ludp->lud_dn,
                      ludp->lud_scope,
                      ludp->lud_filter, ludp->lud_attrs, 0, &ldapmsg);

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -498,24 +498,6 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 
   Curl_pgrsReset(data);
 
-  /* Validate LDAP filter to prevent injection of LDAP metacharacters (RFC 4515).
-     Reject control characters and unbalanced parentheses. */
-  if(ludp->lud_filter) {
-    const char *p = ludp->lud_filter;
-    int depth = 0;
-    bool valid = TRUE;
-    for(; *p && valid; p++) {
-      if((unsigned char)*p < 0x20) { valid = FALSE; break; }
-      if(*p == '(') depth++;
-      else if(*p == ')') { if(--depth < 0) valid = FALSE; }
-    }
-    if(!valid || depth != 0) {
-      failf(data, "LDAP local: unsafe filter");
-      result = CURLE_LDAP_SEARCH_FAILED;
-      goto quit;
-    }
-  }
-
   rc = ldap_search_s(server, ludp->lud_dn,
                      ludp->lud_scope,
                      ludp->lud_filter, ludp->lud_attrs, 0, &ldapmsg);
@@ -859,7 +841,7 @@ static curl_ldap_num_t ldap_url_parse2_low(struct Curl_easy *data,
     LDAP_TRACE(("filter '%s'\n", filter));
 
     /* Unescape the filter */
-    result = Curl_urldecode(filter, 0, &unescaped, NULL, REJECT_ZERO);
+    result = Curl_urldecode(filter, 0, &unescaped, NULL, REJECT_CTRL);
     if(result) {
       rc = LDAP_NO_MEMORY;
 

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -497,6 +497,25 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
   }
 
   Curl_pgrsReset(data);
+
+  /* Validate LDAP filter to prevent injection of LDAP metacharacters (RFC 4515).
+     Reject control characters and unbalanced parentheses. */
+  if(ludp->lud_filter) {
+    const char *p = ludp->lud_filter;
+    int depth = 0;
+    bool valid = TRUE;
+    for(; *p && valid; p++) {
+      if((unsigned char)*p < 0x20) { valid = FALSE; break; }
+      if(*p == '(') depth++;
+      else if(*p == ')') { if(--depth < 0) valid = FALSE; }
+    }
+    if(!valid || depth != 0) {
+      failf(data, "LDAP local: unsafe filter");
+      result = CURLE_LDAP_SEARCH_FAILED;
+      goto quit;
+    }
+  }
+
   rc = ldap_search_s(server, ludp->lud_dn,
                      ludp->lud_scope,
                      ludp->lud_filter, ludp->lud_attrs, 0, &ldapmsg);


### PR DESCRIPTION
## Summary

I've updated the PR. The original approach was wrong: `lud_filter` holds a complete LDAP filter expression, so rejecting LDAP metacharacters like `(`, `)`, `|`, `&`, `*` would break valid filters, and a parenthesis-balance check is not equivalent to RFC 4515 escaping.

This version fixes the concrete issue at the right layer: control characters (bytes < 0x20) in per cent-encoded filter values are now rejected at URL-decode time via `REJECT_CTRL`, before the string is stored in `lud_filter`. The previous ad-hoc validator in `ldap_do` is removed entirely.

## Changes

- `lib/ldap.c`: change `REJECT_ZERO` → `REJECT_CTRL` in `ldap_url_parse2_low` when URL-decoding the filter component; remove the post-parse validator from `ldap_do`

## Why this is the right place

`Curl_urldecode()` already supports `REJECT_CTRL` (used elsewhere in the codebase), which rejects decoded bytes < 0x20. Applying it to the filter decode catches per cent-encoded control characters (`%01`, `%0a`, etc.) as they enter the filter string — before they reach `ldap_search_s`. This is a minimal, targeted fix with a clear justification and no impact on valid LDAP filter syntax.