### PR TITLE
docs: clarify that cookies need domain set to match

### DIFF
--- a/docs/cmdline-opts/cookie.md
+++ b/docs/cmdline-opts/cookie.md
@@ -42,8 +42,8 @@ If the filename is an empty string ("") and is the only cookie input, curl
 activates the cookie engine without any cookies.
 
 The file format of the file to read cookies from should be plain HTTP headers
-(Set-Cookie style) or the Netscape/Mozilla cookie file format. We **strongly**
-discourage the use of the HTTP header style.
+(Set-Cookie style) or the Netscape/Mozilla cookie file format. We discourage
+the use of the HTTP header style.
 
 The file specified with --cookie is only used as input. No cookies are written
 to that file. To store cookies, use the --cookie-jar option.

--- a/docs/cmdline-opts/cookie.md
+++ b/docs/cmdline-opts/cookie.md
@@ -42,15 +42,15 @@ If the filename is an empty string ("") and is the only cookie input, curl
 activates the cookie engine without any cookies.
 
 The file format of the file to read cookies from should be plain HTTP headers
-(Set-Cookie style) or the Netscape/Mozilla cookie file format.
+(Set-Cookie style) or the Netscape/Mozilla cookie file format. We **strongly**
+discourage the use of the HTTP header style.
 
 The file specified with --cookie is only used as input. No cookies are written
 to that file. To store cookies, use the --cookie-jar option.
 
-If you use the Set-Cookie file format and do not specify a domain then the
-cookie is not sent since the domain never matches. To address this, set a
-domain in Set-Cookie line (doing that includes subdomains) or preferably: use
-the Netscape format.
+If you read cookies from a plain HTTP headers file and a domain is set, the
+cookie is only sent when it matches. We suggest using the Netscape file format
+to avoid unexpected side effects.
 
 Users often want to both read cookies from a file and write updated cookies
 back to a file, so using both --cookie and --cookie-jar in the same command

--- a/docs/cmdline-opts/cookie.md
+++ b/docs/cmdline-opts/cookie.md
@@ -48,9 +48,10 @@ discourage the use of the HTTP header style.
 The file specified with --cookie is only used as input. No cookies are written
 to that file. To store cookies, use the --cookie-jar option.
 
-If you read cookies from a plain HTTP headers file and a domain is set, the
-cookie is only sent when it matches. We suggest using the Netscape file format
-to avoid unexpected side effects.
+If you read cookies from a plain HTTP headers file, make sure each `Set-Cookie`
+line specifies a `Domain` attribute. Without an explicit domain, the cookie
+cannot be reliably matched to a target host and may be applied in unexpected
+ways. We suggest using the Netscape file format instead.
 
 Users often want to both read cookies from a file and write updated cookies
 back to a file, so using both --cookie and --cookie-jar in the same command

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
@@ -42,9 +42,10 @@ without reading any initial cookies. If you tell libcurl the filename is "-"
 This option only **reads** cookies. To make libcurl write cookies to file,
 see CURLOPT_COOKIEJAR(3).
 
-If you read cookies from a plain HTTP headers file and a domain is set, the
-cookie is only sent when it matches. We suggest using the Netscape file format
-to avoid unexpected side effects.
+If you read cookies from a plain HTTP headers file, make sure each `Set-Cookie`
+line specifies a `Domain` attribute. Without an explicit domain, libcurl cannot
+reliably associate the cookie with a host and it may be applied in unexpected
+ways. We suggest using the Netscape file format instead.
 
 The application does not have to keep the string around after setting this
 option.

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
@@ -42,11 +42,9 @@ without reading any initial cookies. If you tell libcurl the filename is "-"
 This option only **reads** cookies. To make libcurl write cookies to file,
 see CURLOPT_COOKIEJAR(3).
 
-If you read cookies from a plain HTTP headers file and it does not specify a
-domain in the Set-Cookie line, then the cookie is not sent since the cookie
-domain cannot match the target URL's. To address this, set a domain in
-Set-Cookie line (doing that includes subdomains) or preferably: use the
-Netscape format.
+If you read cookies from a plain HTTP headers file and a domain is set, the
+cookie is only sent when it matches. We suggest using the Netscape file format
+to avoid unexpected side effects.
 
 The application does not have to keep the string around after setting this
 option.


### PR DESCRIPTION
Especially important if reading cookies from HTTP headers, which is a style we discourage.

Reported-by: accl on hackerone
