### PR TITLE
GHA: install MSYS2 Perl manually for latest GitHub runners

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -278,7 +278,7 @@ jobs:
           cache: false
           path-type: inherit
           install: >-
-            mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
+            perl mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
 
       - name: 'install prereqs'
         timeout-minutes: 3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -605,6 +605,7 @@ jobs:
             url: 'https://github.com/skeeto/w64devkit/releases/download/v2.8.0/w64devkit-x64-2.8.0.7z.exe'
             SHA256: 6252bf34fe2231a55ac7f03d482b36d2c7c58697990551bba508102cfb3f342e
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DENABLE_UNIX_SOCKETS=OFF -DCURL_GCC_ANALYZER=ON -DCMAKE_C_FLAGS=-DCURL_DEBUG_NO_WIN32_WND'
+            install: perl
             type: 'Debug'
           - name: 'schannel'  # mingw-w64 10.0
             sys: 'mingw64'
@@ -635,7 +636,7 @@ jobs:
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             SHA256: 12d2c62ad4527ec8a52275ea8485678dcbe20bec4716a3c7ba274f225d696085
             config: '-DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
-            install: mingw-w64-i686-libssh
+            install: perl mingw-w64-i686-libssh
             type: 'Debug'
             tflags: 'skiprun'
           - name: 'schannel !examples'  # mingw-w64 3.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -604,7 +604,7 @@ jobs:
             ver: '16.1.0'
             url: 'https://github.com/skeeto/w64devkit/releases/download/v2.8.0/w64devkit-x64-2.8.0.7z.exe'
             SHA256: 6252bf34fe2231a55ac7f03d482b36d2c7c58697990551bba508102cfb3f342e
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DENABLE_UNIX_SOCKETS=OFF -DCURL_GCC_ANALYZER=ON -DCMAKE_C_FLAGS=-DCURL_DEBUG_NO_WIN32_WND'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DENABLE_UNIX_SOCKETS=OFF -DCURL_GCC_ANALYZER=ON -DCMAKE_C_FLAGS=-DCURL_DEBUG_NO_WIN32_WND'
             install: perl mingw-w64-x86_64-libssh
             type: 'Debug'
           - name: 'schannel'  # mingw-w64 10.0
@@ -635,7 +635,7 @@ jobs:
             ver: '6.4.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             SHA256: 12d2c62ad4527ec8a52275ea8485678dcbe20bec4716a3c7ba274f225d696085
-            config: '-DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
+            config: '-DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
             install: perl mingw-w64-i686-libssh2
             type: 'Debug'
             tflags: 'skiprun'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -605,7 +605,7 @@ jobs:
             url: 'https://github.com/skeeto/w64devkit/releases/download/v2.8.0/w64devkit-x64-2.8.0.7z.exe'
             SHA256: 6252bf34fe2231a55ac7f03d482b36d2c7c58697990551bba508102cfb3f342e
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DENABLE_UNIX_SOCKETS=OFF -DCURL_GCC_ANALYZER=ON -DCMAKE_C_FLAGS=-DCURL_DEBUG_NO_WIN32_WND'
-            install: perl
+            install: perl mingw-w64-x86_64-libssh
             type: 'Debug'
           - name: 'schannel'  # mingw-w64 10.0
             sys: 'mingw64'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -636,7 +636,7 @@ jobs:
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             SHA256: 12d2c62ad4527ec8a52275ea8485678dcbe20bec4716a3c7ba274f225d696085
             config: '-DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBSSH=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DCURL_TARGET_WINDOWS_VERSION=0x0600'
-            install: perl mingw-w64-i686-libssh
+            install: perl mingw-w64-i686-libssh2
             type: 'Debug'
             tflags: 'skiprun'
           - name: 'schannel !examples'  # mingw-w64 3.0


### PR DESCRIPTION
As the MSYS2 update propagates into more GitHub runner images, we need 
to install Perl to avoid native Windows (aka Strawberry) Perl breaking
jobs that are running tests.

For others jobs, this patch leaves the new default Strawberry Perl. It's 
fine to use it a little bit more.

Also:
- libssh 32-bit was dropped upstream, replace with libssh2, and move
  libssh to the 64-bit job running tests.
  https://github.com/msys2/MINGW-packages/commit/f6ae36581d8dd1f6878442575cc8471830b863ed
  https://github.com/msys2/MINGW-packages/pull/30777

Refs:
https://github.com/actions/runner-images/issues/14562
https://github.com/actions/runner-images/pull/14541#issuecomment-5294304716
https://github.com/msys2/MSYS2-packages/commit/636489312cbc55011cb7ec493550598125e7716f
https://github.com/msys2/MSYS2-packages/pull/6491
https://github.com/msys2/MSYS2-packages/pull/6479

Bug: https://github.com/curl/curl/pull/22537#issuecomment-5359154818
Follow-up to d854ab4673c2f9d8048c7f0f6d164b7e4d5e0865 #22580
