### PR TITLE
thrdqueue: drop name strdups from Curl_thrdq_create

### DIFF
--- a/lib/thrdpool.c
+++ b/lib/thrdpool.c
@@ -311,6 +311,7 @@ CURLcode Curl_thrdpool_create(struct curl_thrdpool **ptpool,
 {
   struct curl_thrdpool *tpool;
   CURLcode result = CURLE_OUT_OF_MEMORY;
+  DEBUGASSERT(name);
 
   tpool = curlx_calloc(1, sizeof(*tpool));
   if(!tpool)

--- a/lib/thrdpool.c
+++ b/lib/thrdpool.c
@@ -50,7 +50,7 @@ struct thrdslot {
 };
 
 struct curl_thrdpool {
-  char *name;
+  const char *name;
   uint64_t refcount;
   curl_mutex_t lock;
   curl_cond_t await;
@@ -236,7 +236,6 @@ static bool thrdpool_unlink(struct curl_thrdpool *tpool, bool locked)
   thrdpool_join_zombies(tpool);
   if(locked)
     Curl_mutex_release(&tpool->lock);
-  curlx_free(tpool->name);
   Curl_cond_destroy(&tpool->await);
   Curl_mutex_destroy(&tpool->lock);
   curlx_free(tpool);
@@ -327,9 +326,8 @@ CURLcode Curl_thrdpool_create(struct curl_thrdpool **ptpool,
   tpool->fn_return = fn_return;
   tpool->fn_user_data = user_data;
 
-  tpool->name = curlx_strdup(name);
-  if(!tpool->name)
-    goto out;
+  /* a const string that remains */
+  tpool->name = name;
 
 #ifdef DEBUGBUILD
   {

--- a/lib/thrdqueue.c
+++ b/lib/thrdqueue.c
@@ -206,6 +206,7 @@ CURLcode Curl_thrdq_create(struct curl_thrdq **ptqueue,
 {
   struct curl_thrdq *tqueue;
   CURLcode result = CURLE_OUT_OF_MEMORY;
+  DEBUGASSERT(name);
 
   tqueue = curlx_calloc(1, sizeof(*tqueue));
   if(!tqueue)

--- a/lib/thrdqueue.c
+++ b/lib/thrdqueue.c
@@ -37,7 +37,7 @@
 
 
 struct curl_thrdq {
-  char *name;
+  const char *name;
   curl_mutex_t lock;
   curl_cond_t await;
   struct Curl_llist sendq;
@@ -187,7 +187,6 @@ static void thrdq_unlink(struct curl_thrdq *tqueue, bool locked, bool join)
 
   Curl_llist_destroy(&tqueue->sendq, NULL);
   Curl_llist_destroy(&tqueue->recvq, NULL);
-  curlx_free(tqueue->name);
   Curl_cond_destroy(&tqueue->await);
   if(locked)
     Curl_mutex_release(&tqueue->lock);
@@ -221,9 +220,8 @@ CURLcode Curl_thrdq_create(struct curl_thrdq **ptqueue,
   tqueue->fn_event = fn_event;
   tqueue->fn_user_data = user_data;
 
-  tqueue->name = curlx_strdup(name);
-  if(!tqueue->name)
-    goto out;
+  /* a const string that remains */
+  tqueue->name = name;
 
   result = Curl_thrdpool_create(&tqueue->tpool, name,
                                 min_threads, max_threads, idle_time_ms,


### PR DESCRIPTION
The only usage of the thread queue and pool is for "DNS" which is a static string. No point in strdup'ing it (twice). Future users are *likely* to also use fixed strings, otherwise we revert this change when dynamic names are introduced.

Reported-by: Max Dymond
