### PR TITLE
lib: drop unused `system_win32.h` includes

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -78,7 +78,6 @@
 #include "rand.h"
 #include "sockaddr.h"
 #include "curlx/strdup.h"
-#include "system_win32.h"
 #include "curlx/nonblock.h"
 #include "curlx/strcopy.h"
 #include "curlx/version_win32.h"

--- a/lib/curlx/timeval.c
+++ b/lib/curlx/timeval.c
@@ -25,8 +25,6 @@
 
 #ifdef _WIN32
 
-#include "system_win32.h"
-
 static LARGE_INTEGER s_time_freq;
 
 /* For tool or tests, we must initialize before calling curlx_now().

--- a/lib/url.c
+++ b/lib/url.c
@@ -83,7 +83,6 @@
 #include "getinfo.h"
 #include "pop3.h"
 #include "urlapi-int.h"
-#include "system_win32.h"
 #include "hsts.h"
 #include "proxy.h"
 #include "cfilters.h"

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -48,7 +48,6 @@
 #include "curlx/fopen.h"
 #include "curlx/multibyte.h"
 #include "vtls/x509asn1.h"
-#include "system_win32.h"
 #include "curlx/version_win32.h"
 #include "curlx/winapi.h"
 #include "curlx/strparse.h"


### PR DESCRIPTION
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
