### PR TITLE
headers: name the arguments the way the definitions name them

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1373,13 +1373,15 @@ extern FILE *curl_dbg_logfile;
 /* memory functions */
 CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC ALLOC_SIZE(1)
-  void *curl_dbg_malloc(size_t size, int line, const char *source);
+  void *curl_dbg_malloc(size_t wantedsize, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC ALLOC_SIZE2(1, 2)
-  void *curl_dbg_calloc(size_t n, size_t size, int line, const char *source);
+  void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
+                        int line, const char *source);
 CURL_EXTERN ALLOC_SIZE(2)
-  void *curl_dbg_realloc(void *ptr, size_t size, int line, const char *source);
+  void *curl_dbg_realloc(void *ptr, size_t wantedsize, int line,
+                         const char *source);
 CURL_EXTERN ALLOC_FUNC
-  char *curl_dbg_strdup(const char *str, int line, const char *src);
+  char *curl_dbg_strdup(const char *str, int line, const char *source);
 #if defined(_WIN32) && defined(UNICODE)
 CURL_EXTERN ALLOC_FUNC
   wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source);

--- a/lib/fake_addrinfo.h
+++ b/lib/fake_addrinfo.h
@@ -43,7 +43,7 @@
 #  include <arpa/inet.h>
 #endif
 
-void r_freeaddrinfo(struct addrinfo *res);
+void r_freeaddrinfo(struct addrinfo *cahead);
 int r_getaddrinfo(const char *node,
                   const char *service,
                   const struct addrinfo *hints,

--- a/projects/OS400/ccsidcurl.c
+++ b/projects/OS400/ccsidcurl.c
@@ -1018,7 +1018,7 @@ int curl_formget_ccsid(struct curl_httppost *form, void *arg,
   return curl_formget(form, (void *)&lcfc, Curl_formget_callback_ccsid);
 }
 
-CURLcode curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...)
+CURLcode curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
 {
   CURLcode result;
   va_list arg;
@@ -1026,7 +1026,7 @@ CURLcode curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...)
   char *cp = NULL;
   unsigned int ccsid;
   curl_off_t pfsize;
-  struct Curl_easy *data = easy;
+  struct Curl_easy *data = curl;
 
   va_start(arg, tag);
 

--- a/projects/OS400/ccsidcurl.c
+++ b/projects/OS400/ccsidcurl.c
@@ -1143,7 +1143,7 @@ CURLcode curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
       }
     }
 
-    result = curl_easy_setopt(easy, tag, s);
+    result = curl_easy_setopt(curl, tag, s);
     free(s);
     break;
 
@@ -1157,7 +1157,7 @@ CURLcode curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
     pfsize = data->set.postfieldsize;
 
     if(!s || !pfsize || ccsid == NOCONV_CCSID || ccsid == ASCII_CCSID) {
-      result = curl_easy_setopt(easy, CURLOPT_COPYPOSTFIELDS, s);
+      result = curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, s);
       break;
     }
 
@@ -1204,7 +1204,7 @@ CURLcode curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
       cp = NULL;
     }
 
-    result = curl_easy_setopt(easy, CURLOPT_POSTFIELDS, s);
+    result = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, s);
     data->set.str[STRING_COPYPOSTFIELDS] = s; /* Give to library. */
     break;
 
@@ -1241,12 +1241,12 @@ CURLcode curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...)
         blob.flags = bp->flags | CURL_BLOB_COPY;
         bp = &blob;
       }
-      result = curl_easy_setopt(easy, tag, bp);
+      result = curl_easy_setopt(curl, tag, bp);
       break;
     }
     FALLTHROUGH();
   case CURLOPT_ERRORBUFFER: /* This is an output buffer. */
-    result = Curl_vsetopt(easy, tag, arg);
+    result = Curl_vsetopt(curl, tag, arg);
     break;
   }
 

--- a/projects/OS400/ccsidcurl.h
+++ b/projects/OS400/ccsidcurl.h
@@ -37,13 +37,13 @@ CURL_EXTERN char *curl_easy_unescape_ccsid(CURL *handle, const char *string,
                                            int length, int *outlength,
                                            unsigned int sccsid,
                                            unsigned int dccsid);
-CURL_EXTERN struct curl_slist *curl_slist_append_ccsid(struct curl_slist *l,
+CURL_EXTERN struct curl_slist *curl_slist_append_ccsid(struct curl_slist *list,
                                                        const char *data,
                                                        unsigned int ccsid);
 CURL_EXTERN time_t curl_getdate_ccsid(const char *p, const time_t *unused,
                                       unsigned int ccsid);
-CURL_EXTERN curl_version_info_data *curl_version_info_ccsid(CURLversion stamp,
-                                                            unsigned int cid);
+CURL_EXTERN curl_version_info_data *
+curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid);
 CURL_EXTERN const char *curl_easy_strerror_ccsid(CURLcode error,
                                                  unsigned int ccsid);
 CURL_EXTERN const char *curl_share_strerror_ccsid(CURLSHcode error,
@@ -58,7 +58,7 @@ CURL_EXTERN char *curl_form_long_value(long value);
 CURL_EXTERN int curl_formget_ccsid(struct curl_httppost *form, void *arg,
                                    curl_formget_callback append,
                                    unsigned int ccsid);
-CURL_EXTERN CURLcode curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...);
+CURL_EXTERN CURLcode curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...);
 CURL_EXTERN void curl_certinfo_free_all(struct curl_certinfo *info);
 CURL_EXTERN char *curl_pushheader_bynum_cssid(struct curl_pushheaders *h,
                                               size_t num, unsigned int ccsid);

--- a/projects/OS400/ccsidcurl.h
+++ b/projects/OS400/ccsidcurl.h
@@ -42,8 +42,9 @@ CURL_EXTERN struct curl_slist *curl_slist_append_ccsid(struct curl_slist *list,
                                                        unsigned int ccsid);
 CURL_EXTERN time_t curl_getdate_ccsid(const char *p, const time_t *unused,
                                       unsigned int ccsid);
-CURL_EXTERN curl_version_info_data *
-curl_version_info_ccsid(CURLversion stamp, unsigned int ccsid);
+CURL_EXTERN curl_version_info_data *curl_version_info_ccsid(
+  CURLversion stamp,
+  unsigned int ccsid);
 CURL_EXTERN const char *curl_easy_strerror_ccsid(CURLcode error,
                                                  unsigned int ccsid);
 CURL_EXTERN const char *curl_share_strerror_ccsid(CURLSHcode error,
@@ -58,7 +59,7 @@ CURL_EXTERN char *curl_form_long_value(long value);
 CURL_EXTERN int curl_formget_ccsid(struct curl_httppost *form, void *arg,
                                    curl_formget_callback append,
                                    unsigned int ccsid);
-CURL_EXTERN CURLcode curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...);
+CURL_EXTERN CURLcode curl_easy_setopt_ccsid(CURL *curl, CURLoption tag, ...);
 CURL_EXTERN void curl_certinfo_free_all(struct curl_certinfo *info);
 CURL_EXTERN char *curl_pushheader_bynum_cssid(struct curl_pushheaders *h,
                                               size_t num, unsigned int ccsid);

--- a/src/tool_parsecfg.h
+++ b/src/tool_parsecfg.h
@@ -29,6 +29,6 @@
 #define CONFIG_MAX_LEVELS 5
 ParameterError parseconfig(const char *filename, int max_recursive,
                            char **resolved);
-bool my_get_line(FILE *fp, struct dynbuf *db, bool *error);
+bool my_get_line(FILE *input, struct dynbuf *buf, bool *error);
 
 #endif /* HEADER_CURL_TOOL_PARSECFG_H */


### PR DESCRIPTION
so, eleven arguments are named one way in the header and another in the definition. the compiler only checks types so nothing is broken, but the header is what people read first, and then the name changes under them in the source

```
curl_dbg_malloc          size     ->  wantedsize
curl_dbg_calloc          n, size  ->  wanted_elements, wanted_size
curl_dbg_realloc         size     ->  wantedsize
curl_dbg_strdup          src      ->  source
r_freeaddrinfo           res      ->  cahead
my_get_line              fp, db   ->  input, buf
curl_slist_append_ccsid  l        ->  list
curl_version_info_ccsid  cid      ->  ccsid
curl_easy_setopt_ccsid   curl     ->  easy
```

only the declarations move, the code is untouched. happy to flip any of them the other way if you prefer the header name

oh and one line in ccsidcurl.h had to be rewrapped to stay under 79 columns after the rename. checksrc is clean

btw found with a checker I wrote with the help of Claude Opus 5, which pairs every prototype with its own definition. I read each of these in the source before touching it
