### PR TITLE
tests: support switching off the stdout redirect per-test

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -605,6 +605,9 @@ Set `option="no-output"` to prevent the test script to slap on the `--output`
 argument that directs the output to a file. The `--output` is also not added
 if the verify/stdout section is used.
 
+Set `option="no-stdout"` to prevent the normal stdout redirect template to be
+applied on the command line to run.
+
 Set `option="force-output"` to make use of `--output` even when the test is
 otherwise written to verify stdout.
 

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -991,8 +991,12 @@ sub singletest_run {
         $CMDLINE = "$valgrindcmd $CMDLINE";
     }
 
-    $CMDLINE .= "$cmdargs > " . stdoutfilename($LOGDIR, $testnum) .
-                " 2> " . stderrfilename($LOGDIR, $testnum);
+    my $redirstdout = "> " . stdoutfilename($LOGDIR, $testnum);
+    if($cmdhash{'option'} =~ /no-stdout/) {
+        $redirstdout = "";
+    }
+    $CMDLINE .= "$cmdargs $redirstdout".
+        " 2> " . stderrfilename($LOGDIR, $testnum);
 
     if($verbose) {
         logmsg "$CMDLINE\n";


### PR DESCRIPTION
The `<command>` tag now supports `option="no-stdout"` for this purpose.
