### PR TITLE
tool_msgs: make notef() respect --silent

### DIFF
--- a/docs/cmdline-opts/silent.md
+++ b/docs/cmdline-opts/silent.md
@@ -17,8 +17,8 @@ Example:
 
 # `--silent`
 
-Silent or quiet mode. Do not show progress meter, warning messages or error
-messages. Makes curl mute. It still outputs the data you ask for, potentially
+Silent or quiet mode. Do not show progress meter, note messages, warning
+messages or error messages. Makes curl mute. It still outputs the data you ask for, potentially
 even to the terminal/stdout unless you redirect it.
 
 Use --show-error in addition to this option to disable progress meter but

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -74,11 +74,11 @@ static void voutf(const char *prefix, const char *fmt, va_list ap)
 
 /*
  * Emit 'note' formatted message on configured 'errors' stream, if verbose was
- * selected.
+ * selected and mute (--silent) was not.
  */
 void notef(const char *fmt, ...)
 {
-  if(global && global->tracetype) {
+  if(global && global->tracetype && !global->silent) {
     va_list ap;
     va_start(ap, fmt);
     voutf(NOTE_PREFIX, fmt, ap);

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -225,7 +225,7 @@ test1685 test1686 \
 \
 test1700          test1702 test1703 test1704 test1705 test1706 test1707 \
 test1708 test1709 test1710 test1711 test1712 test1713 test1714 test1715 \
-test1720 test1721 test1722 test1723 test1724 test1725 \
+test1720 test1721 test1722 test1723 test1724 test1725 test1740 test1741 \
 \
 test1800 test1801 test1802 test1847 test1848 test1849 test1850 test1851 \
 \

--- a/tests/data/test1740
+++ b/tests/data/test1740
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+--silent
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<setenv>
+# set the terminal wide to avoid word wrap in the message
+COLUMNS=10000
+</setenv>
+<name>
+--silent suppresses Note: messages when verbose
+</name>
+<command option="no-output">
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --silent -X POST -d foo -o %LOGDIR/out%TESTNUMBER -w '%{stderr}done\n'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes" nonewline="yes">
+POST /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 3
+Content-Type: application/x-www-form-urlencoded
+
+foo
+</protocol>
+<stderr mode="text">
+done
+</stderr>
+</verify>
+</testcase>

--- a/tests/data/test1741
+++ b/tests/data/test1741
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP POST
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<setenv>
+# set the terminal wide to avoid word wrap in the message
+COLUMNS=10000
+</setenv>
+<name>
+Note: messages are shown when verbose without --silent
+</name>
+<command option="no-output">
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -X POST -d foo -o %LOGDIR/out%TESTNUMBER --no-progress-meter -w '%{stderr}done\n'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes" nonewline="yes">
+POST /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 3
+Content-Type: application/x-www-form-urlencoded
+
+foo
+</protocol>
+<stderr mode="text">
+Note: Unnecessary use of -X or --request, POST is already inferred.
+done
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
Fixes #22623

`--silent` used to hide `Note:` messages and stopped doing that in 8.17.0.

The check for `--silent` used to sit inside `voutf()`, so everything that went through it was muted. 56450ce26f pulled that check out to the callers so `errorf()` could honour `--show-error`. `warnf()` and `errorf()` kept a `silent` check, `notef()` did not, so notes have been printed ever since whenever tracing was on.

Repro on master, with `-s`:

```
$ curl -s -v -X POST -d foo http://127.0.0.1:1/ 2>&1 | head -1
Note: Unnecessary use of -X or --request, POST is already inferred.
```

I also added "note messages" to the list in silent.md, since the option now hides them again.

Two test cases: 1740 checks that `--silent` hides the note (fails without the source change), 1741 checks the note is still printed without `--silent`. Both use `-w '%{stderr}done\n'` so the expected stderr is not empty, otherwise the section is skipped by the runner.

Ran 1740, 1741 plus the existing note-emitting tests 433, 994, 996 locally, all pass. (1491 fails here for an unrelated reason: my checkout path has a space in it and the test builds a `file://` URL from it.)