### PR TITLE
openssl: fix DER buffer leak in Apple SecTrust verification

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4669,7 +4669,14 @@ out:
 struct ossl_certs_ctx {
   STACK_OF(X509) *sk;
   size_t num_certs;
+  unsigned char *last_der;
 };
+
+static void ossl_certs_ctx_free_last_der(struct ossl_certs_ctx *chain)
+{
+  OPENSSL_free(chain->last_der);
+  chain->last_der = NULL;
+}
 
 static CURLcode ossl_chain_get_der(struct Curl_cfilter *cf,
                                    struct Curl_easy *data,
@@ -4681,6 +4688,8 @@ static CURLcode ossl_chain_get_der(struct Curl_cfilter *cf,
   struct ossl_certs_ctx *chain = user_data;
   X509 *cert;
   int der_len;
+
+  ossl_certs_ctx_free_last_der(chain);
 
   (void)cf;
   (void)data;
@@ -4695,6 +4704,7 @@ static CURLcode ossl_chain_get_der(struct Curl_cfilter *cf,
   der_len = i2d_X509(cert, pder);
   if(der_len < 0)
     return CURLE_FAILED_INIT;
+  chain->last_der = *pder;
   *pder_len = (size_t)der_len;
   return CURLE_OK;
 }
@@ -4748,6 +4758,7 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
     result = Curl_vtls_apple_verify(cf, data, peer, chain.num_certs,
                                     ossl_chain_get_der, &chain,
                                     ocsp_data, ocsp_len);
+    ossl_certs_ctx_free_last_der(&chain);
     if(!result && ocsp_missing && conn_config->verifystatus &&
        !octx->reused_session) {
       /* verified, but OCSP stapling is required and server sent none */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4672,12 +4672,6 @@ struct ossl_certs_ctx {
   unsigned char *last_der;
 };
 
-static void ossl_certs_ctx_free_last_der(struct ossl_certs_ctx *chain)
-{
-  OPENSSL_free(chain->last_der);
-  chain->last_der = NULL;
-}
-
 static CURLcode ossl_chain_get_der(struct Curl_cfilter *cf,
                                    struct Curl_easy *data,
                                    void *user_data,
@@ -4689,7 +4683,8 @@ static CURLcode ossl_chain_get_der(struct Curl_cfilter *cf,
   X509 *cert;
   int der_len;
 
-  ossl_certs_ctx_free_last_der(chain);
+  OPENSSL_free(chain->last_der);
+  chain->last_der = NULL;
 
   (void)cf;
   (void)data;
@@ -4758,7 +4753,8 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
     result = Curl_vtls_apple_verify(cf, data, peer, chain.num_certs,
                                     ossl_chain_get_der, &chain,
                                     ocsp_data, ocsp_len);
-    ossl_certs_ctx_free_last_der(&chain);
+    OPENSSL_free(chain.last_der);
+    chain.last_der = NULL;
     if(!result && ocsp_missing && conn_config->verifystatus &&
        !octx->reused_session) {
       /* verified, but OCSP stapling is required and server sent none */


### PR DESCRIPTION
`ossl_chain_get_der()` allocates a DER encoding of each peer certificate via `i2d_X509()`, but `Curl_vtls_apple_verify()` only copies it into a CFData and never frees the original. This leaks per certificate, per handshake, whenever USE_APPLE_SECTRUST is used with the OpenSSL/LibreSSL/BoringSSL backend.

Fix frees the buffer inside openssl.c itself, so the GnuTLS backend (which borrows rather than allocates) is unaffected.

In our macOS application this patch reduced memory growth from ~65 - 67 MB/day to ~0.6 - 0.7 MB/day.
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
