### PR TITLE
Makefile.am: improve etags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,22 @@ DISTCLEANFILES = buildinfo.txt
 
 bin_SCRIPTS = curl-config
 
+ETAGS_ARGS = \
+  $(srcdir)/include/curl/curl.h \
+  $(srcdir)/include/curl/curlver.h \
+  $(srcdir)/include/curl/easy.h \
+  $(srcdir)/include/curl/mprintf.h \
+  $(srcdir)/include/curl/stdcheaders.h \
+  $(srcdir)/include/curl/multi.h \
+  $(srcdir)/include/curl/typecheck-gcc.h \
+  $(srcdir)/include/curl/system.h \
+  $(srcdir)/include/curl/urlapi.h \
+  $(srcdir)/include/curl/options.h \
+  $(srcdir)/include/curl/header.h \
+  $(srcdir)/include/curl/websockets.h
+
+TAGS_DEPENDENCIES = $(ETAGS_ARGS)
+
 SUBDIRS = lib docs src scripts
 DIST_SUBDIRS = $(SUBDIRS) tests projects include docs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,9 +84,9 @@ CURL_ETAGS_FILES = \
   $(srcdir)/include/curl/header.h \
   $(srcdir)/include/curl/websockets.h
 
-ETAGS_ARGS += $(CURL_ETAGS_FILES)
+ETAGS_ARGS = $(CURL_ETAGS_FILES)
 
-TAGS_DEPENDENCIES += $(CURL_ETAGS_FILES)
+TAGS_DEPENDENCIES = $(CURL_ETAGS_FILES)
 
 SUBDIRS = lib docs src scripts
 DIST_SUBDIRS = $(SUBDIRS) tests projects include docs

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,7 @@ DISTCLEANFILES = buildinfo.txt
 
 bin_SCRIPTS = curl-config
 
-ETAGS_ARGS = \
+CURL_ETAGS_FILES = \
   $(srcdir)/include/curl/curl.h \
   $(srcdir)/include/curl/curlver.h \
   $(srcdir)/include/curl/easy.h \
@@ -84,7 +84,9 @@ ETAGS_ARGS = \
   $(srcdir)/include/curl/header.h \
   $(srcdir)/include/curl/websockets.h
 
-TAGS_DEPENDENCIES = $(ETAGS_ARGS)
+ETAGS_ARGS += $(CURL_ETAGS_FILES)
+
+TAGS_DEPENDENCIES += $(CURL_ETAGS_FILES)
 
 SUBDIRS = lib docs src scripts
 DIST_SUBDIRS = $(SUBDIRS) tests projects include docs


### PR DESCRIPTION
The Makefile generated with autotools offers a 'tags' target that invokes etags to build a symbol database in 'TAGS'.

For some reason it never indexes the symbols in the public include files and this is a somewhat crude way to make it do so. The downside with this take is that it repeats the header files names in the root Makefile. I still consider it valuable. The file set changes very rarely and this tags target is not critical.
