### PR TITLE
appveyor: save an artifact for the vs2026 debug build

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -114,6 +114,30 @@ else
   echo "Skip running curl.exe. Reason: ${SKIP_RUN}"
 fi
 
+# create artifact
+
+if [[ "${CREATE_ARTIFACT:-}" = 'yes' ]]; then
+  cp /usr/ssl/certs/ca-bundle.crt curl-ca-bundle.crt
+  echo "Checking that https works (it should find curl-ca-bundle.crt if needed)"
+  "${curl}" -v -fsS --retry 6 --retry-all-errors -o /dev/null https://curl.se
+  if [ -n "${APPVEYOR_PULL_REQUEST_NUMBER:-}" ]; then
+    archive="curl_pr${APPVEYOR_PULL_REQUEST_NUMBER}_${APPVEYOR_PULL_REQUEST_HEAD_COMMIT}.zip"
+  else
+    archive="curl_${APPVEYOR_REPO_COMMIT}.zip"
+  fi
+cat << EOF > WARNING.txt
+WARNING: Do not run this build unless the download link was provided by staff.
+Anyone can submit a PR with possibly malicious code to generate a build.
+${archive}
+EOF
+  echo "Finding curl module dependencies"
+  "${curl}" --dump-module-paths | grep -Fv "C:\Windows" | tee > files.tmp
+  echo "Creating artifact"
+  7z a "${archive}" -y -bb1 -bsp0 -mx9 -tzip -i@files.tmp curl-ca-bundle.crt WARNING.txt
+  rm files.tmp
+  appveyor PushArtifact "${archive}"
+fi
+
 # build tests
 
 if [ -n "${CMAKE_GENERATOR:-}" ] && [[ "${APPVEYOR_JOB_NAME}" = *'Build-tests'* ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,6 +94,7 @@ environment:
       CMAKE_SHA256: dfc2b2afac257555e3b9ce375b12b2883964283a366c17fec96cf4d17e4f1677
       CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A x64 -T ClangCl -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=ON'
+      CREATE_ARTIFACT: yes
 
     - job_name: 'CM VS2022, Release, x64, Schannel, Shared, Unicode, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'


### PR DESCRIPTION
- Save an artifact (zip of curl.exe and dependencies) for the job 'CM VS2026, Debug, x64, OpenSSL 3.5 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'.

For user testing.

Ref: https://github.com/curl/curl/issues/22466#issuecomment-5389439586

Closes #xxxx
