### PR TITLE
content_encoding: exact-match the identity transfer-coding token

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -783,7 +783,8 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
        * Exception is "chunked" transfer-encoding which always must happen */
       if((is_transfer && !data->set.http_transfer_encoding && !is_chunked) ||
          (!is_transfer && data->set.http_ce_skip)) {
-        bool is_identity = curl_strnequal(name, "identity", 8);
+        bool is_identity = (namelen == 8) &&
+                           curl_strnequal(name, "identity", 8);
         /* not requested, ignore */
         CURL_TRC_WRITE(data, "decoder not requested, ignored: %.*s",
                        (int)namelen, name);

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -255,7 +255,7 @@ test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
 test2088 test2089 test2090 test2091 test2092 test2093 test2094 \
 test2100 test2101 test2102 test2103 test2104 test2105 test2106 test2107 \
 test2108 test2109 test2110 test2113 test2114 test2115 test2116 test2117 \
-test2118 \
+test2118 test2119 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 test2206 test2207 \
 test2208 \

--- a/tests/data/test2119
+++ b/tests/data/test2119
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+Transfer-Encoding
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 swsclose OK
+Content-Length: 6
+Transfer-Encoding: identityx
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Reject unsolicited Transfer-Encoding token with an identity prefix
+</name>
+# no --tr-encoding, so any transfer-coding other than chunked/identity is
+# unsolicited and must be rejected
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -sS
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+
+# CURLE_BAD_CONTENT_ENCODING is 61
+<errorcode>
+61
+</errorcode>
+<stderr mode="text">
+curl: (61) Unsolicited Transfer-Encoding (identityx) found
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
`Repro:` a response carrying `Transfer-Encoding: identityx` on a normal (no `--tr-encoding`) transfer is accepted and the body delivered, instead of being rejected.
`Cause:` `Curl_build_unencoding_stack()` matches the unsolicited-coding exception `identity` with a bare `curl_strnequal(name, "identity", 8)`, a prefix compare, so any token starting with `identity` slips past the `CURLE_BAD_CONTENT_ENCODING` that every other non-`chunked` coding hits. The `chunked` token just above is already length-checked with `namelen == 7`.
`Fix:` require `namelen == 8` for the identity match, mirroring the `chunked` check.
Test `2119`.