### PR TITLE
mprintf: acknowledge %F

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -397,6 +397,10 @@ static bool parse_conversion(const char f, unsigned int *flagp,
   case 'f':
     type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
     break;
+  case 'F':
+    type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
+    flags |= FLAGS_UPPER;
+    break;
   case 'e':
     type = flags & FLAGS_LONGDOUBLE ? MTYPE_LONGDOUBLE : MTYPE_DOUBLE;
     flags |= FLAGS_FLOATE;
@@ -703,7 +707,7 @@ static bool out_double(void *userp,
   else if(flags & FLAGS_FLOATG)
     *fptr++ = (char)((flags & FLAGS_UPPER) ? 'G' : 'g');
   else
-    *fptr++ = 'f';
+    *fptr++ = (flags & FLAGS_UPPER) ? 'F' : 'f';
 
   *fptr = 0; /* and a final null-termination */
 

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1113,6 +1113,9 @@ static int test_float_formatting(void)
   curl_msnprintf(buf, sizeof(buf), "%f", 9.0);
   errors += string_check(buf, "9.000000");
 
+  curl_msnprintf(buf, sizeof(buf), "%F", 9.0);
+  errors += string_check(buf, "9.000000");
+
   curl_msnprintf(buf, sizeof(buf), "%.1f", 9.1);
   errors += string_check(buf, "9.1");
 


### PR DESCRIPTION
The code previously just ignored it, causing variadic argument desynchronization

Extend test 557 to verify

Reported-by: Stanislav Fort
