### PR TITLE
easy_lock: silence `portability-no-assembler` with clang-tidy 23.1.0+

### DIFF
--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -71,6 +71,7 @@ static CURL_INLINE void curl_simple_lock_lock(curl_simple_lock *lock)
 #ifdef HAVE_BUILTIN_IA32_PAUSE
       __builtin_ia32_pause();
 #elif defined(__aarch64__)
+      /* NOLINTNEXTLINE(portability-no-assembler) */
       __asm__ volatile("yield" ::: "memory");
 #elif defined(HAVE_SCHED_YIELD)
       sched_yield();


### PR DESCRIPTION
```
lib/easy_lock.h:74:7: warning: do not use inline assembler in safety-critical code [portability-no-assembler]
   74 |       __asm__ volatile("yield" ::: "memory");
      |       ^
```
