### PR TITLE
schannel: fix ALPN erroneously disabled

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -136,6 +136,11 @@ static CURLcode global_init(long flags, bool memoryfuncs)
     Curl_ccalloc = (curl_calloc_callback)calloc;
   }
 
+  if(Curl_win32_init(flags)) {
+    DEBUGF(curl_mfprintf(stderr, "Error: win32_init failed\n"));
+    goto fail;
+  }
+
   if(Curl_trc_init()) {
     DEBUGF(curl_mfprintf(stderr, "Error: Curl_trc_init failed\n"));
     goto fail;
@@ -148,11 +153,6 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 
   if(!Curl_vquic_init()) {
     DEBUGF(curl_mfprintf(stderr, "Error: Curl_vquic_init failed\n"));
-    goto fail;
-  }
-
-  if(Curl_win32_init(flags)) {
-    DEBUGF(curl_mfprintf(stderr, "Error: win32_init failed\n"));
     goto fail;
   }
 


### PR DESCRIPTION
- In easy.c global_init, initialize win32 before ssl.

Schannel SSL init depends on win32 initialization.

Prior to this change applications with no compatibility manifest using a libcurl with Schannel had ALPN erroneously disabled. During Schannel init there is a version info check so that ALPN is only enabled for Windows 8.1 or later (>= NT 6.3), but since win32 was not yet initialized the version check would fail even if the OS was more recent.

This change ensures that the pointer to function RtlVerifyVersionInfo is initialized before SSL initialization so that version checks during SSL initialization do not use VerifyVersionInfo as a fallback.

On Windows RtlVerifyVersionInfo compares against the actual OS version info whereas VerifyVersionInfo has behavior that varies depending on whether the application (eg curl tool) has a compatibility manifest. If there is no manifest, VerifyVersionInfo treats the OS version to compare against as Windows 8 (NT 6.2) even on later versions.

So basically NT 6.2 < NT 6.3 caused ALPN to be erroneously disabled.

Reported-by: Jay Satiro

Ref: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-verifyversioninfoa

Fixes https://github.com/curl/curl/pull/22739#issuecomment-5464013950
Closes #xxxx
