### PR TITLE
build: use `bundle.c` for all test bundle targets

### DIFF
--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -43,15 +43,15 @@ if(_CURL_TESTS_CONCAT)
   set(_mk_unity_extra "--concat" "-I${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
-add_custom_command(OUTPUT "${BUNDLE}.c"
+add_custom_command(OUTPUT "bundle.c"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" ${_mk_unity_extra}
-    --include ${UTILS_C} ${CURLX_C} ${TOOLX_C} --test ${TESTS_C} > "${BUNDLE}.c"
+    --include ${UTILS_C} ${CURLX_C} ${TOOLX_C} --test ${TESTS_C} > "bundle.c"
   DEPENDS
     "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
     ${FIRST_C} ${FIRST_H} ${UTILS_C} ${CURLX_C} ${TOOLX_C} ${TESTS_C}
   VERBATIM)
 
-add_executable(${BUNDLE} EXCLUDE_FROM_ALL "${BUNDLE}.c")
+add_executable(${BUNDLE} EXCLUDE_FROM_ALL "bundle.c")
 add_dependencies(tt ${BUNDLE})
 target_link_libraries(${BUNDLE} ${LIB_SELECTED} ${CURL_LIBS})
 target_include_directories(${BUNDLE} PRIVATE

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -72,8 +72,8 @@ endif
 bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) $(TESTS_C) lib1521.c
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) --test $(TESTS_C) lib1521.c > bundle.c
 
-noinst_PROGRAMS = $(BUNDLE)
-nodist_SOURCES = bundle.c
+noinst_PROGRAMS = libtests
+nodist_libtests_SOURCES = bundle.c
 LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
 CLEANFILES = bundle.c lib1521.c
 
@@ -94,4 +94,4 @@ all-local: checksrc
 endif
 
 clean-local:
-	rm -f $(BUNDLE)
+	rm -f libtests

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -73,6 +73,7 @@ bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) --test $(TESTS_C) lib1521.c > bundle.c
 
 noinst_PROGRAMS = $(BUNDLE)
+nodist_SOURCES = bundle.c
 LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
 CLEANFILES = bundle.c lib1521.c
 

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -69,12 +69,12 @@ else
 # These are part of the libcurl static lib. Add them here when linking shared.
 curlx_c_lib = $(CURLX_C)
 endif
-$(BUNDLE).c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) $(TESTS_C) lib1521.c
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) --test $(TESTS_C) lib1521.c > $(BUNDLE).c
+bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) $(TESTS_C) lib1521.c
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) --test $(TESTS_C) lib1521.c > bundle.c
 
 noinst_PROGRAMS = $(BUNDLE)
 LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
-CLEANFILES = $(BUNDLE).c lib1521.c
+CLEANFILES = bundle.c lib1521.c
 
 lib1521.c: $(top_srcdir)/tests/libtest/mk-lib1521.pl $(top_srcdir)/include/curl/curl.h
 	@PERL@ $(top_srcdir)/tests/libtest/mk-lib1521.pl < $(top_srcdir)/include/curl/curl.h lib1521.c
@@ -86,7 +86,7 @@ CS_ = $(CS_0)
 
 # ignore generated C files since they play by slightly different rules!
 checksrc: lib1521.c
-	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/$(BUNDLE).c $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C))
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/bundle.c $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C))
 
 if NOT_CURL_CI
 all-local: checksrc

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -30,15 +30,15 @@ if(_CURL_TESTS_CONCAT)
   set(_mk_unity_extra "--concat" "-I${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
-add_custom_command(OUTPUT "${BUNDLE}.c"
+add_custom_command(OUTPUT "bundle.c"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" ${_mk_unity_extra}
-    --include ${UTILS_C} ${CURLX_C} ${TOOLX_C} --test ${TESTS_C} > "${BUNDLE}.c"
+    --include ${UTILS_C} ${CURLX_C} ${TOOLX_C} --test ${TESTS_C} > "bundle.c"
   DEPENDS
     "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
     ${FIRST_C} ${FIRST_H} ${UTILS_C} ${CURLX_C} ${TOOLX_C} ${TESTS_C}
   VERBATIM)
 
-add_executable(${BUNDLE} EXCLUDE_FROM_ALL "${BUNDLE}.c")
+add_executable(${BUNDLE} EXCLUDE_FROM_ALL "bundle.c")
 add_dependencies(tt ${BUNDLE})
 target_link_libraries(${BUNDLE} ${CURL_NETWORK_AND_TIME_LIBS})
 target_include_directories(${BUNDLE} PRIVATE

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -50,12 +50,12 @@ CFLAGS += @CURL_CFLAG_EXTRAS@
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 
-$(BUNDLE).c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $(CURLX_C) $(TOOLX_C) $(TESTS_C)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(CURLX_C) $(TOOLX_C) --test $(TESTS_C) > $(BUNDLE).c
+bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $(CURLX_C) $(TOOLX_C) $(TESTS_C)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(CURLX_C) $(TOOLX_C) --test $(TESTS_C) > bundle.c
 
 noinst_PROGRAMS = $(BUNDLE)
 LDADD = @CURL_NETWORK_AND_TIME_LIBS@
-CLEANFILES = $(BUNDLE).c
+CLEANFILES = bundle.c
 
 CHECKSRC = $(CS_$(V))
 CS_0 = @echo "  RUN     " $@;
@@ -63,7 +63,7 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/$(BUNDLE).c $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C))
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/bundle.c $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C))
 
 if NOT_CURL_CI
 all-local: checksrc

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -53,8 +53,8 @@ LIBS = $(BLANK_AT_MAKETIME)
 bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $(CURLX_C) $(TOOLX_C) $(TESTS_C)
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(CURLX_C) $(TOOLX_C) --test $(TESTS_C) > bundle.c
 
-noinst_PROGRAMS = $(BUNDLE)
-nodist_SOURCES = bundle.c
+noinst_PROGRAMS = servers
+nodist_servers_SOURCES = bundle.c
 LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 CLEANFILES = bundle.c
 
@@ -71,4 +71,4 @@ all-local: checksrc
 endif
 
 clean-local:
-	rm -f $(BUNDLE)
+	rm -f servers

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -54,6 +54,7 @@ bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(CURLX_C) $(TOOLX_C) --test $(TESTS_C) > bundle.c
 
 noinst_PROGRAMS = $(BUNDLE)
+nodist_SOURCES = bundle.c
 LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 CLEANFILES = bundle.c
 

--- a/tests/tunit/CMakeLists.txt
+++ b/tests/tunit/CMakeLists.txt
@@ -30,15 +30,15 @@ if(_CURL_TESTS_CONCAT)
   set(_mk_unity_extra "--concat" "-I${CMAKE_CURRENT_SOURCE_DIR}" "-I${PROJECT_SOURCE_DIR}/tests/libtest")
 endif()
 
-add_custom_command(OUTPUT "${BUNDLE}.c"
+add_custom_command(OUTPUT "bundle.c"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" ${_mk_unity_extra}
-    --test ${TESTS_C} > "${BUNDLE}.c"
+    --test ${TESTS_C} > "bundle.c"
   DEPENDS
     "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
     ${FIRST_C} ${FIRST_H} ${TESTS_C}
   VERBATIM)
 
-add_executable(${BUNDLE} EXCLUDE_FROM_ALL "${BUNDLE}.c")
+add_executable(${BUNDLE} EXCLUDE_FROM_ALL "bundle.c")
 add_dependencies(tt ${BUNDLE})
 target_link_libraries(${BUNDLE} curltool ${LIB_SELECTED})
 target_include_directories(${BUNDLE} PRIVATE

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -59,8 +59,8 @@ if BUILD_UNITTESTS
 bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C)
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTS_C) > bundle.c
 
-noinst_PROGRAMS = $(BUNDLE)
-nodist_SOURCES = bundle.c
+noinst_PROGRAMS = tunits
+nodist_tunits_SOURCES = bundle.c
 LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurl.la
 CLEANFILES = bundle.c
 else
@@ -80,4 +80,4 @@ all-local: checksrc
 endif
 
 clean-local:
-	rm -f $(BUNDLE)
+	rm -f tunits

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -56,12 +56,12 @@ AM_CPPFLAGS += -DDEBUGBUILD
 endif
 
 if BUILD_UNITTESTS
-$(BUNDLE).c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTS_C) > $(BUNDLE).c
+bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTS_C) > bundle.c
 
 noinst_PROGRAMS = $(BUNDLE)
 LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurl.la
-CLEANFILES = $(BUNDLE).c
+CLEANFILES = bundle.c
 else
 noinst_PROGRAMS =
 endif
@@ -72,7 +72,7 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/$(BUNDLE).c $(TESTS_C))
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/bundle.c $(TESTS_C))
 
 if NOT_CURL_CI
 all-local: checksrc

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -60,6 +60,7 @@ bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C)
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTS_C) > bundle.c
 
 noinst_PROGRAMS = $(BUNDLE)
+nodist_SOURCES = bundle.c
 LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurl.la
 CLEANFILES = bundle.c
 else

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -30,15 +30,15 @@ if(_CURL_TESTS_CONCAT)
   set(_mk_unity_extra "--concat" "-I${CMAKE_CURRENT_SOURCE_DIR}" "-I${PROJECT_SOURCE_DIR}/tests/libtest")
 endif()
 
-add_custom_command(OUTPUT "${BUNDLE}.c"
+add_custom_command(OUTPUT "bundle.c"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" ${_mk_unity_extra}
-    --test ${TESTS_C} > "${BUNDLE}.c"
+    --test ${TESTS_C} > "bundle.c"
   DEPENDS
     "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
     ${FIRST_C} ${FIRST_H} ${TESTS_C}
   VERBATIM)
 
-add_executable(${BUNDLE} EXCLUDE_FROM_ALL "${BUNDLE}.c")
+add_executable(${BUNDLE} EXCLUDE_FROM_ALL "bundle.c")
 add_dependencies(${BUNDLE} curlu-unitprotos)
 add_dependencies(tt ${BUNDLE})
 target_link_libraries(${BUNDLE} curlu)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -64,6 +64,7 @@ $(top_builddir)/lib/unitprotos.h:
 	(cd $(top_builddir)/lib && $(MAKE) unitprotos.h)
 
 noinst_PROGRAMS = $(BUNDLE)
+nodist_SOURCES = bundle.c
 LDADD = $(top_builddir)/lib/libcurlu.la
 CLEANFILES = bundle.c
 else

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -57,15 +57,15 @@ endif
 AM_CPPFLAGS += -DBUILDING_LIBCURL
 
 if BUILD_UNITTESTS
-$(BUNDLE).c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C) $(top_builddir)/lib/unitprotos.h
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTS_C) > $(BUNDLE).c
+bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C) $(top_builddir)/lib/unitprotos.h
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTS_C) > bundle.c
 
 $(top_builddir)/lib/unitprotos.h:
 	(cd $(top_builddir)/lib && $(MAKE) unitprotos.h)
 
 noinst_PROGRAMS = $(BUNDLE)
 LDADD = $(top_builddir)/lib/libcurlu.la
-CLEANFILES = $(BUNDLE).c
+CLEANFILES = bundle.c
 else
 noinst_PROGRAMS =
 endif
@@ -76,7 +76,7 @@ CS_1 =
 CS_ = $(CS_0)
 
 checksrc:
-	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/$(BUNDLE).c $(TESTS_C))
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/bundle.c $(TESTS_C))
 
 if NOT_CURL_CI
 all-local: checksrc

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -63,8 +63,8 @@ bundle.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C) $
 $(top_builddir)/lib/unitprotos.h:
 	(cd $(top_builddir)/lib && $(MAKE) unitprotos.h)
 
-noinst_PROGRAMS = $(BUNDLE)
-nodist_SOURCES = bundle.c
+noinst_PROGRAMS = units
+nodist_units_SOURCES = bundle.c
 LDADD = $(top_builddir)/lib/libcurlu.la
 CLEANFILES = bundle.c
 else
@@ -84,4 +84,4 @@ all-local: checksrc
 endif
 
 clean-local:
-	rm -f $(BUNDLE)
+	rm -f units


### PR DESCRIPTION
Replacing individual names for each. They are in different
subdirectories, thus the same source filename is fine.

~~To simplify excluding them from the source tarball.~~ (this PR lead to a solution which doesn't need this workaround)

Ref: https://github.com/curl/curl/pull/22722#issuecomment-5452794233

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
