### PR TITLE
openssl: avoid conn reuse if provider is used

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3757,7 +3757,8 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
     return CURLE_OUT_OF_MEMORY;
   }
 #ifdef OPENSSL_HAS_PROVIDERS
-  SSL_up_ref(data->state.libctx);
+  if(data->state.libctx)
+    SSL_up_ref(data->state.libctx);
 #endif
 
   if(cb_setup) {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3756,6 +3756,9 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
           ossl_strerror(ERR_peek_error(), error_buffer, sizeof(error_buffer)));
     return CURLE_OUT_OF_MEMORY;
   }
+#ifdef OPENSSL_HAS_PROVIDERS
+  SSL_up_ref(data->state.libctx);
+#endif
 
   if(cb_setup) {
     result = cb_setup(cf, data, cb_user_data);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3758,7 +3758,8 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   }
 #ifdef OPENSSL_HAS_PROVIDERS
   if(data->state.libctx)
-    SSL_up_ref(data->state.libctx);
+    /* forbid connection reuse with provider/engine use */
+    connclose(data->conn);
 #endif
 
   if(cb_setup) {


### PR DESCRIPTION
Reported-by: Stanislav Fort
