### PR TITLE
curlx_inet_pton: drop setting `errno` on error

### DIFF
--- a/lib/curlx/inet_pton.c
+++ b/lib/curlx/inet_pton.c
@@ -196,10 +196,6 @@ static int inet_pton6(const char *src, unsigned char *dst)
  *   0 if the address was not valid (`dst' is untouched in this case)
  *  -1 if some other error occurred (`dst' is untouched in this case, too)
  *
- * On Windows we store the error in the thread errno, not in the Winsock error
- * code. This is to avoid losing the actual last Winsock error. When this
- * function returns NULL, check errno not SOCKERRNO.
- *
  * author:
  *      Paul Vixie, 1996.
  */
@@ -211,7 +207,6 @@ int curlx_inet_pton(int af, const char *src, void *dst)
   case AF_INET6:
     return inet_pton6(src, (unsigned char *)dst);
   default:
-    errno = SOCKEAFNOSUPPORT;
     return -1;
   }
   /* NOTREACHED */


### PR DESCRIPTION
Follow-up to bb406386d9e088873f5f640c55e14a69390abd01 #22229
