### PR TITLE
sspi: enable channel-binding in mingw-w64 <9 builds

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -754,6 +754,11 @@
 /* Offered by mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
 #ifndef SECPKG_ATTR_ENDPOINT_BINDINGS
 #define SECPKG_ATTR_ENDPOINT_BINDINGS 26
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
+typedef struct _SecPkgContext_Bindings {
+  unsigned __LONG32 BindingsLength;
+  SEC_CHANNEL_BINDINGS *Bindings;
+} SecPkgContext_Bindings, *PSecPkgContext_Bindings;
 #endif
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -750,6 +750,13 @@
 #define USE_SPNEGO
 #endif
 
+#ifdef USE_WINDOWS_SSPI
+/* Offered by mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
+#ifndef SECPKG_ATTR_ENDPOINT_BINDINGS
+#define SECPKG_ATTR_ENDPOINT_BINDINGS 26
+#endif
+#endif
+
 /* Single point where USE_KERBEROS5 definition might be defined */
 #if !defined(CURL_DISABLE_KERBEROS_AUTH) &&           \
   (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -750,18 +750,6 @@
 #define USE_SPNEGO
 #endif
 
-#ifdef USE_WINDOWS_SSPI
-/* Offered by mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
-#ifndef SECPKG_ATTR_ENDPOINT_BINDINGS
-#define SECPKG_ATTR_ENDPOINT_BINDINGS 26
-/* !checksrc! disable TYPEDEFSTRUCT 1 */
-typedef struct _SecPkgContext_Bindings {
-  unsigned __LONG32 BindingsLength;
-  SEC_CHANNEL_BINDINGS *Bindings;
-} SecPkgContext_Bindings;
-#endif
-#endif
-
 /* Single point where USE_KERBEROS5 definition might be defined */
 #if !defined(CURL_DISABLE_KERBEROS_AUTH) &&           \
   (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -758,7 +758,7 @@
 typedef struct _SecPkgContext_Bindings {
   unsigned __LONG32 BindingsLength;
   SEC_CHANNEL_BINDINGS *Bindings;
-} SecPkgContext_Bindings, *PSecPkgContext_Bindings;
+} SecPkgContext_Bindings;
 #endif
 #endif
 

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -34,18 +34,6 @@
 #define SECPKG_ATTR_ENDPOINT_BINDINGS 26
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct {
-  unsigned __LONG32 dwInitiatorAddrType;
-  unsigned __LONG32 cbInitiatorLength;
-  unsigned __LONG32 dwInitiatorOffset;
-  unsigned __LONG32 dwAcceptorAddrType;
-  unsigned __LONG32 cbAcceptorLength;
-  unsigned __LONG32 dwAcceptorOffset;
-  unsigned __LONG32 cbApplicationDataLength;
-  unsigned __LONG32 dwApplicationDataOffset;
-} SEC_CHANNEL_BINDINGS;
-
-/* !checksrc! disable TYPEDEFSTRUCT 1 */
-typedef struct {
   unsigned __LONG32 BindingsLength;
   SEC_CHANNEL_BINDINGS *Bindings;
 } SecPkgContext_Bindings;

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -34,7 +34,7 @@
 #define SECPKG_ATTR_ENDPOINT_BINDINGS 26
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct {
-  uint32_t BindingsLength;
+  unsigned long BindingsLength;
   SEC_CHANNEL_BINDINGS *Bindings;
 } SecPkgContext_Bindings;
 #endif

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -29,6 +29,28 @@
 
 #include <sspi.h>
 
+/* Offered by mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
+#ifndef SECPKG_ATTR_ENDPOINT_BINDINGS
+#define SECPKG_ATTR_ENDPOINT_BINDINGS 26
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
+typedef struct {
+  unsigned __LONG32 dwInitiatorAddrType;
+  unsigned __LONG32 cbInitiatorLength;
+  unsigned __LONG32 dwInitiatorOffset;
+  unsigned __LONG32 dwAcceptorAddrType;
+  unsigned __LONG32 cbAcceptorLength;
+  unsigned __LONG32 dwAcceptorOffset;
+  unsigned __LONG32 cbApplicationDataLength;
+  unsigned __LONG32 dwApplicationDataOffset;
+} SEC_CHANNEL_BINDINGS;
+
+/* !checksrc! disable TYPEDEFSTRUCT 1 */
+typedef struct {
+  unsigned __LONG32 BindingsLength;
+  SEC_CHANNEL_BINDINGS *Bindings;
+} SecPkgContext_Bindings;
+#endif
+
 CURLcode Curl_sspi_global_init(void);
 void Curl_sspi_global_cleanup(void);
 

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -34,7 +34,7 @@
 #define SECPKG_ATTR_ENDPOINT_BINDINGS 26
 /* !checksrc! disable TYPEDEFSTRUCT 1 */
 typedef struct {
-  unsigned __LONG32 BindingsLength;
+  uint32_t BindingsLength;
   SEC_CHANNEL_BINDINGS *Bindings;
 } SecPkgContext_Bindings;
 #endif

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -102,7 +102,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
   }
 
   /* Supports SSL channel binding for Windows ISS extended protection */
-#if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
+#ifdef USE_WINDOWS_SSPI
   neg_ctx->sslContext = conn->sslContext;
 #endif
   /* Check if the connection is using SSL and get the channel binding data */

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -168,9 +168,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     if(!Curl_pSecFn)
       return result;
   }
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   ntlm->sslContext = conn->sslContext;
-#endif
 #endif
 
   Curl_bufref_init(&ntlmmsg);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -325,8 +325,8 @@ struct connectdata {
   char *options; /* options string, allocated */
 
   /*************** Request - specific items ************/
-#if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
-  CtxtHandle *sslContext;  /* mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
+#ifdef USE_WINDOWS_SSPI
+  CtxtHandle *sslContext;
 #endif
 
 #ifdef USE_NTLM

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -242,9 +242,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   SecBufferDesc type_3_desc;
   SECURITY_STATUS status;
   unsigned long attrs;
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   SecPkgContext_Bindings pkgBindings = { 0, NULL };
-#endif
 
   (void)creds;
 
@@ -256,7 +254,6 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   type_2_bufs[0].pvBuffer   = ntlm->input_token;
   type_2_bufs[0].cbBuffer   = curlx_uztoul(ntlm->input_token_len);
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   /* SSL context comes from schannel.
    * When extended protection is used in IIS server,
    * we have to pass a second SecBuffer to the SecBufferDesc
@@ -277,7 +274,6 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
       type_2_bufs[1].pvBuffer = pkgBindings.Bindings;
     }
   }
-#endif
 
   /* Setup the type-3 "output" security buffer */
   type_3_desc.ulVersion = SECBUFFER_VERSION;
@@ -297,10 +293,8 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                                   &type_3_desc,
                                                   &attrs, NULL);
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   if(pkgBindings.Bindings)
     Curl_pSecFn->FreeContextBuffer(pkgBindings.Bindings);
-#endif
 
   if(status != SEC_E_OK) {
     infof(data, "NTLM handshake failure (type-3 message): Status=0x%08lx",

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -93,9 +93,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   SecBufferDesc chlg_desc;
   SecBufferDesc resp_desc;
   unsigned long attrs;
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   SecPkgContext_Bindings pkgBindings = { 0, NULL };
-#endif
 
   if(nego->context && nego->status == SEC_E_OK) {
     /* We finished successfully our part of authentication, but server
@@ -222,7 +220,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     chlg_buf[0].cbBuffer   = curlx_uztoul(chlglen);
   }
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   /* SSL context comes from Schannel.
    * When extended protection is used in IIS server, pass its channel
    * bindings on the initial call too. HTTP Negotiate can create and send a
@@ -242,7 +239,6 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       binding_buf->pvBuffer   = pkgBindings.Bindings;
     }
   }
-#endif
 
   /* Setup the response "output" security buffer */
   resp_desc.ulVersion = SECBUFFER_VERSION;
@@ -269,10 +265,8 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                              &resp_desc, &attrs, NULL);
   }
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   if(pkgBindings.Bindings)
     Curl_pSecFn->FreeContextBuffer(pkgBindings.Bindings);
-#endif
 
   /* Free the decoded challenge as it is not required anymore */
   curlx_free(chlg);

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -164,9 +164,7 @@ struct ntlmdata {
 /* The sslContext is used for the Schannel bindings. The
  * api is available on the Windows 7 SDK and later.
  */
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   CtxtHandle *sslContext;
-#endif
   CredHandle *credentials;
   CtxtHandle *context;
   SEC_WINNT_AUTH_IDENTITY_EX identity;
@@ -298,9 +296,7 @@ struct negotiatedata {
 #endif
 #else
 #ifdef USE_WINDOWS_SSPI
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
   CtxtHandle *sslContext;
-#endif
   SECURITY_STATUS status;
   CredHandle *credentials;
   CtxtHandle *context;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1747,14 +1747,12 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
 
     connssl->state = ssl_connection_complete;
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+, MS SDK 7.0A/VS2010+ */
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.
      * Available on Windows 7 or later.
      */
     cf->conn->sslContext = &backend->ctxt->ctxt_handle;
-#endif
 
     *done = TRUE;
   }


### PR DESCRIPTION
Drop `SECPKG_ATTR_ENDPOINT_BINDINGS` guards and declare the missing
macro and struct for mingw-w64 <9. To bring these builds on par with the
rest of supported Windows toolchains.

Follow-up to 09662337441c40c23da7b557c4cceacd7cc3b76e #3321
