### PR TITLE
docs: remove doubled word in SECURITY-ADVISORY.md

### DIFF
--- a/docs/SECURITY-ADVISORY.md
+++ b/docs/SECURITY-ADVISORY.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: curl
 
 As described in the [vulnerability disclosure
 policy](https://curl.se/dev/vuln-disclosure.html), when a vulnerability has
-been reported to the project and and it has been confirmed by the team, we
+been reported to the project and it has been confirmed by the team, we
 author an advisory document for the issue.
 
 <p> This advisory document should ideally be written in cooperation with the


### PR DESCRIPTION
"reported to the project and and it has been confirmed" → "and" once.

Found during a second docs pass; re-ran `verify-examples.pl` (513 pages ok) and `verify-synopsis.pl` (`docs/libcurl/curl*.md`) locally beforehand — both clean.