### PR TITLE
CI: add a test of labeler patterns

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,10 @@
 # patterns, they must be joined with commas to a single string surrounded by
 # braces. For example: '{lib/**,src/**}'.
 #
+# Note that the labelercheck.sh script is sensitive to the specific formatting
+# of this file; strictly follow the established template when adding new
+# patterns.
+#
 # See https://github.com/actions/labeler/ for documentation on this file.
 ---
 
@@ -208,7 +212,6 @@ documentation:
               .github/scripts/verify-synopsis.pl,\
               **/*.md,\
               **/*.txt,\
-              **/*.1,\
               CHANGES.md,\
               docs/**,\
               LICENSES/**,\

--- a/.github/scripts/labelercheck.sh
+++ b/.github/scripts/labelercheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (C) 2026 Dan Fandrich
+#
+# SPDX-License-Identifier: curl
+
+# Look for invalid patterns in labeler config.
+# This is highly sensitive to the format of the labeler.yml file.
+# It will also fail if patterns are added containing special shell characters
+# like "$" or "|".
+grep -E '^ {14}[^-].*\\$' .github/labeler.yml | \
+  sed -E -e '/^[[:space:]]*#/d' -e 's/,?\\$//' | \
+  xargs -I{} /bin/bash -c 'shopt -s globstar dotglob; ls -d {}' >/dev/null

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -74,6 +74,9 @@ jobs:
       - name: 'cmake options in documentation'
         run: scripts/cmakeopts.sh
 
+      - name: 'labelercheck'
+        run: .github/scripts/labelercheck.sh
+
       - name: 'perlcheck'
         run: scripts/perlcheck.sh
 


### PR DESCRIPTION
When source files are renamed or removed, labeler patterns can refer to
nonexistent files. Verify that the globs in the labeler config are still
valid so they can be updated when corresponding source changes occur.
This check does nothing when new files are added; those must be manually
checked to see if they warrant new matching patterns in the config.

Closes #22727


<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->