### PR TITLE
u8_strset: start with 8 default entries

### DIFF
--- a/lib/uint-hashset.h
+++ b/lib/uint-hashset.h
@@ -36,7 +36,7 @@
  * meaning 91% of our tests to not set more than 4 strings and
  * 99% do not set more than 8.
  */
-#define CURL_U8_STRSET_START_BITS   2
+#define CURL_U8_STRSET_START_BITS   3
 #define CURL_U8_STRSET_START_DIM    (1U << CURL_U8_STRSET_START_BITS)
 
 /* A set that can hold up to 256 strings identified by an `id'.

--- a/tests/unit/unit3211.c
+++ b/tests/unit/unit3211.c
@@ -151,9 +151,9 @@ static void t3211_check_strset1(void)
   Curl_u8_strset_unset(&set, 0);
   fail_unless(!Curl_u8_strset_get(&set, 0), "unset failed");
 
-  /* Initial size is 4, add 4 hash collisions */
-  for(i = 0; i < 4; ++i) {
-    idx = (uint8_t)((4 * i) + 3);
+  /* Initial size is 8, add 8 hash collisions */
+  for(i = 0; i < 8; ++i) {
+    idx = (uint8_t)((8 * i) + 3);
     curl_msnprintf(buf, sizeof(buf), "str-%d", idx);
     result = Curl_u8_strset_set(&set, idx, buf);
     fail_unless(!result, "loop4-add failed");
@@ -162,47 +162,47 @@ static void t3211_check_strset1(void)
   }
 
   /* Remove collided entry 2, check again */
-  idx = (uint8_t)((4 * 2) + 3);
+  idx = (uint8_t)((8 * 2) + 3);
   Curl_u8_strset_unset(&set, idx);
   fail_unless(!Curl_u8_strset_get(&set, idx), "unset2 failed");
-  for(i = 0; i < 4; ++i) {
+  for(i = 0; i < 8; ++i) {
     if(i == 2)
       continue;
-    idx = (uint8_t)((4 * i) + 3);
+    idx = (uint8_t)((8 * i) + 3);
     curl_msnprintf(buf, sizeof(buf), "str-%d", idx);
     fail_unless(!t3211_strcmp(buf, Curl_u8_strset_get(&set, idx)),
                 "wrong get loop6");
   }
 
   /* Add entry 2 again, check */
-  idx = (uint8_t)((4 * 2) + 3);
+  idx = (uint8_t)((8 * 2) + 3);
   curl_msnprintf(buf, sizeof(buf), "str-%d", idx);
   result = Curl_u8_strset_set(&set, idx, buf);
   fail_unless(!result, "re-add 2 failed");
   fail_unless(!t3211_strcmp(buf, Curl_u8_strset_get(&set, idx)),
               "wrong re-add 2 get");
-  for(i = 0; i < 4; ++i) {
-    idx = (uint8_t)((4 * i) + 3);
+  for(i = 0; i < 8; ++i) {
+    idx = (uint8_t)((8 * i) + 3);
     curl_msnprintf(buf, sizeof(buf), "str-%d", idx);
     fail_unless(!t3211_strcmp(buf, Curl_u8_strset_get(&set, idx)),
                 "wrong get loop6");
   }
 
-  /* Add a 5th, set grows */
-  fail_unless(Curl_u8_strset_count(&set) == 4, "wrong count pre add 5");
-  idx = (uint8_t)((4 * 4) + 3);
+  /* Add a 9th, set grows */
+  fail_unless(Curl_u8_strset_count(&set) == 8, "wrong count pre add 5");
+  idx = (uint8_t)((9 * 4) + 3);
   curl_msnprintf(buf, sizeof(buf), "str-%d", idx);
   result = Curl_u8_strset_set(&set, idx, buf);
   fail_unless(!result, "add4 failed");
   fail_unless(!t3211_strcmp(buf, Curl_u8_strset_get(&set, idx)),
               "wrong get4");
-  for(i = 0; i < 5; ++i) {
-    idx = (uint8_t)((4 * i) + 3);
+  for(i = 0; i < 9; ++i) {
+    idx = (uint8_t)((8 * i) + 3);
     curl_msnprintf(buf, sizeof(buf), "str-%d", idx);
     fail_unless(!t3211_strcmp(buf, Curl_u8_strset_get(&set, idx)),
                 "wrong get loop5");
   }
-  fail_unless(Curl_u8_strset_count(&set) == 5, "wrong count aftger add 5");
+  fail_unless(Curl_u8_strset_count(&set) == 9, "wrong count aftger add 5");
 
   Curl_u8_strset_clear(&set);
 


### PR DESCRIPTION
The previous 4 entries were exhausted on simple command lines, depending on environment/build. Grow the initial size to 8 to avoid early allocs.


