### PR TITLE
setopt: make NULL `CURLOPT_AWS_SIGV4` disable aws-sigv4 auth

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2069,6 +2069,8 @@ static CURLcode setopt_cptr_http_mqtt(struct Curl_easy *data,
      */
     if(CURL_EASY_STR(data, STRING_AWS_SIGV4))
       s->httpauth = CURLAUTH_AWS_SIGV4;
+    else
+      s->httpauth &= ~(uint32_t)CURLAUTH_AWS_SIGV4;
     break;
 #endif
 #ifndef CURL_DISABLE_HTTPSIG

--- a/tests/data/test1978
+++ b/tests/data/test1978
@@ -70,6 +70,25 @@ header-no-value:
 header-some-no-value:
 header-some-no-value: value
 
+PUT /%TESTNUMBER/testapi/test HTTP/1.1
+Host: 127.0.0.1:9000
+x-amz-meta-test: test2
+some-other-header: value
+x-amz-meta-test: test1
+duplicate-header: duplicate
+x-amz-meta-test: test3
+X-amz-meta-test2: test2
+x-amz-meta-blah: blah
+x-Amz-meta-test2: test1
+x-amz-Meta-test2: test3
+curr-header-no-colon: value
+next-header-no-colon: value
+duplicate-header: duplicate
+header-no-value:
+header-no-value:
+header-some-no-value:
+header-some-no-value: value
+
 </protocol>
 </verify>
 </testcase>

--- a/tests/libtest/lib1978.c
+++ b/tests/libtest/lib1978.c
@@ -90,6 +90,11 @@ static CURLcode test_lib1978(const char *URL)
   easy_setopt(curl, CURLOPT_CONNECT_TO, connect_to);
 
   result = curl_easy_perform(curl);
+  if(result)
+    goto test_cleanup;
+
+  easy_setopt(curl, CURLOPT_AWS_SIGV4, NULL);
+  result = curl_easy_perform(curl);
 
 test_cleanup:
 


### PR DESCRIPTION
Disable `CURLAUTH_AWS_SIGV4` when `CURLOPT_AWS_SIGV4` is set to NULL.
Syncing behavior with `CURLAUTH_HTTPSIG`.

Reported-by: Stanislav Fort
