### PR TITLE
tool_paramhlp: --proto only supports one modifier

### DIFF
--- a/docs/cmdline-opts/proto.md
+++ b/docs/cmdline-opts/proto.md
@@ -18,7 +18,7 @@ Example:
 
 Limit what protocols to allow for transfers. Protocols are evaluated left to
 right, are comma separated, and are each a protocol name or 'all', optionally
-prefixed by zero or more modifiers. Available modifiers are:
+prefixed by a modifier. Available modifiers are:
 
 ## +
 Permit this protocol in addition to protocols already permitted (this is

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -482,7 +482,8 @@ ParameterError proto2num(const char * const *val, char **ostr, const char *str)
            if no protocols are allowed */
         if(action == set)
           protoset[0] = NULL;
-        warnf("unrecognized protocol '%s'", buffer);
+        errorf("unrecognized protocol '%s'", buffer);
+        return PARAM_BAD_USE;
       }
     }
     if(next)

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -60,7 +60,7 @@ test280 test281 test282 test283 test284 test285 test286 test287 test288 \
 test289 test290 test291 test292 test293 test294 test295 test296 test297 \
 test298 test299 test300 test301 test302 test303 test304 test305 test306 \
 test307 test308 test309 test310 test311 test312 test313 test314 test315 \
-test316 test317 test318 test319 test320                                 \
+test316 test317 test318 test319 test320         test322                 \
 test325 test326 test327 test328 test329 test330 test331 test332 test333 \
 test334 test335 test336 test337 test338 test339 test340 test341 test342 \
 test343 test344 test345 test346 test347 test348 test349 test350 test351 \

--- a/tests/data/test322
+++ b/tests/data/test322
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+--proto
+</keywords>
+</info>
+
+<client>
+<features>
+http
+</features>
+<name>
+--proto with multiple modifiers
+</name>
+<command>
+http://localhost/wont-get-this --proto +-http
+</command>
+</client>
+
+<verify>
+<errorcode>
+2
+</errorcode>
+<stderr mode="text">
+curl: unrecognized protocol '-http'
+curl: option --proto: is badly used here
+curl: try 'curl --help' or 'curl --manual' for more information
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
1 - clarify the documentation

2 - make curl exit with an error for unknown protocols to make users
    better notice when they get it wrong

Verified in test 322
