### PR TITLE
CI: dump `libcurl.pc` (and `curl-config`) to log, verify `.pc` with `pccritic` tool

### DIFF
--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -133,8 +133,8 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 99 bld-am/libcurl.pc
-          pccritic --min-score 99 bld-cm/libcurl.pc
+          pccritic --min-score 97 bld-am/libcurl.pc
+          pccritic --min-score 97 bld-cm/libcurl.pc
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -37,6 +37,7 @@ concurrency:
 permissions: {}
 
 env:
+  CURL_CI: github
   DO_NOT_TRACK: '1'
   HOMEBREW_NO_INSTALL_CLEANUP: '1'
 

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -133,6 +133,7 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
+          pccritic --version
           pccritic --min-score 97 bld-am/libcurl.pc
           pccritic --min-score 97 bld-cm/libcurl.pc
 

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -65,7 +65,7 @@ jobs:
       - name: 'cmake log'
         run: cat bld-cm/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
-      - name: 'dump generated files'
+      - name: 'generated libcurl.pc files'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
@@ -127,7 +127,7 @@ jobs:
       - name: 'cmake log'
         run: cat bld-cm/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
-      - name: 'dump generated files'
+      - name: 'generated libcurl.pc files'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
@@ -181,7 +181,7 @@ jobs:
       - name: 'cmake log'
         run: cat bld-cm/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
-      - name: 'dump generated files'
+      - name: 'generated libcurl.pc files'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -134,8 +134,8 @@ jobs:
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
           pccritic --version
-          pccritic --min-score 97 bld-am/libcurl.pc
-          pccritic --min-score 97 bld-cm/libcurl.pc
+          pccritic --min-score 98 bld-am/libcurl.pc
+          pccritic --min-score 98 bld-cm/libcurl.pc
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -133,8 +133,8 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 92 bld-am/libcurl.pc
-          pccritic --min-score 92 bld-cm/libcurl.pc
+          pccritic --min-score 99 bld-am/libcurl.pc
+          pccritic --min-score 99 bld-cm/libcurl.pc
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -71,6 +71,8 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
+          pccritic bld-am/libcurl.pc 2>/dev/null || true
+          pccritic bld-cm/libcurl.pc 2>/dev/null || true
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
@@ -133,6 +135,8 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
+          pccritic bld-am/libcurl.pc 2>/dev/null || true
+          pccritic bld-cm/libcurl.pc 2>/dev/null || true
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
@@ -187,6 +191,8 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
+          pccritic bld-am/libcurl.pc 2>/dev/null || true
+          pccritic bld-cm/libcurl.pc 2>/dev/null || true
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -71,8 +71,6 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld-am/libcurl.pc 2>/dev/null || true
-          pccritic bld-cm/libcurl.pc 2>/dev/null || true
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
@@ -135,8 +133,8 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld-am/libcurl.pc 2>/dev/null || true
-          pccritic bld-cm/libcurl.pc 2>/dev/null || true
+          pccritic --min-score 92 bld-am/libcurl.pc
+          pccritic --min-score 92 bld-cm/libcurl.pc
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
@@ -191,8 +189,6 @@ jobs:
             echo "::group::AM ${f}"; grep -v '^#' bld-am/"${f}" || true; echo '::endgroup::'
             echo "::group::CM ${f}"; grep -v '^#' bld-cm/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld-am/libcurl.pc 2>/dev/null || true
-          pccritic bld-cm/libcurl.pc 2>/dev/null || true
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -815,7 +815,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -820,7 +820,6 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'test configs'
         run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -815,6 +815,13 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
+
       - name: 'test configs'
         run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -886,7 +886,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -886,6 +886,13 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
+
       - name: 'test configs'
         run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -891,7 +891,6 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'test configs'
         run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -181,6 +181,13 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
+
       - name: 'build'
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
@@ -511,6 +518,13 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
+
       - name: 'test configs'
         run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true
 
@@ -773,6 +787,13 @@ jobs:
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
+
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build / ${{ matrix.build }}'
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -187,7 +187,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 92 bld/libcurl.pc
+            pccritic --min-score 99 bld/libcurl.pc
           fi
 
       - name: 'build'
@@ -526,7 +526,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 92 bld/libcurl.pc
+            pccritic --min-score 99 bld/libcurl.pc
           fi
 
       - name: 'test configs'
@@ -798,7 +798,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 92 bld/libcurl.pc
+            pccritic --min-score 99 bld/libcurl.pc
           fi
 
       - name: 'build / ${{ matrix.build }}'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -187,6 +187,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
+            pccritic --version
             pccritic --min-score 97 bld/libcurl.pc
           fi
 
@@ -526,6 +527,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
+            pccritic --version
             pccritic --min-score 93 bld/libcurl.pc
           fi
 
@@ -798,6 +800,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
+            pccritic --version
             pccritic --min-score 93 bld/libcurl.pc
           fi
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -188,7 +188,7 @@ jobs:
           done
           if command -v pccritic >/dev/null 2>&1; then
             pccritic --version
-            pccritic --min-score 97 bld/libcurl.pc
+            pccritic --min-score 98 bld/libcurl.pc
           fi
 
       - name: 'build'
@@ -528,7 +528,7 @@ jobs:
           done
           if command -v pccritic >/dev/null 2>&1; then
             pccritic --version
-            pccritic --min-score 93 bld/libcurl.pc
+            pccritic --min-score 94 bld/libcurl.pc
           fi
 
       - name: 'test configs'
@@ -801,7 +801,7 @@ jobs:
           done
           if command -v pccritic >/dev/null 2>&1; then
             pccritic --version
-            pccritic --min-score 93 bld/libcurl.pc
+            pccritic --min-score 94 bld/libcurl.pc
           fi
 
       - name: 'build / ${{ matrix.build }}'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -793,7 +793,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
+          pccritic --min-score 95 bld/libcurl.pc
 
       - name: 'build / ${{ matrix.build }}'
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -526,7 +526,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 97 bld/libcurl.pc
+            pccritic --min-score 93 bld/libcurl.pc
           fi
 
       - name: 'test configs'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -528,7 +528,7 @@ jobs:
           done
           if command -v pccritic >/dev/null 2>&1; then
             pccritic --version
-            pccritic --min-score 94 bld/libcurl.pc
+            pccritic --min-score 96 bld/libcurl.pc
           fi
 
       - name: 'test configs'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -187,7 +187,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 99 bld/libcurl.pc
+            pccritic --min-score 97 bld/libcurl.pc
           fi
 
       - name: 'build'
@@ -526,7 +526,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 99 bld/libcurl.pc
+            pccritic --min-score 97 bld/libcurl.pc
           fi
 
       - name: 'test configs'
@@ -798,7 +798,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 99 bld/libcurl.pc
+            pccritic --min-score 97 bld/libcurl.pc
           fi
 
       - name: 'build / ${{ matrix.build }}'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -186,7 +186,9 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 92 bld/libcurl.pc
+          if command -v pccritic >/dev/null 2>&1; then
+            pccritic --min-score 92 bld/libcurl.pc
+          fi
 
       - name: 'build'
         run: |
@@ -523,7 +525,9 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 92 bld/libcurl.pc
+          if command -v pccritic >/dev/null 2>&1; then
+            pccritic --min-score 92 bld/libcurl.pc
+          fi
 
       - name: 'test configs'
         run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -186,7 +186,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
+          pccritic --min-score 92 bld/libcurl.pc
 
       - name: 'build'
         run: |
@@ -523,7 +523,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
+          pccritic --min-score 92 bld/libcurl.pc
 
       - name: 'test configs'
         run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true
@@ -793,7 +793,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 95 bld/libcurl.pc
+          pccritic --min-score 92 bld/libcurl.pc
 
       - name: 'build / ${{ matrix.build }}'
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -798,7 +798,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 97 bld/libcurl.pc
+            pccritic --min-score 93 bld/libcurl.pc
           fi
 
       - name: 'build / ${{ matrix.build }}'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -797,7 +797,9 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 92 bld/libcurl.pc
+          if command -v pccritic >/dev/null 2>&1; then
+            pccritic --min-score 92 bld/libcurl.pc
+          fi
 
       - name: 'build / ${{ matrix.build }}'
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -181,7 +181,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
@@ -518,7 +518,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
@@ -788,7 +788,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -329,7 +329,6 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         run: |
@@ -554,7 +553,6 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         run: |

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -189,7 +189,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 99 bld/libcurl.pc
+            pccritic --min-score 97 bld/libcurl.pc
           fi
 
       - name: 'build'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -190,7 +190,7 @@ jobs:
           done
           if command -v pccritic >/dev/null 2>&1; then
             pccritic --version
-            pccritic --min-score 97 bld/libcurl.pc
+            pccritic --min-score 98 bld/libcurl.pc
           fi
 
       - name: 'build'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -188,7 +188,9 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
+          if command -v pccritic >/dev/null 2>&1; then
+            pccritic --min-score 92 bld/libcurl.pc
+          fi
 
       - name: 'build'
         run: |

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -183,7 +183,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
@@ -322,7 +322,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
@@ -426,7 +426,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
@@ -547,7 +547,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -407,16 +407,16 @@ jobs:
         if: ${{ !cancelled() }}
         run: cat bld/config.log bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
 
-      - name: 'dump config files'
-        run: |
-          for f in libcurl.pc curl-config; do
-            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
-          done
-
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
+
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
 
       - name: 'build'
         run: |

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -189,6 +189,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
+            pccritic --version
             pccritic --min-score 97 bld/libcurl.pc
           fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -189,7 +189,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 92 bld/libcurl.pc
+            pccritic --min-score 99 bld/libcurl.pc
           fi
 
       - name: 'build'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -183,6 +183,13 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
+
       - name: 'build'
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
@@ -314,6 +321,13 @@ jobs:
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
+
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         run: |
@@ -532,6 +546,13 @@ jobs:
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
+
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1131,7 +1131,7 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
-      - name: 'libcurl.pc and curl-config'
+      - name: 'libcurl.pc, curl-config'
         run: |
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 92 bld/libcurl.pc
+          pccritic --min-score 99 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 10
@@ -431,7 +431,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 92 bld/libcurl.pc
+            pccritic --min-score 99 bld/libcurl.pc
           fi
 
       - name: 'build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -432,7 +432,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            sed -i.bak 's/\x0d//g' bld/libcurl.pc  # to avoid warning: style/PC061
+            sed -i.bak 's/\x0d//g' bld/libcurl.pc  # to suppress pccritic warning: style/PC061
             pccritic --version
             pccritic --min-score 100 bld/libcurl.pc
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -424,13 +424,13 @@ jobs:
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
-          cat bld/cmake_install.cmake || true
 
       - name: 'libcurl.pc, curl-config, cmake_install.cmake'
         run: |
           for f in libcurl.pc curl-config cmake_install.cmake; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         timeout-minutes: 10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -162,7 +162,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           pccritic --version
-          pccritic --min-score 99 bld/libcurl.pc
+          pccritic --min-score 100 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 10
@@ -433,7 +433,7 @@ jobs:
           done
           if command -v pccritic >/dev/null 2>&1; then
             pccritic --version
-            pccritic --min-score 99 bld/libcurl.pc
+            pccritic --min-score 100 bld/libcurl.pc
           fi
 
       - name: 'build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -432,7 +432,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            dos2unix bld/libcurl.pc  # to avoid warning: style/PC061
+            sed -i.bak 's/\x0d//g' bld/libcurl.pc  # to avoid warning: style/PC061
             pccritic --version
             pccritic --min-score 100 bld/libcurl.pc
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -432,6 +432,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
+            dos2unix bld/libcurl.pc  # to avoid warning: style/PC061
             pccritic --version
             pccritic --min-score 100 bld/libcurl.pc
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 99 bld/libcurl.pc
+          pccritic --min-score 97 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 10
@@ -431,7 +431,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 99 bld/libcurl.pc
+            pccritic --min-score 97 bld/libcurl.pc
           fi
 
       - name: 'build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -105,7 +105,7 @@ jobs:
           # https://cygwin.com/cgi-bin2/package-grep.cgi
           packages: >-
             ${{ matrix.build == 'autotools' && 'autoconf automake libtool make' || 'cmake ninja' }}
-            gcc-core binutils perl
+            gcc-core binutils perl pkgconf
             openssh
             libpsl-devel
             zlib-devel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,6 +161,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         timeout-minutes: 10
@@ -720,6 +721,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         timeout-minutes: 5
@@ -867,6 +869,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         run: |
@@ -1127,6 +1130,13 @@ jobs:
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
+
+      - name: 'libcurl.pc and curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         timeout-minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
+          pccritic --min-score 92 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 10
@@ -430,7 +430,7 @@ jobs:
           for f in libcurl.pc curl-config cmake_install.cmake; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
+          pccritic --min-score 92 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 10
@@ -721,7 +721,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
+          pccritic --min-score 92 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 5
@@ -869,7 +869,6 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         run: |
@@ -1136,7 +1135,6 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic bld/libcurl.pc 2>/dev/null || true
 
       - name: 'build'
         timeout-minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,6 +161,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
+          pccritic --version
           pccritic --min-score 99 bld/libcurl.pc
 
       - name: 'build'
@@ -431,6 +432,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
+            pccritic --version
             pccritic --min-score 99 bld/libcurl.pc
           fi
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,7 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 97 bld/libcurl.pc
+          pccritic --min-score 99 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 10
@@ -431,7 +431,7 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            pccritic --min-score 97 bld/libcurl.pc
+            pccritic --min-score 99 bld/libcurl.pc
           fi
 
       - name: 'build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -430,7 +430,9 @@ jobs:
           for f in libcurl.pc curl-config cmake_install.cmake; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 92 bld/libcurl.pc
+          if command -v pccritic >/dev/null 2>&1; then
+            pccritic --min-score 92 bld/libcurl.pc
+          fi
 
       - name: 'build'
         timeout-minutes: 10
@@ -721,7 +723,6 @@ jobs:
           for f in libcurl.pc curl-config; do
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
-          pccritic --min-score 92 bld/libcurl.pc
 
       - name: 'build'
         timeout-minutes: 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2366,23 +2366,13 @@ if(NOT CURL_DISABLE_INSTALL)
   endif()
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
-    "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY NEWLINE_STYLE LF)
+    "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
   # Strip trailing spaces, duplicate spaces after colon, empty properties
   file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
-  set(_libcurl_pc_prev "${_libcurl_pc}")
   string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
   string(REGEX REPLACE "\nLibs\.private: +" "\nLibs.private: " _libcurl_pc "${_libcurl_pc}")
   string(REGEX REPLACE "\n([A-Za-z.]+:\n)+" "\n" _libcurl_pc "${_libcurl_pc}")
-  if(NOT _libcurl_pc_prev STREQUAL _libcurl_pc)
-    # Terrible hack to enforce LF newlines, unless this would cause a potential accidental macro replacement,
-    # or run into a CMake 3.18 bug and break on '<' characters in the copyright header.
-    if(_libcurl_pc MATCHES "@[A-Za-z0-9_]+@" OR CMAKE_VERSION VERSION_LESS 3.19)
-      file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
-    else()
-      file(CONFIGURE OUTPUT "${PROJECT_BINARY_DIR}/libcurl.pc" CONTENT "${_libcurl_pc}"  # cmake-lint: disable=E1126
-        @ONLY NEWLINE_STYLE LF)
-    endif()
-  endif()
+  file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2341,6 +2341,7 @@ if(NOT CURL_DISABLE_INSTALL)
 
   # Generate a pkg-config file matching this config.
   # Consumed variables:
+  #   CURL_PACKAGE_MAINTAINER
   #   CURLVERSION
   #   exec_prefix
   #   includedir
@@ -2360,6 +2361,9 @@ if(NOT CURL_DISABLE_INSTALL)
   #   https://manpages.debian.org/unstable/pkgconf/pkg-config.1.en.html
   #   https://manpages.debian.org/unstable/pkg-config/pkg-config.1.en.html
   #   https://www.msys2.org/docs/pkgconfig/
+  if(NOT "$ENV{CURL_CI}" STREQUAL "")
+    set(CURL_PACKAGE_MAINTAINER "https://curl.se/")
+  endif()
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
     "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY NEWLINE_STYLE LF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2362,13 +2362,23 @@ if(NOT CURL_DISABLE_INSTALL)
   #   https://www.msys2.org/docs/pkgconfig/
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
-    "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
+    "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY NEWLINE_STYLE LF)
   # Strip trailing spaces, duplicate spaces after colon, empty properties
   file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
+  set(_libcurl_pc_prev "${_libcurl_pc}")
   string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
   string(REGEX REPLACE "\nLibs\.private: +" "\nLibs.private: " _libcurl_pc "${_libcurl_pc}")
   string(REGEX REPLACE "\n([A-Za-z.]+:\n)+" "\n" _libcurl_pc "${_libcurl_pc}")
-  file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
+  if(NOT _libcurl_pc_prev STREQUAL _libcurl_pc)
+    # Terrible hack to enforce LF newlines, unless this would cause a potential accidental macro replacement,
+    # or run into a CMake 3.18 bug and break on '<' characters in the copyright header.
+    if(_libcurl_pc MATCHES "@[A-Za-z0-9_]+@" OR CMAKE_VERSION VERSION_LESS 3.19)
+      file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
+    else()
+      file(CONFIGURE OUTPUT "${PROJECT_BINARY_DIR}/libcurl.pc" CONTENT "${_libcurl_pc}"  # cmake-lint: disable=E1126
+        @ONLY NEWLINE_STYLE LF)
+    endif()
+  endif()
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -89,6 +89,7 @@ if [ -n "${CMAKE_GENERATOR:-}" ]; then
     false
   fi
   echo 'curl_config.h'; grep -F '#define' _bld/lib/curl_config.h | sort || true
+  echo '--- libcurl.pc:'; grep -v '^#' '_bld/libcurl.pc' || true; echo '---'
   time cmake --build _bld --config "${PRJ_CFG}" --parallel 2
   [[ "${CMAKE_GENERATE:-}" != *'-DBUILD_SHARED_LIBS=OFF'* ]] && PATH="$(pwd)/_bld/lib/${PRJ_CFG}:$PATH"
   [[ "${CMAKE_GENERATE:-}" = *'-DCURL_USE_OPENSSL=ON'* ]] && { PATH="${openssl_root}:$PATH"; cp "${openssl_root}"/*.dll "_bld/src/${PRJ_CFG}"; }

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -89,7 +89,7 @@ if [ -n "${CMAKE_GENERATOR:-}" ]; then
     false
   fi
   echo 'curl_config.h'; grep -F '#define' _bld/lib/curl_config.h | sort || true
-  echo '--- libcurl.pc:'; grep -v '^#' '_bld/libcurl.pc' || true; echo '---'
+  echo 'libcurl.pc'; grep -v '^#' '_bld/libcurl.pc' || true
   time cmake --build _bld --config "${PRJ_CFG}" --parallel 2
   [[ "${CMAKE_GENERATE:-}" != *'-DBUILD_SHARED_LIBS=OFF'* ]] && PATH="$(pwd)/_bld/lib/${PRJ_CFG}:$PATH"
   [[ "${CMAKE_GENERATE:-}" = *'-DCURL_USE_OPENSSL=ON'* ]] && { PATH="${openssl_root}:$PATH"; cp "${openssl_root}"/*.dll "_bld/src/${PRJ_CFG}"; }

--- a/configure.ac
+++ b/configure.ac
@@ -5217,6 +5217,11 @@ fi
 AC_SUBST(LIBCURL_PC_REQUIRES)
 AC_SUBST(LIBCURL_PC_LIBS)
 
+if test -n "$CURL_CI"; then
+  CURL_PACKAGE_MAINTAINER=https://curl.se/
+  AC_SUBST(CURL_PACKAGE_MAINTAINER)
+fi
+
 rm "$compilersh"
 
 dnl

--- a/libcurl.pc.in
+++ b/libcurl.pc.in
@@ -33,6 +33,7 @@ Name: libcurl
 URL: https://curl.se/
 Description: Library to transfer files with HTTP, FTP, etc.
 License: curl
+Maintainer: @CURL_PACKAGE_MAINTAINER@
 Version: @CURLVERSION@
 Source: https://curl.se/download/curl-@CURLVERSION@.tar.gz
 Requires: @LIBCURL_PC_REQUIRES@


### PR DESCRIPTION
`pccritic` is available on the latest macOS runner revision (not every
job runs get it yet), Cygwin, MSYS2/mingw-w64 (one job, others will
follow on the next msys2/setup-msys2 Action bump). It will be
automatically used on BSDs, once they start offering it. Missing from
Linux jobs.

Also:
- GHA/windows: convert `libcurl.pc` to Unix newlines to bump score
  96 to 100 in mingw-w64 jobs.
  CMake-specific fix pending in: #22556
- GHA: verify with minimum `pccritic` score 94 to 100 (depending on CI
  job).
- build: fill `Maintainer:` `libcurl.pc` property when run curl CI.

Issues remaining:

macOS:
```
[info    ] Cflags adds an include path already on the default search path (pkgconf strips it): -I/usr/local/include (cflags/PC031)
[info    ] Libs adds a library path already on the default search path (pkgconf strips it): -L/usr/local/lib (libs/PC040)
[minor   ] Libs.private contains an unexpected flag: /Applications/Xcode_26.6.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk/System/Library/Frameworks/GSS.framework (libs/PC041)
```

Windows:
```
[minor   ] file uses CRLF line endings (style/PC061)
```

Ref: #22556
Follow-up to b9254da6175360102176303ecf9dbb5519b0ffcf #22548
Follow-up to 852f5d34da772de65d057897278aa1e75dd060d1 #22553 
Follow-up to 4d9ba9fef48e43903815e0c0e96f917eaf9f185c #22545
Follow-up to 6c7993d4d9f8722a869207f86a31f20fa9e8780d #22536
Follow-up to 3f1c033afe008123680306663cc01279e831ac2d #22519

---

- [x] unfold fixes into separate PRs:
  - #22548
  - #22553
  - #22554
  - #22556
- [x] FIXME (or lower `--min-score` to 60):
  ```
  $ pccritic libcurl.pc
  bld/libcurl.pc
    score: 63/100  grade: D  (0 critical, 0 major, 9 minor, 1 info)
    [minor   ] 'libssh2' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'libidn2' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'openssl' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'zlib' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'libbrotlidec' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'libbrotlicommon' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'libzstd' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'libnghttp2' appears in both Requires and Requires.private (requires/PC051)
    [minor   ] 'libpsl' appears in both Requires and Requires.private (requires/PC051)
    [info    ] missing 'Maintainer:' field; the NTIA SBOM supplier name cannot be determined (sbom/PC070)
  ```
  Ref: 98e5904165859679cd78825bcccb52306ee3bb66 #5373

  pccritic flags the above solution, which, if I understand correctly, is meant to
  work around consumers wanting to link static, but not passing `--static` to
  `pkg-config`. While this is certainly a thing a consumer project can do, I 
  wonder if the fix would rather be for them passing `--static`, instead of
  generating a `libcurl.pc` that behaves like it without this option.

  This solution was later mechanically extended to modules, also in CMake, which
  is the ones flagged by pccritic.

  Unless I'm missing something this is a conflict between this
  solution/workaround and `pccritic`. FWIW there is no way to suppress
  specific issues in `pccritic` (as of 3.0.5).

  A possible alternative may be to omit the `*.private` lines in this
  situation. `pccritic` doesn't complain.

---

Moved to separate PR #22556:

- cmake: fix to save `libcurl.pc` with LF newlines (was: CRLF), to fix `pccritic`.
  Fixing in mingw-w64 job:
  ```
  [minor   ] file uses CRLF line endings (style/PC061)
  ```
  Ref: https://github.com/curl/curl/actions/runs/31511261662/job/93845409075?pr=22543
  CMake makes this very complicated, so also add workarounds for edge
  cases, and leave `libcurl.pc` with CRLF newlines if there is no better alternative.

---

[ Another potential overlinking issue, apparently not flagged, is that
`libcurl.pc` lists both modules and the actual libs they represent. It's
possibly trickier to fix in both AM and CM. It's been reported under an
unrelated issue by Kai Pastor (I don't have the URL at hand). ]
