### PR TITLE
transfer: DID handling

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2677,8 +2677,11 @@ static CURLMcode multistate_did(struct Curl_multi *multi,
      CONN_SOCK_IDX_VALID(data->conn->send_idx)) {
     multistate(data, MSTATE_PERFORMING);
     /* Do not return CURLM_CALL_MULTI_PERFORM to give other transfers
-     * a chance to send of their requests. */
-    return (multi->xfers_alive > 1) ?
+     * a chance to send of their requests.
+     * Note: Some SFTP handlers do not seem to like this.
+     *       Restrict it to HTTP families. */
+    return ((multi->xfers_alive > 1) &&
+            (data->conn->scheme->protocol & PROTO_FAMILY_HTTP)) ?
            CURLM_OK : CURLM_CALL_MULTI_PERFORM;
   }
   else {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2677,7 +2677,7 @@ static CURLMcode multistate_did(struct Curl_multi *multi,
      CONN_SOCK_IDX_VALID(data->conn->send_idx)) {
     multistate(data, MSTATE_PERFORMING);
     /* Do not return CURLM_CALL_MULTI_PERFORM to give other transfers
-     * a chance to send of their requests.
+     * a chance to send off their requests.
      * Note: Some SFTP handlers do not seem to like this.
      *       Restrict it to HTTP families. */
     return ((multi->xfers_alive > 1) &&

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2674,8 +2674,13 @@ static CURLMcode multistate_did(struct Curl_multi *multi,
   /* Only perform the transfer if there is a good socket to work with.
      Having both BAD is a signal to skip immediately to DONE */
   if(CONN_SOCK_IDX_VALID(data->conn->recv_idx) ||
-     CONN_SOCK_IDX_VALID(data->conn->send_idx))
+     CONN_SOCK_IDX_VALID(data->conn->send_idx)) {
     multistate(data, MSTATE_PERFORMING);
+    /* Do not return CURLM_CALL_MULTI_PERFORM to give other transfers
+     * a chance to send of their requests. */
+    return (multi->xfers_alive > 1) ?
+           CURLM_OK : CURLM_CALL_MULTI_PERFORM;
+  }
   else {
 #ifndef CURL_DISABLE_FTP
     if(data->state.wildcardmatch &&
@@ -2684,8 +2689,8 @@ static CURLMcode multistate_did(struct Curl_multi *multi,
     }
 #endif
     multistate(data, MSTATE_DONE);
+    return CURLM_CALL_MULTI_PERFORM;
   }
-  return CURLM_CALL_MULTI_PERFORM;
 }
 
 static CURLMcode multistate_done(struct Curl_easy *data, CURLcode *presult)


### PR DESCRIPTION
When a transfer leaves its DID state and goes to PERFORM, it should not hog the multi processing when there are other transfers alive. Make multistate_did() return CURLM_OK then which triggers the processing of the next easy handle.

This gives more fairness among easy handles:
- on a fast server, responses may arrive very quickly and processing a response is costly. All this time is then lost to other transfers that have not even sent their request
- on a slow server, directly trying to receive the response will not work and is an unnecessary network call.

Local scorecard tests with h1 requests showed that the former handling was only using 10 connections for 40 parallel requests after an initial peak of 40 connections. The change makes libcurl use all 40 connections continuously.

This also explains the h1-requests memory use development. When we closed connections more aggressively, the 40 initial connections shrank and released their memory. But the parallelism was not good.

