### PR TITLE
build: strip empty properties from `libcurl.pc`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -156,6 +156,12 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'libcurl.pc, curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+
       - name: 'build'
         timeout-minutes: 10
         run: |
@@ -418,6 +424,12 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
           cat bld/cmake_install.cmake || true
+
+      - name: 'libcurl.pc, curl-config, cmake_install.cmake'
+        run: |
+          for f in libcurl.pc curl-config cmake_install.cmake; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
 
       - name: 'build'
         timeout-minutes: 10
@@ -703,6 +715,12 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'libcurl.pc, curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
+
       - name: 'build'
         timeout-minutes: 5
         run: |
@@ -843,6 +861,12 @@ jobs:
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
+
+      - name: 'libcurl.pc, curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
 
       - name: 'build'
         run: |
@@ -1107,6 +1131,12 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5
+
+      - name: 'libcurl.pc, curl-config'
+        run: |
+          for f in libcurl.pc curl-config; do
+            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
+          done
 
       - name: 'curl -V'
         timeout-minutes: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2363,10 +2363,11 @@ if(NOT CURL_DISABLE_INSTALL)
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
     "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
-  # Strip trailing spaces, and duplicate spaces after colon
+  # Strip trailing spaces, duplicate spaces after colon, empty properties
   file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
   string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
   string(REGEX REPLACE "\nLibs\.private: +" "\nLibs.private: " _libcurl_pc "${_libcurl_pc}")
+  string(REGEX REPLACE "\n([A-Za-z.]+:\n)+" "\n" _libcurl_pc "${_libcurl_pc}")
   file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/configure.ac
+++ b/configure.ac
@@ -5560,8 +5560,8 @@ AC_CONFIG_FILES([\
 ])
 AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_CONFIG_FILES([libcurl.pc], [
-  dnl strip trailing spaces, and duplicate spaces after colon
-  "$SED" -e 's/ *$//g' -e 's/^Libs\.private:  */Libs.private: /g' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
+  dnl strip trailing spaces, duplicate spaces after colon, empty properties
+  "$SED" -e 's/ *$//g' -e 's/^Libs\.private:  */Libs.private: /' -e '/^@<:@A-Za-z.@:>@*:$/d' libcurl.pc > libcurl.pc.tmp && mv libcurl.pc.tmp libcurl.pc
 ], [SED="$SED"])
 AC_OUTPUT
 


### PR DESCRIPTION
To keep it tidy and to support properties in the template that only
appear in the generated `libcurl.pc` when filled.

E.g. `Required.private` may remain empty after #22548.

Also:
- GHA/windows: dump `libcurl.pc` to log in every job
- tidy up a pre-existing regex in the updated command.
  2c22d3069aef507d6a6876a6d20616fe5e50c6a3 #22544

Ref: b9254da6175360102176303ecf9dbb5519b0ffcf #22548
Cherry-picked from #22543
