### PR TITLE
GHA/non-native: disable riscv64 FreeBSD job due to upstream issue

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -75,9 +75,9 @@ jobs:
               install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
 
-          - { os: 'freebsd'     , version: '15.1',  build: 'cmake'    , arch: 'riscv64', cc: 'clang', desc: 'openssl !examples', tflags: 'HTTP --min=0 --subset=0/10 -R --seed',
-              install: 'cmake-core ninja perl5',
-              options: '-D_CURL_PREFILL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF -DCURL_DISABLE_HTTPSIG=OFF -DCURL_DISABLE_TYPECHECK=ON' }
+          # { os: 'freebsd'     , version: '15.1',  build: 'cmake'    , arch: 'riscv64', cc: 'clang', desc: 'openssl !examples', tflags: 'HTTP --min=0 --subset=0/10 -R --seed',
+          #   install: 'cmake-core ninja perl5',
+          #   options: '-D_CURL_PREFILL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF -DCURL_DISABLE_HTTPSIG=OFF -DCURL_DISABLE_TYPECHECK=ON' }
 
           - { os: 'freebsd'     , version: '14.3',  build: 'autotools', arch: 'arm64'  , cc: 'clang', desc: 'openssl !examples', tflags: 'skipall',
               install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel',


### PR DESCRIPTION
CI jobs fail early with these errors:
```
pkg: https://cross-platform-actions.github.io/freebsd-pkg-repo/FreeBSD:15:riscv64/meta.txz: Not Found
pkg: https://cross-platform-actions.github.io/freebsd-pkg-repo/FreeBSD:15:riscv64/data.pkg: Not Found
pkg: https://cross-platform-actions.github.io/freebsd-pkg-repo/FreeBSD:15:riscv64/data.tzst: Not Found
pkg: https://cross-platform-actions.github.io/freebsd-pkg-repo/FreeBSD:15:riscv64/packagesite.pkg: Not Found
pkg: https://cross-platform-actions.github.io/freebsd-pkg-repo/FreeBSD:15:riscv64/packagesite.tzst: Not Found
```
Ref: https://github.com/curl/curl/actions/runs/33252993091/job/99101785035#step:4:35 (first seen)

Ref: https://github.com/cross-platform-actions/action/issues/166
Follow-up to 9f05091b596e3015bf214ea15f6c56f6eb7647f6 #22748

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
