### PR TITLE
vssh: silence gcc-11 `-Wnull-dereference`, dedupe `CURL_EASY_STR()` calls

### DIFF
--- a/lib/vssh/vssh.c
+++ b/lib/vssh/vssh.c
@@ -366,6 +366,8 @@ CURLcode Curl_ssh_setup_pkey(struct Curl_easy *data, struct ssh_conn *sshc)
 {
   char *home = NULL;
   if(data->set.ssh_auth_types & CURLSSH_AUTH_PUBLICKEY) {
+    const char *str;
+
     sshc->pub_key = sshc->priv_key = NULL;
 
     if(CURL_EASY_STR(data, STRING_SSH_PRIVATE_KEY)) {
@@ -418,9 +420,9 @@ CURLcode Curl_ssh_setup_pkey(struct Curl_easy *data, struct ssh_conn *sshc)
      * library extract the public key from the private key file. This is done
      * by passing sshc->pub_key = NULL.
      */
-    if(CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY) &&
-       /* treat empty string the same way as NULL */
-       CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY)[0]) {
+    str = CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY);
+    /* treat empty string the same way as NULL */
+    if(str && *str) {
       sshc->pub_key = curlx_strdup(
         CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY));
       if(!sshc->pub_key)

--- a/lib/vssh/vssh.c
+++ b/lib/vssh/vssh.c
@@ -422,8 +422,7 @@ CURLcode Curl_ssh_setup_pkey(struct Curl_easy *data, struct ssh_conn *sshc)
      */
     str = CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY);
     if(str && *str) {  /* treat empty string the same way as NULL */
-      sshc->pub_key = curlx_strdup(
-        CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY));
+      sshc->pub_key = curlx_strdup(str);
       if(!sshc->pub_key)
         goto fail;
     }

--- a/lib/vssh/vssh.c
+++ b/lib/vssh/vssh.c
@@ -421,8 +421,7 @@ CURLcode Curl_ssh_setup_pkey(struct Curl_easy *data, struct ssh_conn *sshc)
      * by passing sshc->pub_key = NULL.
      */
     str = CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY);
-    /* treat empty string the same way as NULL */
-    if(str && *str) {
+    if(str && *str) {  /* treat empty string the same way as NULL */
       sshc->pub_key = curlx_strdup(
         CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY));
       if(!sshc->pub_key)


### PR DESCRIPTION
Silencing:
```
In file included from libcurl_unity.c:179:
vssh/vssh.c: In function ‘Curl_ssh_setup_pkey.part.0’:
vssh/vssh.c:423:50: error: potential null pointer dereference [-Werror=null-dereference]
  423 |        CURL_EASY_STR(data, STRING_SSH_PUBLIC_KEY)[0]) {
libtool: compile:  gcc -DHAVE_CONFIG_H -I../include -I../lib -I../lib -I. -DBUILDING_LIBCURL -DCURL_STATICLIB -DUNITTESTS -D_GNU_SOURCE -Werror-implicit-functi
```
Ref: https://app.circleci.com/pipelines/gh/curl/curl/20825/workflows/c3eb591b-5a7d-40da-baa8-d2d9980b0cb2/jobs/181277

Follow-up to c8df3defd9664cd276adc33754210ee07b5bbf71 #22628
