### PR TITLE
tidy-up: drop redundant parentheses

### DIFF
--- a/docs/examples/getinmemory.c
+++ b/docs/examples/getinmemory.c
@@ -50,7 +50,7 @@ static size_t write_cb(char *contents, size_t size, size_t nmemb, void *userp)
   }
 
   mem->memory = ptr;
-  memcpy(&(mem->memory[mem->size]), contents, realsize);
+  memcpy(&mem->memory[mem->size], contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;
 

--- a/docs/examples/http2-pushinmemory.c
+++ b/docs/examples/http2-pushinmemory.c
@@ -48,7 +48,7 @@ static size_t write_cb(char *contents, size_t size, size_t nmemb, void *userp)
   }
 
   mem->memory = ptr;
-  memcpy(&(mem->memory[mem->size]), contents, realsize);
+  memcpy(&mem->memory[mem->size], contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;
 

--- a/docs/examples/postinmemory.c
+++ b/docs/examples/postinmemory.c
@@ -49,7 +49,7 @@ static size_t write_cb(char *contents, size_t size, size_t nmemb, void *userp)
   }
 
   mem->memory = ptr;
-  memcpy(&(mem->memory[mem->size]), contents, realsize);
+  memcpy(&mem->memory[mem->size], contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;
 

--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -30,7 +30,7 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <windows.h>
-#define sleep(s) Sleep((DWORD)(s * 1000))
+#define sleep(s) Sleep((DWORD)((s) * 1000))
 #else
 #include <unistd.h>
 #endif

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -409,7 +409,7 @@ evaluate:
 
   /* check if a running baller connects now */
   VERBOSE(i = -1);
-  for(panchor = &bs->running; *panchor; panchor = &((*panchor)->next)) {
+  for(panchor = &bs->running; *panchor; panchor = &(*panchor)->next) {
     VERBOSE(++i);
     a = *panchor;
     a->result = cf_ip_attempt_connect(a, data, connected);
@@ -509,7 +509,7 @@ evaluate:
       /* append to running list */
       panchor = &bs->running;
       while(*panchor)
-        panchor = &((*panchor)->next);
+        panchor = &(*panchor)->next;
       *panchor = a;
       bs->last_attempt_started = *Curl_pgrs_now(data);
       bs->last_attempt_ai_family = ai_family;

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -409,7 +409,7 @@ bool Curl_conn_cf_discard(struct Curl_cfilter **pcf,
           found = TRUE;
           break;
         }
-        pprev = &((*pprev)->next);
+        pprev = &(*pprev)->next;
       }
     }
     Curl_conn_cf_discard_chain(pcf, data);

--- a/lib/curl_share.c
+++ b/lib/curl_share.c
@@ -100,11 +100,11 @@ static uint32_t share_ref_inc(struct Curl_share *share)
   uint32_t n;
 #ifdef USE_MUTEX
   Curl_mutex_acquire(&share->lock);
-  n = ++(share->ref_count);
+  n = ++share->ref_count;
   share->has_been_shared = TRUE;
   Curl_mutex_release(&share->lock);
 #else
-  n = ++(share->ref_count);
+  n = ++share->ref_count;
   share->has_been_shared = TRUE;
 #endif
   return n;
@@ -116,10 +116,10 @@ static uint32_t share_ref_dec(struct Curl_share *share)
 #ifdef USE_MUTEX
   Curl_mutex_acquire(&share->lock);
   DEBUGASSERT(share->ref_count);
-  n = --(share->ref_count);
+  n = --share->ref_count;
   Curl_mutex_release(&share->lock);
 #else
-  n = --(share->ref_count);
+  n = --share->ref_count;
 #endif
   return n;
 }

--- a/lib/curlx/strparse.c
+++ b/lib/curlx/strparse.c
@@ -263,7 +263,7 @@ int curlx_str_cmp(struct Curl_str *str, const char *check)
     size_t clen = strlen(check);
     return ((str->len == clen) && !strncmp(str->str, check, clen));
   }
-  return !!(str->len);
+  return !!str->len;
 }
 
 /* Trim off 'num' number of bytes from the beginning (left side) of the

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2328,7 +2328,7 @@ static CURLcode ftp_do_more(struct Curl_easy *data, domore *more)
       if(result)
         ;
       else if((data->state.list_only || !ftpc->file) &&
-              !(data->set.prequote)) {
+              !data->set.prequote) {
         /* The specified path ends with a slash, and therefore we think this
            is a directory that is requested, use LIST. Before that, we also
            need to set ASCII transfer mode. */
@@ -2846,7 +2846,7 @@ static CURLcode ftp_state_get_resp(struct Curl_easy *data,
 
     if(data->req.size > data->req.maxdownload && data->req.maxdownload > 0)
       data->req.size = data->req.maxdownload;
-    else if((instate != FTP_LIST) && (data->state.prefer_ascii))
+    else if((instate != FTP_LIST) && data->state.prefer_ascii)
       data->req.size = -1; /* for servers that understate ASCII mode file
                               size */
 

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -329,7 +329,7 @@ static CURLcode ftp_pl_insert_finfo(struct Curl_easy *data,
     if(compare(data->set.fnmatch_data, wc->pattern, finfo->filename) == 0) {
       /* discard symlink which is containing multiple " -> " */
       if((finfo->filetype == CURLFILETYPE_SYMLINK) && finfo->strings.target &&
-         (strstr(finfo->strings.target, " -> "))) {
+         strstr(finfo->strings.target, " -> ")) {
         add = FALSE;
       }
     }

--- a/lib/http.c
+++ b/lib/http.c
@@ -1730,7 +1730,7 @@ static bool http_may_use_1_1(const struct Curl_easy *data)
     return FALSE;
   /* We want 1.0 and have seen no previous response on *this* connection
      with a higher version (maybe no response at all yet). */
-  if((data->state.http_neg.only_10) &&
+  if(data->state.http_neg.only_10 &&
      (!conn || conn->httpversion_seen <= 10))
     return FALSE;
   /* We are not restricted to use 1.0 only. */
@@ -3179,7 +3179,7 @@ static statusline checkhttpprefix(struct Curl_easy *data,
     head = head->next;
   }
 
-  if((rc != STATUS_DONE) && (checkprefixmax("HTTP/", s, len)))
+  if((rc != STATUS_DONE) && checkprefixmax("HTTP/", s, len))
     rc = onmatch;
 
   return rc;

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -223,7 +223,7 @@ static char *escape_string(struct Curl_easy *data,
   table = formtable;
   /* data can be NULL when this function is called indirectly from
      curl_formget(). */
-  if(strategy == MIMESTRATEGY_MAIL || (data && (data->set.mime_formescape)))
+  if(strategy == MIMESTRATEGY_MAIL || (data && data->set.mime_formescape))
     table = mimetable;
 
   curlx_dyn_init(&db, CURL_MAX_INPUT_LENGTH);

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1134,11 +1134,13 @@ static CURLcode do_init_reader_stack(struct Curl_easy *data,
   clen = r->crt->total_length(data, r);
   /* if we do not have 0 length init, and CRLF conversion is wanted,
    * add the reader for it */
-  if(clen && (data->set.crlf
+  if(clen &&
 #ifdef CURL_PREFER_LF_LINEENDS
-     || data->state.prefer_ascii
+    (data->set.crlf || data->state.prefer_ascii)
+#else
+    data->set.crlf
 #endif
-    )) {
+    ) {
     result = cr_lc_add(data);
     if(result)
       return result;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -336,7 +336,7 @@ static void cwriter_add(struct Curl_easy *data,
   /* Insert the writer as first in its phase.
    * Skip existing writers of lower phases. */
   while(*anchor && (*anchor)->phase < writer->phase)
-    anchor = &((*anchor)->next);
+    anchor = &(*anchor)->next;
   writer->next = *anchor;
   *anchor = writer;
 }
@@ -851,7 +851,7 @@ static CURLcode cr_in_rewind(struct Curl_easy *data,
     int err;
 
     CURL_CBAPI_START(&guard, data, easy_seek_func);
-    err = (data->set.seek_func)(data->set.seek_client, 0, SEEK_SET);
+    err = data->set.seek_func(data->set.seek_client, 0, SEEK_SET);
     CURL_CBAPI_END(&guard);
     CURL_TRC_READ(data, "cr_in, rewind via set.seek_func -> %d", err);
     if(err) {
@@ -864,8 +864,8 @@ static CURLcode cr_in_rewind(struct Curl_easy *data,
     curlioerr err;
 
     CURL_CBAPI_START(&guard, data, easy_ioctl_func);
-    err = (data->set.ioctl_func)(data, CURLIOCMD_RESTARTREAD,
-                                 data->set.ioctl_client);
+    err = data->set.ioctl_func(data, CURLIOCMD_RESTARTREAD,
+                               data->set.ioctl_client);
     CURL_CBAPI_END(&guard);
     CURL_TRC_READ(data, "cr_in, rewind via set.ioctl_func -> %d", (int)err);
     if(err) {
@@ -1182,7 +1182,7 @@ CURLcode Curl_creader_add(struct Curl_easy *data,
   /* Insert the writer as first in its phase.
    * Skip existing readers of lower phases. */
   while(*anchor && (*anchor)->phase < reader->phase)
-    anchor = &((*anchor)->next);
+    anchor = &(*anchor)->next;
   reader->next = *anchor;
   *anchor = reader;
   return CURLE_OK;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -878,7 +878,7 @@ static CURLcode smtp_perform_command(struct Curl_easy *data,
     else {
       /* Establish whether we should report that we support SMTPUTF8 for EXPN
          commands to the server as per RFC-6531 sect. 3.1 point 6 */
-      utf8 = (smtpc->utf8_supported) && (!strcmp(smtp->custom, "EXPN"));
+      utf8 = smtpc->utf8_supported && !strcmp(smtp->custom, "EXPN");
 
       /* Send the custom recipient based command such as the EXPN command */
       result = Curl_pp_sendf(data, &smtpc->pp,

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -957,7 +957,7 @@ static CURLcode tftp_connect(struct Curl_easy *data, bool *done)
     return CURLE_FAILED_INIT;
 
   ((struct sockaddr *)&state->local_addr)->sa_family =
-    (CURL_SA_FAMILY_T)(remote_addr->family);
+    (CURL_SA_FAMILY_T)remote_addr->family;
 
   result = tftp_set_timeouts(state);
   if(result)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -404,7 +404,7 @@ CURLcode Curl_sendrecv(struct Curl_easy *data)
      * The transfer has been performed. Make some general checks before
      * returning.
      */
-    if(!(data->req.no_body) && (k->size != -1) &&
+    if(!data->req.no_body && (k->size != -1) &&
        (k->bytecount != k->size) && !k->newurl) {
       failf(data, "transfer closed with %" FMT_OFF_T
             " bytes remaining to read", k->size - k->bytecount);

--- a/lib/url.c
+++ b/lib/url.c
@@ -2302,7 +2302,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data)
     DEBUGASSERT(needle->scheme->run->connect_it);
     data->info.conn_scheme = needle->scheme->name;
     /* conn_protocol can only provide "old" protocols */
-    data->info.conn_protocol = (needle->scheme->protocol) & CURLPROTO_MASK;
+    data->info.conn_protocol = needle->scheme->protocol & CURLPROTO_MASK;
     result = needle->scheme->run->connect_it(data, &done);
     if(result)
       goto out;
@@ -2454,7 +2454,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data)
   /* persist the scheme and handler the transfer is using */
   data->info.conn_scheme = data->conn->scheme->name;
   /* conn_protocol can only provide "old" protocols */
-  data->info.conn_protocol = (data->conn->scheme->protocol) & CURLPROTO_MASK;
+  data->info.conn_protocol = data->conn->scheme->protocol & CURLPROTO_MASK;
   data->info.used_proxy =
 #ifdef CURL_DISABLE_PROXY
     0

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -861,7 +861,7 @@ static int ssl_ui_reader(UI *ui, UI_STRING *uis)
   default:
     break;
   }
-  return (UI_method_get_reader(UI_OpenSSL()))(ui, uis);
+  return UI_method_get_reader(UI_OpenSSL())(ui, uis);
 }
 
 /*
@@ -880,7 +880,7 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
   default:
     break;
   }
-  return (UI_method_get_writer(UI_OpenSSL()))(ui, uis);
+  return UI_method_get_writer(UI_OpenSSL())(ui, uis);
 }
 
 /*

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -905,7 +905,7 @@ static int use_certificate_blob(SSL_CTX *ctx, const struct curl_blob *blob,
   X509 *x = NULL;
   /* the typecast of blob->len is fine since it is guaranteed to never be
      larger than CURL_MAX_INPUT_LENGTH */
-  BIO *in = BIO_new_mem_buf(blob->data, (int)(blob->len));
+  BIO *in = BIO_new_mem_buf(blob->data, (int)blob->len);
   if(!in)
     return CURLE_OUT_OF_MEMORY;
 
@@ -939,7 +939,7 @@ static int use_privatekey_blob(SSL_CTX *ctx, const struct curl_blob *blob,
 {
   int ret = 0;
   EVP_PKEY *pkey = NULL;
-  BIO *in = BIO_new_mem_buf(blob->data, (int)(blob->len));
+  BIO *in = BIO_new_mem_buf(blob->data, (int)blob->len);
   if(!in)
     return CURLE_OUT_OF_MEMORY;
 
@@ -967,7 +967,7 @@ static int use_certificate_chain_blob(SSL_CTX *ctx,
 {
   int ret = 0;
   X509 *x = NULL;
-  BIO *in = BIO_new_mem_buf(blob->data, (int)(blob->len));
+  BIO *in = BIO_new_mem_buf(blob->data, (int)blob->len);
   if(!in)
     return CURLE_OUT_OF_MEMORY;
 
@@ -1319,7 +1319,7 @@ static int pkcs12load(struct Curl_easy *data,
   int cert_done = 0;
   STACK_OF(X509) *ca = NULL;
   if(cert_blob) {
-    cert_bio = BIO_new_mem_buf(cert_blob->data, (int)(cert_blob->len));
+    cert_bio = BIO_new_mem_buf(cert_blob->data, (int)cert_blob->len);
     if(!cert_bio) {
       failf(data, "BIO_new_mem_buf NULL, " OSSL_PACKAGE " error %s",
             ossl_strerror(ERR_get_error(), error_buffer,

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -737,7 +737,7 @@ static CURLcode schannel_acquire_credential_handle(struct Curl_cfilter *cf,
   DWORD enabled_protocols = 0;
 
   struct schannel_ssl_backend_data *backend =
-    (struct schannel_ssl_backend_data *)(connssl->backend);
+    (struct schannel_ssl_backend_data *)connssl->backend;
 
   DEBUGASSERT(backend);
 

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -1031,7 +1031,7 @@ CURLcode Curl_ssl_scache_take(struct Curl_cfilter *cf,
     n = Curl_llist_head(&peer->sessions);
     if(n) {
       s = Curl_node_take_elem(n);
-      (scache->age)++;            /* increase general age */
+      scache->age++;           /* increase general age */
       peer->age = scache->age; /* set this as used in this age */
     }
   }

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -338,7 +338,7 @@ static SANITIZEcode rename_if_reserved_dos(char ** const sanitized,
              curl_strnequal(p, "PRN", 3) ||
              curl_strnequal(p, "AUX", 3) ||
              curl_strnequal(p, "NUL", 3)) ? 3 :
-            (curl_strnequal(p, "CLOCK$", 6)) ? 6 :
+             curl_strnequal(p, "CLOCK$", 6) ? 6 :
             (curl_strnequal(p, "COM", 3) || curl_strnequal(p, "LPT", 3)) ?
               (('1' <= p[3] && p[3] <= '9') ? 4 : 3) : 0;
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2145,7 +2145,7 @@ static ParameterError opt_bool(struct OperationConfig *config,
   case C_HEAD: /* --head */
     config->no_body = toggle;
     config->show_headers = toggle;
-    if(SetHTTPrequest((config->no_body) ? TOOL_HTTPREQ_HEAD :
+    if(SetHTTPrequest(config->no_body ? TOOL_HTTPREQ_HEAD :
                       TOOL_HTTPREQ_GET, &config->httpreq))
       return PARAM_BAD_USE;
     break;

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -602,7 +602,7 @@ void glob_cleanup(struct URLGlob *glob)
     for(i = 0; i < glob->pnum; i++) {
       DEBUGASSERT(glob->pattern[i].type);
       if((glob->pattern[i].type == GLOB_SET) &&
-         (glob->pattern[i].c.set.elem)) {
+         glob->pattern[i].c.set.elem) {
         curl_off_t elem;
         for(elem = 0; elem < glob->pattern[i].c.set.size; elem++)
           curlx_safefree(glob->pattern[i].c.set.elem[elem]);
@@ -636,7 +636,7 @@ CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
       pat = &glob->pattern[glob->pnum - 1 - i];
       switch(pat->type) {
       case GLOB_SET:
-        if((pat->c.set.elem) && (++pat->c.set.idx == pat->c.set.size)) {
+        if(pat->c.set.elem && (++pat->c.set.idx == pat->c.set.size)) {
           pat->c.set.idx = 0;
           carry = TRUE;
         }

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -251,7 +251,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
       break;
     case VAR_ERRORMSG:
       if(per_result) {
-        strinfo = (per->errorbuffer[0]) ? per->errorbuffer :
+        strinfo = per->errorbuffer[0] ? per->errorbuffer :
           curl_easy_strerror(per_result);
         valid = TRUE;
       }

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -242,7 +242,7 @@ static int t518_test_rlimit(int keep_open)
 
   /* verify that we do not overflow size_t in curlx_malloc() */
 
-  if((size_t)(t518_num_open.rlim_max) > ((size_t)-1) / sizeof(*t518_testfd)) {
+  if((size_t)t518_num_open.rlim_max > ((size_t)-1) / sizeof(*t518_testfd)) {
     tutil_rlim2str(strbuff1, sizeof(strbuff1), t518_num_open.rlim_max);
     curl_msnprintf(strbuff, sizeof(strbuff),
                    "unable to allocate an array for %s "
@@ -259,7 +259,7 @@ static int t518_test_rlimit(int keep_open)
   curl_mfprintf(stderr, "allocating array for %s file descriptors\n", strbuff);
 
   t518_testfd = curlx_malloc(sizeof(*t518_testfd) *
-                             (size_t)(t518_num_open.rlim_max));
+                             (size_t)t518_num_open.rlim_max);
   if(!t518_testfd) {
     t518_store_errmsg("testfd, malloc() failed", errno);
     curl_mfprintf(stderr, "%s\n", t518_msgbuff);

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -237,7 +237,7 @@ static int t537_test_rlimit(int keep_open)
 
   /* verify that we do not overflow size_t in curlx_malloc() */
 
-  if((size_t)(t537_num_open.rlim_max) > ((size_t)-1) / sizeof(*t537_testfd)) {
+  if((size_t)t537_num_open.rlim_max > ((size_t)-1) / sizeof(*t537_testfd)) {
     tutil_rlim2str(strbuff1, sizeof(strbuff1), t537_num_open.rlim_max);
     curl_msnprintf(strbuff, sizeof(strbuff),
                    "unable to allocate an array for %s "
@@ -256,7 +256,7 @@ static int t537_test_rlimit(int keep_open)
                   strbuff);
 
     t537_testfd = curlx_malloc(sizeof(*t537_testfd) *
-                               (size_t)(t537_num_open.rlim_max));
+                               (size_t)t537_num_open.rlim_max);
     if(!t537_testfd) {
       curl_mfprintf(stderr, "testfd, malloc() failed\n");
       t537_num_open.rlim_max /= 2;
@@ -338,7 +338,7 @@ static int t537_test_rlimit(int keep_open)
 
       tmpfd = curlx_realloc(t537_testfd,
                             sizeof(*t537_testfd) *
-                            (size_t)(t537_num_open.rlim_max));
+                            (size_t)t537_num_open.rlim_max);
       if(tmpfd) {
         t537_testfd = tmpfd;
         tmpfd = NULL;

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -253,7 +253,7 @@ static curl_socket_t socks4(curl_socket_t fd,
   }
   if(!s_config.port)
     s4port = (uint16_t)((buffer[SOCKS4_DSTPORT] << 8) |
-                        (buffer[SOCKS4_DSTPORT + 1]));
+                         buffer[SOCKS4_DSTPORT + 1]);
   else
     s4port = s_config.port;
 
@@ -500,7 +500,7 @@ static curl_socket_t sockit(curl_socket_t fd)
 
   if(!s_config.port) {
     const unsigned char *portp = &buffer[SOCKS5_DSTADDR + len];
-    s5port = (uint16_t)((portp[0] << 8) | (portp[1]));
+    s5port = (uint16_t)((portp[0] << 8) | portp[1]);
   }
   else
     s5port = s_config.port;


### PR DESCRIPTION
Flagged by clang-tidy 23.1.0 (`readability-redundant-parentheses`).

Also:
- examples/websocket: add missing parantheses.
