### PR TITLE
build: strip duplicate spaces after `Libs.private:` in `libcurl.pc`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2365,7 +2365,7 @@ if(NOT CURL_DISABLE_INSTALL)
   # Strip trailing spaces, and duplicate spaces after colon
   file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
   string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
-  string(REGEX REPLACE "^Libs\.private: +" "Libs.private: " _libcurl_pc "${_libcurl_pc}")
+  string(REGEX REPLACE "\nLibs\.private: +" "\nLibs.private: " _libcurl_pc "${_libcurl_pc}")
   file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2362,9 +2362,10 @@ if(NOT CURL_DISABLE_INSTALL)
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
     "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
-  # Strip trailing spaces
+  # Strip trailing spaces, and duplicate spaces after colons
   file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
   string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
+  string(REGEX REPLACE ": +" ": " _libcurl_pc "${_libcurl_pc}")
   file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2362,10 +2362,10 @@ if(NOT CURL_DISABLE_INSTALL)
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
     "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
-  # Strip trailing spaces, and duplicate spaces after colons
+  # Strip trailing spaces, and duplicate spaces after colon
   file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
   string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
-  string(REGEX REPLACE ": +" ": " _libcurl_pc "${_libcurl_pc}")
+  string(REGEX REPLACE "^Libs\.private: +" "Libs.private: " _libcurl_pc "${_libcurl_pc}")
   file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/configure.ac
+++ b/configure.ac
@@ -5559,8 +5559,8 @@ AC_CONFIG_FILES([\
 ])
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
-  dnl strip trailing spaces, and duplicate spaces after colons
-  "$SED" -e 's/ *$//g' -e 's/:  */: /g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
+  dnl strip trailing spaces, and duplicate spaces after colon
+  "$SED" -e 's/ *$//g' -e 's/^Libs\.private:  */Libs.private: /g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
 ], [SED="$SED"])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -5559,8 +5559,8 @@ AC_CONFIG_FILES([\
 ])
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
-  dnl strip trailing spaces
-  "$SED" 's/ *$//g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
+  dnl strip trailing spaces, and duplicate spaces after colons
+  "$SED" -e 's/ *$//g' -e 's/:  */: /g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
 ], [SED="$SED"])
 AC_OUTPUT
 


### PR DESCRIPTION
When `LIBCURL_PC_LDFLAGS_PRIVATE` is empty and `LIBCURL_PC_LIBS_PRIVATE`
is not.

To keep it tidy.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
