### PR TITLE
macos sectrust: fail ocsp verify when not builtin

### DIFF
--- a/lib/vtls/apple.c
+++ b/lib/vtls/apple.c
@@ -200,8 +200,9 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
     goto out;
   }
 
-#if defined(HAVE_BUILTIN_AVAILABLE) && defined(SUPPORTS_SecOCSP)
   if(ocsp_len > 0) {
+    bool checked = FALSE;
+#if defined(HAVE_BUILTIN_AVAILABLE) && defined(SUPPORTS_SecOCSP)
     if(__builtin_available(macOS 10.9, iOS 7, tvOS 9, watchOS 2, *)) {
       CFDataRef ocspdata = CFDataCreate(NULL, ocsp_buf, (CFIndex)ocsp_len);
 
@@ -213,16 +214,16 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
         result = CURLE_PEER_FAILED_VERIFICATION;
         goto out;
       }
+      checked = TRUE;
+    }
+#endif
+    if(!checked) {
+      (void)ocsp_buf;
+      failf(data, "Apple SecTrust: OCSP verification not supported");
+      result = CURLE_NOT_BUILT_IN;
+      goto out;
     }
   }
-#else
-  (void)ocsp_buf;
-  if(ocsp_len > 0) {
-    failf(data, "Apple SecTrust: OCSP verification not supported");
-    result = CURLE_NOT_BUILT_IN;
-    goto out;
-  }
-#endif
 
 #ifdef SUPPORTS_SecTrustEvaluateWithError
 #ifdef HAVE_BUILTIN_AVAILABLE

--- a/lib/vtls/apple.c
+++ b/lib/vtls/apple.c
@@ -217,7 +217,11 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
   }
 #else
   (void)ocsp_buf;
-  (void)ocsp_len;
+  if(ocsp_len > 0) {
+    failf(data, "Apple SecTrust: OCSP verification not supported");
+    result = CURLE_NOT_BUILT_IN;
+    goto out;
+  }
 #endif
 
 #ifdef SUPPORTS_SecTrustEvaluateWithError


### PR DESCRIPTION
When compiling macOS SecTrust with a compiler that does not support __builtin_available(), OCSP verfication is not available. This means it is not Apple's clang.

Instead of ignoring this, fail the handshake when ocsp status is requested.

