### PR TITLE
connection reuse: check SSL configs when doing a scheme upgrade

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -723,6 +723,10 @@ static bool url_match_ssl_use(struct connectdata *conn,
     if(!(m->needle->scheme->flags & PROTOPT_SSL_REUSE) ||
        (get_protocol_family(conn->scheme) != m->needle->scheme->protocol))
       return FALSE;
+    /* We may reuse this as an auto-TLS upgrade, but only if the SSL
+     * config parameters match. */
+    if(!Curl_ssl_conn_config_match(m->data, conn, FALSE))
+      return FALSE;
   }
   else if(m->require_tls)
     /* a clear-text STARTTLS protocol with required TLS */


### PR DESCRIPTION
When reusing a SSL variant of a scheme for a non-SSL transfer, do also check if the SSL configurations match.

