### PR TITLE
CURLOPT_SOCKOPTFUNCTION.md: ALREADY_CONNECTED does not work for HTTP/3

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
@@ -74,7 +74,7 @@ an already connected socket with CURLOPT_OPENSOCKETFUNCTION(3) and then have
 this function make libcurl not attempt to connect (again).
 
 The *CURL_SOCKOPT_ALREADY_CONNECTED* feature does not work for HTTP/3 (QUIC)
-connections, and might never do.
+connections.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
@@ -73,6 +73,9 @@ then libcurl does no attempt to connect. This allows an application to pass in
 an already connected socket with CURLOPT_OPENSOCKETFUNCTION(3) and then have
 this function make libcurl not attempt to connect (again).
 
+The *CURL_SOCKOPT_ALREADY_CONNECTED* feature does not work for HTTP/3 (QUIC)
+connections, and might never do.
+
 # DEFAULT
 
 NULL


### PR DESCRIPTION
Reported-by: Stanislav Fort
