### PR TITLE
aws-lc ocsp workaround

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4755,8 +4755,9 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
       ocsp_len = (long)SSL_get_tlsext_status_ocsp_resp(octx->ssl, &ocsp_data);
 
     /* SSL_get_tlsext_status_ocsp_resp() returns the length of the OCSP
-       response data or -1 if there is no OCSP response data. */
-    if(ocsp_len < 0) {
+       response data or -1 if there is no OCSP response data.
+       AWS-LC breaks the API and returns 0 when there is no data. */
+    if(ocsp_len <= 0) {
       ocsp_len = 0; /* no data available */
       ocsp_missing = TRUE;
     }


### PR DESCRIPTION
SSL_get_tlsext_status_ocsp_resp() is documented to return -1 on a missing OCSP stapling from the server, however AWS-LC is breaking that by returning 0.

Since it does not semantically make a difference if the data is reported missing or has 0 length, treat 0 also as a missing stapling.

