### PR TITLE
mprintf: avoid never-ending loop for positive-infinite

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -682,7 +682,7 @@ static bool out_double(void *userp,
       prec = maxprec - 1;
     if(width > 0 && prec <= width)
       maxprec -= width;
-    while(val >= 10.0) {
+    while(maxprec && (val >= 10.0)) {
       val /= 10;
       maxprec--;
     }


### PR DESCRIPTION
Floating point is odd but it features this concept of "infinite" (which can happen with the new typecast from long double to double) and apparently dividing infinite with 10 is still infinte.

Follow-up to bdda3a268f0fd1a1bb4

Pointed out by: Codex Security
