### PR TITLE
test_07_upload: skip tests if nghttpx lacks QUIC

### DIFF
--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -654,7 +654,7 @@ class TestUpload:
         r.check_exit_code(0)
 
     # nghttpx is the only server we have that supports TLS early data
-    @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx")
+    @pytest.mark.skipif(condition=not Env.have_h3_server(), reason="no QUIC in nghttpx")
     @pytest.mark.parametrize("proto,upload_size", [
         pytest.param('http/1.1', 100, id='h1-small-body'),
         pytest.param('http/1.1', 10 * 1024, id='h1-medium-body'),


### PR DESCRIPTION
If nghttpx is available but lacks QUIC support, disable the tests that
depend on that support.

Fixes #22609
Closes #22624


<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->