### PR TITLE
schannel: reuse the send buffer

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1996,13 +1996,18 @@ static CURLcode schannel_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     len = backend->stream_sizes.cbMaximumMessage;
   }
 
-  /* calculate the complete message length and allocate a buffer for it */
+  /* calculate the complete message length and prepare the send buffer */
   data_len = backend->stream_sizes.cbHeader + len +
     backend->stream_sizes.cbTrailer;
-  ptr = curlx_malloc(data_len);
-  if(!ptr) {
-    return CURLE_OUT_OF_MEMORY;
+  if(data_len > backend->send_buffer_len) {
+    ptr = curlx_realloc(backend->send_buffer, data_len);
+    if(!ptr)
+      return CURLE_OUT_OF_MEMORY;
+    backend->send_buffer = ptr;
+    backend->send_buffer_len = data_len;
   }
+  else
+    ptr = backend->send_buffer;
 
   /* setup output buffers (header, data, trailer, empty) */
   InitSecBuffer(&outbuf[0], SECBUFFER_STREAM_HEADER,
@@ -2090,8 +2095,6 @@ static CURLcode schannel_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   else {
     result = CURLE_SEND_ERROR;
   }
-
-  curlx_safefree(ptr);
 
   if(len == *pnwritten)
     /* Encrypted message including header, data and trailer entirely sent.
@@ -2566,6 +2569,10 @@ static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     Curl_ssl_scache_unlock(data);
     backend->cred = NULL;
   }
+
+  /* free the buffer used to encrypt outgoing data */
+  curlx_safefree(backend->send_buffer);
+  backend->send_buffer_len = 0;
 
   /* free internal buffer for received encrypted data */
   if(backend->encdata.buffer) {

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -112,6 +112,8 @@ struct sbuffer {
 };
 
 struct schannel_ssl_backend_data {
+  unsigned char *send_buffer;
+  size_t send_buffer_len;
   struct sbuffer encdata;
   struct sbuffer decdata;
   struct Curl_schannel_cred *cred;


### PR DESCRIPTION
Reuse a connection-local buffer for encrypted Schannel writes instead of allocating and freeing a buffer for every send. Grow it when needed and release it when the connection is closed.

In a native Windows debug build, 30 sequential HTTPS transfers over one reused connection changed the send-buffer heap activity from 30 allocations and 30 frees to one allocation and one close-time free.

Verified with checksrc, MinGW 32-bit and 64-bit Schannel builds, and native Windows 11 Schannel runs.