### PR TITLE
libcurl.pc: add `License` tag

### DIFF
--- a/libcurl.pc.in
+++ b/libcurl.pc.in
@@ -32,6 +32,7 @@ supported_features="@SUPPORT_FEATURES@"
 Name: libcurl
 URL: https://curl.se/
 Description: Library to transfer files with HTTP, FTP, etc.
+License: curl
 Version: @CURLVERSION@
 Source: https://curl.se/download/curl-@CURLVERSION@.tar.gz
 Requires: @LIBCURL_PC_REQUIRES@


### PR DESCRIPTION
Also to improve `pccritic` score.

Idea-by: Dan Fandrich

Follow-up to 3f1c033afe008123680306663cc01279e831ac2d #22519
Cherry-picked from #22543
