### PR TITLE
tool: checkfds, open on null device

### DIFF
--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -85,13 +85,8 @@ int _CRT_glob = 0;
  */
 static int main_checkfds(void)
 {
-#if defined(HAVE_FCNTL) && (defined(HAVE_PIPE) || defined(_WIN32))
-  static const char * const devnull =
-#ifdef _WIN32
-    "nul";
-#else
-    "/dev/null";
-#endif
+#if defined(HAVE_FCNTL) && defined(HAVE_PIPE)
+  const char * const devnull = "/dev/null";
   int fd;
   while((fcntl(STDIN_FILENO, F_GETFD) == -1)) {
     fd = curlx_open(devnull, O_RDONLY);
@@ -108,7 +103,7 @@ static int main_checkfds(void)
     if(fd < 0)
       return 1;
   }
-#endif /* HAVE_PIPE || _WIN32 */
+#endif /* HAVE_FCNTL && HAVE_PIPE */
   return 0;
 }
 

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -73,7 +73,6 @@ int _CRT_glob = 0;
 /* if we build a static library for unit tests, there is no main() function */
 #ifndef UNITTESTS
 
-#if defined(HAVE_PIPE) && defined(HAVE_FCNTL)
 /*
  * Ensure that file descriptors 0, 1 and 2 (stdin, stdout, stderr) are
  * open before starting to run. Otherwise, the first three network
@@ -86,17 +85,32 @@ int _CRT_glob = 0;
  */
 static int main_checkfds(void)
 {
-  int fd[2];
-  while((fcntl(STDIN_FILENO, F_GETFD) == -1) ||
-        (fcntl(STDOUT_FILENO, F_GETFD) == -1) ||
-        (fcntl(STDERR_FILENO, F_GETFD) == -1))
-    if(pipe(fd))
+#if defined(HAVE_FCNTL) && (defined(HAVE_PIPE) || defined(_WIN32))
+  static const char * const devnull =
+#ifdef _WIN32
+    "nul";
+#else
+    "/dev/null";
+#endif
+  int fd;
+  while((fcntl(STDIN_FILENO, F_GETFD) == -1)) {
+    fd = curlx_open(devnull, O_RDONLY);
+    if(fd < 0)
       return 1;
+  }
+  while((fcntl(STDOUT_FILENO, F_GETFD) == -1)) {
+    fd = curlx_open(devnull, O_WRONLY);
+    if(fd < 0)
+      return 1;
+  }
+  while((fcntl(STDERR_FILENO, F_GETFD) == -1)) {
+    fd = curlx_open(devnull, O_WRONLY);
+    if(fd < 0)
+      return 1;
+  }
+#endif /* HAVE_PIPE || _WIN32 */
   return 0;
 }
-#else
-#define main_checkfds() 0
-#endif
 
 #ifdef CURL_MEMDEBUG
 static void memory_tracking_init(void)


### PR DESCRIPTION
When stdin/out/err are closed on tool start, checkfds() tries to fill them by invoking `pipe()` which is may allocate file descriptors in an unwanted order and may create a pipe between stdout and stdin which is not what we want.

Use 'nul' on Windows or '/dev/null' if HAVE_PIPE is defined to open the closed descriptors.

**Caveat**: I am not 100% sure that HAVE_PIPE implies that /dev/null works, but it seems likely?

