### PR TITLE
tests: verify AWS SigV4 redirect auth scope

### DIFF
--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -296,7 +296,7 @@ test4000 test4001 \
 test5000 test5001 test5002 test5003 test5004 test5005 test5006 test5007 \
 test5008 test5009 test5010 test5011 test5012 test5013 test5014 test5015 \
 test5016 test5017 test5018 test5019 test5020 test5021 test5022 test5023 \
-test5024 test5025
+test5024 test5025 test5026 test5027
 
 EXTRA_DIST = $(TESTCASES) DISABLED data-xml1 \
 data1461.txt data1463.txt  \

--- a/tests/data/test5026
+++ b/tests/data/test5026
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+followlocation
+aws-sigv4
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+contents
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data2>
+
+<datacheck>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+AWS SigV4 redirect to a different host
+</name>
+<command>
+http://first.host.it.is/we/want/that/page/%TESTNUMBER -x %HOSTIP:%HTTPPORT -u user:secret --aws-sigv4 "aws:amz:us-east-2:es" --location
+</command>
+<features>
+Debug
+aws
+proxy
+</features>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://first.host.it.is/we/want/that/page/%TESTNUMBER HTTP/1.1
+Host: first.host.it.is
+Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=5524f6f960590dc88a36551f11e407031a373e9e2caa3d3f7a3d9280cae367e2
+X-Amz-Date: 19700101T000000Z
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://goto.second.host.now/%TESTNUMBER0002 HTTP/1.1
+Host: goto.second.host.now
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test5027
+++ b/tests/data/test5027
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP proxy
+followlocation
+aws-sigv4
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+contents
+</data>
+<data2>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data2>
+
+<datacheck>
+HTTP/1.1 302 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Location: http://goto.second.host.now/%TESTNUMBER0002
+Content-Length: 8
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+AWS SigV4 trusted redirect to a different host
+</name>
+<command>
+http://first.host.it.is/we/want/that/page/%TESTNUMBER -x %HOSTIP:%HTTPPORT -u user:secret --aws-sigv4 "aws:amz:us-east-2:es" --location-trusted
+</command>
+<features>
+Debug
+aws
+proxy
+</features>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET http://first.host.it.is/we/want/that/page/%TESTNUMBER HTTP/1.1
+Host: first.host.it.is
+Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=c540681cd0bba0cd9f6983a4529a45545ca4693192b65f60d8288ea617670f55
+X-Amz-Date: 19700101T000000Z
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+GET http://goto.second.host.now/%TESTNUMBER0002 HTTP/1.1
+Host: goto.second.host.now
+Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=f73dad70768d102fbfc307cedf6c77a5ef2ce9da51989647b6240e903340dd26
+X-Amz-Date: 19700101T000000Z
+User-Agent: curl/%VERSION
+Accept: */*
+Proxy-Connection: Keep-Alive
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Add tests for AWS SigV4 authentication across redirects.

Verify that credentials are not sent to a different host with --location, and that --location-trusted signs the redirected request for the new host.

Tests 439, 778, 975, 5026 and 5027 pass.