### PR TITLE
mprintf: fix long double output

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -105,6 +105,7 @@ struct va_input {
     int64_t nums; /* signed */
     uint64_t numu; /* unsigned */
     double dnum;
+    long double ldnum;
   } val;
 };
 
@@ -395,22 +396,22 @@ static bool parse_conversion(const char f, unsigned int *flagp,
     flags |= FLAGS_CHAR;
     break;
   case 'f':
-    type = MTYPE_DOUBLE;
+    type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
     break;
   case 'e':
-    type = MTYPE_DOUBLE;
+    type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
     flags |= FLAGS_FLOATE;
     break;
   case 'E':
-    type = MTYPE_DOUBLE;
+    type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
     flags |= FLAGS_FLOATE | FLAGS_UPPER;
     break;
   case 'g':
-    type = MTYPE_DOUBLE;
+    type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
     flags |= FLAGS_FLOATG;
     break;
   case 'G':
-    type = MTYPE_DOUBLE;
+    type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
     flags |= FLAGS_FLOATG | FLAGS_UPPER;
     break;
   default:
@@ -618,6 +619,10 @@ static int parsefmt(const char *format,
       iptr->val.dnum = va_arg(arglist, double);
       break;
 
+    case MTYPE_LONGDOUBLE:
+      iptr->val.ldnum = va_arg(arglist, long double);
+      break;
+
     default:
       DEBUGASSERT(NULL); /* unexpected */
       break;
@@ -638,7 +643,7 @@ struct mproperty {
 static bool out_double(void *userp,
                        int (*stream)(unsigned char, void *),
                        struct mproperty *p,
-                       double dnum,
+                       long double dnum,
                        char *work, int *donep)
 {
   char fmt[32] = "%";
@@ -672,7 +677,7 @@ static bool out_double(void *userp,
     /* for each digit in the integer part, we can have one less
        precision */
     int maxprec = BUFFSIZE - 1;
-    double val = dnum;
+    long double val = dnum;
     int len;
     if(prec > maxprec)
       prec = maxprec - 1;
@@ -693,6 +698,8 @@ static bool out_double(void *userp,
   }
   if(flags & FLAGS_LONG)
     *fptr++ = 'l';
+  else if(flags & FLAGS_LONGDOUBLE)
+    *fptr++ = 'L';
 
   if(flags & FLAGS_FLOATE)
     *fptr++ = (char)((flags & FLAGS_UPPER) ? 'E' : 'e');
@@ -712,10 +719,11 @@ static bool out_double(void *userp,
 #ifdef _WIN32
   curlx_win32_snprintf(work, BUFFSIZE, fmt, dnum);
 #else
-  /* !checksrc! disable BANNEDFUNC 1 */
-  /* !checksrc! disable LONGLINE */
-  /* NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling) */
-  snprintf(work, BUFFSIZE, fmt, dnum);
+  /* !checksrc! disable BANNEDFUNC 2 */
+  if(flags & FLAGS_LONGDOUBLE)
+    snprintf(work, BUFFSIZE, fmt, dnum);
+  else
+    snprintf(work, BUFFSIZE, fmt, (double)dnum);
 #endif
 #ifdef CURL_HAVE_DIAG
 #pragma GCC diagnostic pop
@@ -1066,6 +1074,11 @@ static int formatf(void *userp, /* untouched by format(), sent to the
 
     case MTYPE_DOUBLE:
       if(out_double(userp, stream, &p, iptr->val.dnum, work, &done))
+        return done;
+      break;
+
+    case MTYPE_LONGDOUBLE:
+      if(out_double(userp, stream, &p, iptr->val.ldnum, work, &done))
         return done;
       break;
 

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -683,7 +683,7 @@ static bool out_double(void *userp,
       prec = maxprec - 1;
     if(width > 0 && prec <= width)
       maxprec -= width;
-    while(val >= 10.0) {
+    while(val >= (long double)10.0) {
       val /= 10;
       maxprec--;
     }
@@ -1073,7 +1073,7 @@ static int formatf(void *userp, /* untouched by format(), sent to the
       break;
 
     case MTYPE_DOUBLE:
-      if(out_double(userp, stream, &p, iptr->val.dnum, work, &done))
+      if(out_double(userp, stream, &p, (long double)iptr->val.dnum, work, &done))
         return done;
       break;
 

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -105,7 +105,6 @@ struct va_input {
     int64_t nums; /* signed */
     uint64_t numu; /* unsigned */
     double dnum;
-    long double ldnum;
   } val;
 };
 
@@ -620,7 +619,7 @@ static int parsefmt(const char *format,
       break;
 
     case MTYPE_LONGDOUBLE:
-      iptr->val.ldnum = va_arg(arglist, long double);
+      iptr->val.dnum = (double)va_arg(arglist, long double);
       break;
 
     default:
@@ -643,7 +642,7 @@ struct mproperty {
 static bool out_double(void *userp,
                        int (*stream)(unsigned char, void *),
                        struct mproperty *p,
-                       long double dnum,
+                       double dnum,
                        char *work, int *donep)
 {
   char fmt[32] = "%";
@@ -677,13 +676,13 @@ static bool out_double(void *userp,
     /* for each digit in the integer part, we can have one less
        precision */
     int maxprec = BUFFSIZE - 1;
-    long double val = dnum;
+    double val = dnum;
     int len;
     if(prec > maxprec)
       prec = maxprec - 1;
     if(width > 0 && prec <= width)
       maxprec -= width;
-    while(val >= (long double)10.0) {
+    while(val >= 10.0) {
       val /= 10;
       maxprec--;
     }
@@ -698,8 +697,6 @@ static bool out_double(void *userp,
   }
   if(flags & FLAGS_LONG)
     *fptr++ = 'l';
-  else if(flags & FLAGS_LONGDOUBLE)
-    *fptr++ = 'L';
 
   if(flags & FLAGS_FLOATE)
     *fptr++ = (char)((flags & FLAGS_UPPER) ? 'E' : 'e');
@@ -720,10 +717,7 @@ static bool out_double(void *userp,
   curlx_win32_snprintf(work, BUFFSIZE, fmt, dnum);
 #else
   /* !checksrc! disable BANNEDFUNC 2 */
-  if(flags & FLAGS_LONGDOUBLE)
-    snprintf(work, BUFFSIZE, fmt, dnum);
-  else
-    snprintf(work, BUFFSIZE, fmt, (double)dnum);
+  snprintf(work, BUFFSIZE, fmt, dnum);
 #endif
 #ifdef CURL_HAVE_DIAG
 #pragma GCC diagnostic pop
@@ -1073,13 +1067,8 @@ static int formatf(void *userp, /* untouched by format(), sent to the
       break;
 
     case MTYPE_DOUBLE:
-      if(out_double(userp, stream, &p, (long double)iptr->val.dnum,
-                    work, &done))
-        return done;
-      break;
-
     case MTYPE_LONGDOUBLE:
-      if(out_double(userp, stream, &p, iptr->val.ldnum, work, &done))
+      if(out_double(userp, stream, &p, iptr->val.dnum, work, &done))
         return done;
       break;
 

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1073,7 +1073,8 @@ static int formatf(void *userp, /* untouched by format(), sent to the
       break;
 
     case MTYPE_DOUBLE:
-      if(out_double(userp, stream, &p, (long double)iptr->val.dnum, work, &done))
+      if(out_double(userp, stream, &p, (long double)iptr->val.dnum,
+                    work, &done))
         return done;
       break;
 

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -46,6 +46,16 @@
 #endif
 #endif
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+#ifdef CURL_HAVE_DIAG
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+
+
 #define BUFSZ 256
 
 struct unsshort_st {
@@ -1065,14 +1075,7 @@ static int double_check(void)
   };
   for(i = 0; i < CURL_ARRAYSIZE(c); i++) {
     char curl_out[128];
-#if defined(__GNUC__) && __GNUC__ >= 7
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-#endif
     curl_msnprintf(curl_out, sizeof(curl_out), c[i].fmt, val);
-#if defined(__GNUC__) && __GNUC__ >= 7
-#pragma GCC diagnostic pop
-#endif
     if(strcmp(curl_out, c[i].out)) {
       curl_mfprintf(stderr,
                     "MISMATCH: %s curl=%s libc=%s\n",
@@ -1285,14 +1288,6 @@ static int test_return_codes(void)
   - curl_mvsprintf
   - curl_mvaprintf
  */
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-#ifdef CURL_HAVE_DIAG
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-#endif
 static int var557(int expected_len, const char *format, ...)
 {
   va_list arg;
@@ -1358,12 +1353,6 @@ error:
     curl_mprintf("The v-functions test failed!\n");
   return errors;
 }
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-#ifdef CURL_HAVE_DIAG
-#pragma GCC diagnostic pop
-#endif
 
 static int test_vversions(void)
 {
@@ -1408,4 +1397,7 @@ static CURLcode test_lib557(const char *URL)
 
 #ifdef CURL_HAVE_DIAG
 #pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
 #endif

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1047,6 +1047,43 @@ static int test_weird_arguments(void)
   return errors;
 }
 
+static int double_check(void)
+{
+  const long double val = 1.234567890123456789L;
+  int mismatches = 0;
+  unsigned int i;
+  struct dbcheck {
+    const char *fmt;
+    const char *out;
+  };
+  struct dbcheck c[] = {
+    { "%.17Lf", "1.23456789012345669" },
+    { "%.17Le", "1.23456789012345669e+00" },
+    { "%.17LE", "1.23456789012345669E+00" },
+    { "%.17Lg", "1.2345678901234567" },
+    { "%.17LG", "1.2345678901234567" }
+  };
+  for(i = 0; i < CURL_ARRAYSIZE(c); i++) {
+    char curl_out[128];
+#if defined(__GNUC__) && __GNUC__ >= 7
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+    curl_msnprintf(curl_out, sizeof(curl_out), c[i].fmt, val);
+#if defined(__GNUC__) && __GNUC__ >= 7
+#pragma GCC diagnostic pop
+#endif
+    if(strcmp(curl_out, c[i].out)) {
+      curl_mfprintf(stderr,
+                    "%s curl=%s libc=%s match=%s\n",
+                    c[i].fmt, curl_out, c[i].out);
+      mismatches++;
+    }
+  }
+  curl_mfprintf(stderr, "mismatches=%d/5\n", mismatches);
+  return mismatches;
+}
+
 /* DBL_MAX value from Linux */
 #define MAXIMIZE (-1.7976931348623157081452E+308)
 
@@ -1164,6 +1201,8 @@ static int test_float_formatting(void)
   errors += strlen_check(buf, 4);
   curl_msnprintf(buf, 6, "%f", MAXIMIZE);
   errors += strlen_check(buf, 5);
+
+  errors += double_check();
 
   if(!errors)
     curl_mprintf("All float strings tests OK!\n");

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -55,7 +55,6 @@
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
 
-
 #define BUFSZ 256
 
 struct unsshort_st {
@@ -1064,22 +1063,39 @@ static int double_check(void)
   unsigned int i;
   struct dbcheck {
     const char *fmt;
-    const char *out;
+    const char *prefix; /* starts with this */
+    const char *suffix; /* ends with this */
   };
+  /* because floats are annoying beasts, different libc's produce different
+     outputs so we cannot compare exact output, only prefix + suffix */
   struct dbcheck c[] = {
-    { "%.17Lf", "1.23456789012345669" },
-    { "%.17Le", "1.23456789012345669e+00" },
-    { "%.17LE", "1.23456789012345669E+00" },
-    { "%.17Lg", "1.2345678901234567" },
-    { "%.17LG", "1.2345678901234567" }
+    { "%.17Lf", /* "1.23456789012345669" */
+      "1.23456789012345", "", },
+    { "%.17Le", /* "1.23456789012345669e+00" */
+      "1.234567890123456", "e+00" },
+    { "%.17LE", /* "1.23456789012345669E+00" */
+      "1.234567890123456", "E+00" },
+    { "%.17Lg", /* "1.2345678901234567" */
+      "1.234567890123456", "" },
+    { "%.17LG", /* "1.2345678901234567" */
+      "1.234567890123456", ""}
   };
   for(i = 0; i < CURL_ARRAYSIZE(c); i++) {
     char curl_out[128];
-    curl_msnprintf(curl_out, sizeof(curl_out), c[i].fmt, val);
-    if(strcmp(curl_out, c[i].out)) {
+    size_t len =
+      curl_msnprintf(curl_out, sizeof(curl_out), c[i].fmt, val);
+    if(strncmp(curl_out, c[i].prefix, strlen(c[i].prefix))) {
       curl_mfprintf(stderr,
-                    "MISMATCH: %s curl=%s libc=%s\n",
-                    c[i].fmt, curl_out, c[i].out);
+                    "MISMATCH (prefix): %s curl=%s libc=%s\n",
+                    c[i].fmt, curl_out, c[i].prefix);
+      mismatches++;
+    }
+    if((len < strlen(c[i].suffix) ||
+        strncmp(curl_out + len - strlen(c[i].suffix),
+               c[i].suffix, strlen(c[i].suffix)))) {
+      curl_mfprintf(stderr,
+                    "MISMATCH (suffix): %s curl=%s libc=%s\n",
+                    c[i].fmt, curl_out, c[i].suffix);
       mismatches++;
     }
   }

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1075,7 +1075,7 @@ static int double_check(void)
 #endif
     if(strcmp(curl_out, c[i].out)) {
       curl_mfprintf(stderr,
-                    "%s curl=%s libc=%s match=%s\n",
+                    "MISMATCH: %s curl=%s libc=%s\n",
                     c[i].fmt, curl_out, c[i].out);
       mismatches++;
     }


### PR DESCRIPTION
curl does not use this, and we discourage users from using these functions but since we claim printf() compatibility this still seems worth fixing.

Verified in test 557.

Reported-by: Stanislav Fort
