### PR TITLE
tool: find curlrc in Unicode home on Windows

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -229,7 +229,8 @@ static CURLcode ssh_setopts(struct OperationConfig *config, CURL *curl,
   if(!config->insecure_ok) {
     char *known = config->knownhosts;
     if(!known) {
-      char *found = findfile(".ssh/known_hosts", FALSE);
+      /* the path goes to libssh2/libssh, which expect the current locale */
+      char *found = findfile(".ssh/known_hosts", FALSE, FALSE);
       if(found) {
         known = curlx_strdup(found);
         curl_free(found);

--- a/src/tool_findfile.c
+++ b/src/tool_findfile.c
@@ -60,6 +60,53 @@ static const struct finder conf_list[] = {
   { NULL, NULL, FALSE }
 };
 
+static char *findfile_getenv(const char *variable, bool utf8env)
+{
+#if defined(_WIN32) && defined(UNICODE)
+  wchar_t *name;
+  wchar_t *buf = NULL;
+  char *value = NULL;
+  DWORD size;
+
+  if(!utf8env)
+    return curl_getenv(variable);
+
+  name = curlx_convert_UTF8_to_wchar(variable);
+  if(!name)
+    return NULL;
+
+  size = GetEnvironmentVariableW(name, NULL, 0);
+  while(size) {
+    wchar_t *tmp;
+    DWORD rc;
+
+    if(size > 32768)
+      break;
+
+    tmp = curlx_realloc(buf, size * sizeof(*buf));
+    if(!tmp)
+      break;
+    buf = tmp;
+
+    rc = GetEnvironmentVariableW(name, buf, size);
+    if(!rc)
+      break;
+    if(rc < size) {
+      value = curlx_convert_wchar_to_UTF8(buf);
+      break;
+    }
+    size = rc;
+  }
+
+  curlx_free(buf);
+  curlx_free(name);
+  return value;
+#else
+  (void)utf8env;
+  return curl_getenv(variable);
+#endif
+}
+
 static char *checkhome(const char *home, const char *fname, bool dotscore)
 {
   static const char pref[2] = { '.', '_' };
@@ -95,7 +142,7 @@ static char *checkhome(const char *home, const char *fname, bool dotscore)
  *    the given file to be accessed there, then it is a match.
  * 2. Non-Windows: try getpwuid
  */
-char *findfile(const char *fname, int dotscore)
+char *findfile(const char *fname, int dotscore, bool utf8env)
 {
   int i;
   DEBUGASSERT(fname && fname[0]);
@@ -105,7 +152,7 @@ char *findfile(const char *fname, int dotscore)
     return NULL;
 
   for(i = 0; conf_list[i].env; i++) {
-    char *home = curl_getenv(conf_list[i].env);
+    char *home = findfile_getenv(conf_list[i].env, utf8env);
     if(home) {
       char *path;
       const char *filename = fname;

--- a/src/tool_findfile.h
+++ b/src/tool_findfile.h
@@ -31,6 +31,10 @@
 #define CURLRC_DOTSCORE 1 /* regular .curlrc check */
 #endif
 
-char *findfile(const char *fname, int dotscore);
+/* 'utf8env' should be TRUE when the returned path is consumed by the curlx_*
+   file functions, which expect UTF-8 in Windows Unicode builds, and FALSE
+   when the path is handed to a third-party library that expects it in the
+   current locale. */
+char *findfile(const char *fname, int dotscore, bool utf8env);
 
 #endif /* HEADER_CURL_TOOL_HOMEDIR_H */

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -92,7 +92,8 @@ static FILE *open_config_file(const char *filename,
 
   if(!filename) {
     /* NULL means load .curlrc from homedir! */
-    char *curlrc = findfile(".curlrc", CURLRC_DOTSCORE);
+    /* the path goes to curlx_fopen(), which expects UTF-8 */
+    char *curlrc = findfile(".curlrc", CURLRC_DOTSCORE, TRUE);
     if(curlrc) {
       file = curlx_fopen(curlrc, FOPEN_READTEXT);
       if(!file) {

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -289,7 +289,7 @@ test3223 test3224 test3225 test3226 test3227 test3228 test3229 \
 \
 test3300 test3301 test3302 test3303 test3304 test3305 test3306 \
 \
-test3400 test3401 \
+test3400 test3401 test3402 \
 \
 test4000 test4001 \
 \

--- a/tests/data/test3402
+++ b/tests/data/test3402
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+unittest
+</features>
+<name>
+unit test for findfile() with a Unicode home directory
+</name>
+<tool>
+tool%TESTNUMBER
+</tool>
+</client>
+
+<verify>
+<stdout mode="text">
+</stdout>
+</verify>
+</testcase>

--- a/tests/tunit/Makefile.inc
+++ b/tests/tunit/Makefile.inc
@@ -35,4 +35,5 @@ TESTS_C = \
   tool1621.c \
   tool1622.c \
   tool1623.c \
-  tool1720.c
+  tool1720.c \
+  tool3402.c

--- a/tests/tunit/tool3402.c
+++ b/tests/tunit/tool3402.c
@@ -1,0 +1,71 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+#include "tool_findfile.h"
+
+static CURLcode test_tool3402(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+
+#if defined(_WIN32) && defined(UNICODE)
+  static const wchar_t dirname_w[] = L"curl-home-\x6f22\x5b57";
+  static const wchar_t filename_w[] =
+    L"curl-home-\x6f22\x5b57\\_curlrc";
+  static const char expected[] =
+    "curl-home-\xe6\xbc\xa2\xe5\xad\x97\\_curlrc";
+  FILE *file;
+  char *path;
+
+  (void)DeleteFileW(filename_w);
+  (void)RemoveDirectoryW(dirname_w);
+
+  fail_unless(CreateDirectoryW(dirname_w, NULL),
+              "failed to create Unicode directory");
+
+  file = curlx_fopen(expected, "wb");
+  fail_unless(file,
+              "failed to create Unicode config file");
+  if(file)
+    curlx_fclose(file);
+
+  fail_unless(SetEnvironmentVariableW(L"CURL_HOME", dirname_w),
+              "failed to set Unicode CURL_HOME");
+
+  path = findfile(".curlrc", CURLRC_DOTSCORE, TRUE);
+  fail_unless(path, "findfile did not find the Unicode config path");
+  if(path) {
+    fail_unless(!strcmp(path, expected),
+                "findfile did not return the UTF-8 config path");
+    curlx_free(path);
+  }
+
+  (void)SetEnvironmentVariableW(L"CURL_HOME", NULL);
+  (void)DeleteFileW(filename_w);
+  (void)RemoveDirectoryW(dirname_w);
+#else
+  curl_mfprintf(stderr, "Skipped test not for Windows Unicode builds\n");
+#endif
+
+  UNITTEST_END_SIMPLE
+}


### PR DESCRIPTION
Read the home-directory environment variables with the Windows Unicode API when the Unicode curl tool searches for its default config file. Convert only those directory values to UTF-8 before using curl's existing UTF-8-aware file functions.

This keeps curl_getenv and its encoding behavior unchanged for libcurl and third-party library callers.

Add a tool unit test that creates `_curlrc` under a Unicode CURL_HOME path. The test fails before this change and passes afterward in a native Windows 11 Unicode build.

Verified with 32-bit and 64-bit MinGW builds, a MinGW Unicode debug build, checksrc, and the native Windows 11 regression test.