### PR TITLE
processhelp.pm: do not let killsockfilters kill a recycled pid

### DIFF
--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -416,6 +416,36 @@ sub killpid {
 }
 
 #######################################################################
+# pidissockfilt checks if the process with a given pid still is a
+# sockfilt process. The sockfilt pidfiles hold Windows pids (with the
+# 4194304 offset) and Windows reuses pids of dead processes quickly,
+# so a pid read from a stale pidfile can meanwhile belong to an
+# unrelated process. On Cygwin/msys this verifies the command line of
+# the kill target through /proc. Returns 1 whenever the command line
+# cannot be determined, to keep the previous behavior in all cases
+# this cannot inspect.
+#
+sub pidissockfilt {
+    my $pid = $_[0];
+    if(($^O eq 'cygwin' || $^O eq 'msys') && ($pid > 0)) {
+        # translate a pidfile (Windows) pid into the Cygwin pid of
+        # whatever process currently owns it, like the kill would
+        $pid = winpid_to_pid($pid);
+        if(($pid > 0) && ($pid <= 4194304) &&
+           open(my $pfh, "<", "/proc/$pid/cmdline")) {
+            local $/;
+            my $cmdline = <$pfh>;
+            close($pfh);
+            if(defined $cmdline) {
+                $cmdline =~ s/\0/ /g;
+                return ($cmdline =~ /sockfilt/) ? 1 : 0;
+            }
+        }
+    }
+    return 1; # cannot inspect, assume it is a sockfilt
+}
+
+#######################################################################
 # killsockfilters kills sockfilter processes for a given server.
 #
 sub killsockfilters {
@@ -434,6 +464,15 @@ sub killsockfilters {
     if(!$which || ($which eq 'main')) {
         $pidfile = mainsockf_pidfilename($piddir, $proto, $ipvnum, $idnum);
         $pid = processexists($pidfile);
+        if(($pid > 0) && !pidissockfilt($pid)) {
+            # the pid was recycled onto an unrelated process after the
+            # sockfilt died. Killing it would hit an innocent victim, like
+            # the shell running the test client (showing up as the client
+            # dying with "returned 2009"). Only drop the stale pidfile.
+            printf("* NOT killing pid %d, no longer a sockfilt process\n",
+                $pid) if($verbose);
+            $pid = 0;
+        }
         if($pid > 0) {
             printf("* kill pid for %s-%s => %d\n", $server,
                 ($proto eq 'ftp')?'ctrl':'filt', $pid) if($verbose);
@@ -448,6 +487,12 @@ sub killsockfilters {
     if(!$which || ($which eq 'data')) {
         $pidfile = datasockf_pidfilename($piddir, $proto, $ipvnum, $idnum);
         $pid = processexists($pidfile);
+        if(($pid > 0) && !pidissockfilt($pid)) {
+            # see the comment in the 'main' branch above
+            printf("* NOT killing pid %d, no longer a sockfilt process\n",
+                $pid) if($verbose);
+            $pid = 0;
+        }
         if($pid > 0) {
             printf("* kill pid for %s-data => %d\n", $server,
                 $pid) if($verbose);

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -426,20 +426,46 @@ sub killpid {
 # this cannot inspect.
 #
 sub pidissockfilt {
-    my $pid = $_[0];
-    if(($^O eq 'cygwin' || $^O eq 'msys') && ($pid > 0)) {
+    my $vpid = $_[0];
+    return 1 if($vpid <= 0);
+    if($^O eq 'cygwin' || $^O eq 'msys') {
         # translate a pidfile (Windows) pid into the Cygwin pid of
         # whatever process currently owns it, like the kill would
-        $pid = winpid_to_pid($pid);
+        my $pid = winpid_to_pid($vpid);
         if(($pid > 0) && ($pid <= 4194304) &&
            open(my $pfh, "<", "/proc/$pid/cmdline")) {
             local $/;
             my $cmdline = <$pfh>;
             close($pfh);
-            if(defined $cmdline) {
+            # only trust a non-empty command line: native Windows
+            # children can be listed by Cygwin with no cmdline data,
+            # and an empty read must not count as "not a sockfilt"
+            if(defined $cmdline && $cmdline =~ /\S/) {
                 $cmdline =~ s/\0/ /g;
                 return ($cmdline =~ /sockfilt/) ? 1 : 0;
             }
+        }
+    }
+    if(($vpid > 4194304) && os_is_win()) {
+        # a native Windows process: it has no useful /proc entry even
+        # under Cygwin/msys, so ask the system for its image name, the
+        # same way pidexists/pidterm/pidkill reach such processes
+        my $winpid = $vpid - 4194304;
+        my $name;
+        if($has_win32_process) {
+            my %processes = Win32::Process::List->new()->GetProcesses();
+            $name = $processes{$winpid} if(exists $processes{$winpid});
+        }
+        else {
+            my $filter = "PID eq $winpid";
+            # https://ss64.com/nt/tasklist.html
+            my $result = qx(tasklist -fi \"$filter\" -fo csv -nh 2>$dev_null);
+            if(defined $result && $result =~ /^"([^"]+)","$winpid"/m) {
+                $name = $1;
+            }
+        }
+        if(defined $name) {
+            return ($name =~ /sockfilt/i) ? 1 : 0;
         }
     }
     return 1; # cannot inspect, assume it is a sockfilt


### PR DESCRIPTION
On Windows, sockfilt pidfiles hold Windows pids (with the 4194304 offset from `our_getpid()`), and Windows reuses pids of dead processes. When a sockfilt dies while its pidfile is left behind, a later `killsockfilters` resolves the stale pid to whatever process owns that Windows pid at that moment and SIGKILLs it, unverified. When the victim is the shell that `system()` spawned for the test command, runtests reports the client "returned 2009" (2000 + SIGKILL, per `normalize_cmdres`) while curl itself ran to completion and its output sits complete in the already-open log files. That matches the signature that got test 498 disabled as flaky in #16748: "curl returned 2009, when expecting 56" with `curl: (56) Too large response headers` right there in the log.

I could not trigger the failure naturally on a Windows 11 machine (200 isolated repeats of test 498, 500 more pinned to two cores, and full -j8 suite runs all stayed green), so I verified the mechanism piece by piece instead. Killing the intermediate shell of a test command from another msys process reproduces exactly 2009 with intact curl output, deterministically. The msys2 runtime's exit-code plumbing (pinfo.cc) cannot produce a "killed by 9" wait status from any native process termination or NTSTATUS mapping - only a Cygwin-side kill() can - and the only place the harness sends a SIGKILL without a graceful TERM first is `pidkill` via `killsockfilters`. A live sockfilt spawned the way `startsf` does confirms the pidfile carries winpid+4194304 while `/proc/<cygpid>/cmdline` exposes its full command line for verification.

The change makes `killsockfilters` check through `/proc` that the kill target still is a sockfilt, drop the stale pidfile without killing otherwise, and log the skip. It deliberately keeps killing whenever the command line cannot be inspected, so behavior is unchanged on other platforms and in any case the check cannot see.

Verified on Windows 11 with an MSYS2 UCRT64 Schannel debug build (gcc 16.2): planting a live shell's Windows pid in a stale sockfilt pidfile no longer gets the shell killed and the pidfile is removed; a real sockfilt registered in the same pidfile is still killed; the full suite passes with the change and with test 498 enabled: 1675 out of 1675 reported OK. One environmental note: midway through this work Windows Defender false-positived MSYS2's cygwin-console-helper.exe and quarantined it, so I re-ran the signature reproduction, both guard scenarios and a full suite with the helper absent and again after restoring it - identical results both ways, including a second full 1675/1675 run after the restore. What I have not observed is the recycling collision firing naturally, so I cannot promise this is the only path to the 2009 failures - if it is, test 498 could eventually be re-enabled on Windows CI, which this PR does not touch. The analysis was AI-assisted; every probe, measurement and test above was run and verified on my machine.
