### PR TITLE
scripts/testnum: provide a few available test numbers

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -27,7 +27,8 @@ EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl          \
   cdall cd2cd managen dmaketgz maketgz release-tools.sh verify-release        \
   cmakelint.sh cmakeopts.sh mdlinkcheck CMakeLists.txt perlcheck.sh           \
   pythonlint.sh spacecheck.pl randdisable wcurl top-complexity                \
-  extract-unit-protos .checksrc badwords badwords-all badwords.txt top-length
+  extract-unit-protos .checksrc badwords badwords-all badwords.txt top-length \
+  testnum
 
 dist_bin_SCRIPTS = wcurl
 

--- a/scripts/testnum
+++ b/scripts/testnum
@@ -23,7 +23,7 @@
 #
 ###########################################################################
 
-my $num = 25; # provide (at least) this many proposals
+my $num = 10; # provide (at least) this many proposals
 
 open(F, "<tests/data/Makefile.am");
 while(<F>) {

--- a/scripts/testnum
+++ b/scripts/testnum
@@ -1,0 +1,56 @@
+#!/usr/bin/env perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+my $num = 10; # provide this many proposals
+
+open(F, "<tests/data/Makefile.am");
+while(<F>) {
+    if(/^TESTCASES/) {
+        $expect = 1;
+    }
+    elsif($expect) {
+        if(/^  test(\d+)/) {
+            my $f = $1;
+            if($f == $expect) {
+                $expect = $f + 1;
+            }
+            else {
+                if(($f - 1) != $expect) {
+                    # a range
+                    printf "test$expect - ".($f -1)."\n";
+                }
+                else {
+                    # single value
+                    printf "test$expect\n";
+                }
+                if(!--$num) {
+                    last;
+                }
+            }
+            $expect = $f + 1;
+        }
+    }
+}
+close(F);

--- a/scripts/testnum
+++ b/scripts/testnum
@@ -23,7 +23,7 @@
 #
 ###########################################################################
 
-my $num = 10; # provide this many proposals
+my $num = 25; # provide (at least) this many proposals
 
 open(F, "<tests/data/Makefile.am");
 while(<F>) {
@@ -39,13 +39,15 @@ while(<F>) {
             else {
                 if(($f - 1) != $expect) {
                     # a range
-                    printf "test$expect - ".($f -1)."\n";
+                    for my $t ($expect .. ($f - 1)) {
+                        push @all, $t;
+                    }
                 }
                 else {
                     # single value
-                    printf "test$expect\n";
+                    push @all, $expect;
                 }
-                if(!--$num) {
+                if(scalar(@all) >= $num) {
                     last;
                 }
             }
@@ -53,4 +55,9 @@ while(<F>) {
         }
     }
 }
-close(F);
+
+use List::Util qw(shuffle);
+
+for my $t (shuffle @all) {
+    print "test$t\n";
+}

--- a/scripts/testnum
+++ b/scripts/testnum
@@ -47,9 +47,6 @@ while(<F>) {
                     # single value
                     push @all, $expect;
                 }
-                if(scalar(@all) >= $num) {
-                    last;
-                }
             }
             $expect = $f + 1;
         }
@@ -60,4 +57,7 @@ use List::Util qw(shuffle);
 
 for my $t (shuffle @all) {
     print "test$t\n";
+    if(!--$num) {
+        last;
+    }
 }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -25,6 +25,9 @@ all:
 install:
 test:
 
+# The helper script ./scripts/testnum provides a set of available test
+# numbers.
+
 # this list is in numerical order
 TESTCASES = \
   test1 \


### PR DESCRIPTION
With `tests/data/Makefile.am` being a long list of files, finding gaps in the range is now a challenge for us mere mortals. Here's a script that spews out 10 random available test cases:

~~~
$ ./scripts/testnum 
test2971
test3319
test4387
test4752
test3468
test3529
test3121
test3276
test4747
test2573

