### PR TITLE
CURL_EASY_STR_SET, add length

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -81,11 +81,12 @@ static CURLcode setopt_set_timeout_ms(timediff_t *ptimeout_ms, long ms)
 CURLcode Curl_setstropt(struct Curl_easy *data,
                         enum dupstring id, const char *s)
 {
+  size_t slen = s ? strlen(s) : 0;
   DEBUGASSERT((unsigned)id <= UINT8_MAX);
-  if(s && (strlen(s) > CURL_MAX_INPUT_LENGTH))
+  if(s && (slen > CURL_MAX_INPUT_LENGTH))
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
-  return CURL_EASY_STR_SET(data, (uint8_t)id, s);
+  return CURL_EASY_STR_SET(data, (uint8_t)id, s, slen);
 }
 
 CURLcode Curl_setblobopt(struct curl_blob **blobp,
@@ -2499,24 +2500,25 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 {
   typedef CURLcode (*ptrfunc)(struct Curl_easy *data, CURLoption option,
                               char *ptr);
+  /* Order by likeliness */
   static const ptrfunc setopt_call[] = {
+    setopt_cptr_misc,
+#if defined(USE_SSL) || defined(USE_SSH)
+    setopt_cptr_ssl,
+#endif
 #ifndef CURL_DISABLE_PROXY
     setopt_cptr_proxy,
 #endif
-#if defined(USE_SSL) || defined(USE_SSH)
-    setopt_cptr_ssl,
+    setopt_cptr_net,
+#ifndef CURL_DISABLE_FTP
+    setopt_cptr_ftp,
 #endif
 #ifdef USE_SSH
     setopt_cptr_ssh,
 #endif
-#ifndef CURL_DISABLE_FTP
-    setopt_cptr_ftp,
-#endif
 #if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_MQTT)
     setopt_cptr_http_mqtt,
 #endif
-    setopt_cptr_net,
-    setopt_cptr_misc,
   };
   size_t i;
 

--- a/lib/uint-hashset.c
+++ b/lib/uint-hashset.c
@@ -24,6 +24,7 @@
 #include "curl_setup.h"
 
 #include "uint-hashset.h"
+#include "curlx/strdup.h"
 
 /* random patterns for API verification */
 #ifdef DEBUGBUILD
@@ -237,8 +238,8 @@ CURLcode Curl_u8_strset_setn(struct u8_strset *set,
 }
 
 
-CURLcode Curl_u8_strset_set(struct u8_strset *set,
-                            uint8_t id, const char *str)
+CURLcode Curl_u8_strset_setx(struct u8_strset *set,
+                             uint8_t id, const char *str, size_t slen)
 {
   char *val;
 
@@ -248,10 +249,16 @@ CURLcode Curl_u8_strset_set(struct u8_strset *set,
     return CURLE_OK;
   }
 
-  val = curlx_strdup(str);
+  val = curlx_memdup0(str, slen);
   if(!val)
     return CURLE_OUT_OF_MEMORY;
   return Curl_u8_strset_setn(set, id, val);
+}
+
+CURLcode Curl_u8_strset_set(struct u8_strset *set,
+                            uint8_t id, const char *str)
+{
+  return Curl_u8_strset_setx(set, id, str, str ? strlen(str) : 0);
 }
 
 static void u8_strset_unset(struct u8_strset *set, uint8_t id, bool zero)

--- a/lib/uint-hashset.h
+++ b/lib/uint-hashset.h
@@ -67,6 +67,8 @@ const char *Curl_u8_strset_get(struct u8_strset *set, uint8_t id);
 /* Set string for id, makes a copy. */
 CURLcode Curl_u8_strset_set(struct u8_strset *set,
                             uint8_t id, const char *str);
+CURLcode Curl_u8_strset_setx(struct u8_strset *set,
+                             uint8_t id, const char *str, size_t slen);
 /* Set string for id, takes ownership of `str` even on failure. */
 CURLcode Curl_u8_strset_setn(struct u8_strset *set,
                              uint8_t id, char *str);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1226,8 +1226,8 @@ struct Curl_easy {
 
 #define CURL_EASY_STR(d, id) \
         Curl_u8_strset_get(&(d)->set.strings, (uint8_t)(id))
-#define CURL_EASY_STR_SET(d, id, s) \
-        Curl_u8_strset_set(&(d)->set.strings, (uint8_t)(id), (s))
+#define CURL_EASY_STR_SET(d, id, s, slen) \
+        Curl_u8_strset_setx(&(d)->set.strings, (uint8_t)(id), (s), (slen))
 #define CURL_EASY_STR_SETN(d, id, s) \
         Curl_u8_strset_setn(&(d)->set.strings, (uint8_t)(id), (s))
 #define CURL_EASY_STR_CLEAR(d, id) \


### PR DESCRIPTION
Since we check the input lengths of strings before setting, pass the known length to the hash set.

