### PR TITLE
tests: fix Content-Length mismatch in test2064

### DIFF
--- a/tests/data/test2064
+++ b/tests/data/test2064
@@ -9,7 +9,7 @@ HTTP Digest auth
 </info>
 # Server-side
 <reply>
-<data crlf="yes">
+<data crlf="headers">
 HTTP/1.1 401 Authorization Required
 Server: Apache/1.3.27 (Darwin) PHP/4.1.2
 WWW-Authenticate: Digest realm="testrealm", nonce="2053604145", algorithm="SHA-256"


### PR DESCRIPTION
Spotted when packaging rc2 for Debian, other similar tests (2061-2066) already have `crlf="headers"` for the Server-side.