### PR TITLE
getenv: use Unicode API in Windows Unicode builds

### DIFF
--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -162,15 +162,6 @@ Passing in Unicode character with -d:
 
 [curl issue 12231](https://github.com/curl/curl/issues/12231)
 
-Windows Unicode builds use the home directory in current locale.
-
-The Windows Unicode builds of curl use the current locale, but expect Unicode
-UTF-8 encoded paths for internal use such as open, access and stat. The user's
-home directory is retrieved via curl_getenv in the current locale and not as
-UTF-8 encoded Unicode.
-
-See [curl pull request 7252](https://github.com/curl/curl/pull/7252) and [curl pull request 7281](https://github.com/curl/curl/pull/7281)
-
 Cannot handle Unicode arguments in non-Unicode builds on Windows
 
 If a URL or filename cannot be encoded using the user's current code page then

--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -23,6 +23,10 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+#if defined(_WIN32) && defined(UNICODE)
+#include "curlx/multibyte.h"
+#endif
+
 char *curl_getenv(const char *variable)
 {
 #if defined(CURL_WINDOWS_UWP) || \
@@ -32,17 +36,29 @@ char *curl_getenv(const char *variable)
 #elif defined(_WIN32)
   /* This uses Windows API instead of C runtime getenv() to get the environment
      variable since some changes are not always visible to the latter. #4774 */
+#ifdef UNICODE
+  wchar_t *buf = NULL;
+  wchar_t *tmp;
+  wchar_t *name = curlx_convert_UTF8_to_wchar(variable);
+#else
   char *buf = NULL;
   char *tmp;
+  const char *name = variable;
+#endif
+  char *result = NULL;
   DWORD bufsize;
   DWORD rc = 1;
   const DWORD max = 32768; /* max env var size from MSCRT source */
 
+#ifdef UNICODE
+  if(!name)
+    return NULL;
+#endif
+
   for(;;) {
-    tmp = curlx_realloc(buf, rc);
+    tmp = curlx_realloc(buf, rc * sizeof(*buf));
     if(!tmp) {
-      curlx_free(buf);
-      return NULL;
+      break;
     }
 
     buf = tmp;
@@ -50,18 +66,33 @@ char *curl_getenv(const char *variable)
 
     /* it is possible for rc to be 0 if the variable was found but empty.
        Since getenv does not make that distinction we ignore it as well. */
-    rc = GetEnvironmentVariableA(variable, buf, bufsize);
-    if(!rc || rc == bufsize || rc > max) {
-      curlx_free(buf);
-      return NULL;
+#ifdef UNICODE
+    rc = GetEnvironmentVariableW(name, buf, bufsize);
+#else
+    rc = GetEnvironmentVariableA(name, buf, bufsize);
+#endif
+    if(!rc || rc == bufsize || rc > max)
+      break;
+
+    /* if rc < bufsize then rc excludes the terminating null */
+    if(rc < bufsize) {
+#ifdef UNICODE
+      result = curlx_convert_wchar_to_UTF8(buf);
+#else
+      result = buf;
+      buf = NULL;
+#endif
+      break;
     }
 
-    /* if rc < bufsize then rc is bytes written not including null */
-    if(rc < bufsize)
-      return buf;
-
-    /* else rc is bytes needed, try again */
+    /* else rc is characters needed, try again */
   }
+
+  curlx_free(buf);
+#ifdef UNICODE
+  curlx_free(name);
+#endif
+  return result;
 #else
   char *env = getenv(variable);
   return (env && env[0]) ? curlx_strdup(env) : NULL;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -289,7 +289,7 @@ test3223 test3224 test3225 test3226 test3227 test3228 test3229 \
 \
 test3300 test3301 test3302 test3303 test3304 test3305 test3306 \
 \
-test3400 test3401 \
+test3400 test3401 test3402 \
 \
 test4000 test4001 \
 \

--- a/tests/data/test3402
+++ b/tests/data/test3402
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+win32
+environment
+Unicode
+</keywords>
+</info>
+
+<client>
+<features>
+unittest
+win32
+Unicode
+</features>
+<name>
+curl_getenv returns a Windows Unicode environment value as UTF-8
+</name>
+</client>
+</testcase>

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -51,4 +51,4 @@ TESTS_C = \
   unit3211.c unit3212.c unit3213.c unit3214.c            unit3216.c unit3219.c \
   unit3227.c \
   unit3300.c unit3301.c unit3302.c unit3303.c unit3304.c unit3306.c \
-  unit3400.c
+  unit3400.c unit3402.c

--- a/tests/unit/unit3402.c
+++ b/tests/unit/unit3402.c
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "unitcheck.h"
+
+static CURLcode test_unit3402(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+
+#if defined(_WIN32) && defined(UNICODE)
+  static const wchar_t name_w[] = L"CURL_UNITTEST_GETENV";
+  static const wchar_t value_w[] = L"curl-\x6f22\x5b57";
+  static const char value_utf8[] =
+    "curl-\xe6\xbc\xa2\xe5\xad\x97";
+  char *value;
+
+  fail_unless(SetEnvironmentVariableW(name_w, value_w),
+              "failed to set Unicode environment value");
+
+  value = curl_getenv("CURL_UNITTEST_GETENV");
+  fail_unless(value, "curl_getenv returned NULL");
+  if(value) {
+    fail_unless(!strcmp(value, value_utf8),
+                "curl_getenv did not return UTF-8");
+    curl_free(value);
+  }
+
+  fail_unless(SetEnvironmentVariableW(name_w, NULL),
+              "failed to remove environment value");
+#endif
+
+  UNITTEST_END_SIMPLE
+}


### PR DESCRIPTION
Use GetEnvironmentVariableW in Windows Unicode builds and convert the returned value to UTF-8. Keep GetEnvironmentVariableA unchanged for non-Unicode builds.

This allows paths obtained through curl_getenv, including CURL_HOME, to contain characters outside the active Windows code page. Remove the corresponding entry from KNOWN_BUGS and add a Windows Unicode unit test.

Verified with MinGW 32-bit and 64-bit builds, checksrc, a native Windows 11 unit test, and loading the default config from a CURL_HOME path containing Unicode characters.