### PR TITLE
tool_cb_hdr: do not truncate etags output to stdout

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -268,6 +268,7 @@ static size_t save_etag(const char *etag_h, const char *endp,
 
       /* Truncate regular files to avoid stale etag content */
       if((fd != -1) &&
+         etag_save->regular_file &&
          !curlx_fstat(fd, &file) &&
          (S_ISREG(file.st_mode) &&
           toolx_ftruncate(fd, 0)))

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -60,7 +60,7 @@ test280 test281 test282 test283 test284 test285 test286 test287 test288 \
 test289 test290 test291 test292 test293 test294 test295 test296 test297 \
 test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
-test316 test317 test318 test319 test320                                 \
+test316 test317 test318 test319 test320 test321                         \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \

--- a/tests/data/test321
+++ b/tests/data/test321
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+ETag: "remote"
+Content-Length: 0
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+--etag-save to stdout append to file
+</name>
+<command option="no-stdout">
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --etag-save - >> %LOGDIR/out%TESTNUMBER
+</command>
+
+<file name="%LOGDIR/out%TESTNUMBER">
+initial content
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<file name="%LOGDIR/out%TESTNUMBER">
+initial content
+"remote"
+</file>
+</verify>
+</testcase>

--- a/tests/data/test321
+++ b/tests/data/test321
@@ -2,8 +2,7 @@
 <testcase>
 <info>
 <keywords>
-HTTP
-HTTP GET
+etags
 </keywords>
 </info>
 

--- a/tests/data/test321
+++ b/tests/data/test321
@@ -2,7 +2,7 @@
 <testcase>
 <info>
 <keywords>
-etags
+etag
 </keywords>
 </info>
 


### PR DESCRIPTION
Verified by test 321

Reported-by: Stanislav Fort
