### PR TITLE
schannel: clear PFX password before free

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -484,6 +484,7 @@ static CURLcode get_client_cert(struct Curl_cfilter *cf,
 
         cert_store = PFXImportCertStore(&datablob, pszPassword,
                                         PKCS12_NO_PERSIST_KEY);
+        curlx_memzero(pszPassword, sizeof(WCHAR) * (pwd_len + 1));
         curlx_free(pszPassword);
       }
       if(!blob)


### PR DESCRIPTION
The temporary UTF-16 password used for PFX import was freed without being cleared.
Zero the buffer before freeing it to reduce the lifetime of sensitive credential data.