### PR TITLE
cookie: allow loading cookies for localhost

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -839,10 +839,14 @@ static bool is_public_suffix(struct Curl_easy *data,
           lcase[dlen] = 0;
           acceptable = psl_is_cookie_domain_acceptable(psl, lcase, lcookie);
         }
-        else
-          /* note that this PSL function returns the opposite value than
-             psl_is_cookie_domain_acceptable() does */
-          acceptable = !psl_is_public_suffix(psl, lcookie);
+        else {
+          /* libpsl says localhost is a PSL, we think not */
+          acceptable =
+            curl_strequal(lcookie, "localhost") ||
+            /* note that this PSL function returns the opposite value than
+               psl_is_cookie_domain_acceptable() does */
+            !psl_is_public_suffix(psl, lcookie);
+        }
         Curl_psl_release(data);
       }
       else

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -60,7 +60,7 @@ test280 test281 test282 test283 test284 test285 test286 test287 test288 \
 test289 test290 test291 test292 test293 test294 test295 test296 test297 \
 test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
-test316 test317 test318 test319                                         \
+test316 test317 test318 test319 test320                                 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \

--- a/tests/data/test320
+++ b/tests/data/test320
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+cookies
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: something-close, close-something, close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<features>
+cookies
+PSL
+</features>
+<server>
+http
+</server>
+<name>
+Load cookies from file for localhost
+</name>
+<command>
+http://localhost:%HTTPPORT/%TESTNUMBER -b %LOGDIR/cookies.txt --resolve localhost:%HTTPPORT:%HOSTIP
+</command>
+<file name="%LOGDIR/cookies.txt">
+localhost%TABTRUE%TAB/%TABFALSE%TAB0%TABgood%TABallowed
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: localhost:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Cookie: good=allowed
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
The added code to avoid loading PSL cookies from files from PR #22500 (c041895, not shipped in a release), calls psl_is_public_suffix(), returns TRUE also for "localhost" (!).

We now allow cookies again for localhost. Added test 320 to verify.

Reported-by: Athos Ribeiro
Fixes #22645
