### PR TITLE
runtests: divide minimum required tests by subsets

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2346,11 +2346,9 @@ if(@ARGV && $ARGV[-1] eq '$TFLAGS') {
     push(@ARGV, split(' ', $ENV{'TFLAGS'})) if defined($ENV{'TFLAGS'});
 }
 
-if($ENV{"CURL_TEST_MIN"}) {
-    $mintotal = $ENV{"CURL_TEST_MIN"};
-}
-
 $args = join(' ', @ARGV);
+
+my $mintotalany = 0;
 
 $valgrind = checktestcmd("valgrind");
 my $number = 0;
@@ -2450,6 +2448,7 @@ while(@ARGV) {
     elsif($ARGV[0] =~ /--min=(\d+)/) {
         my ($num) = ($1);
         $mintotal = $num;
+        $mintotalany = 1;
     }
     elsif($ARGV[0] eq "-n") {
         # no valgrind
@@ -2761,8 +2760,11 @@ if(!$jobs) {
     setlogfunc(\&logmsg);
 }
 
-if($useshares && $mintotal) {
-    $mintotal /= $useshares;
+if(!$mintotalany && $ENV{"CURL_TEST_MIN"}) {
+    $mintotal = $ENV{"CURL_TEST_MIN"};
+    if($useshares) {
+        $mintotal /= $useshares;
+    }
 }
 
 #######################################################################

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2761,6 +2761,10 @@ if(!$jobs) {
     setlogfunc(\&logmsg);
 }
 
+if($useshares && $mintotal) {
+    $mintotal /= $useshares;
+}
+
 #######################################################################
 # Output curl version and host info being tested
 #


### PR DESCRIPTION
When the minimum comes from `CURL_TEST_MIN`, to improve the default
behavior. It may still need manual adjustment in cases.

Follow-up to e669179681044514099ca726dbaa55653528f4fb #22616
Follow-up to 58cb1e2f1fa8d8f1c71596918707e566c6353cb2 #22618
Cherry-picked from #22617
