### PR TITLE
perf: add a subdir for libcurl performance test programs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -942,6 +942,15 @@ jobs:
             make -C bld V=1 -C tests
           fi
 
+      - name: 'build perf tests'
+        if: ${{ !contains(matrix.build.install_steps, 'skipall') }}
+        run: |
+          if [ "${MATRIX_BUILD}" = 'cmake' ]; then
+            cmake --build bld --verbose --target perf
+          else
+            make -C bld V=1 -C perf
+          fi
+
       - name: 'install test prereqs'
         if: ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') && matrix.build.container == null }}
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -948,7 +948,7 @@ jobs:
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target perf
           else
-            make -C bld V=1 -C perf
+            make -C bld V=1 -C tests/perf
           fi
 
       - name: 'install test prereqs'

--- a/configure.ac
+++ b/configure.ac
@@ -5563,6 +5563,7 @@ AC_CONFIG_FILES([\
   tests/tunit/Makefile \
   tests/http/config.ini \
   tests/http/Makefile \
+  tests/perf/Makefile \
   projects/Makefile \
   projects/vms/Makefile
 ])

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -96,7 +96,7 @@ DIST_UNIT = unit tunit
 endif
 
 SUBDIRS = certs data server libtest http $(BUILD_UNIT)
-DIST_SUBDIRS = $(SUBDIRS) $(DIST_UNIT)
+DIST_SUBDIRS = $(SUBDIRS) $(DIST_UNIT) perf
 
 PERLFLAGS = -I$(srcdir)
 

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -1,0 +1,55 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# Get BUNDLE, FIRST_C, FIRST_H, UTILS_C, UTILS_H, CURLX_C, TOOLX_C, TESTS_C variables
+curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+
+if(_CURL_TESTS_CONCAT)
+  set(_mk_unity_extra "--concat" "-I${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
+add_custom_command(OUTPUT "${BUNDLE}.c"
+  COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" ${_mk_unity_extra}
+    --include ${UTILS_C} ${CURLX_C} ${TOOLX_C} --test ${TESTS_C} > "${BUNDLE}.c"
+  DEPENDS
+    "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
+    ${FIRST_C} ${FIRST_H} ${UTILS_C} ${CURLX_C} ${TOOLX_C} ${TESTS_C}
+  VERBATIM)
+
+add_executable(${BUNDLE} EXCLUDE_FROM_ALL "${BUNDLE}.c")
+add_dependencies(tt ${BUNDLE})
+target_link_libraries(${BUNDLE} ${CURL_NETWORK_AND_TIME_LIBS})
+target_include_directories(${BUNDLE} PRIVATE
+  "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
+  "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h", curlx
+  "${PROJECT_SOURCE_DIR}/src"            # for toolx
+  "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
+)
+set_target_properties(${BUNDLE} PROPERTIES OUTPUT_NAME "${BUNDLE}" PROJECT_LABEL "Test ${BUNDLE}" UNITY_BUILD OFF)
+
+if(NOT _CURL_TESTS_CONCAT)
+  set_target_properties(${BUNDLE} PROPERTIES C_CLANG_TIDY "")
+  curl_add_clang_tidy_test_target("${BUNDLE}-clang-tidy" ${BUNDLE} ${FIRST_C} ${UTILS_C} ${TESTS_C})
+endif()

--- a/tests/perf/Makefile.am
+++ b/tests/perf/Makefile.am
@@ -1,0 +1,88 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+AUTOMAKE_OPTIONS = foreign nostdinc
+
+# Specify our include paths here, and do it relative to $(top_srcdir) and
+# $(top_builddir), to ensure that these paths which belong to the library
+# being currently built and tested are searched before the library which
+# might possibly already be installed in the system.
+#
+# $(top_srcdir)/include is for libcurl's external include files
+# $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
+# $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
+# $(top_srcdir)/src for toolx header files
+# $(srcdir) for the generated bundle source to find included test sources
+
+AM_CPPFLAGS = -I$(top_srcdir)/include        \
+              -I$(top_builddir)/lib          \
+              -I$(top_srcdir)/lib            \
+              -I$(top_srcdir)/src            \
+              -I$(srcdir)
+
+# Get BUNDLE, FIRST_C, FIRST_H, UTILS_C, UTILS_H, CURLX_C, TOOLX_C, TESTS_C variables
+include Makefile.inc
+
+EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C)
+
+CFLAGS += @CURL_CFLAG_EXTRAS@
+
+# Prevent LIBS from being used for all link targets
+LIBS = $(BLANK_AT_MAKETIME)
+
+if USE_CPPFLAG_CURL_STATICLIB
+AM_CPPFLAGS += -DCURL_STATICLIB
+endif
+if DEBUGBUILD
+AM_CPPFLAGS += -DDEBUGBUILD
+endif
+
+if USE_CPPFLAG_CURL_STATICLIB
+curlx_c_lib =
+else
+# These are part of the libcurl static lib. Add them here when linking shared.
+curlx_c_lib = $(CURLX_C)
+endif
+
+$(BUNDLE).c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(UTILS_C) $(curlx_c_lib) $(TOOLX_C) $(TESTS_C)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS_C) $(CURLX_C) $(TOOLX_C) --test $(TESTS_C) > $(BUNDLE).c
+
+noinst_PROGRAMS = $(BUNDLE)
+nodist_perf_SOURCES = $(BUNDLE).c
+LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
+CLEANFILES = $(BUNDLE).c
+
+CHECKSRC = $(CS_$(V))
+CS_0 = @echo "  RUN     " $@;
+CS_1 =
+CS_ = $(CS_0)
+
+checksrc:
+	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) -W$(srcdir)/$(BUNDLE).c $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C))
+
+if NOT_CURL_CI
+all-local: checksrc
+endif
+
+clean-local:
+	rm -f $(BUNDLE)

--- a/tests/perf/Makefile.inc
+++ b/tests/perf/Makefile.inc
@@ -1,0 +1,45 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+# Shared between CMakeLists.txt and Makefile.am
+
+BUNDLE = perf
+
+# Files referenced from the bundle source
+FIRST_C = first.c
+FIRST_H = first.h
+
+# Common files used by the performance test programs
+UTILS_C =
+UTILS_H =
+
+CURLX_C = \
+  ../../lib/curlx/base64.c \
+  ../../lib/curlx/fopen.c \
+  ../../lib/curlx/strparse.c
+
+# All test programs
+TESTS_C = \
+  base64.c \
+  snprintf.c \
+  urlparser.c

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,0 +1,30 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
+# Performance tests
+
+This directory contains small stand-alone libcurl-using programs that each
+test specific aspects of the library's performance.
+
+The idea is to have a set of tests here that can be used to verify various
+libcurl function's performance when we have no other good means of doing so.
+Performance is best tested relatively. Does it run slower or faster than
+before?
+
+Ideally these tests run without using any servers.
+
+## `urlparser`
+
+Provide this test with a list of many URLs and it times how fast it can parse
+them: `./perf urlparser URLs.txt [loops]`
+
+A test sample of 100K URLs can be found [here](https://github.com/ada-url/url-various-datasets/blob/main/top100/top100.txt)
+
+## `base64`
+
+This test first base64 encodes a 256 bytes buffer that has every different
+byte octet represented. It then decodes that string. Repeatedly in a loop the
+provided number of times: `./perf base64 [loops]`

--- a/tests/perf/base64.c
+++ b/tests/perf/base64.c
@@ -1,0 +1,88 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <curl/curl.h>
+
+/*
+ */
+static int test_base64(int argc, const char **argv)
+{
+  struct timeval start;
+  struct timeval end;
+  unsigned char array[256];
+  unsigned int c;
+  int i;
+  time_t diff;
+  long us;
+  long long hn;
+  curl_off_t loops = 10000000;
+
+  if(argc > 1) {
+    const char *ptr = argv[2];
+    curlx_str_number(&ptr, &loops, CURL_OFF_T_MAX);
+  }
+
+  for(c = 0; c < 256; c++) {
+    array[c] = (unsigned char)c;
+  }
+
+  gettimeofday(&start, NULL);
+  for(i = 0; i < loops; i++) {
+    char *encoded;
+    size_t enclen;
+    CURLcode rc =
+      curlx_base64_encode(array, sizeof(array), &encoded, &enclen);
+    if(!rc) {
+      unsigned char *recoded = NULL;
+      size_t reclen;
+      /* now decoded it again */
+      rc = curlx_base64_decode(encoded, &recoded, &reclen);
+      curlx_free(recoded);
+    }
+    if(rc) {
+      curl_mfprintf(stderr, "unexpected coding error: %d\n", (int)rc);
+      return 1;
+    }
+    curlx_free(encoded);
+  }
+  gettimeofday(&end, NULL);
+  diff = end.tv_sec-start.tv_sec;
+  /* how many microseconds */
+  us = diff * 1000000 + end.tv_usec-start.tv_usec;
+  hn = us*100000/loops; /* 100 times too big */
+  curl_mprintf("Loops:     %" CURL_FORMAT_CURL_OFF_T "\n"
+               "Time:      %ld usecs\n"
+               "Time/loop: %lld.%lld ns\n",
+               loops,
+               us,
+               hn / 100,
+               hn % 100);
+  return 0;
+}

--- a/tests/perf/first.c
+++ b/tests/perf/first.c
@@ -1,0 +1,62 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+#include <stdio.h>
+
+int main(int argc, const char *argv[])
+{
+  entry_func_t entry_func;
+  const char *entry_name;
+  int result;
+  size_t tmp;
+
+  if(argc < 2) {
+    curl_mfprintf(stderr, "Pass perftest as first argument\n");
+    return 1;
+  }
+
+  entry_name = argv[1];
+  entry_func = NULL;
+  for(tmp = 0; s_entries[tmp].ptr; ++tmp) {
+    if(!strcmp(entry_name, s_entries[tmp].name)) {
+      entry_func = s_entries[tmp].ptr;
+      break;
+    }
+  }
+
+  if(!entry_func) {
+    curl_mfprintf(stderr, "Test '%s' not found.\n", entry_name);
+    return 99;
+  }
+
+#ifdef _WIN32
+  if(win32_init())
+    return 2;
+#endif
+
+  result = entry_func(argc - 1, argv + 1);
+
+  return result;
+}

--- a/tests/perf/first.h
+++ b/tests/perf/first.h
@@ -1,0 +1,45 @@
+#ifndef HEADER_PERF_FIRST_H
+#define HEADER_PERF_FIRST_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#define CURL_NO_OLDIES
+#define CURL_DISABLE_DEPRECATION
+
+/* Now include the curl_setup.h file from libcurl's private libdir (the source
+   version, but that might include "curl_config.h" from the build directory so
+   we need both of them in the include path), so that we get good in-depth
+   knowledge about the system we are building this on */
+#include "curl_setup.h"
+
+typedef int (*entry_func_t)(int, const char **);
+
+struct entry_s {
+  const char *name;
+  entry_func_t ptr;
+};
+
+extern const struct entry_s s_entries[];
+
+#endif /* HEADER_PERF_FIRST_H */

--- a/tests/perf/snprintf.c
+++ b/tests/perf/snprintf.c
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <curl/curl.h>
+
+/*
+ */
+static int test_snprintf(int argc, const char **argv)
+{
+  struct timeval start;
+  struct timeval end;
+  int i;
+  time_t diff;
+  long us;
+  long long hn;
+  char buffer[256];
+  curl_off_t loops = 10000000;
+
+  if(argc > 1) {
+    const char *ptr = argv[2];
+    curlx_str_number(&ptr, &loops, CURL_OFF_T_MAX);
+  }
+
+  gettimeofday(&start, NULL);
+  for(i = 0; i < loops; i++) {
+    curl_msnprintf(buffer, sizeof(buffer),
+                   "Add %-4d stuff %u to %3d the %3u output %s "
+                   "%*s"
+                   "for %lld testing %lu\n",
+                   123, (unsigned int)123,
+                   123, (unsigned int)123, "helllo",
+                   14, "01234567890123456",
+                   (long long)987871231231,
+                   (unsigned long)6732673);
+  }
+  gettimeofday(&end, NULL);
+  diff = end.tv_sec-start.tv_sec;
+  /* how many microseconds */
+  us = diff * 1000000 + end.tv_usec-start.tv_usec;
+  hn = us*100000/loops; /* 100 times too big */
+  curl_mprintf("Loops:     %" CURL_FORMAT_CURL_OFF_T "\n"
+               "Time:      %ld usecs\n"
+               "Time/loop: %lld.%lld ns\n",
+               loops,
+               us,
+               hn / 100,
+               hn % 100);
+  return 0;
+}

--- a/tests/perf/urlparser.c
+++ b/tests/perf/urlparser.c
@@ -1,0 +1,159 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <curl/curl.h>
+
+static const int options[] = {
+  CURLU_DEFAULT_PORT,
+  CURLU_NO_DEFAULT_PORT,
+  CURLU_DEFAULT_SCHEME,
+  CURLU_NON_SUPPORT_SCHEME,
+  CURLU_ALLOW_SPACE,
+  CURLU_GUESS_SCHEME,
+  CURLU_PATH_AS_IS,
+  CURLU_DISALLOW_USER
+};
+
+#define MAX_URLS 200000
+
+static char *urls[MAX_URLS];
+
+/*
+ * Read many URLS from a given file.
+ * Parse them with all listed option combinations
+ */
+static int test_urlparser(int argc, const char **argv)
+{
+  size_t o;
+  size_t count = 0;
+  size_t ecount = 0; /* errors */
+  struct timeval start;
+  struct timeval end;
+  time_t diff;
+  long us;
+  long long hn;
+  int fd;
+  char *buffer;
+  size_t i;
+  int loop;
+  size_t nsize;
+  size_t nurls = 0; /* number of URLs */
+  struct stat info;
+  curl_off_t iterations = 10;
+  char *p;
+  CURLU *uh;
+
+  if(argc < 2) {
+    curl_mfprintf(stderr, "%s <URL file> [iterations]\n", argv[0]);
+    return 2;
+  }
+  if(argc > 2) {
+    const char *ptr = argv[2];
+    curlx_str_number(&ptr, &iterations, 100000);
+  }
+
+  fd = curlx_open(argv[1], O_RDONLY);
+  if(fd == -1) {
+    curl_mfprintf(stderr, "Can't open %s, exiting\n", argv[1]);
+    return 3;
+  }
+
+  if(curlx_fstat(fd, &info) == -1) {
+    curl_mfprintf(stderr, "Can't open %s, exiting\n", argv[1]);
+    return 3;
+  }
+
+  nsize = info.st_size;
+
+  buffer = curlx_malloc(nsize + 1);
+  if(!buffer) {
+    curl_mfprintf(stderr, "Can't malloc the buffer\n");
+    return 4;
+  }
+
+  if((ssize_t)nsize != read(fd, buffer, nsize)) {
+    curl_mfprintf(stderr, "Can't load the file\n");
+    return 4;
+  }
+  buffer[nsize] = 0;
+  p = buffer;
+  while(1) {
+    if(nurls >= MAX_URLS) {
+      curl_mfprintf(stderr,
+                    "TOO many URLs in file, rebuild with higher max\n");
+      return 4;
+    }
+    urls[nurls++] = p;
+    p = strchr(p, '\n');
+    if(!p)
+      break;
+    *p = '\0';
+    p++;
+  }
+  curl_mprintf("Found %zu URLs to test for %" CURL_FORMAT_CURL_OFF_T
+               " iterations (%zu variations)\n",
+               nurls, iterations, CURL_ARRAYSIZE(options));
+
+  uh = curl_url();
+  gettimeofday(&start, NULL);
+  for(loop = 0; loop < iterations; loop++) {
+    for(i = 0 ; i < nurls; i++) {
+      for(o = 0; o < CURL_ARRAYSIZE(options); o++) {
+        CURLUcode hcode =
+          curl_url_set(uh, CURLUPART_URL, urls[i], options[o]);
+        count++;
+        if(hcode) {
+#if 0
+          curl_mfprintf(stderr, "Failed [%u]: %s\n", (int)hcode, buffer);
+#endif
+          ecount++;
+        }
+      }
+    }
+  }
+  gettimeofday(&end, NULL);
+  curl_url_cleanup(uh);
+  diff = end.tv_sec-start.tv_sec;
+  /* how many microseconds */
+  us = diff * 1000000 + end.tv_usec-start.tv_usec;
+  hn = us*100000/count; /* 100 times too big */
+  curl_mprintf("URLs:     %zu\n"
+               "Time:     %ld usecs\n"
+               "Time/URL: %lld.%lld ns\n"
+               "URLs/sec: %lu\n"
+               "Errors:   %zu\n",
+               count,
+               us,
+               hn / 100,
+               hn % 100,
+               (count * 1000000) / us,
+               ecount);
+  return 0;
+}


### PR DESCRIPTION
These programs does not build by default since they are a bit niche and maybe not interesting to most.

The idea is to have a set of tests here that can be used to verify various libcurl function's performance when we have no other good means of doing so. Performance is best tested relatively. Does it run slower or faster than before?

'make -C tests' builds the performance test tools in an autotools build.
