### PR TITLE
schannel: clear borrowed sslContext on close

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2552,6 +2552,9 @@ static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   /* free SSPI Schannel API security context handle */
   if(backend->ctxt) {
+    if(cf->conn->sslContext == &backend->ctxt->ctxt_handle)
+      cf->conn->sslContext = NULL;
+
     DEBUGF(infof(data, "schannel: clear security context handle"));
     Curl_pSecFn->DeleteSecurityContext(&backend->ctxt->ctxt_handle);
     curlx_safefree(backend->ctxt);


### PR DESCRIPTION
The current Negotiate and NTLM consumers were traced, and no reachable post-free dereference was found.

The pointer is still left dangling after Schannel teardown, so clear it when the context is destroyed.