### PR TITLE
ipv6 scope_id: set from first peer

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1576,19 +1576,6 @@ static CURLcode url_set_conn_origin_etc(struct Curl_easy *data,
     }
   }
 
-#ifdef USE_IPV6
-  if(data->set.scope_id)
-    conn->scope_id = data->set.scope_id;
-  else {
-    struct Curl_peer *first = Curl_conn_get_first_peer(conn, FIRSTSOCKET);
-    if(!first) {
-      result = CURLE_FAILED_INIT;
-      goto out;
-    }
-    conn->scope_id = first->scopeid;
-  }
-#endif
-
 out:
   return result;
 }
@@ -1666,6 +1653,17 @@ static CURLcode setup_connection_internals(struct Curl_easy *data,
 
   Curl_strntolower(conn->destination, conn->destination,
                    strlen(conn->destination));
+
+#ifdef USE_IPV6
+  if(data->set.scope_id)
+    conn->scope_id = data->set.scope_id;
+  else {
+    struct Curl_peer *first = Curl_conn_get_first_peer(conn, FIRSTSOCKET);
+    if(!first)
+      return CURLE_FAILED_INIT;
+    conn->scope_id = first->scopeid;
+  }
+#endif
 
   return CURLE_OK;
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -1577,8 +1577,16 @@ static CURLcode url_set_conn_origin_etc(struct Curl_easy *data,
   }
 
 #ifdef USE_IPV6
-  conn->scope_id = data->set.scope_id ?
-                   data->set.scope_id : data->state.origin->scopeid;
+  if(data->set.scope_id)
+    conn->scope_id = data->set.scope_id;
+  else {
+    struct Curl_peer *first = Curl_conn_get_first_peer(conn, FIRSTSOCKET);
+    if(!first) {
+      result = CURLE_FAILED_INIT;
+      goto out;
+    }
+    conn->scope_id = first->scopeid;
+  }
 #endif
 
 out:


### PR DESCRIPTION
When not explicitly set, give the connection a present scope_id from the first peer of a connection, not from its origin. This accounts for proxies.


