### PR TITLE
fix(curl): throttle stdin poll in tool_readbusy_cb to 25ms

### DIFF
--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -170,9 +170,9 @@ int tool_readbusy_cb(void *clientp,
   if(config->readbusy) {
     if(ulprev == ulnow) {
 #ifndef _WIN32
-      waitfd(1, per->infd);
+      waitfd(25, per->infd);
 #else
-      curlx_wait_ms(1); /* sleep */
+      curlx_wait_ms(25); /* sleep */
 #endif
     }
 


### PR DESCRIPTION
Busy-loop in tool_readbusy_cb polls stdin at 1000 Hz.

The callback at src/tool_cb_rea.c:173 calls waitfd(1) and curlx_wait_ms(1) when no upload progress has occurred, causing about 1000 wakes per second while waiting for stdin. This burns CPU for the common `-T .` and piped input cases.

Fix: throttle the poll to 25ms on both the poll and sleep paths. This reduces wake rate to 40 Hz, negligible latency impact for interactive stdin while cutting CPU use substantially.

Verified with RED/GREEN checksrc pass. Diff is two lines in src/tool_cb_rea.c.