### PR TITLE
GHA/windows: install MSYS2 Perl manually on Windows 2025 runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1164,11 +1164,7 @@ jobs:
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
-        run: |
-          echo '--------------------------'
-          ls -lA '/c/Program Files/OpenSSL/bin'
-          echo '--------------------------'
-          cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
+        run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
 
       - name: 'cache test prereqs (stunnel)'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -941,6 +941,53 @@ jobs:
               -DCURL_ENABLE_SSL=OFF
               -DUSE_WIN32_IDN=ON
 
+          - name: 'openssl +examples T'
+            install-msys2: >-
+              mingw-w64-ucrt-x86_64-brotli
+              mingw-w64-ucrt-x86_64-zlib
+              mingw-w64-ucrt-x86_64-zstd
+              mingw-w64-ucrt-x86_64-openssl
+              mingw-w64-ucrt-x86_64-libssh2
+              mingw-w64-ucrt-x86_64-nghttp2
+              mingw-w64-ucrt-x86_64-nghttp3
+              mingw-w64-ucrt-x86_64-ngtcp2
+
+            arch: 'x64'
+            env: 'ucrt-x86_64'
+            plat: 'windows'
+            type: 'Debug'
+            image: 'windows-2025'
+            chkprefill: '_chkprefill'
+            tflags: '--min=1850'
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
+              -DOPENSSL_INCLUDE_DIR=/ucrt64/include
+              -DSSL_EAY_DEBUG=/ucrt64/lib/libssl.dll.a
+              -DSSL_EAY_RELEASE=/ucrt64/lib/libssl.dll.a
+              -DLIB_EAY_DEBUG=/ucrt64/lib/libcrypto.dll.a
+              -DLIB_EAY_RELEASE=/ucrt64/lib/libcrypto.dll.a
+              -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
+              -DBROTLI_INCLUDE_DIR=/ucrt64/include
+              -DBROTLICOMMON_LIBRARY=/ucrt64/lib/libbrotlicommon.dll.a
+              -DBROTLIDEC_LIBRARY=/ucrt64/lib/libbrotlidec.dll.a
+              -DZSTD_INCLUDE_DIR=/ucrt64/include
+              -DZSTD_LIBRARY=/ucrt64/lib/libzstd.dll.a
+              -DZLIB_INCLUDE_DIR=/ucrt64/include
+              -DZLIB_LIBRARY=/ucrt64/lib/libz.dll.a
+              -DLIBSSH2_INCLUDE_DIR=/ucrt64/include
+              -DLIBSSH2_LIBRARY=/ucrt64/lib/libssh2.dll.a
+              -DNGHTTP2_INCLUDE_DIR=/ucrt64/include
+              -DNGHTTP2_LIBRARY=/ucrt64/lib/libnghttp2.dll.a
+              -DNGHTTP3_INCLUDE_DIR=/ucrt64/include
+              -DNGHTTP3_LIBRARY=/ucrt64/lib/libnghttp3.dll.a
+              -DNGTCP2_INCLUDE_DIR=/ucrt64/include
+              -DNGTCP2_LIBRARY=/ucrt64/lib/libngtcp2.dll.a
+              -DNGTCP2_CRYPTO_OSSL_LIBRARY=/ucrt64/lib/libngtcp2_crypto_ossl.dll.a
+              -DCURL_CA_NATIVE=ON
+              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
+              -D_CURL_SKIP_BUILD_CERTS=ON
+
           - name: 'openssl +examples'
             install-msys2: >-
               mingw-w64-ucrt-x86_64-brotli
@@ -1003,7 +1050,7 @@ jobs:
             tflags: '--min=1850'
             config: >-
               -DENABLE_DEBUG=ON
-              -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
+              -DCURL_USE_OPENSSL=ON
               -DOPENSSL_INCLUDE_DIR=/ucrt64/include
               -DSSL_EAY_DEBUG=/ucrt64/lib/libssl.dll.a
               -DSSL_EAY_RELEASE=/ucrt64/lib/libssl.dll.a
@@ -1031,7 +1078,6 @@ jobs:
             tflags: '--min=1850'
             config: >-
               -DENABLE_DEBUG=ON
-              -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
               -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_CA_NATIVE=ON
               -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -943,6 +943,7 @@ jobs:
 
           - name: 'openssl +examples'
             install-msys2: >-
+              perl
               mingw-w64-ucrt-x86_64-brotli
               mingw-w64-ucrt-x86_64-zlib
               mingw-w64-ucrt-x86_64-zstd
@@ -1012,7 +1013,6 @@ jobs:
           cache: ${{ contains(matrix.image, 'arm') }}
           path-type: inherit
           install: >-
-            perl
             mingw-w64-${{ matrix.env }}-libpsl
             ${{ matrix.install-msys2 }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1164,7 +1164,11 @@ jobs:
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
-        run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
+        run: |
+          echo '--------------------------'
+          ls -lA '/c/Program Files/OpenSSL/bin'
+          echo '--------------------------'
+          cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
 
       - name: 'cache test prereqs (stunnel)'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1167,11 +1167,7 @@ jobs:
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
-        run: |
-          echo '-------------------'
-          perl --version
-          echo '-------------------'
-          cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
+        run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
 
       - name: 'cache test prereqs (stunnel)'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -941,53 +941,6 @@ jobs:
               -DCURL_ENABLE_SSL=OFF
               -DUSE_WIN32_IDN=ON
 
-          - name: 'openssl +examples T'
-            install-msys2: >-
-              mingw-w64-ucrt-x86_64-brotli
-              mingw-w64-ucrt-x86_64-zlib
-              mingw-w64-ucrt-x86_64-zstd
-              mingw-w64-ucrt-x86_64-openssl
-              mingw-w64-ucrt-x86_64-libssh2
-              mingw-w64-ucrt-x86_64-nghttp2
-              mingw-w64-ucrt-x86_64-nghttp3
-              mingw-w64-ucrt-x86_64-ngtcp2
-
-            arch: 'x64'
-            env: 'ucrt-x86_64'
-            plat: 'windows'
-            type: 'Debug'
-            image: 'windows-2025'
-            chkprefill: '_chkprefill'
-            tflags: '--min=1850'
-            config: >-
-              -DENABLE_DEBUG=ON
-              -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
-              -DOPENSSL_INCLUDE_DIR=/ucrt64/include
-              -DSSL_EAY_DEBUG=/ucrt64/lib/libssl.dll.a
-              -DSSL_EAY_RELEASE=/ucrt64/lib/libssl.dll.a
-              -DLIB_EAY_DEBUG=/ucrt64/lib/libcrypto.dll.a
-              -DLIB_EAY_RELEASE=/ucrt64/lib/libcrypto.dll.a
-              -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
-              -DBROTLI_INCLUDE_DIR=/ucrt64/include
-              -DBROTLICOMMON_LIBRARY=/ucrt64/lib/libbrotlicommon.dll.a
-              -DBROTLIDEC_LIBRARY=/ucrt64/lib/libbrotlidec.dll.a
-              -DZSTD_INCLUDE_DIR=/ucrt64/include
-              -DZSTD_LIBRARY=/ucrt64/lib/libzstd.dll.a
-              -DZLIB_INCLUDE_DIR=/ucrt64/include
-              -DZLIB_LIBRARY=/ucrt64/lib/libz.dll.a
-              -DLIBSSH2_INCLUDE_DIR=/ucrt64/include
-              -DLIBSSH2_LIBRARY=/ucrt64/lib/libssh2.dll.a
-              -DNGHTTP2_INCLUDE_DIR=/ucrt64/include
-              -DNGHTTP2_LIBRARY=/ucrt64/lib/libnghttp2.dll.a
-              -DNGHTTP3_INCLUDE_DIR=/ucrt64/include
-              -DNGHTTP3_LIBRARY=/ucrt64/lib/libnghttp3.dll.a
-              -DNGTCP2_INCLUDE_DIR=/ucrt64/include
-              -DNGTCP2_LIBRARY=/ucrt64/lib/libngtcp2.dll.a
-              -DNGTCP2_CRYPTO_OSSL_LIBRARY=/ucrt64/lib/libngtcp2_crypto_ossl.dll.a
-              -DCURL_CA_NATIVE=ON
-              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
-              -D_CURL_SKIP_BUILD_CERTS=ON
-
           - name: 'openssl +examples'
             install-msys2: >-
               mingw-w64-ucrt-x86_64-brotli
@@ -1034,54 +987,6 @@ jobs:
               -DCURL_CA_NATIVE=ON
               -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
-          - name: 'openssl +examples 2'
-            install-msys2: >-
-              mingw-w64-ucrt-x86_64-brotli
-              mingw-w64-ucrt-x86_64-zlib
-              mingw-w64-ucrt-x86_64-zstd
-              mingw-w64-ucrt-x86_64-openssl
-
-            arch: 'x64'
-            env: 'ucrt-x86_64'
-            plat: 'windows'
-            type: 'Debug'
-            image: 'windows-2025'
-            chkprefill: '_chkprefill'
-            tflags: '--min=1850'
-            config: >-
-              -DENABLE_DEBUG=ON
-              -DCURL_USE_OPENSSL=ON
-              -DOPENSSL_INCLUDE_DIR=/ucrt64/include
-              -DSSL_EAY_DEBUG=/ucrt64/lib/libssl.dll.a
-              -DSSL_EAY_RELEASE=/ucrt64/lib/libssl.dll.a
-              -DLIB_EAY_DEBUG=/ucrt64/lib/libcrypto.dll.a
-              -DLIB_EAY_RELEASE=/ucrt64/lib/libcrypto.dll.a
-              -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
-              -DBROTLI_INCLUDE_DIR=/ucrt64/include
-              -DBROTLICOMMON_LIBRARY=/ucrt64/lib/libbrotlicommon.dll.a
-              -DBROTLIDEC_LIBRARY=/ucrt64/lib/libbrotlidec.dll.a
-              -DZSTD_INCLUDE_DIR=/ucrt64/include
-              -DZSTD_LIBRARY=/ucrt64/lib/libzstd.dll.a
-              -DZLIB_INCLUDE_DIR=/ucrt64/include
-              -DZLIB_LIBRARY=/ucrt64/lib/libz.dll.a
-              -DCURL_CA_NATIVE=ON
-              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
-
-          - name: 'openssl +examples 3'
-
-            arch: 'x64'
-            env: 'ucrt-x86_64'
-            plat: 'windows'
-            type: 'Debug'
-            image: 'windows-2025'
-            chkprefill: '_chkprefill'
-            tflags: '--min=1850'
-            config: >-
-              -DENABLE_DEBUG=ON
-              -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
-              -DCURL_CA_NATIVE=ON
-              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
-
           - name: 'schannel U'
             install-vcpkg: 'zlib libssh2[core,zlib]'
             arch: 'arm64'
@@ -1110,7 +1015,7 @@ jobs:
             mingw-w64-${{ matrix.env }}-libpsl
             ${{ matrix.install-msys2 }}
 
-      - name: 'move Strawberry Perl'
+      - name: 'move Strawberry Perl off PATH'
         run: mv /c/Strawberry /c/Strawberry-bak
 
       - name: 'vcpkg versions'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1110,6 +1110,9 @@ jobs:
             mingw-w64-${{ matrix.env }}-libpsl
             ${{ matrix.install-msys2 }}
 
+      - name: 'move Strawberry Perl'
+        run: mv /c/Strawberry /c/Strawberry-bak
+
       - name: 'vcpkg versions'
         if: ${{ matrix.install-vcpkg  }}
         timeout-minutes: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -987,6 +987,55 @@ jobs:
               -DCURL_CA_NATIVE=ON
               -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
 
+          - name: 'openssl +examples 2'
+            install-msys2: >-
+              mingw-w64-ucrt-x86_64-brotli
+              mingw-w64-ucrt-x86_64-zlib
+              mingw-w64-ucrt-x86_64-zstd
+              mingw-w64-ucrt-x86_64-openssl
+
+            arch: 'x64'
+            env: 'ucrt-x86_64'
+            plat: 'windows'
+            type: 'Debug'
+            image: 'windows-2025'
+            chkprefill: '_chkprefill'
+            tflags: '--min=1850'
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
+              -DOPENSSL_INCLUDE_DIR=/ucrt64/include
+              -DSSL_EAY_DEBUG=/ucrt64/lib/libssl.dll.a
+              -DSSL_EAY_RELEASE=/ucrt64/lib/libssl.dll.a
+              -DLIB_EAY_DEBUG=/ucrt64/lib/libcrypto.dll.a
+              -DLIB_EAY_RELEASE=/ucrt64/lib/libcrypto.dll.a
+              -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
+              -DBROTLI_INCLUDE_DIR=/ucrt64/include
+              -DBROTLICOMMON_LIBRARY=/ucrt64/lib/libbrotlicommon.dll.a
+              -DBROTLIDEC_LIBRARY=/ucrt64/lib/libbrotlidec.dll.a
+              -DZSTD_INCLUDE_DIR=/ucrt64/include
+              -DZSTD_LIBRARY=/ucrt64/lib/libzstd.dll.a
+              -DZLIB_INCLUDE_DIR=/ucrt64/include
+              -DZLIB_LIBRARY=/ucrt64/lib/libz.dll.a
+              -DCURL_CA_NATIVE=ON
+              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
+
+          - name: 'openssl +examples 3'
+
+            arch: 'x64'
+            env: 'ucrt-x86_64'
+            plat: 'windows'
+            type: 'Debug'
+            image: 'windows-2025'
+            chkprefill: '_chkprefill'
+            tflags: '--min=1850'
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
+              -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
+              -DCURL_CA_NATIVE=ON
+              -DCURL_ENABLE_NTLM=ON -DUSE_PROXY_HTTP3=ON
+
           - name: 'schannel U'
             install-vcpkg: 'zlib libssh2[core,zlib]'
             arch: 'arm64'
@@ -1164,7 +1213,11 @@ jobs:
       - name: 'build tests'
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
-        run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
+        run: |
+          echo '-------------------'
+          perl --version
+          echo '-------------------'
+          cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
 
       - name: 'cache test prereqs (stunnel)'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1012,11 +1012,9 @@ jobs:
           cache: ${{ contains(matrix.image, 'arm') }}
           path-type: inherit
           install: >-
+            perl
             mingw-w64-${{ matrix.env }}-libpsl
             ${{ matrix.install-msys2 }}
-
-      - name: 'move Strawberry Perl off PATH'
-        run: mv /c/Strawberry /c/Strawberry-bak
 
       - name: 'vcpkg versions'
         if: ${{ matrix.install-vcpkg  }}

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -79,6 +79,7 @@ if(!$CAPREFIX) {
             }
         }
         if(!$found) {
+            printf "PATH used: %s\n", join(', ', File::Spec->path());
             opensslfail();
         }
     }

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -84,7 +84,7 @@ printf "TRC-8\n";
         # find openssl in PATH
         my $found = 0;
         foreach(File::Spec->path()) {
-            printf "Pre-checking: |%s|\n", $file;
+            printf "TRC-9\n";
             my $file = File::Spec->catfile($_, $OPENSSL);
             printf "Checking: |%s|\n", $file;
             if(-f $file) {

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -37,26 +37,13 @@ sub opensslfail {
         "the curl test suite needs for all its TLS related tests.";
 }
 
-printf "TRC-1|%s|\n", $^O;
-print "Perl: $^V ($^X)\n";
-
 my $OPENSSL = 'openssl';
-my $windos = $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys';
-printf "TRC-2\n";
-#if($windos) {
-#printf "TRC-3\n";
-#    $OPENSSL .= '.exe';
-#printf "TRC-4\n";
-#}
-printf "TRC-5\n";
 if(-f '/usr/local/ssl/bin/openssl') {
     $OPENSSL = '/usr/local/ssl/bin/openssl';
 }
-printf "TRC-6\n";
 
 my $SRCDIR = dirname(__FILE__);
 my $fh;
-printf "TRC-7\n";
 
 my $KEYSIZE = 'prime256v1';
 my $DURATION;
@@ -80,14 +67,11 @@ if(!$CAPREFIX) {
 } elsif(! -f "$CAPREFIX-ca.cacert" ||
         ! -f "$CAPREFIX-ca.key") {
 
-    if($OPENSSL eq basename($OPENSSL) && !$windos) {  # has no directory component
-printf "TRC-8\n";
+    if($OPENSSL eq basename($OPENSSL)) {  # has no directory component
         # find openssl in PATH
         my $found = 0;
         foreach(File::Spec->path()) {
-            printf "TRC-9\n";
             my $file = File::Spec->catfile($_, $OPENSSL);
-            printf "Checking: |%s|\n", $file;
             if(-f $file) {
                 $OPENSSL = $file;
                 $found = 1;

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -41,7 +41,7 @@ printf "TRC-1|%s|\n", $^O;
 print "Perl: $^V ($^X)\n";
 
 my $OPENSSL = 'openssl';
-my $windos = $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys'
+my $windos = $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys';
 printf "TRC-2\n";
 #if($windos) {
 #printf "TRC-3\n";

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -40,9 +40,9 @@ sub opensslfail {
 printf "TRC-1\n";
 
 my $OPENSSL = 'openssl';
+my $windos = $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'dos' || $^O eq 'os2';
 printf "TRC-2\n";
-if($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' ||
-   $^O eq 'dos' || $^O eq 'os2') {
+if($windos) {
 printf "TRC-3\n";
     $OPENSSL .= '.exe';
 printf "TRC-4\n";
@@ -79,7 +79,7 @@ if(!$CAPREFIX) {
 } elsif(! -f "$CAPREFIX-ca.cacert" ||
         ! -f "$CAPREFIX-ca.key") {
 
-    if($OPENSSL eq basename($OPENSSL)) {  # has no directory component
+    if($OPENSSL eq basename($OPENSSL) && !$windos) {  # has no directory component
 printf "TRC-8\n";
         # find openssl in PATH
         my $found = 0;

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -37,16 +37,17 @@ sub opensslfail {
         "the curl test suite needs for all its TLS related tests.";
 }
 
-printf "TRC-1\n";
+printf "TRC-1|%s|\n", $^O;
+print "Perl: $^V ($^X)\n";
 
 my $OPENSSL = 'openssl';
-my $windos = $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' || $^O eq 'dos' || $^O eq 'os2';
+my $windos = $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys'
 printf "TRC-2\n";
-if($windos) {
-printf "TRC-3\n";
-    $OPENSSL .= '.exe';
-printf "TRC-4\n";
-}
+#if($windos) {
+#printf "TRC-3\n";
+#    $OPENSSL .= '.exe';
+#printf "TRC-4\n";
+#}
 printf "TRC-5\n";
 if(-f '/usr/local/ssl/bin/openssl') {
     $OPENSSL = '/usr/local/ssl/bin/openssl';

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -38,6 +38,10 @@ sub opensslfail {
 }
 
 my $OPENSSL = 'openssl';
+if($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' ||
+   $^O eq 'dos' || $^O eq 'os2') {
+    $OPENSSL .= '.exe';
+}
 if(-f '/usr/local/ssl/bin/openssl') {
     $OPENSSL = '/usr/local/ssl/bin/openssl';
 }

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -37,17 +37,25 @@ sub opensslfail {
         "the curl test suite needs for all its TLS related tests.";
 }
 
+printf "TRC-1\n";
+
 my $OPENSSL = 'openssl';
+printf "TRC-2\n";
 if($^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'msys' ||
    $^O eq 'dos' || $^O eq 'os2') {
+printf "TRC-3\n";
     $OPENSSL .= '.exe';
+printf "TRC-4\n";
 }
+printf "TRC-5\n";
 if(-f '/usr/local/ssl/bin/openssl') {
     $OPENSSL = '/usr/local/ssl/bin/openssl';
 }
+printf "TRC-6\n";
 
 my $SRCDIR = dirname(__FILE__);
 my $fh;
+printf "TRC-7\n";
 
 my $KEYSIZE = 'prime256v1';
 my $DURATION;
@@ -72,9 +80,11 @@ if(!$CAPREFIX) {
         ! -f "$CAPREFIX-ca.key") {
 
     if($OPENSSL eq basename($OPENSSL)) {  # has no directory component
+printf "TRC-8\n";
         # find openssl in PATH
         my $found = 0;
         foreach(File::Spec->path()) {
+            printf "Pre-checking: |%s|\n", $file;
             my $file = File::Spec->catfile($_, $OPENSSL);
             printf "Checking: |%s|\n", $file;
             if(-f $file) {

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -76,6 +76,7 @@ if(!$CAPREFIX) {
         my $found = 0;
         foreach(File::Spec->path()) {
             my $file = File::Spec->catfile($_, $OPENSSL);
+            printf "Checking: |%s|\n", $file;
             if(-f $file) {
                 $OPENSSL = $file;
                 $found = 1;


### PR DESCRIPTION
In GitHub runner image windows-2025-vs2026 v20260810.198.2, the default
Perl binary changed from MSYS2 to Strawberry. The reason is that the MSYS2
installation not longer has Perl preinstalled.

As seen in CMake configuration:
```diff
- -- Found Perl: C:/a/_temp/msys64/usr/bin/perl.exe (found version "5.42.2")
+ -- Found Perl: C:/Strawberry/perl/bin/perl.exe (found version "5.42.0")
```

curl's Perl scripts require an MSYS2 Perl. Fix by installing it manually
in this one job.

Symptom was `gencert.pl` no longer finding openssl.exe:
```
Missing or broken 'openssl' tool. openssl 1.0.2+ is required.
```
Then the script hanging while trying to trace it.

Also:
- add distinct error message and list PATH elements if openssl is not
  found via `gencert.pl`.
- tried falling back to Git for Windows Perl, which caused the test step
  to either hang or run too slowly to fit the time slot.

Refs:
https://github.com/actions/runner-images/pull/14541
https://github.com/actions/runner-images/releases/tag/win25-vs2026%2F20260810.198

Bug: https://github.com/curl/curl/pull/22577#issuecomment-5286533641
Bug: https://github.com/curl/curl/pull/22577#issuecomment-5291468024

---

→ https://github.com/actions/runner-images/issues/14562