### PR TITLE
urldata: drop four strings from the 'aptr' struct

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2014,17 +2014,6 @@ void Curl_http_method(struct Curl_easy *data,
   *reqp = httpreq;
 }
 
-static CURLcode http_useragent(struct Curl_easy *data)
-{
-  /* The User-Agent string might have been allocated already, because
-     it might have been used in the proxy connect, but if we have got a header
-     with the user-agent string specified, we erase the previously made string
-     here. */
-  if(Curl_checkheaders(data, STRCONST("User-Agent")))
-    curlx_safefree(data->state.aptr.uagent);
-  return CURLE_OK;
-}
-
 static CURLcode http_set_aptr_host(struct Curl_easy *data)
 {
   struct connectdata *conn = data->conn;
@@ -2961,10 +2950,12 @@ static CURLcode http_add_hd(struct Curl_easy *data,
     break;
 
   case H1_HD_USER_AGENT:
-    if(data->set.str[STRING_USERAGENT] && /* User-Agent: */
-       *data->set.str[STRING_USERAGENT] &&
-       data->state.aptr.uagent)
-      result = curlx_dyn_add(req, data->state.aptr.uagent);
+    if(!Curl_checkheaders(data, STRCONST("User-Agent"))) {
+      if(data->set.str[STRING_USERAGENT] &&
+         *data->set.str[STRING_USERAGENT])
+        result = curlx_dyn_addf(req, "User-Agent: %s\r\n",
+                                data->set.str[STRING_USERAGENT]);
+    }
     break;
 
   case H1_HD_ACCEPT:
@@ -2983,7 +2974,6 @@ static CURLcode http_add_hd(struct Curl_easy *data,
     break;
 
   case H1_HD_ACCEPT_ENCODING:
-    curlx_safefree(data->state.aptr.accept_encoding);
     if(!Curl_checkheaders(data, STRCONST("Accept-Encoding")) &&
        data->set.str[STRING_ENCODING])
       result = curlx_dyn_addf(req, "Accept-Encoding: %s\r\n",
@@ -2991,7 +2981,6 @@ static CURLcode http_add_hd(struct Curl_easy *data,
     break;
 
   case H1_HD_REFERER:
-    curlx_safefree(data->state.aptr.ref);
     if(Curl_bufref_ptr(&data->state.referer) &&
        !Curl_checkheaders(data, STRCONST("Referer")))
       result = curlx_dyn_addf(req, "Referer: %s\r\n",
@@ -3114,8 +3103,6 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
     result = Curl_http_output_auth(data, data->conn, method, httpreq,
                                    data->state.up.path,
                                    data->state.up.query, FALSE);
-  if(!result)
-    result = http_useragent(data);
   /* Setup input reader, resume information and ranges */
   if(!result)
     result = set_reader(data, httpreq);

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -319,14 +319,14 @@ struct rtsp_blocks {
   const char *request;
   const char *session_id;
   const char *accept;
-  const char *accept_encoding;
   const char *range;
-  const char *referrer;
   const char *stream_uri;
-  const char *transport;
-  const char *uagent;
   const char *hd_proxy_auth;
   const char *hd_auth;
+  char *referrer;
+  char *accept_encoding;
+  char *transport;
+  BIT(transport_alloc); /* if 'transport' is allocated */
 };
 
 static CURLcode rtsp_setup_request(struct Curl_easy *data,
@@ -351,17 +351,16 @@ static CURLcode rtsp_setup_request(struct Curl_easy *data,
     if(data->set.str[STRING_RTSP_TRANSPORT]) {
       result = rtsp_header_alloc("Transport",
                                  data->set.str[STRING_RTSP_TRANSPORT],
-                                 &data->state.aptr.rtsp_transport);
+                                 &b->transport);
       if(result)
         return result;
+      b->transport_alloc = TRUE;
     }
     else {
       failf(data,
             "Refusing to issue an RTSP SETUP without a Transport: header.");
       return CURLE_BAD_FUNCTION_ARGUMENT;
     }
-
-    b->transport = data->state.aptr.rtsp_transport;
   }
 
   /* Accept Headers for DESCRIBE requests */
@@ -375,24 +374,10 @@ static CURLcode rtsp_setup_request(struct Curl_easy *data,
        data->set.str[STRING_ENCODING]) {
       result = rtsp_header_alloc("Accept-Encoding",
                                  data->set.str[STRING_ENCODING],
-                                 &data->state.aptr.accept_encoding);
+                                 &b->accept_encoding);
       if(result)
         return result;
-      b->accept_encoding = data->state.aptr.accept_encoding;
     }
-  }
-
-  /* The User-Agent string might have been allocated already, because
-     it might have been used in the proxy connect, but if we have got a header
-     with the user-agent string specified, we erase the previously made string
-     here. */
-  if(Curl_checkheaders(data, STRCONST("User-Agent")) &&
-     data->state.aptr.uagent) {
-    curlx_safefree(data->state.aptr.uagent);
-  }
-  else if(!Curl_checkheaders(data, STRCONST("User-Agent")) &&
-          data->set.str[STRING_USERAGENT]) {
-    b->uagent = data->state.aptr.uagent;
   }
 
   /* setup the authentication headers */
@@ -407,13 +392,10 @@ static CURLcode rtsp_setup_request(struct Curl_easy *data,
   b->hd_auth = data->req.hd_auth;
 
   /* Referrer */
-  curlx_safefree(data->state.aptr.ref);
   if(Curl_bufref_ptr(&data->state.referer) &&
      !Curl_checkheaders(data, STRCONST("Referer")))
-    data->state.aptr.ref =
+    b->referrer =
       curl_maprintf("Referer: %s\r\n", Curl_bufref_ptr(&data->state.referer));
-
-  b->referrer = data->state.aptr.ref;
 
   /*
    * Range Header
@@ -513,19 +495,25 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                           "%s" /* accept-encoding */
                           "%s" /* range */
                           "%s" /* referrer */
-                          "%s" /* user-agent */
-                          "%s" /* hd_proxy_auth */
-                          "%s" /* hd_auth */
                           ,
                           block.transport ? block.transport : "",
                           block.accept ? block.accept : "",
                           block.accept_encoding ? block.accept_encoding : "",
                           block.range ? block.range : "",
-                          block.referrer ? block.referrer : "",
-                          block.uagent ? block.uagent : "",
-                          block.hd_proxy_auth ? block.hd_proxy_auth : "",
-                          block.hd_auth ? block.hd_auth : "");
+                          block.referrer ? block.referrer : "");
 
+  if(!result &&
+     data->set.str[STRING_USERAGENT] && *data->set.str[STRING_USERAGENT])
+    result = curlx_dyn_addf(&req_buffer,
+                            "User-Agent: %s\r\n",
+                            data->set.str[STRING_USERAGENT]);
+
+  if(!result)
+    result = curlx_dyn_addf(&req_buffer,
+                            "%s" /* hd_proxy_auth */
+                            "%s", /* hd_auth */
+                            block.hd_proxy_auth ? block.hd_proxy_auth : "",
+                            block.hd_auth ? block.hd_auth : "");
   if(result)
     goto out;
 
@@ -567,6 +555,9 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     result = Curl_pgrsUpdate(data);
   }
 out:
+  if(block.transport_alloc)
+    curlx_free(block.transport);
+  curlx_free(block.accept_encoding);
   curlx_dyn_free(&req_buffer);
   return result;
 }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -393,9 +393,12 @@ static CURLcode rtsp_setup_request(struct Curl_easy *data,
 
   /* Referrer */
   if(Curl_bufref_ptr(&data->state.referer) &&
-     !Curl_checkheaders(data, STRCONST("Referer")))
+     !Curl_checkheaders(data, STRCONST("Referer"))) {
     b->referrer =
       curl_maprintf("Referer: %s\r\n", Curl_bufref_ptr(&data->state.referer));
+    if(!b->referrer)
+      result = CURLE_OUT_OF_MEMORY;
+  }
 
   /*
    * Range Header
@@ -403,7 +406,8 @@ static CURLcode rtsp_setup_request(struct Curl_easy *data,
    *
    * Go ahead and use the Range stuff supplied for HTTP
    */
-  if(data->state.use_range &&
+  if(!result &&
+     data->state.use_range &&
      ((rtspreq == RTSPREQ_PLAY) ||
       (rtspreq == RTSPREQ_PAUSE) ||
       (rtspreq == RTSPREQ_RECORD))) {

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -507,6 +507,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                           block.referrer ? block.referrer : "");
 
   if(!result &&
+     !Curl_checkheaders(data, STRCONST("User-Agent")) &&
      data->set.str[STRING_USERAGENT] && *data->set.str[STRING_USERAGENT])
     result = curlx_dyn_addf(&req_buffer,
                             "User-Agent: %s\r\n",

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -562,6 +562,7 @@ out:
   if(block.transport_alloc)
     curlx_free(block.transport);
   curlx_free(block.accept_encoding);
+  curlx_free(block.referrer);
   curlx_dyn_free(&req_buffer);
   return result;
 }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -583,18 +583,6 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     result = Curl_hsts_loadcb(data, data->hsts);
   }
 
-  /*
-   * Set user-agent. Used for HTTP, but since we can attempt to tunnel
-   * anything through an HTTP proxy we cannot limit this based on protocol.
-   */
-  if(!result && data->set.str[STRING_USERAGENT]) {
-    curlx_free(data->state.aptr.uagent);
-    data->state.aptr.uagent =
-      curl_maprintf("User-Agent: %s\r\n", data->set.str[STRING_USERAGENT]);
-    if(!data->state.aptr.uagent)
-      return CURLE_OUT_OF_MEMORY;
-  }
-
   data->req.headerbytecount = 0;
   Curl_headers_cleanup(data);
   return result;

--- a/lib/url.c
+++ b/lib/url.c
@@ -279,16 +279,10 @@ CURLcode Curl_close(struct Curl_easy **datap)
 
   Curl_hash_destroy(&data->meta_hash);
   Curl_creds_unlink(&data->state.creds);
-  curlx_safefree(data->state.aptr.uagent);
-  curlx_safefree(data->state.aptr.accept_encoding);
   curlx_safefree(data->state.aptr.rangeline);
-  curlx_safefree(data->state.aptr.ref);
   curlx_safefree(data->state.aptr.host);
 #ifndef CURL_DISABLE_COOKIES
   curlx_safefree(data->req.cookiehost);
-#endif
-#ifndef CURL_DISABLE_RTSP
-  curlx_safefree(data->state.aptr.rtsp_transport);
 #endif
 
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_FORM_API)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -622,14 +622,8 @@ struct UrlState {
   /* Dynamically allocated strings, MUST be freed before this struct is
      killed. */
   struct dynamically_allocated_data {
-    char *uagent;
-    char *accept_encoding;
     char *rangeline;
-    char *ref;
     char *host;
-#ifndef CURL_DISABLE_RTSP
-    char *rtsp_transport;
-#endif
   } aptr;
 #ifndef CURL_DISABLE_HTTP
   struct http_negotiation http_neg;


### PR DESCRIPTION
There is no need to keep this data around once the RTSP request has been issued.
