### PR TITLE
CI: add a test of Python code using pyrefly

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -4,5 +4,6 @@
 
 cmakelang==0.6.13
 codespell==2.4.3
+pyrefly==1.2.0
 reuse==6.2.0
 ruff==0.16.2

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -82,6 +82,12 @@ jobs:
           source ~/venv/bin/activate
           scripts/pythonlint.sh
 
+      - name: 'pyrefly'
+        run: |
+          source ~/venv/bin/activate
+          cd tests/http/
+          pyrefly check --python-version=3.8 --preset=basic --check-unannotated-defs --summary
+
       - name: filter off code from all C and H files
         run: |
           git ls-files -z '**.[ch]' | xargs -0 -r -n1 ./.github/scripts/c-strip


### PR DESCRIPTION
pytype is no longer supported and will stop working one day when newer
Python becomes the default. pyrefly is a bit too pedantic in its default
configuration, so run it with only the basic set of checks.

Closes #22728


<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->