### PR TITLE
urldata cleanups

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -786,7 +786,7 @@ out:
 static CURLcode cf_hc_add(struct Curl_easy *data,
                           struct Curl_peer *destination,
                           struct connectdata *conn,
-                          int sockindex,
+                          int8_t sockindex,
                           uint8_t def_transport)
 {
   struct Curl_cfilter *cf;
@@ -809,7 +809,7 @@ out:
 CURLcode Curl_cf_https_setup(struct Curl_easy *data,
                              struct Curl_peer *destination,
                              struct connectdata *conn,
-                             int sockindex)
+                             int8_t sockindex)
 {
   CURLcode result = CURLE_OK;
 

--- a/lib/cf-https-connect.h
+++ b/lib/cf-https-connect.h
@@ -38,7 +38,7 @@ extern struct Curl_cftype Curl_cft_http_connect;
 CURLcode Curl_cf_https_setup(struct Curl_easy *data,
                              struct Curl_peer *destination,
                              struct connectdata *conn,
-                             int sockindex);
+                             int8_t sockindex);
 
 #endif /* !CURL_DISABLE_HTTP */
 #endif /* HEADER_CURL_CF_HTTP_H */

--- a/lib/cf-recvbuf.c
+++ b/lib/cf-recvbuf.c
@@ -137,7 +137,7 @@ out:
 
 CURLcode Curl_cf_recvbuf_add(struct Curl_easy *data,
                              struct connectdata *conn,
-                             int sockindex,
+                             int8_t sockindex,
                              const uint8_t *buf, size_t blen)
 {
   struct Curl_cfilter *cf;

--- a/lib/cf-recvbuf.h
+++ b/lib/cf-recvbuf.h
@@ -30,7 +30,7 @@
 
 CURLcode Curl_cf_recvbuf_add(struct Curl_easy *data,
                              struct connectdata *conn,
-                             int sockindex,
+                             int8_t sockindex,
                              const uint8_t *buf, size_t blen);
 
 extern struct Curl_cftype Curl_cft_recvbuf;

--- a/lib/cf-setup.c
+++ b/lib/cf-setup.c
@@ -159,7 +159,7 @@ static CURLcode cf_setup_add_http_proxy(struct Curl_cfilter *cf,
 /* Get the origin curl connects its socket to.
  * Can be origin or the first proxy. */
 static struct Curl_peer *conn_get_first_origin(struct connectdata *conn,
-                                             int sockindex)
+                                             int8_t sockindex)
 {
 #ifndef CURL_DISABLE_PROXY
   if(conn->socks_proxy.peer)
@@ -445,7 +445,7 @@ out:
 
 CURLcode Curl_cf_setup_add(struct Curl_easy *data,
                            struct connectdata *conn,
-                           int sockindex,
+                           int8_t sockindex,
                            uint8_t transport,
                            int ssl_mode)
 {

--- a/lib/cf-setup.h
+++ b/lib/cf-setup.h
@@ -32,7 +32,7 @@ struct Curl_str;
 
 CURLcode Curl_cf_setup_add(struct Curl_easy *data,
                            struct connectdata *conn,
-                           int sockindex,
+                           int8_t sockindex,
                            uint8_t transport,
                            int ssl_mode);
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -2320,7 +2320,7 @@ struct Curl_cftype Curl_cft_tcp_accept = {
 
 CURLcode Curl_conn_tcp_listen_set(struct Curl_easy *data,
                                   struct connectdata *conn,
-                                  int sockindex, curl_socket_t *s)
+                                  int8_t sockindex, curl_socket_t *s)
 {
   CURLcode result;
   struct Curl_cfilter *cf = NULL;
@@ -2360,7 +2360,7 @@ out:
 }
 
 bool Curl_conn_is_tcp_listen(struct Curl_easy *data,
-                             int sockindex)
+                             int8_t sockindex)
 {
   struct Curl_cfilter *cf = data->conn->cfilter[sockindex];
   while(cf) {

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -122,7 +122,7 @@ CURLcode Curl_cf_unix_create(struct Curl_cfilter **pcf,
  */
 CURLcode Curl_conn_tcp_listen_set(struct Curl_easy *data,
                                   struct connectdata *conn,
-                                  int sockindex,
+                                  int8_t sockindex,
                                   curl_socket_t *s);
 
 /**
@@ -130,7 +130,7 @@ CURLcode Curl_conn_tcp_listen_set(struct Curl_easy *data,
  * Curl_conn_tcp_listen_set().
  */
 bool Curl_conn_is_tcp_listen(struct Curl_easy *data,
-                             int sockindex);
+                             int8_t sockindex);
 
 /**
  * Peek at the socket and remote ip/port the socket filter is using.

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -128,7 +128,7 @@ CURLcode Curl_cf_def_query(struct Curl_cfilter *cf,
 
 #ifdef CURLVERBOSE
 void Curl_conn_trc_filters(struct Curl_easy *data,
-                           int sockindex, const char *info)
+                           int8_t sockindex, const char *info)
 {
   if(CURL_TRC_M_is_verbose(data) && data->conn) {
     struct Curl_cfilter *cf = data->conn->cfilter[sockindex];
@@ -177,14 +177,15 @@ void Curl_conn_cf_discard_chain(struct Curl_cfilter **pcf,
 }
 
 void Curl_conn_cf_discard_all(struct Curl_easy *data,
-                              struct connectdata *conn, int sockindex)
+                              struct connectdata *conn, int8_t sockindex)
 {
   struct curltime *pt = &conn->shutdown.start[sockindex];
   memset(pt, 0, sizeof(*pt));
   Curl_conn_cf_discard_chain(&conn->cfilter[sockindex], data);
 }
 
-CURLcode Curl_conn_shutdown(struct Curl_easy *data, int sockindex, bool *done)
+CURLcode Curl_conn_shutdown(struct Curl_easy *data,
+                            int8_t sockindex, bool *done)
 {
   struct Curl_cfilter *cf;
   CURLcode result = CURLE_OK;
@@ -239,7 +240,7 @@ CURLcode Curl_conn_shutdown(struct Curl_easy *data, int sockindex, bool *done)
   return result;
 }
 
-CURLcode Curl_cf_recv(struct Curl_easy *data, int sockindex, char *buf,
+CURLcode Curl_cf_recv(struct Curl_easy *data, int8_t sockindex, char *buf,
                       size_t len, size_t *pnread)
 {
   struct Curl_cfilter *cf;
@@ -257,7 +258,7 @@ CURLcode Curl_cf_recv(struct Curl_easy *data, int sockindex, char *buf,
   return CURLE_FAILED_INIT;
 }
 
-CURLcode Curl_cf_send(struct Curl_easy *data, int sockindex,
+CURLcode Curl_cf_send(struct Curl_easy *data, int8_t sockindex,
                       const uint8_t *buf, size_t len, bool eos,
                       size_t *pnwritten)
 {
@@ -358,7 +359,7 @@ out:
 
 void Curl_conn_cf_add(struct Curl_easy *data,
                       struct connectdata *conn,
-                      int sockindex,
+                      int8_t sockindex,
                       struct Curl_cfilter *cf)
 {
   DEBUGASSERT(conn);
@@ -468,7 +469,7 @@ void Curl_conn_cntrl_update_info(struct Curl_easy *data,
 }
 
 void Curl_conn_remove_setup_filters(struct Curl_easy *data,
-                                    int sockindex)
+                                    int8_t sockindex)
 {
   struct Curl_cfilter **anchor = &data->conn->cfilter[sockindex];
   while(*anchor) {
@@ -485,14 +486,14 @@ void Curl_conn_remove_setup_filters(struct Curl_easy *data,
   }
 }
 
-bool Curl_conn_is_setup(struct connectdata *conn, int sockindex)
+bool Curl_conn_is_setup(struct connectdata *conn, int8_t sockindex)
 {
   if(!CONN_SOCK_IDX_VALID(sockindex))
     return FALSE;
   return !!conn->cfilter[sockindex];
 }
 
-bool Curl_conn_is_connected(struct connectdata *conn, int sockindex)
+bool Curl_conn_is_connected(struct connectdata *conn, int8_t sockindex)
 {
   struct Curl_cfilter *cf;
 
@@ -506,7 +507,7 @@ bool Curl_conn_is_connected(struct connectdata *conn, int sockindex)
   return FALSE;
 }
 
-bool Curl_conn_is_ip_connected(struct Curl_easy *data, int sockindex)
+bool Curl_conn_is_ip_connected(struct Curl_easy *data, int8_t sockindex)
 {
   struct Curl_cfilter *cf;
 
@@ -533,14 +534,14 @@ static bool cf_is_tunneling(struct Curl_cfilter *cf)
   return FALSE;
 }
 
-bool Curl_conn_is_tunneling(struct connectdata *conn, int sockindex)
+bool Curl_conn_is_tunneling(struct connectdata *conn, int8_t sockindex)
 {
   if(!CONN_SOCK_IDX_VALID(sockindex))
     return FALSE;
   return conn ? cf_is_tunneling(conn->cfilter[sockindex]) : FALSE;
 }
 #else
-bool Curl_conn_is_tunneling(struct connectdata *conn, int sockindex)
+bool Curl_conn_is_tunneling(struct connectdata *conn, int8_t sockindex)
 {
   (void)conn;
   (void)sockindex;
@@ -561,7 +562,7 @@ static bool cf_is_ssl(struct Curl_cfilter *cf)
   return FALSE;
 }
 
-bool Curl_conn_is_ssl(struct connectdata *conn, int sockindex)
+bool Curl_conn_is_ssl(struct connectdata *conn, int8_t sockindex)
 {
   if(!CONN_SOCK_IDX_VALID(sockindex))
     return FALSE;
@@ -569,7 +570,7 @@ bool Curl_conn_is_ssl(struct connectdata *conn, int sockindex)
 }
 
 bool Curl_conn_get_ssl_info(struct Curl_easy *data,
-                            struct connectdata *conn, int sockindex,
+                            struct connectdata *conn, int8_t sockindex,
                             int query,
                             struct curl_tlssessioninfo *info)
 {
@@ -586,7 +587,7 @@ bool Curl_conn_get_ssl_info(struct Curl_easy *data,
 }
 
 CURLcode Curl_conn_get_ip_info(struct Curl_easy *data,
-                               struct connectdata *conn, int sockindex,
+                               struct connectdata *conn, int8_t sockindex,
                                bool *is_ipv6, struct ip_quadruple *ipquad)
 {
   struct Curl_cfilter *cf;
@@ -596,7 +597,7 @@ CURLcode Curl_conn_get_ip_info(struct Curl_easy *data,
   return Curl_conn_cf_get_ip_info(cf, data, is_ipv6, ipquad);
 }
 
-bool Curl_conn_is_multiplex(struct connectdata *conn, int sockindex)
+bool Curl_conn_is_multiplex(struct connectdata *conn, int8_t sockindex)
 {
   struct Curl_cfilter *cf;
 
@@ -673,7 +674,7 @@ unsigned char Curl_conn_http_version(struct Curl_easy *data,
   return (unsigned char)(result ? 0 : v);
 }
 
-bool Curl_conn_data_pending(struct Curl_easy *data, int sockindex)
+bool Curl_conn_data_pending(struct Curl_easy *data, int8_t sockindex)
 {
   struct Curl_cfilter *cf;
 
@@ -703,7 +704,7 @@ bool Curl_conn_cf_needs_flush(struct Curl_cfilter *cf,
   return (result || !pending) ? FALSE : TRUE;
 }
 
-bool Curl_conn_needs_flush(struct Curl_easy *data, int sockindex)
+bool Curl_conn_needs_flush(struct Curl_easy *data, int8_t sockindex)
 {
   if(!CONN_SOCK_IDX_VALID(sockindex))
     return FALSE;
@@ -736,7 +737,7 @@ CURLcode Curl_conn_adjust_pollset(struct Curl_easy *data,
 {
   CURLcode result = CURLE_OK;
   bool want_io = !!ps->n;
-  int i;
+  int8_t i;
 
   DEBUGASSERT(data);
   DEBUGASSERT(conn);
@@ -790,7 +791,7 @@ int Curl_conn_cf_poll(struct Curl_cfilter *cf,
   return rc;
 }
 
-void Curl_conn_get_current_host(struct Curl_easy *data, int sockindex,
+void Curl_conn_get_current_host(struct Curl_easy *data, int8_t sockindex,
                                 const char **phost, int *pport)
 {
   struct Curl_cfilter *cf, *cf_proxy = NULL;
@@ -924,7 +925,7 @@ curl_socket_t Curl_conn_get_first_socket(struct Curl_easy *data)
 }
 
 const struct Curl_sockaddr_ex *Curl_conn_get_remote_addr(
-  struct Curl_easy *data, int sockindex)
+  struct Curl_easy *data, int8_t sockindex)
 {
   struct Curl_cfilter *cf =
     (data->conn && CONN_SOCK_IDX_VALID(sockindex)) ?
@@ -937,7 +938,7 @@ CURLcode Curl_conn_ev_data_setup(struct Curl_easy *data)
   return cf_cntrl_all(data->conn, data, FALSE, CF_CTRL_DATA_SETUP, 0, NULL);
 }
 
-CURLcode Curl_conn_flush(struct Curl_easy *data, int sockindex)
+CURLcode Curl_conn_flush(struct Curl_easy *data, int8_t sockindex)
 {
   if(!CONN_SOCK_IDX_VALID(sockindex))
     return CURLE_BAD_FUNCTION_ARGUMENT;
@@ -993,7 +994,7 @@ CURLcode Curl_conn_keep_alive(struct Curl_easy *data,
 
 size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
                                     struct connectdata *conn,
-                                    int sockindex)
+                                    int8_t sockindex)
 {
   struct Curl_cfilter *cf;
   CURLcode result;
@@ -1013,7 +1014,7 @@ size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
 
 int Curl_conn_get_stream_error(struct Curl_easy *data,
                                struct connectdata *conn,
-                               int sockindex)
+                               int8_t sockindex)
 {
   struct Curl_cfilter *cf;
   CURLcode result;
@@ -1028,7 +1029,7 @@ int Curl_conn_get_stream_error(struct Curl_easy *data,
   return (result || n < 0) ? 0 : n;
 }
 
-int Curl_conn_sockindex(struct Curl_easy *data, curl_socket_t sockfd)
+int8_t Curl_conn_sockindex(struct Curl_easy *data, curl_socket_t sockfd)
 {
   if(data && data->conn &&
      sockfd != CURL_SOCKET_BAD && sockfd == data->conn->sock[SECONDARYSOCKET])
@@ -1036,7 +1037,7 @@ int Curl_conn_sockindex(struct Curl_easy *data, curl_socket_t sockfd)
   return FIRSTSOCKET;
 }
 
-CURLcode Curl_conn_recv(struct Curl_easy *data, int sockindex,
+CURLcode Curl_conn_recv(struct Curl_easy *data, int8_t sockindex,
                         char *buf, size_t len, size_t *pnread)
 {
   DEBUGASSERT(data);
@@ -1049,7 +1050,7 @@ CURLcode Curl_conn_recv(struct Curl_easy *data, int sockindex,
   return CURLE_FAILED_INIT;
 }
 
-CURLcode Curl_conn_send(struct Curl_easy *data, int sockindex,
+CURLcode Curl_conn_send(struct Curl_easy *data, int8_t sockindex,
                         const void *buf, size_t len, bool eos,
                         size_t *pnwritten)
 {

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -231,7 +231,7 @@ struct Curl_cfilter {
   struct Curl_cfilter *next;     /* next filter in chain */
   void *ctx;                     /* filter type specific settings */
   struct connectdata *conn;      /* the connection this filter belongs to */
-  int sockindex;                 /* the index the filter is installed at */
+  int8_t sockindex;                 /* the index the filter is installed at */
   BIT(connected);                /* != 0 iff this filter is connected */
   BIT(shutdown);                 /* != 0 iff this filter has shut down */
 };
@@ -286,7 +286,7 @@ CURLcode Curl_cf_create(struct Curl_cfilter **pcf,
  */
 void Curl_conn_cf_add(struct Curl_easy *data,
                       struct connectdata *conn,
-                      int sockindex,
+                      int8_t sockindex,
                       struct Curl_cfilter *cf);
 
 /**
@@ -314,7 +314,7 @@ void Curl_conn_cf_discard_chain(struct Curl_cfilter **pcf,
  * Remove and destroy all filters at chain `sockindex` on connection `conn`.
  */
 void Curl_conn_cf_discard_all(struct Curl_easy *data,
-                              struct connectdata *conn, int sockindex);
+                              struct connectdata *conn, int8_t sockindex);
 
 CURLcode Curl_conn_cf_connect(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
@@ -359,31 +359,31 @@ const char *Curl_conn_cf_get_alpn_negotiated(struct Curl_cfilter *cf,
 /**
  * Check if a filter chain at `sockindex` for connection `conn` exists.
  */
-bool Curl_conn_is_setup(struct connectdata *conn, int sockindex);
+bool Curl_conn_is_setup(struct connectdata *conn, int8_t sockindex);
 
 /**
  * Check if the filter chain at `sockindex` for connection `conn` is
  * completely connected.
  */
-bool Curl_conn_is_connected(struct connectdata *conn, int sockindex);
+bool Curl_conn_is_connected(struct connectdata *conn, int8_t sockindex);
 
 /**
  * Determine if we have reached the remote host on IP level, e.g.
  * have a TCP connection. This turns TRUE before a possible SSL
  * handshake has been started/done.
  */
-bool Curl_conn_is_ip_connected(struct Curl_easy *data, int sockindex);
+bool Curl_conn_is_ip_connected(struct Curl_easy *data, int8_t sockindex);
 
 /**
  * Determine if the connection is using SSL to the remote host
  * (or will be once connected). This will return FALSE, if SSL
  * is only used in proxying and not for the tunnel itself.
  */
-bool Curl_conn_is_ssl(struct connectdata *conn, int sockindex);
+bool Curl_conn_is_ssl(struct connectdata *conn, int8_t sockindex);
 
 /* Determine if the connection has one or more proxy filters.
  * e.g. is tunneling. */
-bool Curl_conn_is_tunneling(struct connectdata *conn, int sockindex);
+bool Curl_conn_is_tunneling(struct connectdata *conn, int8_t sockindex);
 
 /*
  * Fill `info` with information about the TLS instance securing the connection
@@ -391,18 +391,18 @@ bool Curl_conn_is_tunneling(struct connectdata *conn, int sockindex);
  * FALSE. 'query' should be CF_QUERY_SSL_INFO or CF_QUERY_SSL_CTX_INFO.
  */
 bool Curl_conn_get_ssl_info(struct Curl_easy *data,
-                            struct connectdata *conn, int sockindex,
+                            struct connectdata *conn, int8_t sockindex,
                             int query,
                             struct curl_tlssessioninfo *info);
 
 CURLcode Curl_conn_get_ip_info(struct Curl_easy *data,
-                               struct connectdata *conn, int sockindex,
+                               struct connectdata *conn, int8_t sockindex,
                                bool *is_ipv6, struct ip_quadruple *ipquad);
 
 /**
  * Connection provides multiplexing of easy handles at `socketindex`.
  */
-bool Curl_conn_is_multiplex(struct connectdata *conn, int sockindex);
+bool Curl_conn_is_multiplex(struct connectdata *conn, int8_t sockindex);
 
 /**
  * Return the HTTP version used on the FIRSTSOCKET connection filters
@@ -423,32 +423,33 @@ void Curl_conn_cntrl_update_info(struct Curl_easy *data,
                                  struct connectdata *conn);
 
 void Curl_conn_remove_setup_filters(struct Curl_easy *data,
-                                    int sockindex);
+                                    int8_t sockindex);
 
 /**
  * Shutdown the connection at `sockindex` non-blocking, using timeout
  * from `data->set.shutdowntimeout`, default DEFAULT_SHUTDOWN_TIMEOUT_MS.
  * Return CURLE_OK and *done == FALSE if not finished.
  */
-CURLcode Curl_conn_shutdown(struct Curl_easy *data, int sockindex, bool *done);
+CURLcode Curl_conn_shutdown(struct Curl_easy *data,
+                            int8_t sockindex, bool *done);
 
 /**
  * Return if data is pending in some connection filter at chain
  * `sockindex` for connection `data->conn`.
  */
 bool Curl_conn_data_pending(struct Curl_easy *data,
-                            int sockindex);
+                            int8_t sockindex);
 
 /**
  * Return TRUE if any of the connection filters at chain `sockindex`
  * have data still to send.
  */
-bool Curl_conn_needs_flush(struct Curl_easy *data, int sockindex);
+bool Curl_conn_needs_flush(struct Curl_easy *data, int8_t sockindex);
 
 /**
  * Flush any pending data on the connection filters at chain `sockindex`.
  */
-CURLcode Curl_conn_flush(struct Curl_easy *data, int sockindex);
+CURLcode Curl_conn_flush(struct Curl_easy *data, int8_t sockindex);
 
 /**
  * Return the socket used on data's connection for FIRSTSOCKET,
@@ -459,12 +460,12 @@ curl_socket_t Curl_conn_get_first_socket(struct Curl_easy *data);
 
 /* Return a pointer to the connected socket address or NULL. */
 const struct Curl_sockaddr_ex *
-Curl_conn_get_remote_addr(struct Curl_easy *data, int sockindex);
+Curl_conn_get_remote_addr(struct Curl_easy *data, int8_t sockindex);
 
 /**
  * Tell filters to forget about the socket at sockindex.
  */
-void Curl_conn_forget_socket(struct Curl_easy *data, int sockindex);
+void Curl_conn_forget_socket(struct Curl_easy *data, int8_t sockindex);
 
 /**
  * Adjust the pollset for the filter chain starting at `cf`.
@@ -494,7 +495,7 @@ int Curl_conn_cf_poll(struct Curl_cfilter *cf,
  * `data->conn`. Copy at most `len` bytes into `buf`. Return the
  * actual number of bytes copied in `*pnread`or an error.
  */
-CURLcode Curl_cf_recv(struct Curl_easy *data, int sockindex, char *buf,
+CURLcode Curl_cf_recv(struct Curl_easy *data, int8_t sockindex, char *buf,
                       size_t len, size_t *pnread);
 
 /**
@@ -502,7 +503,7 @@ CURLcode Curl_cf_recv(struct Curl_easy *data, int sockindex, char *buf,
  * at connection `data->conn`. Return the actual number of bytes written
  * in `*pnwritten` or on error.
  */
-CURLcode Curl_cf_send(struct Curl_easy *data, int sockindex,
+CURLcode Curl_cf_send(struct Curl_easy *data, int8_t sockindex,
                       const uint8_t *buf, size_t len, bool eos,
                       size_t *pnwritten);
 
@@ -571,7 +572,7 @@ CURLcode Curl_conn_keep_alive(struct Curl_easy *data,
  * During connect, when tunneling proxies are involved (http or socks),
  * it will be the name and port the proxy currently negotiates with.
  */
-void Curl_conn_get_current_host(struct Curl_easy *data, int sockindex,
+void Curl_conn_get_current_host(struct Curl_easy *data, int8_t sockindex,
                                 const char **phost, int *pport);
 
 /**
@@ -580,18 +581,18 @@ void Curl_conn_get_current_host(struct Curl_easy *data, int sockindex,
  */
 size_t Curl_conn_get_max_concurrent(struct Curl_easy *data,
                                     struct connectdata *conn,
-                                    int sockindex);
+                                    int8_t sockindex);
 
 /**
  * Get the underlying error code for a transfer stream or 0 if not known.
  */
 int Curl_conn_get_stream_error(struct Curl_easy *data,
                                struct connectdata *conn,
-                               int sockindex);
+                               int8_t sockindex);
 
 #ifdef CURLVERBOSE
 void Curl_conn_trc_filters(struct Curl_easy *data,
-                           int sockindex, const char *info);
+                           int8_t sockindex, const char *info);
 #endif
 
 /**
@@ -599,20 +600,20 @@ void Curl_conn_trc_filters(struct Curl_easy *data,
  * Useful in calling `Curl_conn_send()/Curl_conn_recv()` with the
  * correct socket index.
  */
-int Curl_conn_sockindex(struct Curl_easy *data, curl_socket_t sockfd);
+int8_t Curl_conn_sockindex(struct Curl_easy *data, curl_socket_t sockfd);
 
 /*
  * Receive data on the connection, using FIRSTSOCKET/SECONDARYSOCKET.
  * Return CURLE_AGAIN iff blocked on receiving.
  */
-CURLcode Curl_conn_recv(struct Curl_easy *data, int sockindex,
+CURLcode Curl_conn_recv(struct Curl_easy *data, int8_t sockindex,
                         char *buf, size_t len, size_t *pnread);
 
 /*
  * Send data on the connection, using FIRSTSOCKET/SECONDARYSOCKET.
  * Return CURLE_AGAIN iff blocked on sending.
  */
-CURLcode Curl_conn_send(struct Curl_easy *data, int sockindex,
+CURLcode Curl_conn_send(struct Curl_easy *data, int8_t sockindex,
                         const void *buf, size_t len, bool eos,
                         size_t *pnwritten);
 

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -658,7 +658,8 @@ bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
     maxconnects = data->multi->maxconnects;
   }
 
-  conn->lastused = *Curl_pgrs_now(data); /* it was used up until now */
+  /* remember times, connection had been used just before */
+  conn->lastchecked = conn->lastupkeep = conn->lastused = *Curl_pgrs_now(data);
   if(cpool && maxconnects) {
     /* may be called form a callback already under lock */
     bool do_lock = !CPOOL_IS_LOCKED(cpool);
@@ -783,15 +784,17 @@ static int conn_upkeep(struct cpool *cpool,
                        struct connectdata *conn,
                        void *param)
 {
+  const struct curltime *pnow = Curl_pgrs_now(admin);
+
   (void)param;
-  if(curlx_ptimediff_ms(Curl_pgrs_now(admin), &conn->keepalive) >=
+  if(curlx_ptimediff_ms(pnow, &conn->lastupkeep) >=
      admin->set.upkeep_interval_ms) {
     CURLcode result;
 
+    conn->lastupkeep = *pnow;
     /* briefly attach for action */
     Curl_attach_connection(admin, conn, FALSE);
     result = Curl_conn_keep_alive(admin, conn);
-    conn->keepalive = *Curl_pgrs_now(admin);
     Curl_detach_connection(admin);
 
     if(result && !CONN_INUSE(conn)) {

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -108,7 +108,7 @@ timediff_t Curl_timeleft_ms(struct Curl_easy *data)
   return timeleft_now_ms(data, Curl_pgrs_now(data));
 }
 
-void Curl_shutdown_start(struct Curl_easy *data, int sockindex,
+void Curl_shutdown_start(struct Curl_easy *data, int8_t sockindex,
                          int timeout_ms)
 {
   struct connectdata *conn = data->conn;
@@ -128,7 +128,7 @@ void Curl_shutdown_start(struct Curl_easy *data, int sockindex,
 
 timediff_t Curl_shutdown_timeleft(struct Curl_easy *data,
                                   struct connectdata *conn,
-                                  int sockindex)
+                                  int8_t sockindex)
 {
   timediff_t left_ms;
 
@@ -146,7 +146,7 @@ timediff_t Curl_conn_shutdown_timeleft(struct Curl_easy *data,
                                        struct connectdata *conn)
 {
   timediff_t left_ms = 0, ms;
-  int i;
+  int8_t i;
 
   for(i = 0; conn->shutdown.timeout_ms && (i < 2); ++i) {
     if(!conn->shutdown.start[i].tv_sec)
@@ -158,13 +158,13 @@ timediff_t Curl_conn_shutdown_timeleft(struct Curl_easy *data,
   return left_ms;
 }
 
-void Curl_shutdown_clear(struct Curl_easy *data, int sockindex)
+void Curl_shutdown_clear(struct Curl_easy *data, int8_t sockindex)
 {
   struct curltime *pt = &data->conn->shutdown.start[sockindex];
   memset(pt, 0, sizeof(*pt));
 }
 
-bool Curl_shutdown_started(struct connectdata *conn, int sockindex)
+bool Curl_shutdown_started(struct connectdata *conn, int8_t sockindex)
 {
   const struct curltime *pt = &conn->shutdown.start[sockindex];
   return (pt->tv_sec > 0) || (pt->tv_usec > 0);
@@ -232,7 +232,7 @@ void Curl_conncontrol(struct connectdata *conn, int ctrl)
 
 CURLcode Curl_conn_setup(struct Curl_easy *data,
                          struct connectdata *conn,
-                         int sockindex,
+                         int8_t sockindex,
                          int ssl_mode)
 {
   struct Curl_peer *first_peer = Curl_conn_get_first_peer(conn, sockindex);
@@ -326,7 +326,7 @@ static void conn_report_connect_stats(struct Curl_cfilter *cf,
 }
 
 CURLcode Curl_conn_connect(struct Curl_easy *data,
-                           int sockindex,
+                           int8_t sockindex,
                            bool blocking,
                            bool *done)
 {
@@ -385,7 +385,7 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
        * socket and ip related information. */
       Curl_conn_cntrl_update_info(data, data->conn);
       conn_report_connect_stats(cf, data);
-      data->conn->keepalive = *Curl_pgrs_now(data);
+      data->conn->lastupkeep = *Curl_pgrs_now(data);
       VERBOSE(result = conn_connect_trace(data, cf));
       VERBOSE(Curl_conn_trc_filters(data, sockindex, "connected"));
       Curl_conn_remove_setup_filters(data, sockindex);
@@ -458,14 +458,14 @@ void Curl_conn_set_multiplex(struct connectdata *conn)
 }
 
 struct Curl_peer *Curl_conn_get_origin(struct connectdata *conn,
-                                       int sockindex)
+                                       int8_t sockindex)
 {
   return (sockindex == SECONDARYSOCKET) ?
     conn->origin2 : conn->origin;
 }
 
 struct Curl_peer *Curl_conn_get_destination(struct connectdata *conn,
-                                            int sockindex)
+                                            int8_t sockindex)
 {
   return (sockindex == SECONDARYSOCKET) ?
     (conn->via_peer2 ? conn->via_peer2 : conn->origin2) :
@@ -473,7 +473,7 @@ struct Curl_peer *Curl_conn_get_destination(struct connectdata *conn,
 }
 
 struct Curl_peer *Curl_conn_get_first_peer(struct connectdata *conn,
-                                           int sockindex)
+                                           int8_t sockindex)
 {
 #ifndef CURL_DISABLE_PROXY
   if(conn->socks_proxy.peer)

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -41,24 +41,24 @@ timediff_t Curl_timeleft_ms(struct Curl_easy *data);
 
 #define DEFAULT_SHUTDOWN_TIMEOUT_MS   (2 * 1000)
 
-void Curl_shutdown_start(struct Curl_easy *data, int sockindex,
+void Curl_shutdown_start(struct Curl_easy *data, int8_t sockindex,
                          int timeout_ms);
 
 /* return how much time there is left to shutdown the connection at
  * sockindex. Returns 0 if there is no limit or shutdown has not started. */
 timediff_t Curl_shutdown_timeleft(struct Curl_easy *data,
                                   struct connectdata *conn,
-                                  int sockindex);
+                                  int8_t sockindex);
 
 /* return how much time there is left to shutdown the connection.
  * Returns 0 if there is no limit or shutdown has not started. */
 timediff_t Curl_conn_shutdown_timeleft(struct Curl_easy *data,
                                        struct connectdata *conn);
 
-void Curl_shutdown_clear(struct Curl_easy *data, int sockindex);
+void Curl_shutdown_clear(struct Curl_easy *data, int8_t sockindex);
 
 /* TRUE iff shutdown has been started */
-bool Curl_shutdown_started(struct connectdata *conn, int sockindex);
+bool Curl_shutdown_started(struct connectdata *conn, int8_t sockindex);
 
 /*
  * Used to extract socket and connectdata struct for the most recent
@@ -95,7 +95,7 @@ void Curl_conncontrol(struct connectdata *conn, int ctrl);
  */
 CURLcode Curl_conn_setup(struct Curl_easy *data,
                          struct connectdata *conn,
-                         int sockindex,
+                         int8_t sockindex,
                          int ssl_mode);
 
 /**
@@ -105,7 +105,7 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
  * When not `blocking`, calls may return without error and `*done != TRUE`,
  * while the individual filters negotiated the connection.
  */
-CURLcode Curl_conn_connect(struct Curl_easy *data, int sockindex,
+CURLcode Curl_conn_connect(struct Curl_easy *data, int8_t sockindex,
                            bool blocking, bool *done);
 
 /* Set conn to allow multiplexing. */
@@ -113,17 +113,17 @@ void Curl_conn_set_multiplex(struct connectdata *conn);
 
 /* Get the origin peer at sockindex. */
 struct Curl_peer *Curl_conn_get_origin(struct connectdata *conn,
-                                       int sockindex);
+                                       int8_t sockindex);
 
 /* Get the peer the connection actually connects to at sockindex.
  * Often the same as "origin", but can be redirected via "connect-to"
  * or "alt-svc". May tunnel through proxies. */
 struct Curl_peer *Curl_conn_get_destination(struct connectdata *conn,
-                                            int sockindex);
+                                            int8_t sockindex);
 
 /* Get the peer curl connects its socket to.
  * Can be origin, "connect-to" or the first proxy. */
 struct Curl_peer *Curl_conn_get_first_peer(struct connectdata *conn,
-                                           int sockindex);
+                                           int8_t sockindex);
 
 #endif /* HEADER_CURL_CONNECT_H */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1111,6 +1111,7 @@ void curl_easy_reset(CURL *curl)
   if(CURL_EAPI_ENTER(&guard, curl, easy_reset, NULL)) {
     struct Curl_easy *data = curl;
 
+    data->state.lastconnect_id = -1; /* clear remembered connection id */
     Curl_req_hard_reset(&data->req, data);
     Curl_hash_clean(&data->meta_hash);
 
@@ -1128,8 +1129,6 @@ void curl_easy_reset(CURL *curl)
     Curl_initinfo(data);
 
     data->progress.hide = TRUE;
-    data->state.current_speed = -1; /* init to negative == impossible */
-    data->state.lastconnect_id = -1; /* clear remembered connection id */
 
     /* zero out authentication data: */
     memset(&data->state.authhost, 0, sizeof(struct auth));

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -590,7 +590,7 @@ static bool ftp_endofresp(struct Curl_easy *data, struct connectdata *conn,
 
 static CURLcode ftp_readresp(struct Curl_easy *data,
                              struct ftp_conn *ftpc,
-                             int sockindex,
+                             int8_t sockindex,
                              struct pingpong *pp,
                              int *ftpcodep, /* return the ftp-code if done */
                              size_t *size) /* size of the response */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2784,7 +2784,7 @@ struct Curl_cftype Curl_cft_nghttp2 = {
 static CURLcode http2_cfilter_add(struct Curl_cfilter **pcf,
                                   struct Curl_easy *data,
                                   struct connectdata *conn,
-                                  int sockindex,
+                                  int8_t sockindex,
                                   bool via_h1_upgrade)
 {
   struct Curl_cfilter *cf = NULL;
@@ -2894,7 +2894,7 @@ CURLcode Curl_http2_switch_at(struct Curl_cfilter *cf, struct Curl_easy *data)
 }
 
 CURLcode Curl_http2_upgrade(struct Curl_easy *data,
-                            struct connectdata *conn, int sockindex,
+                            struct connectdata *conn, int8_t sockindex,
                             const char *mem, size_t nread)
 {
   struct Curl_cfilter *cf;

--- a/lib/http2.h
+++ b/lib/http2.h
@@ -54,7 +54,7 @@ CURLcode Curl_http2_switch(struct Curl_easy *data);
 CURLcode Curl_http2_switch_at(struct Curl_cfilter *cf, struct Curl_easy *data);
 
 CURLcode Curl_http2_upgrade(struct Curl_easy *data,
-                            struct connectdata *conn, int sockindex,
+                            struct connectdata *conn, int8_t sockindex,
                             const char *mem, size_t nread);
 
 void *Curl_nghttp2_malloc(size_t size, void *user_data);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -650,18 +650,19 @@ static void multi_done_locked(struct connectdata *conn,
   Curl_dnscache_prune(data);
 
   if(multi_conn_should_close(conn, data, (bool)mdctx->premature)) {
-    CURL_TRC_M(data, "multi_done, terminating conn #%" FMT_OFF_T " to %s, "
+    CURL_TRC_M(data, "multi_done, terminating conn #%" FMT_OFF_T " to %s:%u, "
                "forbid=%d, close=%d, premature=%d, conn_multiplex=%d",
-               conn->connection_id, conn->destination,
+               conn->connection_id, conn->origin->user_hostname,
+               conn->origin->port,
                data->set.reuse_forbid, conn->bits.close, mdctx->premature,
                Curl_conn_is_multiplex(conn, FIRSTSOCKET));
     connclose(conn);
     Curl_conn_close(data, conn, (bool)mdctx->premature);
   }
   else if(!Curl_conn_get_max_concurrent(data, conn, FIRSTSOCKET)) {
-    CURL_TRC_M(data, "multi_done, conn #%" FMT_OFF_T " to %s was shutdown"
+    CURL_TRC_M(data, "multi_done, conn #%" FMT_OFF_T " to %s:%u was shutdown"
                " by server, not reusing", conn->connection_id,
-               conn->destination);
+               conn->origin->user_hostname, conn->origin->port);
     connclose(conn);
     Curl_conn_close(data, conn, (bool)mdctx->premature);
   }
@@ -669,8 +670,9 @@ static void multi_done_locked(struct connectdata *conn,
     /* the connection is no longer in use by any transfer */
     if(Curl_cpool_conn_now_idle(data, conn)) {
       /* connection kept in the cpool */
-      infof(data, "Connection #%" FMT_OFF_T " to host %s left intact",
-            conn->connection_id, conn->destination);
+      infof(data, "Connection #%" FMT_OFF_T " to host %s:%u left intact",
+            conn->connection_id, conn->origin->user_hostname,
+            conn->origin->port);
     }
     else {
       /* connection was removed from the cpool and destroyed. */

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1100,7 +1100,7 @@ static CURLcode client_write(struct Curl_easy *data,
   return result;
 }
 
-static CURLcode oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
+static CURLcode oldap_recv(struct Curl_easy *data, int8_t sockindex, char *buf,
                            size_t len, size_t *pnread)
 {
   struct connectdata *conn = data->conn;

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -222,7 +222,7 @@ CURLcode Curl_pp_sendf(struct Curl_easy *data, struct pingpong *pp,
 }
 
 static CURLcode pingpong_read(struct Curl_easy *data,
-                              int sockindex,
+                              int8_t sockindex,
                               char *buffer,
                               size_t buflen,
                               size_t *nread)
@@ -236,7 +236,7 @@ static CURLcode pingpong_read(struct Curl_easy *data,
  * Reads a piece of a server response.
  */
 CURLcode Curl_pp_readresp(struct Curl_easy *data,
-                          int sockindex,
+                          int8_t sockindex,
                           struct pingpong *pp,
                           int *code, /* return the server code if done */
                           size_t *size) /* size of the response */

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -132,7 +132,7 @@ CURLcode Curl_pp_vsendf(struct Curl_easy *data,
  * Reads a piece of a server response.
  */
 CURLcode Curl_pp_readresp(struct Curl_easy *data,
-                          int sockindex,
+                          int8_t sockindex,
                           struct pingpong *pp,
                           int *code, /* return the server code if done */
                           size_t *size); /* size of the response */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -669,8 +669,8 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
 
 static void xfer_setup(
   struct Curl_easy *data,   /* transfer */
-  int send_idx,             /* sockindex to send on or -1 */
-  int recv_idx,             /* sockindex to receive on or -1 */
+  int8_t send_idx,             /* sockindex to send on or -1 */
+  int8_t recv_idx,             /* sockindex to receive on or -1 */
   curl_off_t recv_size      /* how much to receive, -1 if unknown */
   )
 {
@@ -718,20 +718,20 @@ void Curl_xfer_setup_nop(struct Curl_easy *data)
 }
 
 void Curl_xfer_setup_sendrecv(struct Curl_easy *data,
-                              int sockindex,
+                              int8_t sockindex,
                               curl_off_t recv_size)
 {
   xfer_setup(data, sockindex, sockindex, recv_size);
 }
 
 void Curl_xfer_setup_send(struct Curl_easy *data,
-                          int sockindex)
+                          int8_t sockindex)
 {
   xfer_setup(data, sockindex, -1, -1);
 }
 
 void Curl_xfer_setup_recv(struct Curl_easy *data,
-                          int sockindex,
+                          int8_t sockindex,
                           curl_off_t recv_size)
 {
   xfer_setup(data, -1, sockindex, recv_size);

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -69,12 +69,12 @@ void Curl_xfer_setup_nop(struct Curl_easy *data);
 
 /* The transfer sends data on the given socket index */
 void Curl_xfer_setup_send(struct Curl_easy *data,
-                          int sockindex);
+                          int8_t sockindex);
 
 /* The transfer receives data on the given socket index, the
  * amount to receive (or -1 if unknown). */
 void Curl_xfer_setup_recv(struct Curl_easy *data,
-                          int sockindex,
+                          int8_t sockindex,
                           curl_off_t recv_size);
 
 /* *After* Curl_xfer_setup_xxx(), tell the transfer to shutdown the
@@ -89,7 +89,7 @@ void Curl_xfer_set_shutdown(struct Curl_easy *data,
  * the amount to receive or -1 if unknown.
  */
 void Curl_xfer_setup_sendrecv(struct Curl_easy *data,
-                              int sockindex,
+                              int8_t sockindex,
                               curl_off_t recv_size);
 
 /**

--- a/lib/url.c
+++ b/lib/url.c
@@ -476,7 +476,6 @@ CURLcode Curl_open(struct Curl_easy **curl)
   data->mid = UINT32_MAX;
   data->master_mid = UINT32_MAX;
   data->progress.hide = TRUE;
-  data->state.current_speed = -1; /* init to negative == impossible */
 
   Curl_hash_init(&data->meta_hash, 23,
                  Curl_hash_str, curlx_str_key_compare, easy_meta_freeentry);
@@ -497,7 +496,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
 
 void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 {
-  size_t i;
+  int8_t i;
 
   DEBUGASSERT(conn);
 
@@ -505,8 +504,8 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
      !conn->bits.shutdown_handler)
     conn->scheme->run->disconnect(data, conn, TRUE);
 
-  for(i = 0; i < CURL_ARRAYSIZE(conn->cfilter); ++i) {
-    Curl_conn_cf_discard_all(data, conn, (int)i);
+  for(i = 0; i < (int8_t)CURL_ARRAYSIZE(conn->cfilter); ++i) {
+    Curl_conn_cf_discard_all(data, conn, i);
   }
 
 #ifndef CURL_DISABLE_PROXY
@@ -1227,11 +1226,8 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
   conn->connection_id = -1;    /* no ID */
   conn->attached_xfers = 0;
 
-  /* Store creation time to help future close decision making */
-  conn->created = *Curl_pgrs_now(data);
-
-  /* Store current time to give a baseline to keepalive connection times. */
-  conn->keepalive = conn->created;
+  /* Remember time this connection started */
+  conn->lastused = conn->lastupkeep = conn->created = *Curl_pgrs_now(data);
 
 #ifndef CURL_DISABLE_FTP
   conn->bits.ftp_use_epsv = data->set.ftp_use_epsv;
@@ -1256,7 +1252,6 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
      it may live on without (this specific) Curl_easy */
   conn->fclosesocket = data->set.fclosesocket;
   conn->closesocket_client = data->set.closesocket_client;
-  conn->lastused = conn->created;
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   conn->gssapi_delegation = data->set.gssapi_delegation;
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -75,7 +75,7 @@
 
 /* On error return, the value of `pnwritten` has no meaning */
 typedef CURLcode (Curl_send)(struct Curl_easy *data,   /* transfer */
-                             int sockindex,            /* socketindex */
+                             int8_t sockindex,            /* socketindex */
                              const uint8_t *buf,       /* data to write */
                              size_t len,               /* amount to send */
                              bool eos,                 /* last chunk */
@@ -83,7 +83,7 @@ typedef CURLcode (Curl_send)(struct Curl_easy *data,   /* transfer */
 
 /* On error return, the value of `pnread` has no meaning */
 typedef CURLcode (Curl_recv)(struct Curl_easy *data,   /* transfer */
-                             int sockindex,            /* socketindex */
+                             int8_t sockindex,            /* socketindex */
                              char *buf,                /* store data here */
                              size_t len,               /* max amount to read */
                              size_t *pnread);          /* how much received */
@@ -259,74 +259,15 @@ struct ip_quadruple {
  * unique for an entire connection.
  */
 struct connectdata {
-  struct Curl_llist_node cpool_node; /* conncache lists */
-  struct Curl_llist_node cshutdn_node; /* cshutdn list */
-
-  curl_closesocket_callback fclosesocket; /* function closing the socket(s) */
-  void *closesocket_client;
+  curl_off_t connection_id; /* Contains a unique number to make it easier to
+                               track the connections in the log output */
 
   /* This is used by the connection pool logic. If this returns TRUE, this
      handle is still used by one or more easy handles and can only used by any
      other easy handle without careful consideration (== only for
      multiplexing) and it cannot be used by another multi handle! */
 #define CONN_INUSE(c) (!!(c)->attached_xfers)
-
-  /**** Fields set when inited and not modified again */
-  curl_off_t connection_id; /* Contains a unique number to make it easier to
-                               track the connections in the log output */
-  char *destination; /* string carrying normalized hostname+port+scope */
-
-  /* `meta_hash` is a general key-value store for implementations
-   * with the lifetime of the connection.
-   * Elements need to be added with their own destructor to be invoked when
-   * the connection is cleaned up (see Curl_hash_add2()).*/
-  struct Curl_hash meta_hash;
-
-  /* Who the connection is talking to, ultimately */
-  struct Curl_peer *origin; /* connection ultimately talks to this */
-  struct Curl_peer *via_peer; /* if set, connection really talks to this */
-  struct Curl_peer *origin2; /* origin of SECONDARYSOCKET */
-  struct Curl_peer *via_peer2; /* peer of SECONDARYSOCKET */
-#ifndef CURL_DISABLE_PROXY
-  struct proxy_info socks_proxy;
-  struct proxy_info http_proxy;
-#endif
-  struct Curl_creds *creds; /* When connection itself is tied to credentials */
-  struct Curl_peer *creds_origin; /* origin tied credentials are for */
-  char *options; /* options string, allocated */
-  struct curltime created; /* creation time */
-  struct curltime lastused; /* when returned to the connection pool as idle */
-  struct curltime lastchecked; /* when last checked alive status */
-
-  /* A connection can have one or two sockets and connection filters.
-   * The protocol using the 2nd one is FTP for CONTROL+DATA sockets */
-  curl_socket_t sock[2];
-  struct Curl_cfilter *cfilter[2]; /* connection filters */
-  Curl_recv *recv[2];
-  Curl_send *send[2];
-  int recv_idx;  /* on which socket index to receive, default 0 */
-  int send_idx;  /* on which socket index to send, default 0 */
-
-#define CONN_SOCK_IDX_VALID(i)    (((i) >= 0) && ((i) < 2))
-
-  struct {
-    struct curltime start[2]; /* when filter shutdown started */
-    timediff_t timeout_ms; /* 0 means no timeout */
-  } shutdown;
-
-  struct ssl_primary_config ssl_config;
-#ifndef CURL_DISABLE_PROXY
-  struct ssl_primary_config proxy_ssl_config;
-#endif
-  struct ConnectBits bits;    /* various state-flags for this connection */
-
-  const struct Curl_scheme *scheme; /* Connection's protocol handler */
-  const struct Curl_scheme *given;   /* The protocol first given */
-
-  /* Protocols can use a custom keepalive mechanism to keep connections alive.
-     This allows those protocols to track the last time the keepalive mechanism
-     was used on this connection. */
-  struct curltime keepalive;
+  uint32_t attached_xfers; /* # of attached easy handles */
 
   /* A connection cache from a SHARE might be used in several multi handles.
    * We MUST not reuse connections that are running in another multi,
@@ -335,6 +276,59 @@ struct connectdata {
    * when the last one is detached.
    * NEVER call anything on this multi, check for equality. */
   struct Curl_multi *attached_multi;
+
+  /* Who the connection is talking to, ultimately */
+  struct Curl_peer *origin; /* connection ultimately talks to this */
+  struct Curl_peer *via_peer; /* if set, connection really talks to this */
+  struct Curl_peer *origin2; /* origin of SECONDARYSOCKET */
+  struct Curl_peer *via_peer2; /* peer of SECONDARYSOCKET */
+  struct Curl_creds *creds; /* When connection itself is tied to credentials */
+  struct Curl_peer *creds_origin; /* origin tied credentials are for */
+  const struct Curl_scheme *scheme; /* Connection's real protocol handler */
+  const struct Curl_scheme *given;   /* The protocol first given */
+
+  /* `meta_hash` is a general key-value store for implementations
+   * with the lifetime of the connection.
+   * Elements need to be added with their own destructor to be invoked when
+   * the connection is cleaned up (see Curl_hash_add2()).*/
+  struct Curl_hash meta_hash;
+
+  struct Curl_llist_node cpool_node; /* conncache lists */
+  struct Curl_llist_node cshutdn_node; /* cshutdn list */
+  char *destination; /* hostname+port, used in conncache */
+
+  struct curltime created; /* creation time */
+  struct curltime lastused; /* when returned to the connection pool as idle */
+  struct curltime lastchecked; /* when last checked alive status */
+  struct curltime lastupkeep; /* when last done conn_upkeep */
+
+#ifndef CURL_DISABLE_PROXY
+  struct proxy_info socks_proxy;
+  struct proxy_info http_proxy;
+#endif
+
+  struct Curl_cfilter *cfilter[2]; /* connection filters */
+  Curl_recv *recv[2];
+  Curl_send *send[2];
+  /* A connection can have one or two sockets and connection filters.
+   * The protocol using the 2nd one is FTP for CONTROL+DATA sockets */
+  curl_socket_t sock[2];
+
+#define CONN_SOCK_IDX_VALID(i)    (((i) >= 0) && ((i) < 2))
+
+  struct {
+    struct curltime start[2]; /* when filter shutdown started */
+    timediff_t timeout_ms; /* 0 means no timeout */
+  } shutdown;
+
+  curl_closesocket_callback fclosesocket; /* function closing the socket(s) */
+  void *closesocket_client;
+
+  struct ssl_primary_config ssl_config;
+#ifndef CURL_DISABLE_PROXY
+  struct ssl_primary_config proxy_ssl_config;
+#endif
+  char *options; /* options string, allocated */
 
   /*************** Request - specific items ************/
 #if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
@@ -360,13 +354,14 @@ struct connectdata {
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   int socks5_gssapi_enctype;
 #endif
-  uint32_t attached_xfers; /* # of attached easy handles */
 
 #ifdef USE_IPV6
   uint32_t scope_id;  /* Scope id for IPv6 */
 #endif
   uint16_t localportrange;
   uint16_t localport;
+  int8_t recv_idx;  /* on which socket index to receive, default 0 */
+  int8_t send_idx;  /* on which socket index to send, default 0 */
   uint8_t transport_wanted; /* one of the TRNSPRT_* defines. Not necessarily
    the transport the connection ends using due to Alt-Svc and happy
    eyeballing. Use Curl_conn_get_transport() for actual value once the
@@ -376,6 +371,8 @@ struct connectdata {
    * 0 at start, then one of 09, 10, 11, etc. */
   uint8_t httpversion_seen;
   uint8_t gssapi_delegation; /* inherited from set.gssapi_delegation */
+
+  struct ConnectBits bits;    /* various state-flags for this connection */
 };
 
 #ifndef CURL_DISABLE_PROXY
@@ -528,18 +525,7 @@ struct urlpieces {
 };
 
 struct UrlState {
-  /* buffers to store authentication data in, as parsed from input options */
-  struct curltime keeps_speed; /* for the progress meter really */
-
   curl_off_t lastconnect_id; /* The last assigned connection or -1 */
-  struct dynbuf headerb; /* buffer to store headers in */
-#ifndef CURL_DISABLE_HSTS
-  struct curl_slist *hstslist; /* list of HSTS files set by
-                                  curl_easy_setopt(HSTS) calls */
-#endif
-  curl_off_t current_speed;  /* the ProgressShow() function sets this,
-                                bytes / second */
-
   /* Origin of the initial (e.g. not followed) request of a transfer.
      Credentials from CURLOPT_* are only valid for this origin.
      Always set once a transfer starts searching for connections. */
@@ -547,6 +533,13 @@ struct UrlState {
   /* Current origin of the transfer, changes to origin of follow
    * requests. */
   struct Curl_peer *origin;
+
+  struct curltime keeps_speed; /* for the progress meter really */
+  struct dynbuf headerb; /* buffer to store headers in */
+#ifndef CURL_DISABLE_HSTS
+  struct curl_slist *hstslist; /* list of HSTS files set by
+                                  curl_easy_setopt(HSTS) calls */
+#endif
 
   int os_errno;  /* filled in with errno whenever an error occurs */
   int requests; /* request counter: redirects + authentication retakes */
@@ -598,9 +591,6 @@ struct UrlState {
   curl_mimepart *formp; /* storage for old API form-posting, allocated on
                            demand */
 #endif
-  size_t trailers_bytes_sent;
-  struct dynbuf trailers_buf; /* a buffer containing the compiled trailing
-                                 headers */
   struct Curl_llist httphdrs; /* received headers */
   struct curl_header headerout[2]; /* for external purposes */
 #endif

--- a/lib/vdns/cf-dns.c
+++ b/lib/vdns/cf-dns.c
@@ -453,7 +453,7 @@ out:
  * The filter will resolve the peer on the first connect attempt. */
 static CURLcode cf_dns_add(struct Curl_easy *data,
                            struct connectdata *conn,
-                           int sockindex,
+                           int8_t sockindex,
                            struct Curl_peer *peer,
                            uint8_t dns_queries,
                            uint8_t transport)
@@ -502,7 +502,7 @@ static CURLcode cf_dns_insert_after(struct Curl_cfilter *cf_at,
 
 static CURLcode cf_dns_add_resolve(struct Curl_easy *data,
                                    struct connectdata *conn,
-                                   int sockindex,
+                                   int8_t sockindex,
                                    struct Curl_peer *peer,
                                    uint8_t dns_queries,
                                    uint8_t transport)
@@ -552,7 +552,7 @@ static CURLcode cf_dns_add_resolve(struct Curl_easy *data,
 
 CURLcode Curl_conn_dns_add_addr_resolve(struct Curl_easy *data,
                                         struct connectdata *conn,
-                                        int sockindex,
+                                        int8_t sockindex,
                                         struct Curl_peer *peer,
                                         uint8_t dns_queries,
                                         uint8_t transport)
@@ -571,7 +571,7 @@ CURLcode Curl_conn_dns_add_addr_resolve(struct Curl_easy *data,
  * - error returned by the DNS resolv
  */
 CURLcode Curl_conn_dns_addr_result(struct connectdata *conn,
-                                   int sockindex,
+                                   int8_t sockindex,
                                    struct Curl_peer *peer)
 {
   struct Curl_cfilter *cf = conn->cfilter[sockindex];
@@ -595,7 +595,7 @@ CURLcode Curl_conn_dns_addr_result(struct connectdata *conn,
  */
 const struct Curl_addrinfo *Curl_conn_dns_get_ai(struct Curl_easy *data,
                                                  struct Curl_peer *peer,
-                                                 int sockindex,
+                                                 int8_t sockindex,
                                                  int ai_family,
                                                  unsigned int index)
 {
@@ -633,7 +633,7 @@ const struct Curl_addrinfo *Curl_conn_dns_get_ai(struct Curl_easy *data,
 #ifdef USE_HTTPSRR
 CURLcode Curl_conn_dns_add_https_resolve(struct Curl_easy *data,
                                          struct connectdata *conn,
-                                         int sockindex,
+                                         int8_t sockindex,
                                          struct Curl_peer *peer)
 {
   return cf_dns_add_resolve(data, conn, sockindex, peer,
@@ -646,7 +646,7 @@ CURLcode Curl_conn_dns_add_https_resolve(struct Curl_easy *data,
  */
 const struct Curl_https_rrinfo *
 Curl_conn_dns_get_https(struct Curl_easy *data,
-                        int sockindex,
+                        int8_t sockindex,
                         struct Curl_peer *peer)
 {
   struct Curl_cfilter *cf = data->conn->cfilter[sockindex];
@@ -666,7 +666,7 @@ Curl_conn_dns_get_https(struct Curl_easy *data,
 }
 
 bool Curl_conn_dns_resolved_https(struct Curl_easy *data,
-                                  int sockindex,
+                                  int8_t sockindex,
                                   struct Curl_peer *peer)
 {
   struct Curl_cfilter *cf = data->conn->cfilter[sockindex];

--- a/lib/vdns/cf-dns.h
+++ b/lib/vdns/cf-dns.h
@@ -33,33 +33,33 @@ struct Curl_peer;
 
 CURLcode Curl_conn_dns_add_addr_resolve(struct Curl_easy *data,
                                         struct connectdata *conn,
-                                        int sockindex,
+                                        int8_t sockindex,
                                         struct Curl_peer *peer,
                                         uint8_t dns_queries,
                                         uint8_t transport);
 
 CURLcode Curl_conn_dns_addr_result(struct connectdata *conn,
-                                   int sockindex,
+                                   int8_t sockindex,
                                    struct Curl_peer *peer);
 
 const struct Curl_addrinfo *Curl_conn_dns_get_ai(struct Curl_easy *data,
                                                  struct Curl_peer *peer,
-                                                 int sockindex,
+                                                 int8_t sockindex,
                                                  int ai_family,
                                                  unsigned int index);
 
 #ifdef USE_HTTPSRR
 CURLcode Curl_conn_dns_add_https_resolve(struct Curl_easy *data,
                                          struct connectdata *conn,
-                                         int sockindex,
+                                         int8_t sockindex,
                                          struct Curl_peer *peer);
 
 const struct Curl_https_rrinfo *
 Curl_conn_dns_get_https(struct Curl_easy *data,
-                        int sockindex,
+                        int8_t sockindex,
                         struct Curl_peer *peer);
 bool Curl_conn_dns_resolved_https(struct Curl_easy *data,
-                                  int sockindex,
+                                  int8_t sockindex,
                                   struct Curl_peer *peer);
 #else
 #define Curl_conn_dns_get_https(a, b, c)        NULL

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1760,7 +1760,7 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
   return SSH_NO_ERROR;
 }
 
-static void conn_forget_socket(struct Curl_easy *data, int sockindex)
+static void conn_forget_socket(struct Curl_easy *data, int8_t sockindex)
 {
   struct connectdata *conn = data->conn;
   if(conn && CONN_SOCK_IDX_VALID(sockindex)) {
@@ -2778,7 +2778,7 @@ static CURLcode scp_done(struct Curl_easy *data, CURLcode status,
   return myssh_done(data, sshc, status);
 }
 
-static CURLcode scp_send(struct Curl_easy *data, int sockindex,
+static CURLcode scp_send(struct Curl_easy *data, int8_t sockindex,
                          const uint8_t *mem, size_t len, bool eos,
                          size_t *pnwritten)
 {
@@ -2812,7 +2812,7 @@ static CURLcode scp_send(struct Curl_easy *data, int sockindex,
   return CURLE_OK;
 }
 
-static CURLcode scp_recv(struct Curl_easy *data, int sockindex,
+static CURLcode scp_recv(struct Curl_easy *data, int8_t sockindex,
                          char *mem, size_t len, size_t *pnread)
 {
   struct connectdata *conn = data->conn;
@@ -2938,7 +2938,7 @@ static CURLcode sftp_done(struct Curl_easy *data, CURLcode status,
 }
 
 /* return number of sent bytes */
-static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
+static CURLcode sftp_send(struct Curl_easy *data, int8_t sockindex,
                           const uint8_t *mem, size_t len, bool eos,
                           size_t *pnwritten)
 {
@@ -3019,7 +3019,7 @@ static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
  * Return number of received (decrypted) bytes
  * or <0 on error
  */
-static CURLcode sftp_recv(struct Curl_easy *data, int sockindex,
+static CURLcode sftp_recv(struct Curl_easy *data, int8_t sockindex,
                           char *mem, size_t len, size_t *pnread)
 {
   struct connectdata *conn = data->conn;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3278,7 +3278,7 @@ static ssize_t ssh_tls_recv(libssh2_socket_t sock, void *buffer,
                             size_t length, int flags, void **abstract)
 {
   struct Curl_easy *data = (struct Curl_easy *)*abstract;
-  int sockindex = Curl_conn_sockindex(data, sock);
+  int8_t sockindex = Curl_conn_sockindex(data, sock);
   size_t nread;
   CURLcode result;
   struct connectdata *conn = data->conn;
@@ -3306,7 +3306,7 @@ static ssize_t ssh_tls_send(libssh2_socket_t sock, const void *buffer,
                             size_t length, int flags, void **abstract)
 {
   struct Curl_easy *data = (struct Curl_easy *)*abstract;
-  int sockindex = Curl_conn_sockindex(data, sock);
+  int8_t sockindex = Curl_conn_sockindex(data, sock);
   size_t nwrite;
   CURLcode result;
   struct connectdata *conn = data->conn;
@@ -3614,7 +3614,7 @@ static CURLcode scp_done(struct Curl_easy *data, CURLcode status,
   return ssh_done(data, status);
 }
 
-static CURLcode scp_send(struct Curl_easy *data, int sockindex,
+static CURLcode scp_send(struct Curl_easy *data, int8_t sockindex,
                          const uint8_t *mem, size_t len, bool eos,
                          size_t *pnwritten)
 {
@@ -3646,7 +3646,7 @@ static CURLcode scp_send(struct Curl_easy *data, int sockindex,
   return result;
 }
 
-static CURLcode scp_recv(struct Curl_easy *data, int sockindex,
+static CURLcode scp_recv(struct Curl_easy *data, int8_t sockindex,
                          char *mem, size_t len, size_t *pnread)
 {
   struct connectdata *conn = data->conn;
@@ -3772,7 +3772,7 @@ static CURLcode sftp_done(struct Curl_easy *data, CURLcode status,
 }
 
 /* return number of sent bytes */
-static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
+static CURLcode sftp_send(struct Curl_easy *data, int8_t sockindex,
                           const uint8_t *mem, size_t len, bool eos,
                           size_t *pnwritten)
 {
@@ -3803,7 +3803,7 @@ static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
  * Return number of received (decrypted) bytes
  * or <0 on error
  */
-static CURLcode sftp_recv(struct Curl_easy *data, int sockindex,
+static CURLcode sftp_recv(struct Curl_easy *data, int8_t sockindex,
                           char *mem, size_t len, size_t *pnread)
 {
   struct connectdata *conn = data->conn;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5273,7 +5273,7 @@ out:
 }
 
 static CURLcode ossl_get_channel_binding(struct Curl_easy *data,
-                                         int sockindex,
+                                         int8_t sockindex,
                                          struct dynbuf *binding)
 {
   X509 *cert;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -215,7 +215,7 @@ static void cf_ctx_free(struct ssl_connect_data *ctx)
   }
 }
 
-CURLcode Curl_ssl_get_channel_binding(struct Curl_easy *data, int sockindex,
+CURLcode Curl_ssl_get_channel_binding(struct Curl_easy *data, int8_t sockindex,
                                       struct dynbuf *binding)
 {
   if(Curl_ssl->get_channel_binding)
@@ -1390,7 +1390,7 @@ static CURLcode cf_ssl_peer_init(struct Curl_cfilter *cf,
 CURLcode Curl_ssl_cfilter_add(struct Curl_easy *data,
                               struct Curl_peer *origin,
                               struct connectdata *conn,
-                              int sockindex)
+                              int8_t sockindex)
 {
   struct Curl_cfilter *cf;
   struct Curl_peer *peer = (sockindex == SECONDARYSOCKET) ?
@@ -1552,7 +1552,7 @@ out:
 }
 
 CURLcode Curl_ssl_cfilter_remove(struct Curl_easy *data,
-                                 int sockindex, bool send_shutdown)
+                                 int8_t sockindex, bool send_shutdown)
 {
   struct Curl_cfilter *cf, *head;
   CURLcode result = CURLE_OK;
@@ -1779,7 +1779,7 @@ CURLcode Curl_on_session_reuse(struct Curl_cfilter *cf,
 
 struct Curl_ssl_session *Curl_ssl_get_cf_session(struct Curl_easy *data,
                                                  const struct Curl_cftype *cft,
-                                                 int sockindex)
+                                                 int8_t sockindex)
 {
   if(data->conn &&
 #ifndef CURL_DISABLE_PROXY

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -171,7 +171,7 @@ bool Curl_ssl_cert_status_request(void);
  * If channel binding is not supported, binding stays empty and CURLE_OK is
  * returned.
  */
-CURLcode Curl_ssl_get_channel_binding(struct Curl_easy *data, int sockindex,
+CURLcode Curl_ssl_get_channel_binding(struct Curl_easy *data, int8_t sockindex,
                                       struct dynbuf *binding);
 
 #define SSL_SHUTDOWN_TIMEOUT 10000 /* ms */
@@ -179,7 +179,7 @@ CURLcode Curl_ssl_get_channel_binding(struct Curl_easy *data, int sockindex,
 CURLcode Curl_ssl_cfilter_add(struct Curl_easy *data,
                               struct Curl_peer *origin,
                               struct connectdata *conn,
-                              int sockindex);
+                              int8_t sockindex);
 
 CURLcode Curl_cf_ssl_insert_after(struct Curl_cfilter *cf_at,
                                   struct Curl_easy *data,
@@ -187,7 +187,7 @@ CURLcode Curl_cf_ssl_insert_after(struct Curl_cfilter *cf_at,
                                   struct Curl_peer *peer);
 
 CURLcode Curl_ssl_cfilter_remove(struct Curl_easy *data,
-                                 int sockindex, bool send_shutdown);
+                                 int8_t sockindex, bool send_shutdown);
 
 #ifndef CURL_DISABLE_PROXY
 CURLcode Curl_cf_ssl_proxy_insert_after(struct Curl_cfilter *cf_at,

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -184,7 +184,7 @@ struct Curl_ssl {
   CURLcode (*send_plain)(struct Curl_cfilter *cf, struct Curl_easy *data,
                          const void *mem, size_t len, size_t *pnwritten);
 
-  CURLcode (*get_channel_binding)(struct Curl_easy *data, int sockindex,
+  CURLcode (*get_channel_binding)(struct Curl_easy *data, int8_t sockindex,
                                   struct dynbuf *binding);
 };
 
@@ -209,7 +209,7 @@ CURLcode Curl_on_session_reuse(struct Curl_cfilter *cf,
  * data's connection at `sockindex` or NULL if not found/available. */
 struct Curl_ssl_session *Curl_ssl_get_cf_session(struct Curl_easy *data,
                                                  const struct Curl_cftype *cft,
-                                                 int sockindex);
+                                                 int8_t sockindex);
 
 #endif /* USE_SSL */
 

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -9,7 +9,7 @@
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
- * are also available at https://curl.se/docs/copyright.html.
+ * are also available at https://curl.se/docs/'>copyright.html.
  *
  * You may opt to use, copy, modify, merge, publish, distribute and/or sell
  * copies of the Software, and permit persons to whom the Software is

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -9,7 +9,7 @@
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
- * are also available at https://curl.se/docs/'>copyright.html.
+ * are also available at https://curl.se/docs/copyright.html.
  *
  * You may opt to use, copy, modify, merge, publish, distribute and/or sell
  * copies of the Software, and permit persons to whom the Software is


### PR DESCRIPTION
- sockindex: int -> int8_t
- move connectdata members around for fun and profit
- remove data->state.current_speed as unused
- remove data->state.trailers_bytes_sent as unsed
- remove data->state.trailers_buf as unsed

The sockindex type change spread a little.

