### PR TITLE
GHA/linux: replace raw C option with `CMAKE_BUILD_TYPE=Debug` in tsan job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -414,9 +414,9 @@ jobs:
             install_packages: clang-22 libtsan2
             install_steps: pytest openssl-tsan
             CC: clang-22
-            CFLAGS: -fsanitize=thread -g
+            CFLAGS: -fsanitize=thread
             LDFLAGS: -fsanitize=thread
-            generate: -DOPENSSL_ROOT_DIR=/home/runner/openssl -DUSE_ECH=ON -DENABLE_DEBUG=ON
+            generate: -DCMAKE_BUILD_TYPE=Debug -DENABLE_DEBUG=ON -DOPENSSL_ROOT_DIR=/home/runner/openssl -DUSE_ECH=ON
 
           - name: 'memory-sanitizer'
             image: ubuntu-26.04


### PR DESCRIPTION
Ref: #22533
Follow-up to 2a46df31fdb91851895bc46d81f0065e6cafc80b #18274
