### PR TITLE
docs: document that libcurl is not fork-safe

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -229,12 +229,6 @@ socketpair in the multi handle.
 
 See [curl issue 4829](https://github.com/curl/curl/issues/4829)
 
-# Documentation
-
-## Improve documentation about fork safety
-
-See [curl issue 6968](https://github.com/curl/curl/issues/6968)
-
 # FTP
 
 ## A fixed directory listing format

--- a/docs/libcurl/curl_global_init.md
+++ b/docs/libcurl/curl_global_init.md
@@ -62,6 +62,10 @@ lock during that time and it could cause a deadlock.
 See the description in libcurl(3) of global environment requirements for
 details of how to use this function.
 
+libcurl does not guarantee correct behavior if the application calls *fork()*
+after this function (or after libcurl has otherwise been used). See the
+**fork()** section in libcurl-security(3).
+
 # FLAGS
 
 ## CURL_GLOBAL_ALL

--- a/docs/libcurl/libcurl-security.md
+++ b/docs/libcurl/libcurl-security.md
@@ -481,20 +481,18 @@ initialized or used in the process).
 An application that invokes *fork()* gets all file descriptors duplicated in
 the child process, including ones libcurl created. The child also inherits
 libcurl's in-memory state and the state of libraries libcurl depends on (TLS
-backends, name resolver libraries, and so on).
+backends, name resolver libraries, and so on). That inherited state is not
+reset automatically in the child.
 
-That shared state can be unsafe after a fork. For example, some TLS backends
-may leave the parent and the child with the same random number generator
-state, so both processes can produce identical "random" values. See also
-[OpenSSL notes on random numbers after fork](https://wiki.openssl.org/index.php/Random_fork-safety).
-Other dependencies or platform APIs may crash or behave incorrectly in the
-child if they were already in use in a multi-threaded parent.
+If the parent is multi-threaded when it calls *fork()*, POSIX allows the child
+to call only a limited set of functions until it calls *exec()* (or
+equivalent). libcurl is not in that set.
 
 Calling curl_global_cleanup(3) and then curl_global_init(3) in the child is
-**not** a reliable way to recover. Those functions use a reference count: if
-initialization was performed more than once in the parent, a single cleanup
-in the child does not tear everything down, so the following init may not
-initialize the library or its backends again.
+**not** a reliable way to reset the state after a fork. Those functions use a
+reference count: if initialization was performed more than once in the parent,
+a single cleanup in the child does not tear everything down, so the following
+init may not initialize the library or its backends again.
 
 Safer patterns:
 
@@ -505,13 +503,6 @@ Safer patterns:
 - If you still use libcurl after *fork()*, you must ensure that every
   dependency in that process is fork safe for your platform and build.
   libcurl does not document or guarantee that combination.
-
-## Historical note: NTLM WB and fork
-
-Older libcurl versions used *fork()* and *execl()* for the
-**CURLAUTH_NTLM_WB** authentication method, which invoked a helper command in
-a child process with duplicated file descriptors. That feature was removed in
-8.8.0.
 
 # Secrets in memory
 

--- a/docs/libcurl/libcurl-security.md
+++ b/docs/libcurl/libcurl-security.md
@@ -481,20 +481,20 @@ initialized or used in the process).
 An application that invokes *fork()* gets all file descriptors duplicated in
 the child process, including ones libcurl created. The child also inherits
 libcurl's in-memory state and the state of libraries libcurl depends on (TLS
-backends, name resolvers, and so on).
+backends, name resolver libraries, and so on).
 
 That shared state can be unsafe after a fork. For example, some TLS backends
 may leave the parent and the child with the same random number generator
 state, so both processes can produce identical "random" values. See also
-https://wiki.openssl.org/index.php/Random_fork-safety. Other dependencies or
-platform APIs may crash or misbehave in the child if they were already in use
-in a multi-threaded parent.
+[OpenSSL notes on random numbers after fork](https://wiki.openssl.org/index.php/Random_fork-safety).
+Other dependencies or platform APIs may crash or behave incorrectly in the
+child if they were already in use in a multi-threaded parent.
 
 Calling curl_global_cleanup(3) and then curl_global_init(3) in the child is
-**not** a reliable way to recover. Those functions are reference-counted: if
+**not** a reliable way to recover. Those functions use a reference count: if
 initialization was performed more than once in the parent, a single cleanup
 in the child does not tear everything down, so the following init may not
-reinitialize the library or its backends.
+initialize the library or its backends again.
 
 Safer patterns:
 
@@ -503,10 +503,10 @@ Safer patterns:
 - In the child, only call *exec()* (or equivalent) and do not keep using
   libcurl there.
 - If you still use libcurl after *fork()*, you must ensure that every
-  dependency in that process is fork-safe for your platform and build. libcurl
-  does not document or guarantee that combination.
+  dependency in that process is fork safe for your platform and build.
+  libcurl does not document or guarantee that combination.
 
-## Historical note: NTLM_WB and fork
+## Historical note: NTLM WB and fork
 
 Older libcurl versions used *fork()* and *execl()* for the
 **CURLAUTH_NTLM_WB** authentication method, which invoked a helper command in

--- a/docs/libcurl/libcurl-security.md
+++ b/docs/libcurl/libcurl-security.md
@@ -472,18 +472,46 @@ etc), it should be noted that libcurl still might understand proxy environment
 variables that allow the user to redirect libcurl operations to use a proxy
 controlled by the user.
 
-# File descriptors, fork and NTLM
+# fork()
 
-An application that uses libcurl and invokes *fork()* gets all file
-descriptors duplicated in the child process, including the ones libcurl
-created.
+libcurl does **not** guarantee correct or secure behavior if an application
+calls *fork()* after curl_global_init(3) (or after libcurl has otherwise been
+initialized or used in the process).
 
-libcurl itself uses *fork()* and *execl()* if told to use the
-**CURLAUTH_NTLM_WB** authentication method which then invokes the helper
-command in a child process with file descriptors duplicated. Make sure that
-only the trusted and reliable helper program is invoked.
+An application that invokes *fork()* gets all file descriptors duplicated in
+the child process, including ones libcurl created. The child also inherits
+libcurl's in-memory state and the state of libraries libcurl depends on (TLS
+backends, name resolvers, and so on).
 
-This feature was removed from curl in 8.8.0.
+That shared state can be unsafe after a fork. For example, some TLS backends
+may leave the parent and the child with the same random number generator
+state, so both processes can produce identical "random" values. See also
+https://wiki.openssl.org/index.php/Random_fork-safety. Other dependencies or
+platform APIs may crash or misbehave in the child if they were already in use
+in a multi-threaded parent.
+
+Calling curl_global_cleanup(3) and then curl_global_init(3) in the child is
+**not** a reliable way to recover. Those functions are reference-counted: if
+initialization was performed more than once in the parent, a single cleanup
+in the child does not tear everything down, so the following init may not
+reinitialize the library or its backends.
+
+Safer patterns:
+
+- Call *fork()* before any libcurl use, then call curl_global_init(3) only in
+  the processes that need libcurl.
+- In the child, only call *exec()* (or equivalent) and do not keep using
+  libcurl there.
+- If you still use libcurl after *fork()*, you must ensure that every
+  dependency in that process is fork-safe for your platform and build. libcurl
+  does not document or guarantee that combination.
+
+## Historical note: NTLM_WB and fork
+
+Older libcurl versions used *fork()* and *execl()* for the
+**CURLAUTH_NTLM_WB** authentication method, which invoked a helper command in
+a child process with duplicated file descriptors. That feature was removed in
+8.8.0.
 
 # Secrets in memory
 

--- a/docs/libcurl/libcurl-thread.md
+++ b/docs/libcurl/libcurl-thread.md
@@ -125,3 +125,9 @@ to set your own replacement memory functions.
 CURLOPT_DNS_USE_GLOBAL_CACHE(3) is not thread-safe.
 
 curl_version_info(3) is not thread-safe before libcurl initialization.
+
+# fork()
+
+libcurl is not documented as fork-safe. If your application calls *fork()*
+after libcurl has been initialized or used, see the **fork()** section in
+libcurl-security(3).

--- a/docs/libcurl/libcurl-thread.md
+++ b/docs/libcurl/libcurl-thread.md
@@ -128,6 +128,6 @@ curl_version_info(3) is not thread-safe before libcurl initialization.
 
 # fork()
 
-libcurl is not documented as fork-safe. If your application calls *fork()*
+libcurl is not documented as fork safe. If your application calls *fork()*
 after libcurl has been initialized or used, see the **fork()** section in
 libcurl-security(3).


### PR DESCRIPTION
Documents that libcurl does not guarantee correct behavior if
fork() is used after curl_global_init / after libcurl has been used.

Covers duplicated file descriptors, inherited dependency state
(including RNG concerns), why curl_global_cleanup + init is not a
reliable recovery after fork, and safer patterns.

Also points to this from libcurl-thread and curl_global_init, and
removes the TODO entry that tracked this.

Ref: #6968