### PR TITLE
multi: seed the transfer table at 64

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -48,8 +48,12 @@
 #include "socketpair.h"
 #include "bufref.h"
 
-/* initial multi->xfers table size for a full multi */
-#define CURL_XFER_TABLE_SIZE 512
+/* Initial multi->xfers table size. The table and its bitsets grow on
+   demand in multiples of 64 when a transfer does not fit, so this only
+   has to cover the common case: enough rows that typical use never
+   grows the table, few enough that curl_multi_init() is not zeroing
+   rows nothing will ever touch. */
+#define CURL_XFER_TABLE_SIZE 64
 
 /* CURL_SOCKET_HASH_TABLE_SIZE should be a prime number. Increasing it from 97
    to 911 takes on a 32-bit machine 4 x 804 = 3211 more bytes. Still, every


### PR DESCRIPTION
`curl_multi_init()` seeds the transfer table at 512 rows, so every multi handle zeroes a 4KB pointer array. The table and its bitsets already grow on demand in multiples of 64 when a transfer does not fit, and growth is geometric, so
applications running a handful of concurrent transfers pay for rows they never touch. This PR seeds it seeds at 64.

### Benchmarking

Benchmarking was done using a harness located in https://github.com/ron-kuper/curlbench. Note that his harness covers more of the library than this patch touches (e.g. printf, URL parsing, transfer lifecycle). I am measuring several other candidate changes with it and expect to propose some of them separately. Only the cases in the table above are relevant to this one.

I ran this benchmark on 2 embedded targets that are of interest to me. The results are as follows.

| case | x86-64 | Cortex-A55 | 250MHz e300c3 |
|---|---|---|---|
| `curl_multi_init()` + `curl_multi_cleanup()` | −8.9% | −3.2% | −5.6% |
| multi + 8 easy handles added and removed | −3.4% | −2.0% | −3.3% |

These move only the cases they should; nothing else in the suite shifts.

The percentages are small, so the noise floor (i.e., the margin of error) matters. *Repeat noise* (same binary run twice) is 0.12% on the A55 and 0.23% on the e300c3. *Recompile noise* (what a rebuild that changes nothing produces on its own) is 0.10% and 0.13% on `multi/lifecycle` specifically. So −3.2% is roughly 30x its noise and −5.6% about 40x. Measuring against a per-case figure rather than a blanket threshold matters here; a blanket "under 5% is noise" rule would have discarded a real effect.

### AI disclosure

I used an AI assistant on this work: for auditing where `CURL_XFER_TABLE_SIZE` is read and what each read actually means, and for parts of the benchmark harness. The change, the reasoning and the measurements are mine, and I have verified every claim above myself rather than taking them on trust.

### Testing

`make -C tests nonflaky-test` on this patch alone, built `--enable-debug
--enable-warnings --with-openssl --with-nghttp2 --with-zlib`: **1734 of 1734
OK**.
Includes 1502 (multi with cleanup sequence) and 1506 (connection cache
limit), plus 1395-1399.
`scripts/checksrc.pl` clean.
