### PR TITLE
connect timer stats: only on first socket

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -309,7 +309,7 @@ static CURLcode conn_connect_trace(struct Curl_easy *data,
 static void conn_report_connect_stats(struct Curl_cfilter *cf,
                                       struct Curl_easy *data)
 {
-  if(cf) {
+  if(cf && (cf->sockindex == FIRSTSOCKET)) {
     struct curltime connected;
     struct curltime appconnected;
 


### PR DESCRIPTION
Only collect connect/appconnect timer stats on the first socket.

refs #22587

