### PR TITLE
setopt: allow setting a referer from CURLINFO_REFERER

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2089,7 +2089,7 @@ static CURLcode setopt_cptr_http_mqtt(struct Curl_easy *data,
      * String to set in the HTTP Referer: field.
      */
     struct bufref *oldref = &data->state.referer;
-    /* free the old after the storing the new in case the input is actually
+    /* free the old after storing the new in case the input is actually
        pointing back to this */
     result = Curl_setstropt(data, STRING_SET_REFERER, ptr);
     Curl_bufref_free(oldref);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2084,13 +2084,17 @@ static CURLcode setopt_cptr_http_mqtt(struct Curl_easy *data,
     result = Curl_setstropt(data, STRING_HTTPSIG_HEADERS, ptr);
     break;
 #endif
-  case CURLOPT_REFERER:
+  case CURLOPT_REFERER: {
     /*
      * String to set in the HTTP Referer: field.
      */
-    Curl_bufref_free(&data->state.referer);
+    struct bufref *oldref = &data->state.referer;
+    /* free the old after the storing the new in case the input is actually
+       pointing back to this */
     result = Curl_setstropt(data, STRING_SET_REFERER, ptr);
+    Curl_bufref_free(oldref);
     break;
+  }
 
   case CURLOPT_USERAGENT:
     /*

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -1940,7 +1940,7 @@ TESTCASES = \
   test2309 \
   test2310 \
   test2311 \
-  \
+  test2397 \
   test2400 \
   test2401 \
   test2402 \

--- a/tests/data/test2397
+++ b/tests/data/test2397
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+CURLINFO_REFERER
+CURLOPT_REFERER
+</keywords>
+</info>
+
+<reply>
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 redir away
+Content-Length: 0
+Location: /%TESTNUMBER0002
+
+</data>
+<data2 crlf="headers">
+HTTP/1.1 200 OK
+Content-Length: 4
+
+hej
+</data2>
+</reply>
+
+<client>
+<server>
+http
+</server>
+
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<name>
+Get CURLINFO_REFERER set CURLOPT_REFERER
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+Referer: http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -300,6 +300,7 @@ TESTS_C = \
   lib2306.c \
   lib2308.c \
   lib2309.c \
+  lib2397.c \
   lib2402.c \
   lib2404.c \
   lib2405.c \

--- a/tests/libtest/lib2397.c
+++ b/tests/libtest/lib2397.c
@@ -1,0 +1,64 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+static CURLcode test_lib2397(const char *URL)
+{
+  CURLcode result;
+  CURL *curl;
+  char *referer = NULL;
+
+  if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    curl_mfprintf(stderr, "curl_global_init() failed\n");
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl = curl_easy_init();
+  if(!curl) {
+    curl_mfprintf(stderr, "curl_easy_init() failed\n");
+    curl_global_cleanup();
+    return TEST_ERR_MAJOR_BAD;
+  }
+
+  curl_easy_setopt(curl, CURLOPT_URL, URL);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(curl, CURLOPT_AUTOREFERER, 1L);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, tutil_throwaway_cb);
+
+  result = curl_easy_perform(curl);
+  if(result)
+    curl_mfprintf(stderr, "transfer failed: %s\n", curl_easy_strerror(result));
+  else
+    result = curl_easy_getinfo(curl, CURLINFO_REFERER, &referer);
+
+  if(!referer)
+    curl_mfprintf(stderr, "CURLINFO_REFERER was not populated\n");
+  else
+    result = curl_easy_setopt(curl, CURLOPT_REFERER, referer);
+
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  return result;
+}


### PR DESCRIPTION
Reported-by: Stanislav Fort

Verified by test 2397
