### PR TITLE
lib: silence gcc-16 compiler warnings `-Wmaybe-uninitialized`

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -815,7 +815,7 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
  */
 CURLcode curl_easy_perform(CURL *curl)
 {
-  struct Curl_eapi_guard guard;
+  struct Curl_eapi_guard guard = { 0 };
   CURLcode result;
 
   if(CURL_EAPI_ENTER(&guard, curl, easy_perform, &result)) {

--- a/lib/http.c
+++ b/lib/http.c
@@ -200,7 +200,7 @@ static bool http_header_is_empty(const char *header)
  */
 static CURLcode copy_custom_value(const char *header, char **valp)
 {
-  struct Curl_str out;
+  struct Curl_str out = { 0 };
 
   /* find the end of the header name */
   if(header_has_value(&header, &out)) {


### PR DESCRIPTION
Seen in the 'curl-for-win / Windows gcc zlib-classic (x64)' CI job,
after it got an upstream upgrade from gcc-15 to gcc-16:
```
lib/http.c:206:6: error: 'out.str' may be used uninitialized [-Werror=maybe-uninitialized]
  206 |   if(header_has_value(&header, &out)) {
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/api.h:188:3: error: 'guard.data' may be used uninitialized [-Werror=maybe-uninitialized]
  188 |   Curl_mapi_enter((g), (m), CURL_MAPI_FN_##fn, (r)) && (m)
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/multi.c:1695:6: note: in expansion of macro 'CURL_MAPI_ENTER'
 1695 |   if(CURL_MAPI_ENTER(&guard, m, multi_poll, &mresult)) {
      |      ^~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/32626356576/job/97162205296#step:3:4906
