### PR TITLE
spnego_sspi: drop redundant UNICODE branch

### DIFF
--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -166,11 +166,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     /* Use the special name "!ntlm" to prevent NTLM from being used:
      * https://learn.microsoft.com/windows/win32/api/sspi/ns-sspi-sec_winnt_auth_identity_exa
      */
-#ifdef UNICODE
     nego->identity.PackageList = CURL_UNCONST(TEXT("!ntlm"));
-#else
-    nego->identity.PackageList = CURL_UNCONST(TEXT("!ntlm"));
-#endif
     nego->identity.PackageListLength = 5;
 
     /* Allocate our credentials handle */


### PR DESCRIPTION
Follow-up to 8a8ff47b63aff1d72c1796dbdb4955f243beac23 #22559
Follow-up to a8881e5e1d2e22d4b085d45ab6c8ce1df251d602 #21315 #22410
