### PR TITLE
conncache: lower limit for auto maxconnects

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -651,7 +651,12 @@ bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
     return kept;
 
   if(!data->multi->maxconnects) {
-    unsigned int running = Curl_multi_xfers_running(data->multi);
+    /* Running transfers is a weak indicator of business. When many
+     * transfers are done at the same time (parallel h1), the number
+     * may drop quite low and we do not want to close connections
+     * just to have another wave of transfers arriving next. */
+    uint32_t running = Curl_multi_xfers_running(data->multi);
+    running = CURLMAX(running, 128);
     maxconnects = (running <= UINT_MAX / 4) ? running * 4 : UINT_MAX;
   }
   else {


### PR DESCRIPTION
When the `maxconnets` for a multi is not set, we calculate an "auto" limit based on the number of running transfers.

Introduce a minimum of the transfer count, so that we do not evict connctions from the cache when many transfers finish in the same round, causing an "unnatural" low running count.

This should address our low `h1-request` perf stat drop.


