### PR TITLE
spnego_sspi: pass channel bindings on initial context

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -113,6 +113,22 @@ else
   echo "Skip running curl.exe. Reason: ${SKIP_RUN}"
 fi
 
+# save artifacts
+
+if [[ "${APPVEYOR_JOB_NAME}" = 'CM VS2026, Debug, x64, OpenSSL 3.5 + Schannel, Static'* ]]; then
+  CURL_SSL_BACKEND=schannel "${curl}" -v -fL -o curl-ca-bundle.crt https://curl.se/ca/cacert.pem
+  "${curl}" -v https://google.com
+  if [ -n "${APPVEYOR_PULL_REQUEST_NUMBER:-}" ]; then
+    archive="curl_pr${APPVEYOR_PULL_REQUEST_NUMBER}_${APPVEYOR_PULL_REQUEST_HEAD_COMMIT}.zip"
+  else
+    archive="curl_${APPVEYOR_REPO_COMMIT}.zip"
+  fi
+  "${curl}" --dump-module-paths | grep -Fv "C:\Windows" | tee > files.tmp
+  7z a "${archive}" -y -bb1 -bsp0 -mx9 -tzip -i@files.tmp curl-ca-bundle.crt
+  rm files.tmp
+  appveyor PushArtifact "${archive}"
+fi
+
 # build tests
 
 if [ -n "${CMAKE_GENERATOR:-}" ] && [[ "${APPVEYOR_JOB_NAME}" = *'Build-tests'* ]]; then

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -242,6 +242,9 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   SecBufferDesc type_3_desc;
   SECURITY_STATUS status;
   unsigned long attrs;
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  SecPkgContext_Bindings pkgBindings = { 0, NULL };
+#endif
 
   (void)creds;
 
@@ -262,9 +265,6 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
    * https://learn.microsoft.com/security-updates/SecurityAdvisories/2009/973811
    */
   if(ntlm->sslContext) {
-    SEC_CHANNEL_BINDINGS channelBindings;
-    SecPkgContext_Bindings pkgBindings;
-    pkgBindings.Bindings = &channelBindings;
     status = Curl_pSecFn->QueryContextAttributes(
       ntlm->sslContext,
       SECPKG_ATTR_ENDPOINT_BINDINGS,
@@ -296,6 +296,12 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                                   0, ntlm->context,
                                                   &type_3_desc,
                                                   &attrs, NULL);
+
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  if(pkgBindings.Bindings)
+    Curl_pSecFn->FreeContextBuffer(pkgBindings.Bindings);
+#endif
+
   if(status != SEC_E_OK) {
     infof(data, "NTLM handshake failure (type-3 message): Status=0x%08lx",
           (unsigned long)status);

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -93,6 +93,10 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   SecBufferDesc chlg_desc;
   SecBufferDesc resp_desc;
   unsigned long attrs;
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  SEC_CHANNEL_BINDINGS channelBindings;
+  SecPkgContext_Bindings pkgBindings;
+#endif
 
   if(nego->context && nego->status == SEC_E_OK) {
     /* We finished successfully our part of authentication, but server
@@ -196,6 +200,10 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       return CURLE_OUT_OF_MEMORY;
   }
 
+  chlg_desc.ulVersion = SECBUFFER_VERSION;
+  chlg_desc.cBuffers = 0;
+  chlg_desc.pBuffers = chlg_buf;
+
   if(chlg64 && *chlg64) {
     /* Decode the base-64 encoded challenge message */
     if(*chlg64 != '=') {
@@ -211,38 +219,34 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     }
 
     /* Setup the challenge "input" security buffer */
-    chlg_desc.ulVersion    = SECBUFFER_VERSION;
     chlg_desc.cBuffers     = 1;
-    chlg_desc.pBuffers     = &chlg_buf[0];
     chlg_buf[0].BufferType = SECBUFFER_TOKEN;
     chlg_buf[0].pvBuffer   = chlg;
     chlg_buf[0].cbBuffer   = curlx_uztoul(chlglen);
+  }
 
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
-    /* SSL context comes from Schannel.
-     * When extended protection is used in IIS server,
-     * we have to pass a second SecBuffer to the SecBufferDesc
-     * otherwise IIS does not pass the authentication (401 response).
-     * Minimum supported version is Windows 7.
-     * https://learn.microsoft.com/security-updates/SecurityAdvisories/2009/973811
-     */
-    if(nego->sslContext) {
-      SEC_CHANNEL_BINDINGS channelBindings;
-      SecPkgContext_Bindings pkgBindings;
-      pkgBindings.Bindings = &channelBindings;
-      nego->status = Curl_pSecFn->QueryContextAttributes(
-          nego->sslContext,
-          SECPKG_ATTR_ENDPOINT_BINDINGS,
-          &pkgBindings);
-      if(nego->status == SEC_E_OK) {
-        chlg_desc.cBuffers++;
-        chlg_buf[1].BufferType = SECBUFFER_CHANNEL_BINDINGS;
-        chlg_buf[1].cbBuffer   = pkgBindings.BindingsLength;
-        chlg_buf[1].pvBuffer   = pkgBindings.Bindings;
-      }
+  /* SSL context comes from Schannel.
+   * When extended protection is used in IIS server, pass its channel
+   * bindings on the initial call too. HTTP Negotiate can create and send a
+   * Kerberos token before receiving a challenge from the server.
+   * Minimum supported version is Windows 7.
+   * https://learn.microsoft.com/security-updates/SecurityAdvisories/2009/973811
+   */
+  if(nego->sslContext) {
+    pkgBindings.Bindings = &channelBindings;
+    nego->status = Curl_pSecFn->QueryContextAttributes(
+        nego->sslContext,
+        SECPKG_ATTR_ENDPOINT_BINDINGS,
+        &pkgBindings);
+    if(nego->status == SEC_E_OK) {
+      SecBuffer *binding_buf = &chlg_buf[chlg_desc.cBuffers++];
+      binding_buf->BufferType = SECBUFFER_CHANNEL_BINDINGS;
+      binding_buf->cbBuffer   = pkgBindings.BindingsLength;
+      binding_buf->pvBuffer   = pkgBindings.Bindings;
     }
-#endif
   }
+#endif
 
   /* Setup the response "output" security buffer */
   resp_desc.ulVersion = SECBUFFER_VERSION;
@@ -263,7 +267,8 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                              nego->spn,
                                              sspi_flags,
                                              0, SECURITY_NATIVE_DREP,
-                                             chlg ? &chlg_desc : NULL,
+                                             chlg_desc.cBuffers ?
+                                               &chlg_desc : NULL,
                                              0, nego->context,
                                              &resp_desc, &attrs, NULL);
   }

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -94,8 +94,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   SecBufferDesc resp_desc;
   unsigned long attrs;
 #ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
-  SEC_CHANNEL_BINDINGS channelBindings;
-  SecPkgContext_Bindings pkgBindings;
+  SecPkgContext_Bindings pkgBindings = { 0, NULL };
 #endif
 
   if(nego->context && nego->status == SEC_E_OK) {
@@ -234,7 +233,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
    * https://learn.microsoft.com/security-updates/SecurityAdvisories/2009/973811
    */
   if(nego->sslContext) {
-    pkgBindings.Bindings = &channelBindings;
     nego->status = Curl_pSecFn->QueryContextAttributes(
         nego->sslContext,
         SECPKG_ATTR_ENDPOINT_BINDINGS,
@@ -272,6 +270,11 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                              0, nego->context,
                                              &resp_desc, &attrs, NULL);
   }
+
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  if(pkgBindings.Bindings)
+    Curl_pSecFn->FreeContextBuffer(pkgBindings.Bindings);
+#endif
 
   /* Free the decoded challenge as it is not required anymore */
   curlx_free(chlg);


### PR DESCRIPTION
## Reproduction of reproducible bug described in #22466 

Using a domain-joined Windows 11 25H2 client and Windows Server 2022 IIS with Windows Authentication and Extended Protection for Authentication enabled:

```console
curl.exe -v --negotiate -u : https://iis.example.test/default.html
```

The client obtains the correct Kerberos service ticket, but IIS returns HTTP 401. With EPA Required, the IIS Security log records Kerberos status `0xC000035B` (STATUS_BAD_BINDINGS). Disabling EPA allows the request to succeed.

## Root cause

curl sends the initial Kerberos token preemptively, before receiving a server challenge.

The Windows SSPI implementation only added Schannel endpoint bindings to the input passed to `InitializeSecurityContext` when a challenge token was present. Consequently, the initial Kerberos token lacked the channel binding required by IIS EPA.

## Fix

Construct the SSPI input descriptor independently of the challenge token and add Schannel endpoint bindings whenever they are available. This supplies channel bindings on both the initial and subsequent `InitializeSecurityContext` calls.

## Verification

Tested in a three-VM AD/Kerberos lab using Windows 11 25H2, Windows Server 2022 AD DS, and IIS 10.

| IIS EPA mode | curl 8.21.0 | patched curl |
|--------------|-------------|--------------|
| Disabled     | HTTP 200    | HTTP 200     |
| Allow        | HTTP 401    | HTTP 200     |
| Require      | HTTP 401    | HTTP 200     |

The patched Windows UCRT64 Schannel/SSPI build also passed all 78 applicable libcurl and tool unit tests. I am also looking for a new full-time job, I could take care of e.g. any Windows-related issues and feature implementations :)

Fixes #22466 