### PR TITLE
GHA/windows: log preinstalled MSYS2 packages

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -329,8 +329,8 @@ jobs:
               install: 'mingw-w64-i686-c-ares mingw-w64-i686-gnutls mingw-w64-i686-libssh2 mingw-w64-i686-openssl' }
       fail-fast: false
     steps:
-      - name: 'preinstalled tool'
-        shell: sh
+      - name: 'preinstalled tools'
+        shell: bash
         run: echo '::group::MSYS2 packages'; /c/msys64/usr/bin/pacman.exe -Q || true; echo '::endgroup::'
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
@@ -652,7 +652,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
-        shell: sh
+        shell: bash
         run: echo '::group::MSYS2 packages'; /c/msys64/usr/bin/pacman.exe -Q || true; echo '::endgroup::'
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
@@ -1015,7 +1015,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
-        shell: sh
+        shell: bash
         run: echo '::group::MSYS2 packages'; /c/msys64/usr/bin/pacman.exe -Q || true; echo '::endgroup::'
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -330,11 +330,12 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
+        shell: sh
         run: |
           echo '-------------------'
-          sh -c find /c/a || true
+          find /c/a || true
           echo '-------------------'
-          sh -c find /d/a || true
+          find /d/a || true
           echo '-------------------'
           pacman -Q
 
@@ -657,11 +658,12 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
+        shell: sh
         run: |
           echo '-------------------'
-          sh -c find /c/a || true
+          find /c/a || true
           echo '-------------------'
-          sh -c find /d/a || true
+          find /d/a || true
           echo '-------------------'
           pacman -Q
 
@@ -1025,11 +1027,12 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
+        shell: sh
         run: |
           echo '-------------------'
-          sh -c find /c/a || true
+          find /c/a || true
           echo '-------------------'
-          sh -c find /d/a || true
+          find /d/a || true
           echo '-------------------'
           pacman -Q
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -333,11 +333,11 @@ jobs:
         shell: sh
         run: |
           echo '-------------------'
-          find /c/a || true
+          find /c/msys64 || true
           echo '-------------------'
-          find /d/a || true
+          find /d/msys64 || true
           echo '-------------------'
-          pacman -Q
+          /usr/bin/pacman -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         if: ${{ matrix.sys == 'msys' }}
@@ -661,11 +661,11 @@ jobs:
         shell: sh
         run: |
           echo '-------------------'
-          find /c/a || true
+          find /c/msys64 || true
           echo '-------------------'
-          find /d/a || true
+          find /d/msys64 || true
           echo '-------------------'
-          pacman -Q
+          /usr/bin/pacman -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
@@ -1030,11 +1030,11 @@ jobs:
         shell: sh
         run: |
           echo '-------------------'
-          find /c/a || true
+          find /c/msys64 || true
           echo '-------------------'
-          find /d/a || true
+          find /d/msys64 || true
           echo '-------------------'
-          pacman -Q
+          /usr/bin/pacman -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -337,7 +337,7 @@ jobs:
           echo '-------------------'
           find /d/msys64 || true
           echo '-------------------'
-          /usr/bin/pacman -Q
+          /c/msys64/usr/bin/pacman.exe -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         if: ${{ matrix.sys == 'msys' }}
@@ -665,7 +665,7 @@ jobs:
           echo '-------------------'
           find /d/msys64 || true
           echo '-------------------'
-          /usr/bin/pacman -Q
+          /c/msys64/usr/bin/pacman.exe -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
@@ -1034,7 +1034,7 @@ jobs:
           echo '-------------------'
           find /d/msys64 || true
           echo '-------------------'
-          /usr/bin/pacman -Q
+          /c/msys64/usr/bin/pacman.exe -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -329,15 +329,9 @@ jobs:
               install: 'mingw-w64-i686-c-ares mingw-w64-i686-gnutls mingw-w64-i686-libssh2 mingw-w64-i686-openssl' }
       fail-fast: false
     steps:
-      - name: 'preinstalled tools'
+      - name: 'preinstalled tool'
         shell: sh
-        run: |
-          echo '-------------------'
-          find /c/msys64 || true
-          echo '-------------------'
-          find /d/msys64 || true
-          echo '-------------------'
-          /c/msys64/usr/bin/pacman.exe -Q
+        run: echo '::group::MSYS2 packages'; /c/msys64/usr/bin/pacman.exe -Q || true; echo '::endgroup::'
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         if: ${{ matrix.sys == 'msys' }}
@@ -659,13 +653,7 @@ jobs:
     steps:
       - name: 'preinstalled tools'
         shell: sh
-        run: |
-          echo '-------------------'
-          find /c/msys64 || true
-          echo '-------------------'
-          find /d/msys64 || true
-          echo '-------------------'
-          /c/msys64/usr/bin/pacman.exe -Q
+        run: echo '::group::MSYS2 packages'; /c/msys64/usr/bin/pacman.exe -Q || true; echo '::endgroup::'
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
@@ -1028,13 +1016,7 @@ jobs:
     steps:
       - name: 'preinstalled tools'
         shell: sh
-        run: |
-          echo '-------------------'
-          find /c/msys64 || true
-          echo '-------------------'
-          find /d/msys64 || true
-          echo '-------------------'
-          /c/msys64/usr/bin/pacman.exe -Q
+        run: echo '::group::MSYS2 packages'; /c/msys64/usr/bin/pacman.exe -Q || true; echo '::endgroup::'
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -330,7 +330,13 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
-        run: pacman -Q
+        run: |
+          echo '-------------------'
+          sh -c find /c/a || true
+          echo '-------------------'
+          sh -c find /d/a || true
+          echo '-------------------'
+          pacman -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         if: ${{ matrix.sys == 'msys' }}
@@ -651,7 +657,13 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
-        run: pacman -Q
+        run: |
+          echo '-------------------'
+          sh -c find /c/a || true
+          echo '-------------------'
+          sh -c find /d/a || true
+          echo '-------------------'
+          pacman -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
@@ -1013,7 +1025,13 @@ jobs:
       fail-fast: false
     steps:
       - name: 'preinstalled tools'
-        run: pacman -Q
+        run: |
+          echo '-------------------'
+          sh -c find /c/a || true
+          echo '-------------------'
+          sh -c find /d/a || true
+          echo '-------------------'
+          pacman -Q
 
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -329,6 +329,9 @@ jobs:
               install: 'mingw-w64-i686-c-ares mingw-w64-i686-gnutls mingw-w64-i686-libssh2 mingw-w64-i686-openssl' }
       fail-fast: false
     steps:
+      - name: 'preinstalled tools'
+        run: pacman -Q
+
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         if: ${{ matrix.sys == 'msys' }}
         with:
@@ -647,6 +650,9 @@ jobs:
             chkprefill: ''  # Set it once to silence actionlint
       fail-fast: false
     steps:
+      - name: 'preinstalled tools'
+        run: pacman -Q
+
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: ${{ matrix.sys }}
@@ -1006,6 +1012,9 @@ jobs:
 
       fail-fast: false
     steps:
+      - name: 'preinstalled tools'
+        run: pacman -Q
+
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           msystem: ${{ matrix.arch == 'arm64' && 'clangarm64' || 'ucrt64' }}


### PR DESCRIPTION
CI jobs rely on defaults, sometimes to reduce log noise (possibly
improve performance a bit) or simplify, sometimes by accident. List them
to help debug or optimize on changes.

Refs:
https://github.com/actions/runner-images/issues/14562#issuecomment-5301777198
https://github.com/msys2/MSYS2-packages/commit/636489312cbc55011cb7ec493550598125e7716f
https://github.com/msys2/MSYS2-packages/pull/6491
https://github.com/msys2/MSYS2-packages/pull/6479

Follow-up to d854ab4673c2f9d8048c7f0f6d164b7e4d5e0865 #22580
Follow-up to c349bd668c91f2484ae21c0f361ddf497143093c #14097
