### PR TITLE
keylog: add a random size argument to Curl_tls_keylog_write()

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1043,7 +1043,8 @@ static int keylog_callback(gnutls_session_t session, const char *label,
     return -1;
   }
 
-  Curl_tls_keylog_write(label, crandom.data, secret->data, secret->size);
+  Curl_tls_keylog_write(label, crandom.data, crandom.size,
+                        secret->data, secret->size);
   return 0;
 }
 

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -102,19 +102,20 @@ bool Curl_tls_keylog_write_line(const char *line)
   return TRUE;
 }
 
-bool Curl_tls_keylog_write(
-  const char *label,
-  const unsigned char client_random[CLIENT_RANDOM_SIZE],
-  const unsigned char *secret, size_t secretlen)
+bool Curl_tls_keylog_write(const char *label,
+                           const unsigned char *client_random,
+                           size_t random_size,
+                           const unsigned char *secret, size_t secretlen)
 {
   size_t pos, i;
   unsigned char line[KEYLOG_LABEL_MAXLEN + 1 +
                      (2 * CLIENT_RANDOM_SIZE) + 1 +
                      (2 * SECRET_MAXLEN) + 1 + 1];
-
-  if(!keylog_file_fp) {
+  DEBUGASSERT(random_size >= CLIENT_RANDOM_SIZE);
+  if(random_size < CLIENT_RANDOM_SIZE)
     return FALSE;
-  }
+  if(!keylog_file_fp)
+    return FALSE;
 
   pos = strlen(label);
   if(pos > KEYLOG_LABEL_MAXLEN || !secretlen || secretlen > SECRET_MAXLEN) {

--- a/lib/vtls/keylog.h
+++ b/lib/vtls/keylog.h
@@ -61,10 +61,10 @@ const char *Curl_tls_keylog_file_name(void);
  * Appends a key log file entry.
  * Returns true iff the key log file is open and a valid entry was provided.
  */
-bool Curl_tls_keylog_write(
-  const char *label,
-  const unsigned char client_random[CLIENT_RANDOM_SIZE],
-  const unsigned char *secret, size_t secretlen);
+bool Curl_tls_keylog_write(const char *label,
+                           const unsigned char *client_random,
+                           size_t random_size,
+                           const unsigned char *secret, size_t secretlen);
 
 /*
  * Appends a line to the key log file, ensure it is terminated by an LF.

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -700,6 +700,7 @@ static void ossl_log_tls12_secret(const SSL *ssl, bool *keylog_done)
 
   *keylog_done = TRUE;
   Curl_tls_keylog_write("CLIENT_RANDOM", client_random,
+                        sizeof(client_random),
                         master_key, master_key_length);
 }
 #endif /* !HAVE_KEYLOG_CALLBACK */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -521,7 +521,8 @@ static void cr_keylog_log_cb(struct rustls_str label,
   DEBUGASSERT(client_random_len == CLIENT_RANDOM_SIZE);
   /* Turning a "rustls_str" into a null delimited "c" string */
   curl_msnprintf(clabel, sizeof(clabel), "%.*s", (int)label.len, label.data);
-  Curl_tls_keylog_write(clabel, client_random, secret, secret_len);
+  Curl_tls_keylog_write(clabel, client_random, client_random_len,
+                        secret, secret_len);
 }
 
 static CURLcode

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -204,7 +204,7 @@ static void wssl_log_tls12_secret(WOLFSSL *ssl)
     return;
   }
 
-  Curl_tls_keylog_write("CLIENT_RANDOM", cr, crlen, ms, msLen);
+  Curl_tls_keylog_write("CLIENT_RANDOM", cr, crLen, ms, msLen);
 }
 #endif /* OPENSSL_EXTRA */
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -162,7 +162,8 @@ static int wssl_tls13_secret_callback(SSL *ssl, int id,
     return 0;
   }
 
-  Curl_tls_keylog_write(label, client_random, secret, secretSz);
+  Curl_tls_keylog_write(label, client_random, sizeof(client_random),
+                        secret, secretSz);
   return 0;
 }
 #endif /* HAVE_SECRET_CALLBACK && WOLFSSL_TLS13 */
@@ -203,7 +204,7 @@ static void wssl_log_tls12_secret(WOLFSSL *ssl)
     return;
   }
 
-  Curl_tls_keylog_write("CLIENT_RANDOM", cr, ms, msLen);
+  Curl_tls_keylog_write("CLIENT_RANDOM", cr, crlen, ms, msLen);
 }
 #endif /* OPENSSL_EXTRA */
 


### PR DESCRIPTION
To allow the function to verify that the buffer is large enough. Avoids possible future internal mishaps.
