### PR TITLE
cf-socket: avoid broken NetBSD SOCK_NONBLOCK

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1143,7 +1143,7 @@ static int cf_socktype(int x)
 #ifdef SOCK_CLOEXEC
   x &= ~SOCK_CLOEXEC;
 #endif
-#ifdef SOCK_NONBLOCK
+#ifdef CURL_USE_SOCK_NONBLOCK
   x &= ~SOCK_NONBLOCK;
 #endif
   return x;
@@ -1205,7 +1205,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
 
   DEBUGASSERT(ctx->sock == CURL_SOCKET_BAD);
   ctx->started_at = *Curl_pgrs_now(data);
-#ifdef SOCK_NONBLOCK
+#ifdef CURL_USE_SOCK_NONBLOCK
   /* Do not tuck SOCK_NONBLOCK into socktype when opensocket callback is set
    * because we would not know how socktype is about to be used in the
    * callback, SOCK_NONBLOCK might get factored out before calling socket().
@@ -1214,7 +1214,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
     ctx->addr.socktype |= SOCK_NONBLOCK;
 #endif
   result = socket_open(data, &ctx->addr, &ctx->sock);
-#ifdef SOCK_NONBLOCK
+#ifdef CURL_USE_SOCK_NONBLOCK
   /* Restore the socktype after the socket is created. */
   if(!data->set.fopensocket)
     ctx->addr.socktype &= ~SOCK_NONBLOCK;
@@ -1315,7 +1315,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   }
 #endif
 
-#ifndef SOCK_NONBLOCK
+#ifndef CURL_USE_SOCK_NONBLOCK
   /* Set socket non-blocking, must be a non-blocking socket for
    * a non-blocking connect. */
   error = curlx_nonblock(ctx->sock, TRUE);

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1622,7 +1622,7 @@ typedef struct sockaddr_un {
 /* For FreeBSD it is included from curl/curl.h */
 #if defined(__DragonFly__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <sys/param.h>  /* for __DragonFly_version, OpenBSD,
-                            __NetBSD_Version__ */
+                           __NetBSD_Version__ */
 #endif
 
 /* NetBSD before 6.1 did not set SS_NBIO for SOCK_NONBLOCK. */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1625,9 +1625,9 @@ typedef struct sockaddr_un {
                             __NetBSD_Version__ */
 #endif
 
-/* NetBSD before 6.0.7 did not set SS_NBIO for SOCK_NONBLOCK. */
+/* NetBSD before 6.1 did not set SS_NBIO for SOCK_NONBLOCK. */
 #if defined(SOCK_NONBLOCK) && \
-  (!defined(__NetBSD__) || (__NetBSD_Version__ >= 600000700))
+  (!defined(__NetBSD__) || (__NetBSD_Version__ >= 601000000))
 #define CURL_USE_SOCK_NONBLOCK
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1622,7 +1622,13 @@ typedef struct sockaddr_un {
 /* For FreeBSD it is included from curl/curl.h */
 #if defined(__DragonFly__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <sys/param.h>  /* for __DragonFly_version, OpenBSD,
-                           __NetBSD_Version__ */
+                            __NetBSD_Version__ */
+#endif
+
+/* NetBSD before 6.0.7 did not set SS_NBIO for SOCK_NONBLOCK. */
+#if defined(SOCK_NONBLOCK) && \
+  (!defined(__NetBSD__) || (__NetBSD_Version__ >= 600000700))
+#define CURL_USE_SOCK_NONBLOCK
 #endif
 
 #ifndef _CURL_LOCAL_MEMZERO /* to be removed after a couple of releases */

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -96,14 +96,14 @@ static int wakeup_socketpair(curl_socket_t socks[2], bool nonblocking)
 #ifdef SOCK_CLOEXEC
   type |= SOCK_CLOEXEC;
 #endif
-#ifdef SOCK_NONBLOCK
+#ifdef CURL_USE_SOCK_NONBLOCK
   if(nonblocking)
     type |= SOCK_NONBLOCK;
 #endif
 
   if(CURL_SOCKETPAIR(AF_UNIX, type, 0, socks))
     return -1;
-#ifndef SOCK_NONBLOCK
+#ifndef CURL_USE_SOCK_NONBLOCK
   if(nonblocking) {
     if(curlx_nonblock(socks[0], TRUE) < 0 ||
        curlx_nonblock(socks[1], TRUE) < 0) {

--- a/tests/libtest/lib1662.c
+++ b/tests/libtest/lib1662.c
@@ -34,13 +34,13 @@ static size_t t1662_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 
   struct t1662_WriteThis *pooh = (struct t1662_WriteThis *)userp;
 
-  if(size * nmemb < testdatalen)
+  if(size * nmemb < 1)
     return 0;
 
   if(pooh->sizeleft) {
-    memcpy(ptr, testdata, testdatalen);
-    pooh->sizeleft = 0;
-    return testdatalen;
+    *ptr = testdata[testdatalen - pooh->sizeleft];
+    --pooh->sizeleft;
+    return 1;
   }
 
   return 0;                         /* no more data left to deliver */
@@ -52,7 +52,7 @@ static CURLcode test_lib1662(const char *URL)
   CURL *curl;
   curl_mime *mime1;
   curl_mimepart *part1;
-  struct t1662_WriteThis pooh = { 1 };
+  struct t1662_WriteThis pooh = { CURL_CSTRLEN("mooaaa") };
 
   mime1 = NULL;
 


### PR DESCRIPTION
## What does this PR do?

Avoid `SOCK_NONBLOCK` at socket creation on NetBSD releases before 6.1.
Those kernels expose the flag but do not set the socket-layer `SS_NBIO`
state, allowing a supposedly nonblocking `recv()` to block. curl now creates
a plain socket and applies its existing `curlx_nonblock()` fallback there.

The same guard is used for connection sockets and wakeup socket pairs. Existing
test1662 now returns its known-size MIME body one byte at a time to exercise
continued uploads after short callback reads.

Fixes #22586

## How was it tested?

- Reproduced with curl 8.21.0 and current master on NetBSD 6.0.1 i386.
- Verified `1025/1024`, `10/1`, and `10000/1` callback/read-size cases twice
  each after the fix.
- Built with `--enable-debug --enable-werror`.
- `make test TFLAGS='1662 668'`
- `make checksrc`
- `make test-ci`: 1665/1665 reported OK.

Assisted by an LLM; reproduced, fixed and tested locally by the author.
