### PR TITLE
GHA/non-native: bump cross-platform-actions to 1.5.0

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,8 +128,8 @@ jobs:
         with:
           environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS MATRIX_VERSION TFLAGS'
           operating_system: '${{ matrix.os }}'
-          variant: ${{ matrix.os == 'netbsd' && 'microvm' || 'default' }}
           version: '${{ matrix.version }}'
+          variant: ${{ matrix.os == 'netbsd' && matrix.version != '10.1' && 'microvm' || 'default' }}
           architecture: '${{ matrix.arch }}'
 
       - name: 'install prereqs'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -124,10 +124,11 @@ jobs:
           persist-credentials: false
 
       - name: 'setup VM'
-        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4.0
+        uses: cross-platform-actions/action@faa0c6197e94aacf1c5956460152c8380d3560a5 # v1.5.0
         with:
           environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS MATRIX_VERSION TFLAGS'
           operating_system: '${{ matrix.os }}'
+          variant: ${{ matrix.os == 'netbsd' && 'microvm' || 'default' }}
           version: '${{ matrix.version }}'
           architecture: '${{ matrix.arch }}'
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -129,7 +129,6 @@ jobs:
           environment_variables: 'CC CURL_CI CURL_TEST_MIN DO_NOT_TRACK MAKEFLAGS MATRIX_ARCH MATRIX_BUILD MATRIX_INSTALL MATRIX_OPTIONS MATRIX_OS MATRIX_VERSION TFLAGS'
           operating_system: '${{ matrix.os }}'
           version: '${{ matrix.version }}'
-          variant: ${{ matrix.os == 'netbsd' && matrix.version != '10.1' && 'microvm' || 'default' }}
           architecture: '${{ matrix.arch }}'
 
       - name: 'install prereqs'


### PR DESCRIPTION
Also:
- tried `microvm` with NetBSD 11, but ended up not using it because
  tests failed to fork, then the process either hung or took too long to
  fit in 15 minutes.
  Ref: https://github.com/curl/curl/actions/runs/33314257008/job/99268019716?pr=22748

Refs:
https://github.com/cross-platform-actions/action/releases/tag/v1.5.0
https://github.com/cross-platform-actions/action/blob/v1.5.0/readme.md#variants-variant

---

Also an attempt to fix:
```
pkg: https://cross-platform-actions.github.io/freebsd-pkg-repo/FreeBSD:15:riscv64/meta.txz: Not Found
[...]
```
https://github.com/curl/curl/actions/runs/33313502875/job/99262673694?pr=22747
[NOT FIXING IT]
