### PR TITLE
tidy-up: C and CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -423,7 +423,7 @@ jobs:
             install_packages: clang-22
             install_steps: randcurl
             CC: clang-22
-            CFLAGS: -fsanitize=memory -Wformat -Werror=format-security -Werror=array-bounds -g
+            CFLAGS: -fsanitize=memory -Wformat -Werror=format-security -Werror=array-bounds
             LDFLAGS: -fsanitize=memory
             LIBS: -ldl
             configure: --without-ssl --without-zlib --without-brotli --without-zstd --without-libpsl --without-nghttp2 --enable-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1806,7 +1806,7 @@ if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
   # On non-Windows and not cross-compiling, check for writable argv[]
   include(CheckCSourceRuns)
   check_c_source_runs("
-    int main(int argc, char **argv)
+    int main(int argc, char *argv[])
     {
       (void)argc;
       argv[0][0] = ' ';

--- a/configure.ac
+++ b/configure.ac
@@ -1841,7 +1841,7 @@ dnl **********************************************************************
 
 AC_MSG_CHECKING([if argv can be written to])
 CURL_RUN_IFELSE([[
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
 #ifdef _WIN32
   /* on Windows, writing to the argv does not hide the argument in

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -88,7 +88,7 @@ static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
   return nread;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURL *curl;
   CURLcode result;

--- a/docs/examples/ftp-wildcard.c
+++ b/docs/examples/ftp-wildcard.c
@@ -97,7 +97,7 @@ static size_t write_cb(char *buff, size_t size, size_t nmemb, void *cb_data)
   return written;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   /* curl easy handle */
   CURL *curl;

--- a/docs/examples/htmltidy.c
+++ b/docs/examples/htmltidy.c
@@ -74,7 +74,7 @@ static void dumpNode(TidyDoc doc, TidyNode tnod, int indent)
   }
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURL *curl;
   char curl_errbuf[CURL_ERROR_SIZE];

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -187,7 +187,7 @@ static int setup(struct transfer *t, int num)
 /*
  * Download many transfers over HTTP/2, using the same connection!
  */
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURLcode result;
   struct transfer *trans;

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -67,8 +67,7 @@
 #endif
 
 #ifdef _MSC_VER
-#define gettimeofday(a, b) my_gettimeofday(a, b)
-static int my_gettimeofday(struct timeval *tp, void *tzp)
+static int gettimeofday(struct timeval *tp, void *tzp)
 {
   (void)tzp;
   if(tp) {

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -76,10 +76,10 @@ static int gettimeofday(struct timeval *tp, void *tzp)
     union {
       CURL_TYPEOF_CURL_OFF_T ns100; /* time since 1 Jan 1601 in 100ns units */
       FILETIME ft;
-    } _now;
-    GetSystemTimeAsFileTime(&_now.ft);
-    tp->tv_usec = (long)((_now.ns100 / 10) % 1000000);
-    tp->tv_sec = (long)((_now.ns100 - WIN32_FT_OFFSET) / 10000000);
+    } now;
+    GetSystemTimeAsFileTime(&now.ft);
+    tp->tv_usec = (long)((now.ns100 / 10) % 1000000);
+    tp->tv_sec = (long)((now.ns100 - WIN32_FT_OFFSET) / 10000000);
   }
   return 0;
 }

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -71,15 +71,14 @@ static int gettimeofday(struct timeval *tp, void *tzp)
 {
   (void)tzp;
   if(tp) {
-/* Offset between 1601-01-01 and 1970-01-01 in 100 nanosec units */
-#define WIN32_FT_OFFSET 116444736000000000
     union {
       CURL_TYPEOF_CURL_OFF_T ns100; /* time since 1 Jan 1601 in 100ns units */
       FILETIME ft;
     } now;
     GetSystemTimeAsFileTime(&now.ft);
     tp->tv_usec = (long)((now.ns100 / 10) % 1000000);
-    tp->tv_sec = (long)((now.ns100 - WIN32_FT_OFFSET) / 10000000);
+    /* subtract offset between 1601-01-01 and 1970-01-01 in 100ns units */
+    tp->tv_sec = (long)((now.ns100 - 116444736000000000) / 10000000);
   }
   return 0;
 }

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -285,7 +285,7 @@ static int setup(struct input *t, int num, const char *upload)
 /*
  * Upload all files over HTTP/2, using the same physical connection!
  */
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURLcode result;
   struct input *trans;

--- a/docs/examples/httpput-postfields.c
+++ b/docs/examples/httpput-postfields.c
@@ -47,7 +47,7 @@ static const char olivertwist[] =
  * CURLOPT_POSTFIELDS to the URL given as an argument.
  */
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURL *curl;
   CURLcode result;

--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -73,7 +73,7 @@ static size_t read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
   return retcode;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURL *curl;
   CURLcode result;

--- a/docs/examples/multi-event.c
+++ b/docs/examples/multi-event.c
@@ -211,7 +211,7 @@ static int handle_socket(CURL *curl, curl_socket_t s, int action, void *userp,
   return 0;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURLcode result;
 

--- a/docs/examples/multi-uv.c
+++ b/docs/examples/multi-uv.c
@@ -225,7 +225,7 @@ static int cb_socket(CURL *curl, curl_socket_t s, int action,
   return 0;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   CURLcode result;
   struct datauv uv = { 0 };

--- a/docs/examples/smooth-gtk-thread.c
+++ b/docs/examples/smooth-gtk-thread.c
@@ -165,7 +165,7 @@ static gboolean cb_delete(GtkWidget *window, gpointer data)
   return FALSE;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   GtkWidget *top_window, *outside_frame, *inside_frame, *progress_bar;
 

--- a/docs/examples/sslbackend.c
+++ b/docs/examples/sslbackend.c
@@ -40,7 +40,7 @@
  *  **** This example only works with libcurl 7.56.0 and later! ****
  */
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   const char *name = argc > 1 ? argv[1] : "openssl";
   CURLsslset result;

--- a/docs/internals/CODE_STYLE.md
+++ b/docs/internals/CODE_STYLE.md
@@ -104,7 +104,7 @@ if(!x)
 For functions the opening brace should be on a separate line:
 
 ```c
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   return 1;
 }

--- a/docs/libcurl/curl_strequal.md
+++ b/docs/libcurl/curl_strequal.md
@@ -44,7 +44,7 @@ string comparison functions. This function works on all platforms.
 # EXAMPLE
 
 ~~~c
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   const char *name = "compare";
   if(curl_strequal(name, argv[1]))

--- a/docs/libcurl/curl_strnequal.md
+++ b/docs/libcurl/curl_strnequal.md
@@ -47,7 +47,7 @@ string comparison functions. This function works on all platforms.
 # EXAMPLE
 
 ~~~c
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   const char *name = "compare";
   if(curl_strnequal(name, argv[1], 5))

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -140,7 +140,7 @@ static size_t wf(char *ptr, size_t size, size_t nmemb, void *stream)
   return size * nmemb;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   CURLcode result;
   curl = curl_easy_init();

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
@@ -82,7 +82,7 @@ All protocols built-in.
 # EXAMPLE
 
 ~~~c
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   CURL *curl = curl_easy_init();
   if(curl) {

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.md
@@ -65,7 +65,7 @@ All protocols built-in
 # EXAMPLE
 
 ~~~c
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   CURL *curl = curl_easy_init();
   if(curl) {

--- a/docs/libcurl/opts/CURLOPT_READFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_READFUNCTION.md
@@ -100,7 +100,7 @@ size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   return retcode;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   FILE *file = fopen(argv[1], "rb");
   CURLcode result;

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
@@ -87,7 +87,7 @@ HTTP, HTTPS, FTP and FTPS
 # EXAMPLE
 
 ~~~c
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   CURL *curl = curl_easy_init();
   if(curl) {

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.md
@@ -71,7 +71,7 @@ HTTP, HTTPS, FTP and FTPS
 # EXAMPLE
 
 ~~~c
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   CURL *curl = curl_easy_init();
   if(curl) {

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -77,8 +77,7 @@ static CURLcode socks5_sspi_setup(struct Curl_cfilter *cf,
     return CURLE_OUT_OF_MEMORY;
 
   status =
-    Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                       (TCHAR *)CURL_UNCONST(TEXT("Kerberos")),
+    Curl_pSecFn->AcquireCredentialsHandle(NULL, CURL_UNCONST(TEXT("Kerberos")),
                                           SECPKG_CRED_OUTBOUND,
                                           NULL, NULL, NULL, NULL,
                                           cred_handle, NULL);

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -54,7 +54,7 @@ bool Curl_auth_is_digest_supported(void)
   /* Query the security package for Digest */
   status =
     Curl_pSecFn->QuerySecurityPackageInfo(
-                                   (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
+                                   CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
                                    &SecurityPackage);
 
   /* Release the package buffer as it is not required anymore */
@@ -115,7 +115,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   /* Query the security package for DigestSSP */
   status =
     Curl_pSecFn->QuerySecurityPackageInfo(
-                                   (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
+                                   CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
                                    &SecurityPackage);
   if(status != SEC_E_OK) {
     failf(data, "SSPI: could not get auth info");
@@ -158,7 +158,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 
   /* Acquire our credentials handle */
   status = Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                   (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
+                                   CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
                                    SECPKG_CRED_OUTBOUND, NULL,
                                    p_identity, NULL, NULL,
                                    &credentials, NULL);
@@ -402,7 +402,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
   /* Query the security package for DigestSSP */
   status =
     Curl_pSecFn->QuerySecurityPackageInfo(
-                                   (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
+                                   CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
                                    &SecurityPackage);
   if(status != SEC_E_OK) {
     failf(data, "SSPI: could not get auth info");
@@ -502,7 +502,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
 
     /* Acquire our credentials handle */
     status = Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                   (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
+                                   CURL_UNCONST(TEXT(SP_NAME_DIGEST)),
                                    SECPKG_CRED_OUTBOUND, NULL,
                                    p_identity, NULL, NULL,
                                    &credentials, NULL);

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -46,7 +46,7 @@ bool Curl_auth_is_gssapi_supported(void)
 
   /* Query the security package for Kerberos */
   status = Curl_pSecFn->QuerySecurityPackageInfo(
-                                 (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_KERBEROS)),
+                                 CURL_UNCONST(TEXT(SP_NAME_KERBEROS)),
                                  &SecurityPackage);
 
   /* Release the package buffer as it is not required anymore */
@@ -109,7 +109,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
   if(!krb5->output_token) {
     /* Query the security package for Kerberos */
     status = Curl_pSecFn->QuerySecurityPackageInfo(
-                                 (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_KERBEROS)),
+                                 CURL_UNCONST(TEXT(SP_NAME_KERBEROS)),
                                  &SecurityPackage);
     if(status != SEC_E_OK) {
       failf(data, "SSPI: could not get auth info");
@@ -150,7 +150,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
 
     /* Acquire our credentials handle */
     status = Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                 (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_KERBEROS)),
+                                 CURL_UNCONST(TEXT(SP_NAME_KERBEROS)),
                                  SECPKG_CRED_OUTBOUND, NULL,
                                  krb5->p_identity, NULL, NULL,
                                  krb5->credentials, NULL);

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -46,7 +46,7 @@ bool Curl_auth_is_ntlm_supported(void)
 
   /* Query the security package for NTLM */
   status = Curl_pSecFn->QuerySecurityPackageInfo(
-                                     (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NTLM)),
+                                     CURL_UNCONST(TEXT(SP_NAME_NTLM)),
                                      &SecurityPackage);
 
   /* Release the package buffer as it is not required anymore */
@@ -95,7 +95,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
 
   /* Query the security package for NTLM */
   status = Curl_pSecFn->QuerySecurityPackageInfo(
-                                     (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NTLM)),
+                                     CURL_UNCONST(TEXT(SP_NAME_NTLM)),
                                      &SecurityPackage);
   if(status != SEC_E_OK) {
     failf(data, "SSPI: could not get auth info");
@@ -135,7 +135,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
 
   /* Acquire our credentials handle */
   status = Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                     (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NTLM)),
+                                     CURL_UNCONST(TEXT(SP_NAME_NTLM)),
                                      SECPKG_CRED_OUTBOUND, NULL,
                                      ntlm->p_identity, NULL, NULL,
                                      ntlm->credentials, NULL);

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -48,7 +48,7 @@ bool Curl_auth_is_spnego_supported(void)
 
   /* Query the security package for Negotiate */
   status = Curl_pSecFn->QuerySecurityPackageInfo(
-                                (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
+                                CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
                                 &SecurityPackage);
 
   /* Release the package buffer as it is not required anymore */
@@ -114,7 +114,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   if(!nego->output_token) {
     /* Query the security package for Negotiate */
     nego->status = Curl_pSecFn->QuerySecurityPackageInfo(
-                                (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
+                                CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
                                 &SecurityPackage);
     if(nego->status != SEC_E_OK) {
       failf(data, "SSPI: could not get auth info");
@@ -179,7 +179,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
     /* Acquire our credentials handle */
     nego->status = Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                (TCHAR *)CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
+                                CURL_UNCONST(TEXT(SP_NAME_NEGOTIATE)),
                                 SECPKG_CRED_OUTBOUND, NULL,
                                 nego->p_identity, NULL, NULL,
                                 nego->credentials, NULL);

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -166,11 +166,9 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
      * https://learn.microsoft.com/windows/win32/api/sspi/ns-sspi-sec_winnt_auth_identity_exa
      */
 #ifdef UNICODE
-    nego->identity.PackageList =
-      (unsigned short *)CURL_UNCONST(TEXT("!ntlm"));
+    nego->identity.PackageList = CURL_UNCONST(TEXT("!ntlm"));
 #else
-    nego->identity.PackageList =
-      (unsigned char *)CURL_UNCONST(TEXT("!ntlm"));
+    nego->identity.PackageList = CURL_UNCONST(TEXT("!ntlm"));
 #endif
     nego->identity.PackageListLength = 5;
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -627,8 +627,7 @@ static CURLcode acquire_sspi_handle(struct Curl_cfilter *cf,
     }
 
     sspi_status =
-      Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                            (TCHAR *)CURL_UNCONST(UNISP_NAME),
+      Curl_pSecFn->AcquireCredentialsHandle(NULL, CURL_UNCONST(UNISP_NAME),
                                             SECPKG_CRED_OUTBOUND, NULL,
                                             &credentials, NULL, NULL,
                                             &backend->cred->cred_handle, NULL);
@@ -677,8 +676,7 @@ static CURLcode acquire_sspi_handle(struct Curl_cfilter *cf,
     }
 
     sspi_status =
-      Curl_pSecFn->AcquireCredentialsHandle(NULL,
-                                            (TCHAR *)CURL_UNCONST(UNISP_NAME),
+      Curl_pSecFn->AcquireCredentialsHandle(NULL, CURL_UNCONST(UNISP_NAME),
                                             SECPKG_CRED_OUTBOUND, NULL,
                                             &schannel_cred, NULL, NULL,
                                             &backend->cred->cred_handle, NULL);

--- a/projects/OS400/curlmain.c
+++ b/projects/OS400/curlmain.c
@@ -42,13 +42,13 @@ extern int      QadrtFreeEnviron(void);
 extern char *   setlocale_a(int, const char *);
 
 /* The ASCII main program. */
-extern int      main_a(int argc, char **argv);
+extern int      main_a(int argc, char *argv[]);
 
 /* Global values of original EBCDIC arguments. */
 int             ebcdic_argc;
 char **         ebcdic_argv;
 
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   int i;
   int j;

--- a/projects/vms/report_openssl_version.c
+++ b/projects/vms/report_openssl_version.c
@@ -39,7 +39,7 @@ unsigned long LIB$SET_SYMBOL(const struct dsc$descriptor_s *symbol,
                              const struct dsc$descriptor_s *value,
                              const unsigned long *table_type);
 
-int main(int argc, char **argv)
+int main(int argc, char *argv[])
 {
   void *libptr;
   const char *(*ssl_version)(int t);

--- a/src/curlinfo.c
+++ b/src/curlinfo.c
@@ -270,7 +270,7 @@ static const char * const disabled[] = {
 #endif
 };
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   size_t i;
 

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -24,7 +24,7 @@
 #include <curl/curl.h>
 #include <stdio.h>
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   (void)argc;
   puts("libcurl C test:");

--- a/tests/cmake/test.cpp
+++ b/tests/cmake/test.cpp
@@ -34,7 +34,7 @@ public:
   }
 };
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   (void)argc;
   std::cout << "libcurl C++ test:" << std::endl;

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -211,7 +211,7 @@ void ws_close(CURL *curl)
 }
 #endif /* CURL_DISABLE_WEBSOCKETS */
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   const char *URL = "";
   CURLcode result;

--- a/tests/server/first.c
+++ b/tests/server/first.c
@@ -25,7 +25,7 @@
 
 #include <stdio.h>
 
-int main(int argc, const char **argv)
+int main(int argc, const char *argv[])
 {
   entry_func_t entry_func;
   const char *entry_name;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -1097,13 +1097,11 @@ int open_stream_sock(curl_socket_t *psock, uint16_t *pport)
     srvr_sockaddr_union_t localaddr;
     memset(&localaddr, 0, sizeof(localaddr));
 #ifdef USE_IPV6
-    if(socket_domain != AF_INET6)
+    if(socket_domain == AF_INET6)
+      la_size = sizeof(localaddr.sa6);
+    else
 #endif
       la_size = sizeof(localaddr.sa4);
-#ifdef USE_IPV6
-    else
-      la_size = sizeof(localaddr.sa6);
-#endif
     if(getsockname(sock, &localaddr.sa, &la_size) < 0) {
       sockerr = SOCKERRNO;
       logmsg("getsockname() failed with error (%d) %s",


### PR DESCRIPTION
- drop redundant casts for `CURL_UNCONST()` pointers (Windows).
- GHA/linux: delete redundant/dupe `-g` C flag in memory sanitizer job.
  Spotted-by: Daniel Stenberg
- examples/http2-upload: drop local macro.
- examples/http2-upload: drop leading underscore from union name. 
- examples/http2-upload: drop interim macro.
- tests/server/util: reapply patch lost in a rebase.
- sync `main()` declarations across the codebase.
