### PR TITLE
hsts: match complete directive names

### DIFF
--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -205,6 +205,12 @@ UNITTEST struct stsentry *hsts_check(struct hsts *h, const char *hostname,
   return bestsub;
 }
 
+/* RFC 6797 imports the HTTP token syntax for directive names. */
+static bool hsts_tokenchar(char c)
+{
+  return c && (ISALNUM(c) || strchr("!#$%&'*+-.^_`|~", c));
+}
+
 CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
                          const char *header)
 {
@@ -224,7 +230,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
 
   do {
     curlx_str_passblanks(&p);
-    if(curl_strnequal("max-age", p, 7)) {
+    if(curl_strnequal("max-age", p, 7) && !hsts_tokenchar(p[7])) {
       bool quoted = FALSE;
       int rc;
 
@@ -254,7 +260,8 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
       }
       gotma = TRUE;
     }
-    else if(curl_strnequal("includesubdomains", p, 17)) {
+    else if(curl_strnequal("includesubdomains", p, 17) &&
+            !hsts_tokenchar(p[17])) {
       if(gotinc)
         return CURLE_BAD_FUNCTION_ARGUMENT;
       subdomains = TRUE;

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -142,6 +142,23 @@ static CURLcode test_unit1660(const char *arg)
     showsts(e, chost);
   }
 
+  result = Curl_hsts_parse(h, "prefix.example",
+                           "max-age=60; includeSubDomainsExtra");
+  fail_if(result, "failed to parse unknown HSTS directive");
+  e = hsts_check(h, "child.prefix.example",
+                 strlen("child.prefix.example"), TRUE);
+  fail_if(e, "unknown directive enabled subdomain matching");
+  result = Curl_hsts_parse(h, "prefix.example", "max-age=0");
+  fail_if(result, "failed to remove HSTS test entry");
+
+  result = Curl_hsts_parse(h, "unknown.example",
+                           "max-age-extra=1; max-age=60");
+  fail_if(result, "failed to ignore unknown HSTS directive");
+  e = hsts_check(h, "unknown.example", strlen("unknown.example"), FALSE);
+  fail_if(!e, "recognized directive after unknown directive was ignored");
+  result = Curl_hsts_parse(h, "unknown.example", "max-age=0");
+  fail_if(result, "failed to remove HSTS test entry");
+
   curl_mprintf("Number of entries: %zu\n", Curl_llist_count(&h->list));
 
   /* verify that it is exists for 7 seconds */


### PR DESCRIPTION
HSTS directive recognition used case-insensitive prefix comparisons. This made an unknown token such as `includeSubDomainsExtra` enable subdomain policy, while `max-age-extra=1; max-age=60` caused the later valid directive to be ignored.

RFC 6797 defines a directive name as a complete HTTP token and requires unknown directives to be ignored while recognized directives are processed. Check the character following each known name so token continuations take the unknown-directive path.

The unit regression covers both known directive prefixes without changing the cache fixture. Both cases fail on the unpatched parser and pass with this change.

This bug was identified during AI-assisted source review and then independently reproduced, traced, and verified against current `master` and RFC 6797 section 6.1.

Tests:

- `make test TFLAGS='1660'`
- `make test TFLAGS='-j4'` (1,671/1,671 executed tests passed; 2,063 considered)
- `make checksrc`
- maintainer/debug build with strict compiler warnings
- `git diff --check`

Ref: https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1
