### PR TITLE
runtests: introduce a subset option

### DIFF
--- a/docs/runtests.md
+++ b/docs/runtests.md
@@ -260,6 +260,24 @@ script randomly discards entries to fail until the amount is **num**.
 The random seed initially set for this is fixed per month and can be set with
 *--seed*.
 
+## `--subset=<section>/<parts>`
+
+Tell runtests to run a subset of the available tests. The test selection is
+done first based on existing options. The list of selected tests is then
+divided into a number of *parts*. The selected *section* specifier is the
+set of tests this invoke runs. Note that both numbers must be provided and
+*section* is zero indexed so it must be smaller than *parts*.
+
+Using this option you can for example split up an identical test run into
+three separate invokes that combined run all the tests:
+
+     ./runtests.pl --subset=0/3
+     ./runtests.pl --subset=1/3
+     ./runtests.pl --subset=2/3
+
+This option works fine in combination with `-R` but consider also using
+`--seed` for that.
+
 ## `-t[num]`
 
 Selects a **torture** test for the given tests. This makes runtests.pl first

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2351,6 +2351,8 @@ $args = join(' ', @ARGV);
 $valgrind = checktestcmd("valgrind");
 my $number = 0;
 my $fromnum = -1;
+my $useshares;
+my $usepart;
 my @testthis;
 while(@ARGV) {
     if($ARGV[0] eq "-v") {
@@ -2464,6 +2466,14 @@ while(@ARGV) {
 
         if($xtra =~ s/(\d+)$//) {
             $tortalloc = $1;
+        }
+    }
+    elsif($ARGV[0] =~ /^--subset=(\d+)\/(\d+)$/) {
+        # split all tests into $2 parts.
+        # this invoke then runs the part number $1 (0-indexed)
+        ($usepart, $useshares) = ($1, $2);
+        if($useshares < 1 || $usepart >= $useshares) {
+            die "illegal subset specified";
         }
     }
     elsif($ARGV[0] =~ /--shallow=(\d+)/) {
@@ -2895,6 +2905,25 @@ if($scrambleorder) {
         $TESTCASES = join(" ", @all);
     }
     $TESTCASES = join(" ", @rand);
+}
+
+if($useshares) {
+    my @a = grep { length($_) } split(/ +/, $TESTCASES);
+    my $n = scalar(@a);
+
+    if($useshares < 1 || $usepart >= $useshares) {
+        die "illegal subset specified";
+    }
+
+    my $start = int(($n * $usepart) / $useshares);
+    my $end = int(($n * ($usepart + 1)) / $useshares); # one past last index
+    my $run = $end - $start;
+
+    printf STDERR "Subset: 1/%u of the tests (run %u tests out of %u). Part %u\n",
+        $useshares, $run, $n, $usepart;
+
+    my @s = $run ? @a[$start .. $end - 1] : ();
+    $TESTCASES = join(" ", @s);
 }
 
 # Display the contents of the given file.  Line endings are canonicalized


### PR DESCRIPTION
To make it easier to run different subsets of the tests in separate invokes.
