### PR TITLE
multi: do not record connection id on transient attachments

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -763,7 +763,7 @@ static int conn_upkeep(struct Curl_easy *data,
     CURLcode result;
 
     /* briefly attach for action */
-    Curl_attach_connection(data, conn);
+    Curl_attach_connection_transient(data, conn);
     result = Curl_conn_keep_alive(data, conn);
     conn->keepalive = *Curl_pgrs_now(data);
     Curl_detach_connection(data);
@@ -915,14 +915,14 @@ bool Curl_cpool_conn_seems_healthy(struct connectdata *conn,
   else if(curlx_ptimediff_ms(pnow, &conn->lastchecked) < 1000)
     return TRUE;
   else if(conn->scheme->run->connection_is_dead) {
-    Curl_attach_connection(data, conn);
+    Curl_attach_connection_transient(data, conn);
     healthy = !conn->scheme->run->connection_is_dead(data, conn);
     Curl_detach_connection(data);
   }
   else {
     bool input_pending = FALSE;
 
-    Curl_attach_connection(data, conn);
+    Curl_attach_connection_transient(data, conn);
     healthy = Curl_conn_is_alive(data, conn, &input_pending);
     Curl_detach_connection(data);
     if(healthy && input_pending &&

--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -112,7 +112,7 @@ void Curl_cshutdn_run_once(struct Curl_easy *data,
                            bool *done)
 {
   DEBUGASSERT(!data->conn);
-  Curl_attach_connection(data, conn);
+  Curl_attach_connection_transient(data, conn);
   cshutdn_run_once(data, conn, done);
   CURL_TRC_M(data, "[SHUTDOWN] shutdown, done=%d", *done);
   Curl_detach_connection(data);
@@ -139,7 +139,7 @@ void Curl_cshutdn_terminate(struct Curl_easy *data,
   if(data->multi && data->multi->admin)
     admin = data->multi->admin;
 
-  Curl_attach_connection(admin, conn);
+  Curl_attach_connection_transient(admin, conn);
 
   cshutdn_run_conn_handler(admin, conn);
   if(do_shutdown) {
@@ -386,7 +386,7 @@ static CURLMcode cshutdn_update_ev(struct cshutdn *cshutdn,
   DEBUGASSERT(cshutdn);
   DEBUGASSERT(cshutdn->multi->socket_cb);
 
-  Curl_attach_connection(data, conn);
+  Curl_attach_connection_transient(data, conn);
   mresult = Curl_multi_ev_assess_conn(cshutdn->multi, data, conn);
   Curl_detach_connection(data);
   return mresult;
@@ -447,7 +447,7 @@ void Curl_cshutdn_setfds(struct cshutdn *cshutdn,
       CURLcode result;
 
       Curl_pollset_reset(&ps);
-      Curl_attach_connection(data, conn);
+      Curl_attach_connection_transient(data, conn);
       result = Curl_conn_adjust_pollset(data, conn, &ps);
       Curl_detach_connection(data);
 
@@ -488,7 +488,7 @@ unsigned int Curl_cshutdn_add_waitfds(struct cshutdn *cshutdn,
     for(e = Curl_llist_head(&cshutdn->list); e; e = Curl_node_next(e)) {
       conn = Curl_node_elem(e);
       Curl_pollset_reset(&ps);
-      Curl_attach_connection(data, conn);
+      Curl_attach_connection_transient(data, conn);
       result = Curl_conn_adjust_pollset(data, conn, &ps);
       Curl_detach_connection(data);
 
@@ -515,7 +515,7 @@ CURLcode Curl_cshutdn_add_pollfds(struct cshutdn *cshutdn,
     for(e = Curl_llist_head(&cshutdn->list); e; e = Curl_node_next(e)) {
       conn = Curl_node_elem(e);
       Curl_pollset_reset(&ps);
-      Curl_attach_connection(data, conn);
+      Curl_attach_connection_transient(data, conn);
       result = Curl_conn_adjust_pollset(data, conn, &ps);
       Curl_detach_connection(data);
 

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -92,7 +92,8 @@ static struct curl_trc_feat Curl_trc_feat_ids = {
 
 static size_t trc_print_ids(struct Curl_easy *data, char *buf, size_t maxlen)
 {
-  curl_off_t cid = data->state.recent_conn_id;
+  curl_off_t cid = data->conn ?
+                   data->conn->connection_id : data->state.recent_conn_id;
   if(data->id >= 0) {
     if(cid >= 0)
       return curl_msnprintf(buf, maxlen, CURL_TRC_FMT_IDSDC, data->id, cid);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -941,19 +941,25 @@ void Curl_detach_connection(struct Curl_easy *data)
 }
 
 /*
- * Curl_attach_connection() attaches this transfer to this connection.
+ * attach_connection() attaches this transfer to this connection.
+ *
+ * A real attachment records the connection as one this transfer selected
+ * and used. Transient attachments, done by internal maintenance for brief
+ * probes, do not.
  *
  * This is the only function that should assign data->conn
  */
-void Curl_attach_connection(struct Curl_easy *data,
-                            struct connectdata *conn)
+static void attach_connection(struct Curl_easy *data,
+                              struct connectdata *conn,
+                              bool record_recent)
 {
   DEBUGASSERT(data);
   DEBUGASSERT(!data->conn);
   DEBUGASSERT(conn);
   DEBUGASSERT(conn->attached_xfers < UINT32_MAX);
   data->conn = conn;
-  data->state.recent_conn_id = conn->connection_id;
+  if(record_recent)
+    data->state.recent_conn_id = conn->connection_id;
   conn->attached_xfers++;
   /* all attached transfers must be from the same multi */
   if(!conn->attached_multi)
@@ -962,6 +968,18 @@ void Curl_attach_connection(struct Curl_easy *data,
 
   if(conn->scheme && conn->scheme->run->attach)
     conn->scheme->run->attach(data, conn);
+}
+
+void Curl_attach_connection(struct Curl_easy *data,
+                            struct connectdata *conn)
+{
+  attach_connection(data, conn, TRUE);
+}
+
+void Curl_attach_connection_transient(struct Curl_easy *data,
+                                      struct connectdata *conn)
+{
+  attach_connection(data, conn, FALSE);
 }
 
 /* adjust pollset for rate limits/pauses */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -35,6 +35,8 @@ void Curl_expire_done(struct Curl_easy *data, expire_id id);
 CURLMcode Curl_update_timer(struct Curl_multi *multi) WARN_UNUSED_RESULT;
 void Curl_attach_connection(struct Curl_easy *data,
                             struct connectdata *conn);
+void Curl_attach_connection_transient(struct Curl_easy *data,
+                                      struct connectdata *conn);
 void Curl_detach_connection(struct Curl_easy *data);
 bool Curl_multiplex_wanted(const struct Curl_multi *multi);
 CURLcode Curl_preconnect(struct Curl_easy *data);


### PR DESCRIPTION
Fixes #22567.

The health probe in `Curl_cpool_prune_dead()` attaches the transfer to each idle connection to check liveness. That attach records `recent_conn_id`, so a transfer that has never used the connection ends up satisfying the "used this connection before" exception in the SSPI empty-credentials guard.

The issue suggests save/restore around the probe. I went with recording only on genuine attachment instead, because the same assumption holds in `conn_upkeep()` and in the six shutdown/pollset paths in `cshutdn.c`. Call sites already know which kind of attachment they are doing, so no runtime classification is needed.

Not moving the assignment back to `multi_done_locked()`: that is too late for the 401 Negotiate continuation, which needs the connection recorded before the retry re-enters matching. Verified.

`trc_print_ids()` relied on every attachment recording the id, so it gets its `data->conn` fallback back.

Instrumented run (prints around `Curl_cpool_prune_dead`, and in the attach path):

```
base:     before rcid=-1 / attach id=0 (health probe) / after rcid=-1 → 0
patched:  before rcid=-1 / after rcid=-1
```

Tested: Linux test suite clean against master, checksrc clean, Windows Negotiate cases (ambient→explicit, ambient→ambient cross-handle, 401 continuation) unchanged. Serial-URL CLI reuse (`--negotiate -u : url1 url2`) is unaffected, the second URL still reuses the connection.

The same-easy-handle case from 1a17959 is unchanged; not in scope here.