### PR TITLE
perf: restore the -DDEBUGBUILD for debug builds

### DIFF
--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -51,6 +51,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/src"            # for toolx
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )
+target_compile_definitions(${BUNDLE} PRIVATE ${CURL_DEBUG_MACROS})
 set_target_properties(${BUNDLE} PROPERTIES OUTPUT_NAME "${BUNDLE}" PROJECT_LABEL "Test ${BUNDLE}" UNITY_BUILD OFF)
 
 if(NOT _CURL_TESTS_CONCAT)

--- a/tests/perf/Makefile.am
+++ b/tests/perf/Makefile.am
@@ -50,6 +50,10 @@ CFLAGS += @CURL_CFLAG_EXTRAS@
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 
+if DEBUGBUILD
+AM_CPPFLAGS += -DDEBUGBUILD
+endif
+
 if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 curlx_c_lib =

--- a/tests/perf/base64.c
+++ b/tests/perf/base64.c
@@ -48,7 +48,7 @@ static int test_base64(int argc, const char **argv)
 
   start = curlx_now();
   for(loop = 0; loop < loops; loop++) {
-    char *encoded;
+    char *encoded = NULL;
     size_t enclen;
     CURLcode result =
       curlx_base64_encode(array, sizeof(array), &encoded, &enclen);


### PR DESCRIPTION
Otherwise the base64 test segfaults

