### PR TITLE
build: allow skipping the GETTIME_MONOTONIC checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1830,8 +1830,8 @@ curl_internal_test(HAVE_GLIBC_STRERROR_R)
 curl_internal_test(HAVE_POSIX_STRERROR_R)
 
 if(NOT WIN32)
-  set(CURL_DISABLE_GETTIME_MONOTONIC OFF)
-  if(NOT CURL_DISABLE_GETTIME_MONOTONIC)
+  set(CHECK_GETTIME_MONOTONIC OFF)
+  if(NOT CHECK_GETTIME_MONOTONIC)
     curl_internal_test(HAVE_CLOCK_GETTIME_MONOTONIC)  # Check clock_gettime(CLOCK_MONOTONIC, x) support
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1830,7 +1830,10 @@ curl_internal_test(HAVE_GLIBC_STRERROR_R)
 curl_internal_test(HAVE_POSIX_STRERROR_R)
 
 if(NOT WIN32)
-  curl_internal_test(HAVE_CLOCK_GETTIME_MONOTONIC)  # Check clock_gettime(CLOCK_MONOTONIC, x) support
+  set(CURL_DISABLE_GETTIME_MONOTONIC OFF)
+  if(NOT CURL_DISABLE_GETTIME_MONOTONIC)
+    curl_internal_test(HAVE_CLOCK_GETTIME_MONOTONIC)  # Check clock_gettime(CLOCK_MONOTONIC, x) support
+  endif()
 endif()
 
 if(APPLE)

--- a/configure.ac
+++ b/configure.ac
@@ -1424,14 +1424,33 @@ fi
 
 CURL_CHECK_LIBS_CONNECT
 
-dnl **********************************************************************
-dnl In case that function clock_gettime with monotonic timer is available,
-dnl check for additional required libraries.
-dnl **********************************************************************
-CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC
+AC_MSG_CHECKING([check for MONOTONIC clock options?])
+monotonic="yes"
+AC_ARG_ENABLE(monotonic,
+AS_HELP_STRING([--enable-monotonic],[Enable checks for MONOTONIC options])
+AS_HELP_STRING([--disable-monotonic],[Disable checks for MONOTONIC optinos]),
+[ case "$enableval" in
+  no)
+    AC_MSG_RESULT(no)
+    monotonic="no"
+    ;;
+  *)
+    AC_MSG_RESULT(yes)
+    ;;
+  esac ],
+    AC_MSG_RESULT(yes)
+)
 
-dnl Check for even better option
-CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC_RAW
+if test "$monotonic" = "yes"; then
+  dnl **********************************************************************
+  dnl In case that function clock_gettime with monotonic timer is available,
+  dnl check for additional required libraries.
+  dnl **********************************************************************
+  CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC
+
+  dnl Check for even better option
+  CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC_RAW
+fi
 
 dnl **********************************************************************
 dnl The preceding library checks are all potentially useful for test

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -191,6 +191,7 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `BUILD_STATIC_CURL`:                      Build curl executable with static libcurl. Default: `OFF` (turns to `ON`, when building static libcurl only)
 - `BUILD_STATIC_LIBS`:                      Build static libraries. Default: `OFF` (turns to `ON` if `BUILD_SHARED_LIBS` is `OFF`)
 - `BUILD_TESTING`:                          Build tests. Default: `ON`
+- `CHECK_GETTIME_MONOTONIC`                 Check for `clock_gettime(GETTIME_MONOTONIC)`. Switch off to make a macOS binary that works < 10.12.
 - `CURL_BUILD_EVERYTHING`:                  Build optional build targets (examples, tests) by default. Default: `OFF`
                                             Set `QUICK` to build examples quickly with the `curl-examples-build` target (for build tests).
                                             Set `NOEXAMPLES` to not build examples.
@@ -207,7 +208,6 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `CURL_DEFAULT_SSL_BACKEND`:               Override default TLS backend in MultiSSL builds.
                                             Accepted values in order of default priority:
                                             `wolfssl`, `gnutls`, `mbedtls`, `openssl`, `schannel`, `rustls`
-- `CURL_DISABLE_GETTIME_MONOTONIC`          Do not use `clock_gettime(GETTIME_MONOTONIC)`. Useful to make a macOS binary work < 10.12.
 - `CURL_DROP_UNUSED`:                       Drop unused code and data from built binaries. Default: `OFF`
 - `CURL_ENABLE_EXPORT_TARGET`:              Enable CMake export target. Default: `ON`
 - `CURL_GCC_ANALYZER`:                      Enable GCC `--analyzer` option. Default: `OFF`

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -207,6 +207,7 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `CURL_DEFAULT_SSL_BACKEND`:               Override default TLS backend in MultiSSL builds.
                                             Accepted values in order of default priority:
                                             `wolfssl`, `gnutls`, `mbedtls`, `openssl`, `schannel`, `rustls`
+- `CURL_DISABLE_GETTIME_MONOTONIC`          Do not use `clock_gettime(GETTIME_MONOTONIC)`. Useful to make a macOS binary work < 10.12.
 - `CURL_DROP_UNUSED`:                       Drop unused code and data from built binaries. Default: `OFF`
 - `CURL_ENABLE_EXPORT_TARGET`:              Enable CMake export target. Default: `ON`
 - `CURL_GCC_ANALYZER`:                      Enable GCC `--analyzer` option. Default: `OFF`


### PR DESCRIPTION
Users who want to build a macOS binary that needs to run unmodified on macOS before 10.12 can use this.

cmake: add `CHECK_GETTIME_MONOTONIC`

configure: add `--disable-monotonic`
