### PR TITLE
docs: mention possible auth option conflicts

### DIFF
--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -37,6 +37,10 @@ extra network round-trip. Set the actual name and password with the
 CURLOPT_USERPWD(3) option or with the CURLOPT_USERNAME(3) and the
 CURLOPT_PASSWORD(3) options.
 
+Custom `Authorization:` headers set with CURLOPT_HTTPHEADER(3) may interfere
+with and cause unintended side-effects if combined with autentication set with
+CURLOPT_HTTPAUTH(3).
+
 For authentication with a proxy, see CURLOPT_PROXYAUTH(3).
 
 ## CURLAUTH_BASIC

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -38,8 +38,8 @@ CURLOPT_USERPWD(3) option or with the CURLOPT_USERNAME(3) and the
 CURLOPT_PASSWORD(3) options.
 
 Custom `Authorization:` headers set with CURLOPT_HTTPHEADER(3) may interfere
-with and cause unintended side-effects if combined with autentication set with
-CURLOPT_HTTPAUTH(3).
+with and cause unintended side-effects if combined with authentication set
+with CURLOPT_HTTPAUTH(3).
 
 For authentication with a proxy, see CURLOPT_PROXYAUTH(3).
 

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -105,7 +105,7 @@ providing the Content-Length: field in the request.
 ## Authorization:
 
 Custom `Authorization:` headers may interfere with and cause unintended
-side-effects when combined with autentication set with CURLOPT_HTTPAUTH(3).
+side-effects when combined with authentication set with CURLOPT_HTTPAUTH(3).
 
 ## Proxy-Authorization:
 

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -102,6 +102,16 @@ Host: is not sent at all over the wire.
 Tells libcurl the upload is to be done using this chunked encoding instead of
 providing the Content-Length: field in the request.
 
+## Authorization:
+
+Custom `Authorization:` headers may interfere with and cause unintended
+side-effects when combined with autentication set with CURLOPT_HTTPAUTH(3).
+
+## Proxy-Authorization:
+
+Custom `Proxy-Authorization:` headers may interfere with and cause unintended
+side-effects when combined with authentication set with CURLOPT_PROXYAUTH(3).
+
 # SPECIFIC MIME HEADERS
 
 When used to build a MIME email for IMAP or SMTP, the following document-level

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -42,7 +42,7 @@ CURLOPT_HTTPAUTH(3) man page.
 
 Custom `Proxy-Authorization:` headers set with CURLOPT_PROXYHEADER(3) may
 interfere with and cause unintended side-effects if combined with
-authentication set with CURLOPT_HTTPAUTH(3).
+authentication set with CURLOPT_PROXYAUTH(3).
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -40,6 +40,10 @@ option.
 The bitmask can be constructed by the bits listed and described in the
 CURLOPT_HTTPAUTH(3) man page.
 
+Custom `Proxy-Authorization:` headers set with CURLOPT_PROXYHEADER(3) may
+interfere with and cause unintended side-effects if combined with
+autentication set with CURLOPT_HTTPAUTH(3).
+
 # DEFAULT
 
 CURLAUTH_BASIC

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -42,7 +42,7 @@ CURLOPT_HTTPAUTH(3) man page.
 
 Custom `Proxy-Authorization:` headers set with CURLOPT_PROXYHEADER(3) may
 interfere with and cause unintended side-effects if combined with
-autentication set with CURLOPT_HTTPAUTH(3).
+authentication set with CURLOPT_HTTPAUTH(3).
 
 # DEFAULT
 


### PR DESCRIPTION
Do not mix HTTP auth options with custom Authorization headers.
