### PR TITLE
vtls: move 'native_ca_store' ssl_config_data => ssl_primary_config

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -457,7 +457,7 @@ static CURLcode gtls_populate_creds(struct Curl_cfilter *cf,
   }
 
   infof(data, "SSL Trust Anchors:");
-  if(ssl_config->native_ca_store) {
+  if(config->native_ca_store) {
 #ifdef USE_APPLE_SECTRUST
     infof(data, "  Native: Apple SecTrust");
     creds_are_empty = FALSE;
@@ -661,7 +661,7 @@ CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&
     !ssl_config->primary.CRLfile &&
-    !ssl_config->native_ca_store &&
+    !conn_config->native_ca_store &&
     !conn_config->clientcert; /* GnuTLS adds client cert to its credentials! */
 
   if(cache_criteria_met)
@@ -1604,7 +1604,7 @@ static CURLcode gtls_verify_cert(struct Curl_easy *data,
     infof(data, "  SSL certificate verified by GnuTLS");
 
 #ifdef USE_APPLE_SECTRUST
-  if(!verified && ssl_config->native_ca_store) {
+  if(!verified && config->native_ca_store) {
     CURLcode result =
       Curl_vtls_apple_verify(cf, data, peer, chain->num_certs,
                              gtls_chain_get_der, chain, NULL, 0);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2999,7 +2999,6 @@ static CURLcode ossl_load_trust_anchors(struct Curl_cfilter *cf,
                                         X509_STORE *store)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   CURLcode result = CURLE_OK;
   const char * const ssl_cafile =
     /* CURLOPT_CAINFO_BLOB overrides CURLOPT_CAINFO */
@@ -3008,7 +3007,7 @@ static CURLcode ossl_load_trust_anchors(struct Curl_cfilter *cf,
   bool have_native_check = FALSE;
 
   octx->store_is_empty = TRUE;
-  if(ssl_config->native_ca_store) {
+  if(conn_config->native_ca_store) {
 #ifdef USE_WIN32_CRYPTO
     bool added = FALSE;
     result = ossl_windows_load_anchors(cf, data, store, &added);
@@ -3316,7 +3315,7 @@ CURLcode Curl_ssl_setup_x509_store(struct Curl_cfilter *cf,
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&
     !ssl_config->primary.CRLfile &&
-    !ssl_config->native_ca_store;
+    !conn_config->native_ca_store;
 
   ERR_set_mark();
 
@@ -3370,7 +3369,7 @@ static bool ossl_apply_session(
          (SSL_get_verify_result(octx->ssl) != X509_V_OK)
 #ifdef USE_APPLE_SECTRUST
          /* if sectrust is used and verified the session before */
-         && (!ssl_config->native_ca_store || !scs->sectrust_verified)
+         && (!conn_cfg->native_ca_store || !scs->sectrust_verified)
 #endif
         ) {
         /* Session was from unverified connection, cannot reuse here */
@@ -4830,7 +4829,7 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
     infof(data, "SSL certificate verified via OpenSSL.");
 
 #ifdef USE_APPLE_SECTRUST
-  if(!verified && conn_config->verifypeer && ssl_config->native_ca_store) {
+  if(!verified && conn_config->verifypeer && conn_config->native_ca_store) {
     /* we verify using Apple SecTrust *unless* OpenSSL already verified.
      * This may happen if the application intercepted the OpenSSL callback
      * and installed its own. */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1049,7 +1049,7 @@ static CURLcode cr_init_backend(struct Curl_cfilter *cf,
     rustls_client_config_builder_dangerous_set_certificate_verifier(
       config_builder, cr_verify_none);
   }
-  else if(ssl_config->native_ca_store) {
+  else if(conn_config->native_ca_store) {
     if(conn_config->CRLfile) {
       failf(data, "rustls: CRL file not supported with native CA store; "
             "the platform verifier has no CRL attachment API");

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -193,6 +193,7 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
   dest->verifypeer = source->verifypeer;
   dest->verifyhost = source->verifyhost;
   dest->verifystatus = source->verifystatus;
+  dest->native_ca_store = source->native_ca_store;
   dest->cache_session = source->cache_session;
   dest->ssl_options = source->ssl_options;
 

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -141,6 +141,7 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
   if((c1->version == c2->version) &&
      (c1->version_max == c2->version_max) &&
      (c1->ssl_options == c2->ssl_options) &&
+     (c1->native_ca_store == c2->native_ca_store) &&
      (c1->verifypeer == c2->verifypeer) &&
      (c1->verifyhost == c2->verifyhost) &&
      (c1->verifystatus == c2->verifystatus) &&
@@ -225,7 +226,7 @@ static void ssl_easy_config_compl_options(struct Curl_peer *origin,
   /* If set via CURLOPT_(PROXY_)SSL_OPTIONS, we definitely use it.
    * If not, we switch it on for supported backends if no custom
    * CA settings exist. */
-  sslc->native_ca_store = !!(options & CURLSSLOPT_NATIVE_CA);
+  sslc->primary.native_ca_store = !!(options & CURLSSLOPT_NATIVE_CA);
   sslc->enable_beast = !!(options & CURLSSLOPT_ALLOW_BEAST);
   sslc->no_partialchain = !!(options & CURLSSLOPT_NO_PARTIALCHAIN);
   sslc->no_revoke = !!(options & CURLSSLOPT_NO_REVOKE);
@@ -256,7 +257,7 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
   if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
 #if defined(USE_APPLE_SECTRUST) || defined(CURL_CA_NATIVE)
     if(!sslc->custom_capath && !sslc->custom_cafile && !sslc->custom_cablob)
-      sslc->native_ca_store = TRUE;
+      sslc->primary.native_ca_store = TRUE;
 #endif
 #ifdef CURL_CA_PATH
     if(!sslc->custom_capath && !CURL_EASY_STR(data, STRING_SSL_CAPATH)) {
@@ -317,7 +318,7 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
   if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
 #if defined(USE_APPLE_SECTRUST) || defined(CURL_CA_NATIVE)
     if(!sslc->custom_capath && !sslc->custom_cafile && !sslc->custom_cablob)
-      sslc->native_ca_store = TRUE;
+      sslc->primary.native_ca_store = TRUE;
 #endif
 #ifdef CURL_CA_PATH
     if(!sslc->custom_capath &&

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -54,6 +54,7 @@ struct ssl_primary_config {
   BIT(verifypeer);       /* set TRUE if this is desired */
   BIT(verifyhost);       /* set TRUE if CN/SAN must match hostname */
   BIT(verifystatus);     /* set TRUE if certificate status must be checked */
+  BIT(native_ca_store); /* use the native CA store of operating system */
   BIT(cache_session);    /* cache session or not */
   BIT(deep_copy);        /* members are deep copies, eg. owned here */
 };
@@ -70,7 +71,6 @@ struct ssl_config_data {
   BIT(no_partialchain); /* do not accept partial certificate chains */
   BIT(revoke_best_effort); /* ignore SSL revocation offline/missing revocation
                               list errors */
-  BIT(native_ca_store); /* use the native CA store of operating system */
   BIT(auto_client_cert);   /* automatically locate and use a client
                               certificate for authentication (Schannel) */
   BIT(custom_cafile); /* application has set custom CA file */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -592,7 +592,6 @@ static CURLcode wssl_populate_x509_store(struct Curl_cfilter *cf,
     /* CURLOPT_CAINFO_BLOB overrides CURLOPT_CAINFO */
     (ca_info_blob ? NULL : conn_config->CAfile);
   const char * const ssl_capath = conn_config->CApath;
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   bool imported_native_ca = FALSE;
   bool imported_ca_info_blob = FALSE;
 
@@ -601,7 +600,7 @@ static CURLcode wssl_populate_x509_store(struct Curl_cfilter *cf,
 
 #ifndef NO_FILESYSTEM
   /* load native CA certificates */
-  if(ssl_config->native_ca_store) {
+  if(conn_config->native_ca_store) {
 #ifdef WOLFSSL_SYS_CA_CERTS
     if(wolfSSL_CTX_load_system_CA_certs(wssl->ssl_ctx) != WOLFSSL_SUCCESS) {
       infof(data, "error importing native CA store, continuing anyway");
@@ -809,7 +808,7 @@ CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&
     !ssl_config->primary.CRLfile &&
-    !ssl_config->native_ca_store;
+    !conn_config->native_ca_store;
 
   cached_store = cache_criteria_met ? wssl_get_cached_x509_store(cf, data)
                                     : NULL;


### PR DESCRIPTION
And include it as key for connection reuse matching.

Reported-by: Stanislav Fort

