### PR TITLE
runtests: allow resetting `CURL_TEST_MIN` via `--min=0`

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2346,6 +2346,10 @@ if(@ARGV && $ARGV[-1] eq '$TFLAGS') {
     push(@ARGV, split(' ', $ENV{'TFLAGS'})) if defined($ENV{'TFLAGS'});
 }
 
+if($ENV{"CURL_TEST_MIN"}) {
+    $mintotal = $ENV{"CURL_TEST_MIN"};
+}
+
 $args = join(' ', @ARGV);
 
 $valgrind = checktestcmd("valgrind");
@@ -2745,10 +2749,6 @@ get_disttests();
 if(!$jobs) {
     # Disable buffered logging with only one test job
     setlogfunc(\&logmsg);
-}
-
-if(!$mintotal && $ENV{"CURL_TEST_MIN"}) {
-    $mintotal = $ENV{"CURL_TEST_MIN"};
 }
 
 #######################################################################


### PR DESCRIPTION
Set the default to `CURL_TEST_MIN` if set, first. Then process the
command-line options to override it. Previously, the env took over if
the command-line explicitly tried to set it to zero.

Ref: #22617

Follow-up to 3f1cd809eeae05f39fec72fe780f3a69d21972fb #19942
