### PR TITLE
winsock: drop redundant version checks at initialization

### DIFF
--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -38,33 +38,8 @@ CURLcode Curl_win32_init(long flags)
      should take place after this block. */
   if(flags & CURL_GLOBAL_WIN32) {
 #ifdef USE_WINSOCK
-    WORD wVersionRequested;
-    WSADATA wsaData;
-    int res;
-
-    wVersionRequested = MAKEWORD(2, 2);
-    res = WSAStartup(wVersionRequested, &wsaData);
-
-    if(res)
-      /* Tell the user that we could not find a usable */
-      /* winsock.dll. */
-      return CURLE_FAILED_INIT;
-
-    /* Confirm that the Windows Sockets DLL supports what we need.*/
-    /* Note that if the DLL supports versions greater */
-    /* than wVersionRequested, it will still return */
-    /* wVersionRequested in wVersion. wHighVersion contains the */
-    /* highest supported version. */
-
-    if(LOBYTE(wsaData.wVersion) != LOBYTE(wVersionRequested) ||
-       HIBYTE(wsaData.wVersion) != HIBYTE(wVersionRequested)) {
-      /* Tell the user that we could not find a usable */
-
-      /* winsock.dll. */
-      WSACleanup();
-      return CURLE_FAILED_INIT;
-    }
-    /* The Windows Sockets DLL is acceptable. Proceed. */
+    WSADATA wsa;
+    (void)WSAStartup(MAKEWORD(2, 2), &wsa);
 #elif defined(USE_LWIPSOCK)
     lwip_init();
 #endif

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -39,7 +39,8 @@ CURLcode Curl_win32_init(long flags)
   if(flags & CURL_GLOBAL_WIN32) {
 #ifdef USE_WINSOCK
     WSADATA wsa;
-    (void)WSAStartup(MAKEWORD(2, 2), &wsa);
+    if(WSAStartup(MAKEWORD(2, 2), &wsa))
+      return CURLE_FAILED_INIT;
 #elif defined(USE_LWIPSOCK)
     lwip_init();
 #endif

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -134,7 +134,13 @@ int win32_init(void)
 #ifdef USE_WINSOCK
   {
     WSADATA wsa;
-    (void)WSAStartup(MAKEWORD(2, 2), &wsa);
+    if(WSAStartup(MAKEWORD(2, 2), &wsa)) {
+      char buffer[STRERROR_LEN];
+      curlx_strerror(SOCKERRNO, buffer, sizeof(buffer));
+      fprintf(stderr, "Winsock init failed: %s\n", buffer);
+      logmsg("Error initializing Winsock -- aborting");
+      return 1;
+    }
   }
 #endif
   atexit(win32_cleanup);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -133,30 +133,10 @@ int win32_init(void)
   curlx_now_init();
 #ifdef USE_WINSOCK
   {
-    WORD wVersionRequested;
-    WSADATA wsaData;
-    int err;
-    char buffer[STRERROR_LEN];
-
-    wVersionRequested = MAKEWORD(2, 2);
-    err = WSAStartup(wVersionRequested, &wsaData);
-    if(err) {
-      curlx_strerror(SOCKERRNO, buffer, sizeof(buffer));
-      fprintf(stderr, "Winsock init failed: %s\n", buffer);
-      logmsg("Error initializing Winsock -- aborting");
-      return 1;
-    }
-
-    if(LOBYTE(wsaData.wVersion) != LOBYTE(wVersionRequested) ||
-       HIBYTE(wsaData.wVersion) != HIBYTE(wVersionRequested)) {
-      WSACleanup();
-      curlx_strerror(SOCKERRNO, buffer, sizeof(buffer));
-      fprintf(stderr, "Winsock init failed: %s\n", buffer);
-      logmsg("No suitable winsock.dll found -- aborting");
-      return 1;
-    }
+    WSADATA wsa;
+    (void)WSAStartup(MAKEWORD(2, 2), &wsa);
   }
-#endif /* USE_WINSOCK */
+#endif
   atexit(win32_cleanup);
   return 0;
 }


### PR DESCRIPTION
All supported Windows versions (Vista+) support Winsock 2.2, therefore
these checks always succeed for a binary that loaded and started up
successfully.

Ref: https://learn.microsoft.com/windows/win32/api/winsock/nf-winsock-wsastartup
