### PR TITLE
clock: save one call

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -108,6 +108,12 @@ timediff_t Curl_timeleft_ms(struct Curl_easy *data)
   return timeleft_now_ms(data, Curl_pgrs_now(data));
 }
 
+timediff_t Curl_timeleft_now_ms(struct Curl_easy *data,
+                                const struct curltime *pnow)
+{
+  return timeleft_now_ms(data, pnow);
+}
+
 void Curl_shutdown_start(struct Curl_easy *data, int8_t sockindex,
                          int timeout_ms)
 {

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -36,6 +36,8 @@ enum alpnid Curl_alpn2alpnid(const unsigned char *name, size_t len);
 /* generic function that returns how much time there is left to run, according
    to the timeouts set */
 timediff_t Curl_timeleft_ms(struct Curl_easy *data);
+timediff_t Curl_timeleft_now_ms(struct Curl_easy *data,
+                                const struct curltime *pnow);
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1828,12 +1828,13 @@ static CURLcode multi_do_more(struct Curl_easy *data, domore *complete)
  * Check whether a timeout occurred, and handle it if it did
  */
 static bool multi_handle_timeout(struct Curl_easy *data,
+                                 const struct curltime *pnow,
                                  bool *stream_error,
                                  CURLcode *result)
 {
   timediff_t timeout_ms;
 
-  timeout_ms = Curl_timeleft_ms(data);
+  timeout_ms = Curl_timeleft_now_ms(data, pnow);
   if(timeout_ms < 0) {
     /* Handle timed out */
     timerid base_timer = Curl_is_connecting(data) ?
@@ -2373,6 +2374,7 @@ static CURLMcode multistate_connect(struct Curl_multi *multi,
 /* returns the possibly updated result */
 static CURLcode is_finished(struct Curl_multi *multi,
                             struct Curl_easy *data,
+                            const struct curltime *pnow,
                             bool stream_error,
                             CURLcode result)
 {
@@ -2413,7 +2415,7 @@ static CURLcode is_finished(struct Curl_multi *multi,
     }
     /* if there is still a connection to use, call the progress function */
     else if(data->conn && Curl_conn_is_connected(data->conn, FIRSTSOCKET)) {
-      result = Curl_pgrsUpdate(data);
+      result = Curl_pgrsUpdateX(data, pnow);
       if(result) {
         /* aborted due to progress callback return code must close the
            connection */
@@ -2721,6 +2723,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 {
   CURLMcode mresult = CURLM_OK;
   CURLcode result = CURLE_OK;
+  const struct curltime *pnow = NULL;
 
   if(multi->dead) {
     /* a multi-level callback returned error before, meaning every individual
@@ -2756,6 +2759,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
        (HTTP/2), or the full connection for older protocols */
     bool stream_error = FALSE;
     mresult = CURLM_OK;
+    pnow = NULL;
 
     if(multi_ischanged(multi, TRUE)) {
       CURL_TRC_M(data, "multi changed, check CONNECT_PEND queue");
@@ -2774,10 +2778,13 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     /* Wait for the connect state as only then is the start time stored, but
        we must not check already completed handles */
-    if((data->mstate >= MSTATE_CONNECT) && (data->mstate < MSTATE_COMPLETED) &&
-       multi_handle_timeout(data, &stream_error, &result))
-      /* Skip the statemachine and go directly to error handling section. */
-      goto statemachine_end;
+    if((data->mstate >= MSTATE_CONNECT) && (data->mstate < MSTATE_COMPLETED)) {
+      pnow = Curl_pgrs_now(data);
+      if(multi_handle_timeout(data, pnow, &stream_error, &result))
+        /* Skip the statemachine and go directly to error handling section. */
+        goto statemachine_end;
+      pnow = NULL;
+    }
 
     switch(data->mstate) {
     case MSTATE_INIT:
@@ -2865,12 +2872,14 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
        * (i.e. CURLM_CALL_MULTI_PERFORM == TRUE) then we should do that before
        * declaring the connection timed out as we may almost have a completed
        * connection. */
-      multi_handle_timeout(data, &stream_error, &result);
+      pnow = Curl_pgrs_now(data);
+      multi_handle_timeout(data, pnow, &stream_error, &result);
     }
 
 statemachine_end:
-
-    result = is_finished(multi, data, stream_error, result);
+    if(!pnow)
+      pnow = Curl_pgrs_now(data);
+    result = is_finished(multi, data, pnow, stream_error, result);
     if(result)
       mresult = CURLM_CALL_MULTI_PERFORM;
 
@@ -2943,7 +2952,8 @@ static CURLMcode multi_perform(struct Curl_multi *multi,
     if(data->mstate == MSTATE_PENDING) {
       bool stream_unused;
       CURLcode result_unused;
-      if(multi_handle_timeout(data, &stream_unused, &result_unused)) {
+      if(multi_handle_timeout(data, multi_now(multi),
+                              &stream_unused, &result_unused)) {
         infof(data, "PENDING handle timeout");
         move_pending_to_connect(multi, data);
       }

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -715,6 +715,12 @@ CURLcode Curl_pgrsUpdate(struct Curl_easy *data)
   return pgrs_update(data, Curl_pgrs_now(data));
 }
 
+CURLcode Curl_pgrsUpdateX(struct Curl_easy *data,
+                          const struct curltime *pnow)
+{
+  return pgrs_update(data, pnow);
+}
+
 CURLcode Curl_pgrsCheck(struct Curl_easy *data)
 {
   CURLcode result;

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -57,6 +57,7 @@ void Curl_pgrsSetUploadCounter(struct Curl_easy *data, curl_off_t size);
 
 /* perform progress update, invoking callbacks at intervals */
 CURLcode Curl_pgrsUpdate(struct Curl_easy *data);
+CURLcode Curl_pgrsUpdateX(struct Curl_easy *data, const struct curltime *pnow);
 /* perform progress update, no callbacks invoked */
 void Curl_pgrsUpdate_nometer(struct Curl_easy *data);
 /* perform progress update with callbacks and speed checks */


### PR DESCRIPTION
When multi is processing a transfer, it assesses its timeleft and does a progress update repeatedly. Both got a fresh timestamp, but can use the same one. Change implementation for that.

