### PR TITLE
GHA/checksrc: preprocess workflows to lint more shell code

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: 'zizmor/actionlint (prepare)'
         # Replace custom bash-like shell designators with the standard one to make linters process them
-        run: sed -i.bak -E 's/shell: .+ zizmor: ignore.+$/shell: bash/g' .github/workflows/*.yml
+        run: sed -i.bak -E 's/shell\x3a .+ zizmor\x3a ignore.+$/shell\x3a bash/g' .github/workflows/*.yml
 
       - name: 'zizmor GHA'
         env:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -179,9 +179,8 @@ jobs:
           persist-credentials: false
 
       - name: 'zizmor/actionlint (prepare)'
-        run: |
-          # Replace custom bash-like shell designators with the standard one to make linters process them
-          sed -i.bak -E 's/shell: .+ zizmor: ignore.+$/shell: bash/g' .github/workflows/*.yml
+        # Replace custom bash-like shell designators with the standard one to make linters process them
+        run: sed -i.bak -E 's/shell: .+ zizmor: ignore.+$/shell: bash/g' .github/workflows/*.yml
 
       - name: 'zizmor GHA'
         env:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -178,6 +178,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 'zizmor/actionlint (prepare)'
+        run: |
+          # Replace custom bash-like shell designators with the standard one to make linters process them
+          sed -i.bak -E 's/shell: .+ zizmor: ignore.+$/shell: bash/g' .github/workflows/*.yml
+
       - name: 'zizmor GHA'
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
`zizmor` keeps being confused by non-"well-known" shell designators
`msys2 {0}`, `<path>\bash.exe '{0}'`, `cpa.sh {0}`, while `actionlint`
silently skips checking such shell code. Though it's all POSIX/bash.
Replace the unrecognized shell designators with `bash` before running
the linters, to remove these blind spots.

zizmor pedantic persona:
Before: `No findings to report. Good job! (1 ignored, 61 suppressed)`
After: `No findings to report. Good job! (1 ignored)`

zizmor auditor persona:
Before: `No findings to report. Good job! (62 ignored)`
After: `No findings to report. Good job! (1 ignored)`
