### PR TITLE
tool_doswin: fix stdin data truncation

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -740,9 +740,8 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     ssize_t nwritten;
     char buffer[BUFSIZ];
 
+    /* Note when the pipe has ended ReadFile fails with ERROR_BROKEN_PIPE */
     if(!ReadFile(tdata.stdin_handle, buffer, sizeof(buffer), &n, NULL))
-      break;
-    if(n == 0)
       break;
     nwritten = swrite(tdata.socket_w, buffer, n);
     if(nwritten == -1)
@@ -880,9 +879,6 @@ curl_socket_t win32_stdin_read_thread(void)
       break;
     }
 
-    /* Hard close the socket on closesocket() */
-    setsockopt(socket_r, SOL_SOCKET, SO_DONTLINGER, 0, 0);
-
     /* Make the reading socket nonblocking */
     if(curlx_nonblock(socket_r, TRUE)) {
       errorf("curlx_nonblock() error");
@@ -931,11 +927,6 @@ curl_socket_t win32_stdin_read_thread(void)
     }
 
     if(shutdown(tdata.socket_w, SHUT_RD)) {
-      errorf("shutdown error: %d", SOCKERRNO);
-      break;
-    }
-
-    if(shutdown(socket_r, SHUT_WR)) {
       errorf("shutdown error: %d", SOCKERRNO);
       break;
     }

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -740,7 +740,8 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     ssize_t nwritten;
     char buffer[BUFSIZ];
 
-    /* Note when the pipe has ended ReadFile fails with ERROR_BROKEN_PIPE */
+    /* note if stdin is a pipe then ReadFile will fail once the pipe has ended
+       with GetLastError ERROR_BROKEN_PIPE */
     if(!ReadFile(tdata.stdin_handle, buffer, sizeof(buffer), &n, NULL))
       break;
     nwritten = swrite(tdata.socket_w, buffer, n);
@@ -748,6 +749,19 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
       break;
     if((DWORD)nwritten != n)
       break;
+  }
+
+  /* wait for all data to be received by the main thread:
+     shut down the write side of our socket so that a FIN is sent "after all
+     data is sent and acknowledged by the receiver". recv is called to wait for
+     this to happen. the wait time includes socket linger time of up to 2 min
+     (OS typical) since it's possible the receiver will not reply to the FIN.
+     */
+  if(shutdown(tdata.socket_w, SHUT_WR) == 0) {
+    char buf[1024];
+    /* read until close or error while ignoring all incoming */
+    while(sread(tdata.socket_w, buf, sizeof(buf)) > 0)
+      ;
   }
 
   cleanup_tdata_sync();

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -760,8 +760,8 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
   /* wait for all data to be received by the main thread:
      shut down the write side of our socket so that a FIN is sent "after all
      data is sent and acknowledged by the receiver". recv is called to wait for
-     this to happen. the wait time includes socket linger time of up to 2 min
-     (OS typical) since it's possible the receiver will not reply to the FIN.
+     this to happen. the wait time includes time of up to 2 min (OS typical)
+     since it's possible the receiver will not reply to the FIN.
      */
   if(shutdown(tdata.socket_w, SHUT_WR) == 0) {
     char buf[1024];

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -740,9 +740,15 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     ssize_t nwritten;
     char buffer[BUFSIZ];
 
-    /* note if stdin is a pipe then ReadFile will fail once the pipe has ended
-       with GetLastError ERROR_BROKEN_PIPE */
+    /* If stdin is a pipe then end-of-data signaling may differ depending on
+       how curl was built, the shell and the input. Two ways have been
+       observed:
+       - ReadFile fails with GetLastError ERROR_BROKEN_PIPE
+       - ReadFile succeeds with 0 bytes read (seen on mingw) */
+
     if(!ReadFile(tdata.stdin_handle, buffer, sizeof(buffer), &n, NULL))
+      break;
+    if(n == 0)
       break;
     nwritten = swrite(tdata.socket_w, buffer, n);
     if(nwritten == -1)

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -946,11 +946,6 @@ curl_socket_t win32_stdin_read_thread(void)
       break;
     }
 
-    if(shutdown(tdata.socket_w, SHUT_RD)) {
-      errorf("shutdown error: %d", SOCKERRNO);
-      break;
-    }
-
     /* Make a copy of the stdin handle to be used by win_stdin_thread_func */
     if(!DuplicateHandle(GetCurrentProcess(), GetStdHandle(STD_INPUT_HANDLE),
                         GetCurrentProcess(), &tdata.stdin_handle,


### PR DESCRIPTION
- Don't do premature write shutdown (SHUT_WR) on the socket used to read the stdin data (aka socket_r).

- Don't do premature read shutdown (SHUT_RD) on the socket used to write the stdin data (aka socket_w).

- Remove broken setsockopt call for SO_DONTLINGER on socket_r.

- ~~Treat ReadFile receiving 0 bytes as valid (it seems this is allowed).~~ (removed because mingw uses it to signal eof)

- Wait until all data sent from socket_w is acknowledged by socket_r.

Prior to this change a partial shutdown of the write side of the read socket that the main thread reads stdin data from (socket_r) happened before reading the data from the socket. The partial shutdown caused a FIN to be sent which lingered for ~2 minutes (typical OS configured time), and after that time the connection was terminated.

Theory of operation to read stdin on windows is a connection is established to relay stdin from a dedicated thread (write to socket_w) to the main thread (read from socket_r) so reading stdin is non-blocking. Data truncation would occur if this process was not completed by the OS FIN reply wait time.

Ref: https://github.com/curl/curl/pull/22383#issuecomment-5399969303

Closes #xxxx

---

/cc @11soda11 @denandz