### PR TITLE
tool_operate: refactor schannel checks and move Win32 cert checks to function

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2199,6 +2199,31 @@ static bool is_using_schannel(CURLcode *resultp)
 #define is_using_schannel(x) FALSE
 #endif
 
+#ifdef _WIN32
+static CURLcode win32_setup_certs(struct OperationConfig *config)
+{
+  if(!config->capath && !config->cacert) {
+#ifdef CURL_CA_SEARCH_SAFE
+    char *cacert = NULL;
+    FILE *cafile = tool_execpath("curl-ca-bundle.crt", &cacert);
+    if(cafile) {
+      curlx_fclose(cafile);
+      config->cacert = curlx_strdup(cacert);
+      if(!config->cacert)
+        return CURLE_OUT_OF_MEMORY;
+    }
+#elif !defined(CURL_WINDOWS_UWP) && !defined(CURL_DISABLE_CA_SEARCH)
+    result = FindWin32CACert(config, TEXT("curl-ca-bundle.crt"));
+    if(result)
+      return result;
+#endif
+  }
+  return CURLE_OK;
+}
+#else
+#define win32_setup_certs(x) CURLE_OK
+#endif
+
 /* Set the CA cert locations specified in the environment. For Windows if no
  * environment-specified filename is found then check for CA bundle default
  * filename curl-ca-bundle.crt in the user's PATH.
@@ -2213,7 +2238,7 @@ static bool is_using_schannel(CURLcode *resultp)
 static CURLcode cacertpaths(struct OperationConfig *config)
 {
   char *env;
-  CURLcode result;
+  CURLcode result = CURLE_OK;
 
   if(!feature_ssl || config->cacert || config->capath ||
      (config->insecure_ok && (!config->doh_url || config->doh_insecure_ok)))
@@ -2226,55 +2251,34 @@ static CURLcode cacertpaths(struct OperationConfig *config)
   if(env) {
     config->cacert = curlx_strdup(env);
     curl_free(env);
-    if(!config->cacert) {
+    if(!config->cacert)
       result = CURLE_OUT_OF_MEMORY;
-      goto fail;
-    }
   }
   else {
     env = curl_getenv("SSL_CERT_DIR");
     if(env) {
       config->capath = curlx_strdup(env);
       curl_free(env);
-      if(!config->capath) {
+      if(!config->capath)
         result = CURLE_OUT_OF_MEMORY;
-        goto fail;
-      }
     }
-    env = curl_getenv("SSL_CERT_FILE");
-    if(env) {
-      config->cacert = curlx_strdup(env);
-      curl_free(env);
-      if(!config->cacert) {
-        result = CURLE_OUT_OF_MEMORY;
-        goto fail;
+    if(!result) {
+      env = curl_getenv("SSL_CERT_FILE");
+      if(env) {
+        config->cacert = curlx_strdup(env);
+        curl_free(env);
+        if(!config->cacert)
+          result = CURLE_OUT_OF_MEMORY;
       }
     }
   }
 
-#ifdef _WIN32
-  if(!config->capath && !config->cacert) {
-#ifdef CURL_CA_SEARCH_SAFE
-    char *cacert = NULL;
-    FILE *cafile = tool_execpath("curl-ca-bundle.crt", &cacert);
-    if(cafile) {
-      curlx_fclose(cafile);
-      config->cacert = curlx_strdup(cacert);
-      if(!config->cacert) {
-        result = CURLE_OUT_OF_MEMORY;
-        goto fail;
-      }
-    }
-#elif !defined(CURL_WINDOWS_UWP) && !defined(CURL_DISABLE_CA_SEARCH)
-    result = FindWin32CACert(config, TEXT("curl-ca-bundle.crt"));
-    if(result)
-      goto fail;
-#endif
+  if(!result)
+    result = win32_setup_certs(config);
+  if(result) {
+    curlx_safefree(config->capath);
+    curlx_safefree(config->cacert);
   }
-#endif
-  return CURLE_OK;
-fail:
-  curlx_safefree(config->capath);
   return result;
 }
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2213,7 +2213,7 @@ static CURLcode win32_setup_certs(struct OperationConfig *config)
         return CURLE_OUT_OF_MEMORY;
     }
 #elif !defined(CURL_WINDOWS_UWP) && !defined(CURL_DISABLE_CA_SEARCH)
-    result = FindWin32CACert(config, TEXT("curl-ca-bundle.crt"));
+    CURLcode result = FindWin32CACert(config, TEXT("curl-ca-bundle.crt"));
     if(result)
       return result;
 #endif

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2169,6 +2169,8 @@ static CURLcode serial_transfers(CURLSH *share)
 }
 
 #ifdef _WIN32
+/* returns TRUE if using Schannel or if there is an error, passes back result
+   in 'resultp' */
 static bool is_using_schannel(CURLcode *resultp)
 {
   static int using_schannel = -1; /* -1 = not checked

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2197,11 +2197,7 @@ static bool win32_using_schannel(CURLcode *resultp)
   }
   return using_schannel == 1;
 }
-#else
-#define win32_using_schannel(x) FALSE
-#endif
 
-#ifdef _WIN32
 static CURLcode win32_setup_certs(struct OperationConfig *config)
 {
   if(!config->capath && !config->cacert) {
@@ -2224,6 +2220,7 @@ static CURLcode win32_setup_certs(struct OperationConfig *config)
 }
 #else
 #define win32_setup_certs(x) CURLE_OK
+#define win32_using_schannel(x) FALSE
 #endif
 
 /* Set the CA cert locations specified in the environment. For Windows if no

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2169,23 +2169,23 @@ static CURLcode serial_transfers(CURLSH *share)
 }
 
 #ifdef _WIN32
-static CURLcode is_using_schannel(int *pusing)
+static bool is_using_schannel(CURLcode *resultp)
 {
-  CURLcode result = CURLE_OK;
   static int using_schannel = -1; /* -1 = not checked
                                      0 = nope
                                      1 = yes */
+  *resultp = CURLE_OK;
   if(using_schannel == -1) {
     CURL *curltls = curl_easy_init();
     /* The TLS backend remains, so keep the info */
     const struct curl_tlssessioninfo *tls_backend_info = NULL;
 
     if(!curltls)
-      result = CURLE_OUT_OF_MEMORY;
+      *resultp = CURLE_OUT_OF_MEMORY;
     else {
-      result = curl_easy_getinfo(curltls, CURLINFO_TLS_SSL_PTR,
-                                 &tls_backend_info);
-      if(!result)
+      *resultp = curl_easy_getinfo(curltls, CURLINFO_TLS_SSL_PTR,
+                                   &tls_backend_info);
+      if(!*resultp)
         using_schannel =
           (tls_backend_info->backend == CURLSSLBACKEND_SCHANNEL);
     }
@@ -2193,9 +2193,10 @@ static CURLcode is_using_schannel(int *pusing)
     if(result)
       return result;
   }
-  *pusing = using_schannel;
-  return result;
+  return using_schannel == 1;
 }
+#else
+#define is_using_schannel(x) FALSE
 #endif
 
 /* Set the CA cert locations specified in the environment. For Windows if no
@@ -2213,19 +2214,13 @@ static CURLcode cacertpaths(struct OperationConfig *config)
 {
   char *env;
   CURLcode result;
-#ifdef _WIN32
-  int using_schannel;
-#endif
 
   if(!feature_ssl || config->cacert || config->capath ||
      (config->insecure_ok && (!config->doh_url || config->doh_insecure_ok)))
     return CURLE_OK;
 
-#ifdef _WIN32
-  result = is_using_schannel(&using_schannel);
-  if(result || using_schannel)
+  if(is_using_schannel(&result))
     return result;
-#endif
 
   env = curl_getenv("CURL_CA_BUNDLE");
   if(env) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2171,7 +2171,7 @@ static CURLcode serial_transfers(CURLSH *share)
 #ifdef _WIN32
 /* returns TRUE if using Schannel or if there is an error, passes back result
    in 'resultp' */
-static bool is_using_schannel(CURLcode *resultp)
+static bool win32_using_schannel(CURLcode *resultp)
 {
   static int using_schannel = -1; /* -1 = not checked
                                      0 = nope
@@ -2198,7 +2198,7 @@ static bool is_using_schannel(CURLcode *resultp)
   return using_schannel == 1;
 }
 #else
-#define is_using_schannel(x) FALSE
+#define win32_using_schannel(x) FALSE
 #endif
 
 #ifdef _WIN32
@@ -2246,7 +2246,7 @@ static CURLcode cacertpaths(struct OperationConfig *config)
      (config->insecure_ok && (!config->doh_url || config->doh_insecure_ok)))
     return CURLE_OK;
 
-  if(is_using_schannel(&result))
+  if(win32_using_schannel(&result))
     return result;
 
   env = curl_getenv("CURL_CA_BUNDLE");

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2190,8 +2190,8 @@ static bool is_using_schannel(CURLcode *resultp)
           (tls_backend_info->backend == CURLSSLBACKEND_SCHANNEL);
     }
     curl_easy_cleanup(curltls);
-    if(result)
-      return result;
+    if(*resultp)
+      return TRUE;
   }
   return using_schannel == 1;
 }


### PR DESCRIPTION
Reduces #ifdefs in the general code flow