### PR TITLE
include: Include <sys/select.h> when building for modern Linux.

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -93,7 +93,9 @@
     defined(__CYGWIN__) || defined(AMIGA) || defined(__NuttX__) || \
    (defined(__FreeBSD_version) && (__FreeBSD_version < 800000)) || \
    (defined(__MidnightBSD_version) && (__MidnightBSD_version < 100000)) || \
-    defined(__sun__) || defined(__serenity__) || defined(__vxworks__)
+    defined(__sun__) || defined(__serenity__) || defined(__vxworks__) || \
+   (defined(__linux__) && defined(_POSIX_C_SOURCE) && \
+    _POSIX_C_SOURCE >= 200112L)
 #include <sys/select.h>
 #endif
 


### PR DESCRIPTION
Fix curl compilation errors when building on Linux with
LLVM-libc (libc.llvm.org). It provides fd_set type (and
associated macro) in <sys/select.h> according to POSIX.

curl uses fd_set type (and associated FD* macro) that are
provided by <sys/select.h> according to POSIX. In practice,
some libc implementations (notably, glibc on Linux) transitively
include this header from <sys/types.h>, but other implementations
with stricter POSIX compliance may not do that
(see example of LLVM-libc above).

Fix curl compilation under LLVM-libc by including <sys/select.h>
in public <curl.h> when building for Linux and _POSIX_C_SOURCE is set
(by the user or by system libc) to be at least 200112L, referencing
the POSIX standard that added <sys/select.h> / fd_set.