### PR TITLE
fix handling of empty user in ntlm matching

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -933,7 +933,6 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
      * used, nor what token in the next connect attempt will use.
      * To avoid TOCTOU attacks, do not reuse on empty credentials. */
     if(!m->want_ntlm_http ||
-       !Curl_creds_has_user(conn->creds) ||
        !Curl_creds_same(conn->creds, m->data->state.creds) ||
        !Curl_peer_equal(conn->creds_origin, m->data->state.origin))
       return FALSE;

--- a/lib/url.c
+++ b/lib/url.c
@@ -925,17 +925,12 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
 {
   if(conn->http_ntlm_state != NTLMSTATE_NONE) {
     /* Connection is using NTLM. We cannot reuse if transfer
-     * has different Auth input parameters.
-     * Empty user: Negotiate on Windows can make use of an "ambient"
-     * user from a "SecurityToken" associated with the current thread or
-     * process. This token can be switched at any time. We are therefore
-     * not able to find out reliably what token the connection really
-     * used, nor what token in the next connect attempt will use.
-     * To avoid TOCTOU attacks, do not reuse on empty credentials. */
+     * has different Auth input parameters. */
     if(!m->want_ntlm_http ||
        !Curl_creds_same(conn->creds, m->data->state.creds) ||
        !Curl_peer_equal(conn->creds_origin, m->data->state.origin))
       return FALSE;
+    /* Empty credentials need more careful matching for WINDOWS_SSPI */
     if(!url_allow_sspi_empty_creds(conn->creds, m->data, conn))
       return FALSE;
   }


### PR DESCRIPTION
Line should already have been removed in 7103a93, but neither humans nor clankers caught it. tststs...

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
