### PR TITLE
hsts: keep a specific host loaded after a superdomain entry

### DIFF
--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -462,8 +462,11 @@ static CURLcode hsts_add_host_expire(struct hsts *h,
     hostlen--;
 
   if(hostlen) {
-    /* only add it if not already present */
-    e = hsts_check(h, host, hostlen, subdomain);
+    /* Only update an entry for the exact same host. A superdomain entry with
+       includeSubDomains must not swallow a more specific host here, or the
+       specific entry gets dropped and cannot outlive the superdomain one. The
+       header ingestion path checks for an exact match the same way. */
+    e = hsts_check(h, host, hostlen, FALSE);
     if(!e)
       result = hsts_create(h, host, hostlen, subdomain, expires);
     /* 'host' is not necessarily null-terminated */

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -38,6 +38,27 @@ static void showsts(struct stsentry *e, const char *chost)
   }
 }
 
+/* feeds a superdomain includeSubDomains entry first, then a more specific
+   host, both via the HSTS read callback (the load path) */
+static const char * const hsts_load_hosts[] = {
+  "example.hsts",
+  "sub.example.hsts"
+};
+
+static CURLSTScode hsts_load_cb(CURL *easy, struct curl_hstsentry *e,
+                                void *userp)
+{
+  size_t *idx = userp;
+  (void)easy;
+  if(*idx >= sizeof(hsts_load_hosts) / sizeof(hsts_load_hosts[0]))
+    return CURLSTS_DONE;
+  curl_msnprintf(e->name, e->namelen, "%s", hsts_load_hosts[*idx]);
+  e->includeSubDomains = 1;
+  curl_msnprintf(e->expire, sizeof(e->expire), "%s", "20211001 04:47:41");
+  (*idx)++;
+  return CURLSTS_OK;
+}
+
 static CURLcode test_unit1660(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
@@ -158,6 +179,21 @@ static CURLcode test_unit1660(const char *arg)
   fail_if(!e, "recognized directive after unknown directive was ignored");
   result = Curl_hsts_parse(h, "unknown.example", "max-age=0");
   fail_if(result, "failed to remove HSTS test entry");
+
+  /* A more specific host loaded after an includeSubDomains superdomain must
+     keep its own entry instead of being swallowed by the superdomain. */
+  {
+    size_t cbidx = 0;
+    curl_easy_setopt(easy, CURLOPT_HSTSREADFUNCTION, hsts_load_cb);
+    curl_easy_setopt(easy, CURLOPT_HSTSREADDATA, &cbidx);
+    result = Curl_hsts_loadcb(easy, h);
+    fail_if(result, "Curl_hsts_loadcb failed");
+    e = hsts_check(h, "sub.example.hsts", strlen("sub.example.hsts"), FALSE);
+    fail_if(!e, "specific HSTS host dropped by superdomain on load");
+    curl_easy_setopt(easy, CURLOPT_HSTSREADFUNCTION, (void *)NULL);
+    (void)Curl_hsts_parse(h, "example.hsts", "max-age=0");
+    (void)Curl_hsts_parse(h, "sub.example.hsts", "max-age=0");
+  }
 
   curl_mprintf("Number of entries: %zu\n", Curl_llist_count(&h->list));
 

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -50,7 +50,7 @@ static CURLSTScode hsts_load_cb(CURL *easy, struct curl_hstsentry *e,
 {
   size_t *idx = userp;
   (void)easy;
-  if(*idx >= sizeof(hsts_load_hosts) / sizeof(hsts_load_hosts[0]))
+  if(*idx >= CURL_ARRAYSIZE(hsts_load_hosts))
     return CURLSTS_DONE;
   curl_msnprintf(e->name, e->namelen, "%s", hsts_load_hosts[*idx]);
   e->includeSubDomains = 1;


### PR DESCRIPTION
Repro: with `CURLOPT_HSTS` persistence, learn `includeSubDomains` HSTS for `example.com` then for `sub.example.com`, then save and reload the cache.

Cause: `hsts_add_host_expire` dedupes the loaded entry with `hsts_check(h, host, hostlen, subdomain)`; when the new entry has `includeSubDomains` and a superdomain entry already exists, the tail match returns the superdomain, so neither the create nor the exact-host update branch runs and the more specific host is dropped. `sub.example.com` then survives only as long as the `example.com` entry does, and loses its pin once that is cleared with `max-age=0` or expires.

Fix: dedupe against an exact-host match with `FALSE`, the same way the `Curl_hsts_parse` header path already does. Covered by a regression in unit `1660` that drives the read-callback load path.