### PR TITLE
cmake: generate `libcurl.pc` with LF newlines on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -432,7 +432,6 @@ jobs:
             echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
           done
           if command -v pccritic >/dev/null 2>&1; then
-            sed -i.bak 's/\x0d//g' bld/libcurl.pc  # to suppress pccritic warning: style/PC061
             pccritic --version
             pccritic --min-score 100 bld/libcurl.pc
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2376,7 +2376,7 @@ if(NOT CURL_DISABLE_INSTALL)
   if(NOT _libcurl_pc_prev STREQUAL _libcurl_pc)
     # Terrible hack to enforce LF newlines, unless this would cause a potential accidental macro replacement,
     # or run into a CMake 3.18 bug and break on '<' characters in the copyright header.
-    if(_libcurl_pc MATCHES "@[A-Za-z0-9_]+@" OR CMAKE_VERSION VERSION_LESS 3.19)
+    if(_libcurl_pc MATCHES "@[A-Za-z0-9_/.+-]+@" OR CMAKE_VERSION VERSION_LESS 3.19)
       file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
     else()
       file(CONFIGURE OUTPUT "${PROJECT_BINARY_DIR}/libcurl.pc" CONTENT "${_libcurl_pc}"  # cmake-lint: disable=E1126

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2366,13 +2366,23 @@ if(NOT CURL_DISABLE_INSTALL)
   endif()
   configure_file(
     "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
-    "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
+    "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY NEWLINE_STYLE LF)
   # Strip trailing spaces, duplicate spaces after colon, empty properties
   file(READ "${PROJECT_BINARY_DIR}/libcurl.pc" _libcurl_pc)
+  set(_libcurl_pc_prev "${_libcurl_pc}")
   string(REGEX REPLACE " +\n" "\n" _libcurl_pc "${_libcurl_pc}")
   string(REGEX REPLACE "\nLibs\.private: +" "\nLibs.private: " _libcurl_pc "${_libcurl_pc}")
   string(REGEX REPLACE "\n([A-Za-z.]+:\n)+" "\n" _libcurl_pc "${_libcurl_pc}")
-  file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
+  if(NOT _libcurl_pc_prev STREQUAL _libcurl_pc)
+    # Terrible hack to enforce LF newlines, unless this would cause a potential accidental macro replacement,
+    # or run into a CMake 3.18 bug and break on '<' characters in the copyright header.
+    if(_libcurl_pc MATCHES "@[A-Za-z0-9_]+@" OR CMAKE_VERSION VERSION_LESS 3.19)
+      file(WRITE "${PROJECT_BINARY_DIR}/libcurl.pc" "${_libcurl_pc}")
+    else()
+      file(CONFIGURE OUTPUT "${PROJECT_BINARY_DIR}/libcurl.pc" CONTENT "${_libcurl_pc}"  # cmake-lint: disable=E1126
+        @ONLY NEWLINE_STYLE LF)
+    endif()
+  endif()
   install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 


### PR DESCRIPTION
Saving the file with LF is easy, but the post-processing needs reading
it back to memory and saving it back again with `file(WRITE)`. Turns out
`file(WRITE)` doesn't support specifying newline style. Use
`file(CONFIGURE)` as a workaround, if post-processing changes the
content, and exclude it for cases where `file(CONFIGURE)` is buggy
(CMake 3.18) or could result in undesired output (when the content has
`@<name>@` strings in it).

I'm not sure why `pccritic` is unhappy with `.pc` having CRLF newlines,
when these caused an issue that we know of. But it also does not support
suppressing warnings.

configure may also be affected, though the case is no hit in curl CI.

Fixing `pccritic`-flagged issue, e.g. in mingw-w64 jobs:
```
[minor   ] file uses CRLF line endings (style/PC061)
```
Ref: https://github.com/curl/curl/actions/runs/31511261662/job/93845409075?pr=22543

Also:
- GHA/windows: drop workaround from CI job.
- silence cmake-lint false positive.

Refs:
https://github.com/curl/curl/pull/22543#issuecomment-5258074162
https://cmake.org/cmake/help/v4.4/command/file.html#configure
https://gitlab.kitware.com/cmake/cmake/-/work_items/23614
https://gitlab.kitware.com/cmake/cmake/-/work_items/22249
https://github.com/pkgconf/pkgconf/commit/a0065165c46cbea346a7bf47ba149208576ba29f

Follow-up to 943ac04fc4d7d554d9064c7cd03fbe1830ff25d4 #22543
Cherry-picked from #22543

---

https://github.com/curl/curl/pull/22556/files?w=1

- [x] another solution may be to try converting to LF newlines before
  calling `pccritic`, and drop this terrible mess of a chain of bugs and
  workarounds, and possibly report it to the `pkgconf` project to
  reconsider the requirement. → Already merged in master, this PR
  is optional and replaces the CI job-specific workaround.
