### PR TITLE
tool_getparam: scrub credentials embedded in --url from process list

### DIFF
--- a/docs/cmdline-opts/url.md
+++ b/docs/cmdline-opts/url.md
@@ -28,6 +28,14 @@ protocol is used, otherwise it assumes HTTP. Scheme guessing can be avoided by
 providing a full URL including the scheme, or disabled by setting a default
 protocol, see --proto-default for details.
 
+If the URL contains a username and password, as in
+`https://user:password@example.com/`, curl hides those credentials from
+process listings on systems where it works, while leaving the rest of the URL
+visible. This is not enough to protect credentials from possibly getting seen
+by other users on the same system as they still are visible for a moment
+before being cleared. Such sensitive data should be retrieved from a file
+instead or similar and never used in clear text in a command line.
+
 To control where the contents of a retrieved URL is written instead of the
 default stdout, use the --output or the --remote-name options. When retrieving
 multiple URLs in a single invoke, each provided URL needs its own dedicated

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -639,8 +639,16 @@ static void cleanarg(char *str)
     memset(str, '*', len);
   }
 }
+static void cleanurl(char *url)
+{
+  /* like cleanarg(), but for a URL argument: only wipe the embedded
+   * user:password so that the rest of the URL stays visible in the system
+   * process list */
+  mask_userinfo(url);
+}
 #else
 #define cleanarg(x) tool_nop_stmt
+#define cleanurl(x) tool_nop_stmt
 #endif
 
 /* the maximum size we allow the dynbuf generated string */
@@ -3089,6 +3097,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       if(a->desc & ARG_CLEAR)
         cleanarg(CURL_UNCONST(nextarg));
+      else if(a->cmd == C_URL)
+        /* keep credentials embedded in a URL out of the process list */
+        cleanurl(CURL_UNCONST(nextarg));
     }
     else {
       if(a->desc & ARG_DEPR) {

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -730,3 +730,96 @@ ParameterError str2tls_max(unsigned char *val, const char *str)
   }
   return PARAM_BAD_USE;
 }
+
+/*
+ * mask_userinfo() overwrites, in place, the user name and password embedded in
+ * a URL string (the "user:password@" part) with '*' characters. The rest of
+ * the URL - scheme, host, port, path, query and fragment - is left untouched,
+ * so a process listing still shows what the transfer targets.
+ *
+ * This is the URL counterpart of cleanarg(): it keeps credentials passed as
+ * "curl https://user:password@example.com/" out of the system process list.
+ * Unlike cleanarg() it does not blank the whole argument, only the secret.
+ *
+ * libcurl's URL parser decides whether there is userinfo present and whether
+ * the URL is well-formed at all; if it cannot be parsed, or carries no
+ * credentials, the string is left as-is. The parser cannot hand out byte
+ * offsets into the original string, so the range to wipe is worked out here:
+ * skip an explicit scheme and the "//" that introduces the authority, then
+ * wipe up to the last '@' before the authority ends (at the first '/', '?' or
+ * '#', or the end of the string). The string keeps its original length.
+ *
+ * An argument with no '@' in it cannot carry userinfo, and returns before a
+ * URL handle is allocated. Many URLs on the command line or in a config file
+ * therefore cost nothing extra unless credentials are actually there.
+ *
+ * Asking for the scheme with CURLU_NO_GUESS_SCHEME is what tells us whether a
+ * scheme was actually present in the string or merely guessed from the
+ * hostname, which is the difference between "mailto:user@example.com" (scheme
+ * plus userinfo) and "user:password@example.com" (userinfo only).
+ *
+ * Unit test 1726
+ */
+void mask_userinfo(char *url)
+{
+  CURLU *uh;
+  char *user = NULL;
+  char *pw = NULL;
+
+  if(!url)
+    return;
+
+  /* Userinfo is always terminated by '@'. Bail out before allocating a URL
+     handle when the argument cannot possibly carry credentials, which is the
+     common case and keeps this free for URLs that have none. */
+  if(!strchr(url, '@'))
+    return;
+
+  uh = curl_url();
+  if(!uh)
+    return;
+
+  if(!curl_url_set(uh, CURLUPART_URL, url,
+                   CURLU_GUESS_SCHEME | CURLU_NON_SUPPORT_SCHEME)) {
+    bool haveuser = !curl_url_get(uh, CURLUPART_USER, &user, 0);
+    bool havepw = !curl_url_get(uh, CURLUPART_PASSWORD, &pw, 0);
+
+    if(haveuser || havepw) {
+      /* there are credentials - find where the authority starts */
+      char *authstart = url;
+      char *authend;
+      char *at = NULL;
+      char *p;
+      char *scheme = NULL;
+
+      /* Skip over a scheme that is present in the string. A guessed scheme is
+         not in the string and makes this return CURLUE_NO_SCHEME. The parser
+         lowercases the scheme but that does not change its length. */
+      if(!curl_url_get(uh, CURLUPART_SCHEME, &scheme, CURLU_NO_GUESS_SCHEME)) {
+        size_t slen = strlen(scheme);
+        if(curl_strnequal(url, scheme, slen) && (url[slen] == ':'))
+          authstart = &url[slen + 1];
+      }
+      curl_free(scheme);
+
+      /* the authority, when present, is introduced by a double slash */
+      if((authstart[0] == '/') && (authstart[1] == '/'))
+        authstart += 2;
+
+      /* the authority ends at the first '/', '?' or '#', or the string end */
+      authend = authstart + strcspn(authstart, "/?#");
+
+      /* the userinfo is terminated by the last '@' within the authority */
+      for(p = authstart; p < authend; p++)
+        if(*p == '@')
+          at = p;
+
+      if(at)
+        memset(authstart, '*', (size_t)(at - authstart));
+    }
+  }
+
+  curl_free(user);
+  curl_free(pw);
+  curl_url_cleanup(uh);
+}

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -56,4 +56,6 @@ long delegation(const char *str);
 
 ParameterError str2tls_max(unsigned char *val, const char *str);
 
+void mask_userinfo(char *url);
+
 #endif /* HEADER_CURL_TOOL_PARAMHLP_H */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -1729,6 +1729,7 @@ TESTCASES = \
   test1723 \
   test1724 \
   test1725 \
+  test1726 \
   test1740 \
   test1741 \
   \

--- a/tests/data/test1726
+++ b/tests/data/test1726
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+unittest
+</features>
+<name>
+unit test for mask_userinfo()
+</name>
+<tool>
+tool%TESTNUMBER
+</tool>
+</client>
+
+<verify>
+</verify>
+</testcase>

--- a/tests/tunit/Makefile.inc
+++ b/tests/tunit/Makefile.inc
@@ -35,4 +35,5 @@ TESTS_C = \
   tool1621.c \
   tool1622.c \
   tool1623.c \
-  tool1720.c
+  tool1720.c \
+  tool1726.c

--- a/tests/tunit/tool1726.c
+++ b/tests/tunit/tool1726.c
@@ -1,0 +1,115 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+#include "tool_getparam.h"
+#include "tool_paramhlp.h"
+
+static CURLcode test_tool1726(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+
+  struct check {
+    const char *input;
+    const char *expect;
+  };
+
+  static const struct check tests[] = {
+    /* plain user:password embedded in the URL */
+    {"http://user:pass@example.com/path",
+     "http://*********@example.com/path"},
+    /* user name only */
+    {"http://user@example.com/",
+     "http://****@example.com/"},
+    /* IPv6 host literal in brackets */
+    {"https://u:p@[::1]:8080/x?y=1",
+     "https://***@[::1]:8080/x?y=1"},
+    /* password only */
+    {"http://:secret@example.com/",
+     "http://*******@example.com/"},
+    /* percent-encoded '@' inside the user name, real '@' is the separator */
+    {"http://u%40h:pw@example.com/",
+     "http://********@example.com/"},
+    /* '@' in the query string must not be treated as a userinfo separator */
+    {"http://example.com/path?to=a@b",
+     "http://example.com/path?to=a@b"},
+    /* '@' in the path */
+    {"http://example.com/a@b",
+     "http://example.com/a@b"},
+    /* no credentials at all */
+    {"http://example.com/",
+     "http://example.com/"},
+    /* non-HTTP scheme */
+    {"ftp://user:pass@ftp.example.com/file",
+     "ftp://*********@ftp.example.com/file"},
+    /* no scheme - curl guesses one, userinfo still masked */
+    {"user:pass@example.com/x",
+     "*********@example.com/x"},
+    /* a guessed scheme with "://" later in the path must not be mistaken
+       for the scheme separator */
+    {"user:pass@example.com/a://b",
+     "*********@example.com/a://b"},
+    /* the same, with the "://" in the query */
+    {"user:pass@example.com/x?q=://z",
+     "*********@example.com/x?q=://z"},
+    /* curl reads this as the credentials "mailto" and "user" on the host
+       example.com, so that is what gets masked */
+    {"mailto:user@example.com",
+     "***********@example.com"},
+    /* unencoded '@' in the userinfo - curl rejects the URL, left untouched */
+    {"http://us@er:pa@ss@example.com/",
+     "http://us@er:pa@ss@example.com/"},
+    /* a glob in the authority - curl rejects the URL, left untouched */
+    {"http://user:pass@ex{1,2}.com/p",
+     "http://user:pass@ex{1,2}.com/p"},
+    /* not a URL - left untouched */
+    {"this is not a url",
+     "this is not a url"},
+    /* empty string */
+    {"",
+     ""},
+    /* malformed, unparsable - left untouched */
+    {"http://",
+     "http://"},
+    {NULL, NULL}
+  };
+  const struct check *p;
+
+  for(p = tests; p->input; p++) {
+    char *buf = curlx_strdup(p->input);
+    abort_unless(buf, "out of memory");
+    mask_userinfo(buf);
+    if(strcmp(buf, p->expect)) {
+      curl_mprintf("mask_userinfo(\"%s\")\n"
+                   "  expected \"%s\"\n"
+                   "  but got  \"%s\"\n", p->input, p->expect, buf);
+      fail("assertion failure");
+    }
+    curlx_free(buf);
+  }
+
+  /* a NULL argument must be handled without crashing */
+  mask_userinfo(NULL);
+
+  UNITTEST_END_SIMPLE
+}


### PR DESCRIPTION
curl clears the argument to --user, --proxy-user and --cert after parsing so the credentials do not linger in argv, where ps and /proc/[pid]/cmdline expose them. Credentials written into the URL itself were never cleared.

Scrub only the userinfo, so the rest of the URL stays visible:

    curl http://user:secret@example.com/path

shows up in the process list as

    curl http://***********@example.com/path

Covers --url, --url= and the trailing URL argument, and like cleanarg() only acts where HAVE_WRITABLE_ARGV is defined. URLs that do not parse and URLs without credentials are left alone, so a glob in the authority is not scrubbed. --user, --proxy-user and --cert are unchanged.

Verified by hand with /proc/[pid]/cmdline on Linux and ps on macOS. Unit test 1726 covers the masking.

--expand-url is not scrubbed: the expanded copy gets wiped rather than argv, so anything written literally in the argument survives. --expand-user has the same behaviour. Fixing it means wiping argv for every --expand-* option, which seemed out of scope here.

Happy to follow up with the same approach for -x/--proxy if wanted, keeping this one scoped to --url.
