### PR TITLE
http: custom Authorization: header overrides Negotiate

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -698,6 +698,8 @@ static CURLcode output_auth_headers(struct Curl_easy *data,
       if(result)
         return result;
     }
+    else
+      authstatus->done = TRUE;
   }
   else
 #endif

--- a/lib/http.c
+++ b/lib/http.c
@@ -689,12 +689,10 @@ static CURLcode output_auth_headers(struct Curl_easy *data,
   if(authstatus->picked == CURLAUTH_NEGOTIATE) {
     if(
 #ifndef CURL_DISABLE_PROXY
-      (proxy && conn->http_proxy.creds &&
-       !Curl_checkProxyheaders(data, conn,
-                               STRCONST("Proxy-authorization"))) ||
+      (proxy && !Curl_checkProxyheaders(data, conn,
+                                        STRCONST("Proxy-authorization"))) ||
 #endif
-      (!proxy && data->state.creds &&
-       !Curl_checkheaders(data, STRCONST("Authorization")))) {
+      !Curl_checkheaders(data, STRCONST("Authorization"))) {
       auth = "Negotiate";
       result = Curl_output_negotiate(data, conn, proxy);
       if(result)

--- a/lib/http.c
+++ b/lib/http.c
@@ -692,7 +692,7 @@ static CURLcode output_auth_headers(struct Curl_easy *data,
       (proxy && !Curl_checkProxyheaders(data, conn,
                                         STRCONST("Proxy-authorization"))) ||
 #endif
-      !Curl_checkheaders(data, STRCONST("Authorization"))) {
+      (!proxy && !Curl_checkheaders(data, STRCONST("Authorization")))) {
       auth = "Negotiate";
       result = Curl_output_negotiate(data, conn, proxy);
       if(result)

--- a/lib/http.c
+++ b/lib/http.c
@@ -687,10 +687,19 @@ static CURLcode output_auth_headers(struct Curl_easy *data,
 #endif
 #ifdef USE_SPNEGO
   if(authstatus->picked == CURLAUTH_NEGOTIATE) {
-    auth = "Negotiate";
-    result = Curl_output_negotiate(data, conn, proxy);
-    if(result)
-      return result;
+    if(
+#ifndef CURL_DISABLE_PROXY
+      (proxy && conn->http_proxy.creds &&
+       !Curl_checkProxyheaders(data, conn,
+                               STRCONST("Proxy-authorization"))) ||
+#endif
+      (!proxy && data->state.creds &&
+       !Curl_checkheaders(data, STRCONST("Authorization")))) {
+      auth = "Negotiate";
+      result = Curl_output_negotiate(data, conn, proxy);
+      if(result)
+        return result;
+    }
   }
   else
 #endif


### PR DESCRIPTION
As documented and as it does for other methods.

Difficult to test since it needs a successful kerberos ticket.

Reported-by: sdgh179 on github
Fixes #22610

