### PR TITLE
tool_operate: limit `is_using_schannel()` call to Windows

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2196,13 +2196,6 @@ static CURLcode is_using_schannel(int *pusing)
   *pusing = using_schannel;
   return result;
 }
-#else
-/* on non-Windows it can never use Schannel */
-static CURLcode is_using_schannel(int *pusing)
-{
-  *pusing = 0; /* never */
-  return CURLE_OK;
-}
 #endif
 
 /* Set the CA cert locations specified in the environment. For Windows if no
@@ -2220,15 +2213,19 @@ static CURLcode cacertpaths(struct OperationConfig *config)
 {
   char *env;
   CURLcode result;
+#ifdef _WIN32
   int using_schannel;
+#endif
 
   if(!feature_ssl || config->cacert || config->capath ||
      (config->insecure_ok && (!config->doh_url || config->doh_insecure_ok)))
     return CURLE_OK;
 
+#ifdef _WIN32
   result = is_using_schannel(&using_schannel);
   if(result || using_schannel)
     return result;
+#endif
 
   env = curl_getenv("CURL_CA_BUNDLE");
   if(env) {


### PR DESCRIPTION
Follow-up to cd238bb7addf5b1f174df47ccc61651a545c4876 #22552

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
