### PR TITLE
h2 push: use squeaky clean easy handle

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -700,7 +700,7 @@ char *curl_pushheader_byname(struct curl_pushheaders *h, const char *name)
 static struct Curl_easy *h2_duphandle(struct Curl_cfilter *cf,
                                       struct Curl_easy *data)
 {
-  struct Curl_easy *second = curl_easy_duphandle(data);
+  struct Curl_easy *second = curl_easy_init();
   if(second) {
     struct h2_stream_ctx *second_stream;
     http2_data_setup(cf, second, &second_stream);


### PR DESCRIPTION
When a HTTP/2 push requires a new easy handle, create a clean easy and do *not* duplicate the existing one. This avoids messy use of the API `curl_easy_duphandle()`, which has some caveats the applictions must observe and cannot do so for a h2 push.

Using a clean easy handle is also better since the pushed stream has no real relation to the easy handle that was in use when the HTTP/2 push arrived (it could be any easy using the connection).

Inheriting settings/inputs from a somewhat "random" existing easy seems wrong.

