### PR TITLE
build: minor debug option message fixes/improvements

### DIFF
--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -221,7 +221,7 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `CURL_TARGET_WINDOWS_VERSION`:            Minimum target Windows version as hex string, e.g. `0x0a00` for Windows 10.
 - `CURL_WERROR`:                            Turn compiler warnings into errors. Default: `OFF`
 - `ENABLE_CURL_MANUAL`:                     Build the man page for curl and enable its `-M`/`--manual` option. Default: `ON`
-- `ENABLE_DEBUG`:                           Enable curl debug features (for developing curl itself). Default: `OFF`
+- `ENABLE_DEBUG`:                           Enable curl debug features (for developing curl). Default: `OFF`
                                             This also requires Debug configuration enabled/selected at the same time,
                                             via `CMAKE_BUILD_TYPE=Debug`, or `--config Debug` for multi-config generators.
 - `IMPORT_LIB_SUFFIX`:                      Import library suffix. Default: `_imp` for MSVC-like toolchains, otherwise empty.

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -110,11 +110,11 @@ dnl variable want_debug value as appropriate.
 AC_DEFUN([CURL_CHECK_OPTION_DEBUG], [
   AC_BEFORE([$0],[CURL_CHECK_OPTION_WARNINGS])
   AC_BEFORE([$0],[XC_CHECK_PROG_CC])
-  AC_MSG_CHECKING([whether to enable debug build options])
+  AC_MSG_CHECKING([whether to enable curl debug features (for developing curl)])
   OPT_DEBUG_BUILD="default"
   AC_ARG_ENABLE(debug,
 AS_HELP_STRING([--enable-debug],[Enable curl debug features (for developing curl)])
-AS_HELP_STRING([--disable-debug],[Disable curl debug features]),
+AS_HELP_STRING([--disable-debug],[Disable curl debug features (default)]),
   OPT_DEBUG_BUILD=$enableval)
   case "$OPT_DEBUG_BUILD" in
     no)


### PR DESCRIPTION
- CMAKE_INSTALL.md: sync up option desc with `CMakeLists.txt`.
- sync `--enable-debug` configure text with help description.
- say `--disable-debug` is the default in help description.

Follow-up to a15cf1ea07963ab9d92803e23a96ac5541c6ba0f #22512
