### PR TITLE
distfiles.sh: check tarball for unexpected files

### DIFF
--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -30,6 +30,22 @@ gitonly=".git*
 ^scripts/release-notes.pl
 ^scripts/singleuse.pl"
 
+taronly="Makefile.in$
+^aclocal.m4$
+^compile$
+^configure$
+^config.*$
+^depcomp$
+^docs/RELEASE-TOOLS.md$
+^docs/libcurl/libcurl-symbols.md$
+^install-sh$
+^lib/curl_config.h.in$
+^ltmain.sh$
+^m4/libtool.m4$
+^m4/lt*.m4$
+^missing$
+^src/tool_hugehelp.c$"
+
 tarfiles="$(mktemp)"
 gitfiles="$(mktemp)"
 
@@ -50,7 +66,17 @@ echo 'Only in tarball:'
 echo "${dif}" | grep '^-' || true
 echo
 
+exitcode=0
+
+echo 'Unexpected in tarball:'
+if echo "${dif}" | grep '^-' | sed 's|^-||g' \
+  | grep -v -E "($(printf '%s' "${taronly}" | tr $'\n' '|' | sed -e 's|\.|\\.|g' -e 's|\*|.+|g'))$"; then
+  exitcode=1
+fi
+
 echo 'Missing from tarball:'
 if echo "${dif}" | grep '^+'; then
-  exit 1
+  exitcode=1
 fi
+
+exit $exitcode

--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -9,7 +9,9 @@
 set -eu
 
 gitonly=".git*
-^.*
+^.circleci
+^.dir-locals.el
+^.mailmap
 ^appveyor.*
 ^GIT-INFO.md
 ^README.md

--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -79,4 +79,4 @@ if echo "${dif}" | grep '^+'; then
   exitcode=1
 fi
 
-exit $exitcode
+exit "${exitcode}"

--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -9,7 +9,7 @@
 set -eu
 
 gitonly=".git*
-^.circleci
+^.circleci/*
 ^.dir-locals.el
 ^.mailmap
 ^appveyor.*

--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -30,7 +30,8 @@ gitonly=".git*
 ^scripts/release-notes.pl
 ^scripts/singleuse.pl"
 
-taronly="Makefile.in$
+taronly="^Makefile.in$
+/Makefile.in$
 ^aclocal.m4$
 ^compile$
 ^configure$

--- a/.github/scripts/distfiles.sh
+++ b/.github/scripts/distfiles.sh
@@ -34,7 +34,8 @@ taronly="Makefile.in$
 ^aclocal.m4$
 ^compile$
 ^configure$
-^config.*$
+^config.guess$
+^config.sub$
 ^depcomp$
 ^docs/RELEASE-TOOLS.md$
 ^docs/libcurl/libcurl-symbols.md$


### PR DESCRIPTION
Verify if the source tarball has any files that we did not expect.

Follow-up to f8992b6a177a2ccfb5dc04137088534bad68681c #22686

---

Fails as designed with master before #22686:
```
Unexpected in tarball:
tests/libtest/libtests.c
tests/server/servers.c
tests/tunit/tunits.c
tests/unit/units.c
```
Ref: https://github.com/curl/curl/actions/runs/33181857942/job/98885955242?pr=22724#step:4:55

- [x] rebase on #22686
