### PR TITLE
multi: cap expire times to INT_MAX internally

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3757,6 +3757,11 @@ void Curl_expire_ex(struct Curl_easy *data,
   if(!multi)
     return;
   DEBUGASSERT(eid < EXPIRE_LAST);
+  DEBUGASSERT(milli <= INT_MAX);
+  if(milli > INT_MAX)
+    /* Cap ridiculous timeouts, 31-bit ms is still 3.5 weeks. When the time
+       goes to the user, it must fit in this size. */
+    milli = INT_MAX;
 
   set = *Curl_pgrs_now(data);
   set.tv_sec += (time_t)(milli / 1000); /* may be a 64 to 32-bit conversion */


### PR DESCRIPTION
When the time-out value is passed to the outside world it needs to fit in a signed 32-bit variable (on Windows and 32-bit architectures) anyway. Also, this is 3.5 weeks and we should not knowingly set timeouts that long anyway.

The previous cap introduced in 3089e7eec8b694ff was only partial.
