### PR TITLE
imap: APPEND CRLF fix

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -896,7 +896,7 @@ static CURLcode imap_perform_append(struct Curl_easy *data,
   }
 
   /* Check we know the size of the upload. This takes all readers
-   * into account. Expecially crlf conversions which make the size
+   * into account. Especially crlf conversions which make the size
    * unpredictable, e.g. -1. */
   data->state.infilesize = Curl_creader_total_length(data);
   if(data->state.infilesize < 0) {

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -886,7 +886,6 @@ static CURLcode imap_perform_append(struct Curl_easy *data,
       result = Curl_creader_set_mime(data, postp);
     if(result)
       return result;
-    data->state.infilesize = Curl_creader_client_length(data);
   }
   else
 #endif
@@ -896,9 +895,15 @@ static CURLcode imap_perform_append(struct Curl_easy *data,
       return result;
   }
 
-  /* Check we know the size of the upload */
+  /* Check we know the size of the upload. This takes all readers
+   * into account. Expecially crlf conversions which make the size
+   * unpredictable, e.g. -1. */
+  data->state.infilesize = Curl_creader_total_length(data);
   if(data->state.infilesize < 0) {
-    failf(data, "Cannot APPEND with unknown input file size");
+    if(data->set.crlf)
+      failf(data, "Cannot APPEND with CRLF conversion making size unknown");
+    else
+      failf(data, "Cannot APPEND with unknown input file size");
     return CURLE_UPLOAD_FAILED;
   }
 


### PR DESCRIPTION
Deny an APPEND operation with CRLF conversion requested as we are unable to predict the final upload size and APPEND requires us to announce it before starting the upload.

The check for unknown sizes had already been there, but the crlf conversion that renders a known size unknown was not accounted for.
