### PR TITLE
strcase: inline the raw case conversions

### DIFF
--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -26,7 +26,7 @@
 #include "strcase.h"
 
 /* Mapping table to go from lowercase to uppercase for plain ASCII.*/
-static const unsigned char touppermap[256] = {
+const unsigned char Curl_touppermap[256] = {
   0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,
   15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
   30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
@@ -48,7 +48,7 @@ static const unsigned char touppermap[256] = {
 };
 
 /* Mapping table to go from uppercase to lowercase for plain ASCII.*/
-static const unsigned char tolowermap[256] = {
+const unsigned char Curl_tolowermap[256] = {
   0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,
   15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
   30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
@@ -68,20 +68,6 @@ static const unsigned char tolowermap[256] = {
   240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254,
   255
 };
-
-/* Portable, consistent toupper. Do not use toupper() because its behavior is
-   altered by the current locale. */
-char Curl_raw_toupper(char in)
-{
-  return (char)touppermap[(unsigned char)in];
-}
-
-/* Portable, consistent tolower. Do not use tolower() because its behavior is
-   altered by the current locale. */
-char Curl_raw_tolower(char in)
-{
-  return (char)tolowermap[(unsigned char)in];
-}
 
 /* Copy an upper case version of the string from src to dest. The
  * strings may overlap. No more than n characters of the string are copied

--- a/lib/strcase.h
+++ b/lib/strcase.h
@@ -25,8 +25,24 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-char Curl_raw_toupper(char in);
-char Curl_raw_tolower(char in);
+/* Mapping tables for plain ASCII case conversion, defined in strcase.c.
+   Declared here so the conversions below inline at every call site without
+   relying on LTO or a unity build: casecompare() invokes one of them twice
+   per byte compared, where the call costs more than the lookup itself. */
+extern const unsigned char Curl_touppermap[256];
+extern const unsigned char Curl_tolowermap[256];
+
+/* Portable, consistent toupper/tolower. Do not use toupper()/tolower() from
+   <ctype.h>, whose behavior is altered by the current locale. */
+static CURL_INLINE char Curl_raw_toupper(char in)
+{
+  return (char)Curl_touppermap[(unsigned char)in];
+}
+
+static CURL_INLINE char Curl_raw_tolower(char in)
+{
+  return (char)Curl_tolowermap[(unsigned char)in];
+}
 
 /* checkprefix() is a shorter version of the above, used when the first
    argument is the string literal */


### PR DESCRIPTION
`Curl_raw_toupper()` and `Curl_raw_tolower()` are out-of-line functions whose entire body is one 256-byte table lookup, and `casecompare()` invokes one of them twice per byte compared. Every case-insensitive comparison in the library (header matching, scheme and host compares, cookie domains) pays two function calls per byte to do work that could be reduced to a single load.

This PR changes them `static CURL_INLINE` functions in `strcase.h` and gives the two mapping tables external linkage so the lookup inlines in every translation unit. The tables keep the same bytes and the conversion performs the same mapping, so there is no behavior change: only the linkage of the tables and the placement of the lookup change.

### Benchmarking

Benchmarking was done using a harness located in https://github.com/ron-kuper/curlbench. Note that his harness covers more of the library than this patch touches (e.g. printf, URL parsing, transfer lifecycle). I am measuring several other candidate changes with it and expect to propose some of them separately. Only the cases in the table above are relevant to this one.

I ran this benchmark on 2 embedded targets that are of interest to me. The results are as follows.

| case | Cortex-A55 | 250MHz e300c3 |
|---|---|---|
| `curl_strequal`, identical header names | −49.1% | −51.7% |
| `curl_strequal`, case-folded match | −49.1% | −51.6% |
| `curl_strequal`, late mismatch | −49.0% | −51.5% |
| `curl_strnequal` prefix match | −42.9% | −54.6% |
| one response's worth of header dispatch | −43.5% | −39.8% |

There is a margin of error in these results caused by 2 kinds of "noise". *Repeat noise* is when running the same binary run twice yields a different answer. In our benchmarking it is 0.12% median on the A55 and 0.18% on the e300c3. *Recompile noise* is when recompiling the same binary but with non-functioning code changes that merely cause addresses to move around. On the e300c3 it moves unrelated cases by up to 8%.

The performance gains on an x86-64 desktop clock in at about −79% to −81% on the compare cases. However on this machine I've observed that recompile noise can vary the outcome by 24-34% it's hard to make an apples-to-apples comparison.

### Testing

`make -C tests nonflaky-test` on this patch alone, built `--enable-debug --enable-warnings --with-openssl --with-nghttp2 --with-zlib`:
**1734 of 1734 OK**, no new compiler warnings.
Includes 1397 (`Curl_cert_hostcheck`, which exercises the case compares), 1395, 1396, 1398, 1399, 1502 and 1506.
`scripts/checksrc.pl` clean.

### AI disclosure

I used an AI assistant on this work: for auditing the call sites, for the codegen and object-size checks quoted above, and for parts of the benchmark harness. The change, the reasoning and the measurements are mine, and I have
verified every claim above myself rather than taking them on trust.
