### PR TITLE
build: strip trailing spaces from `libcurl.pc`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2362,6 +2362,10 @@ if(NOT CURL_DISABLE_INSTALL)
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
     "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
+  # Strip trailing spaces
+  file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
+  string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
+  file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 

--- a/configure.ac
+++ b/configure.ac
@@ -5561,7 +5561,7 @@ AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
   # strip trailing spaces
   "$SED" 's/ *$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
-])
+], [SED="$SED"])
 AC_OUTPUT
 
 SUPPORT_PROTOCOLS_LOWER=`echo "$SUPPORT_PROTOCOLS" | tr A-Z a-z`

--- a/configure.ac
+++ b/configure.ac
@@ -5555,15 +5555,15 @@ AC_CONFIG_FILES([\
   tests/http/config.ini \
   tests/http/Makefile \
   projects/Makefile \
-  projects/vms/Makefile \
-  libcurl.pc
+  projects/vms/Makefile
 ])
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
+AC_CONFIG_FILES([libcurl.pc], [
+  # strip trailing spaces
+  $SED -i.bak -E 's/ +$//g' libcurl.pc
+  rm libcurl.pc.bak
+])
 AC_OUTPUT
-
-# strip trailing spaces
-$SED -i.bak -E 's/ +$//g' libcurl.pc
-rm libcurl.pc.bak
 
 SUPPORT_PROTOCOLS_LOWER=`echo "$SUPPORT_PROTOCOLS" | tr A-Z a-z`
 

--- a/configure.ac
+++ b/configure.ac
@@ -5560,7 +5560,7 @@ AC_CONFIG_FILES([\
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
   # strip trailing spaces
-  $SED -E 's/ +$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
+  $SED 's/ *$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
 ])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -5561,6 +5561,10 @@ AC_CONFIG_FILES([\
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_OUTPUT
 
+# strip trailing spaces
+$SED -i.bak -E 's/ +$//g' libcurl.pc
+rm libcurl.pc.bak
+
 SUPPORT_PROTOCOLS_LOWER=`echo "$SUPPORT_PROTOCOLS" | tr A-Z a-z`
 
 AC_MSG_NOTICE([Configured to build curl/libcurl:

--- a/configure.ac
+++ b/configure.ac
@@ -5560,7 +5560,7 @@ AC_CONFIG_FILES([\
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
   # strip trailing spaces
-  $SED 's/ *$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
+  "$SED" 's/ *$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
 ])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -5560,8 +5560,7 @@ AC_CONFIG_FILES([\
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
   # strip trailing spaces
-  $SED -i.bak -E 's/ +$//g' libcurl.pc
-  rm libcurl.pc.bak
+  $SED -E 's/ +$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
 ])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -5559,7 +5559,7 @@ AC_CONFIG_FILES([\
 ])
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
-  # strip trailing spaces
+  dnl strip trailing spaces
   "$SED" 's/ *$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
 ], [SED="$SED"])
 AC_OUTPUT


### PR DESCRIPTION
Fixing:
```
$ pccritic libcurl.pc
[...]
  [info    ] file has trailing whitespace on one or more lines (style/PC062)
```
