### PR TITLE
sspi ambient user checks: remove again

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -897,31 +897,6 @@ static bool url_match_ssl_config(struct connectdata *conn,
   return TRUE;
 }
 
-#if defined(USE_SPNEGO) || defined(USE_NTLM)
-static bool url_allow_sspi_empty_creds(struct Curl_creds *conn_creds,
-                                       struct Curl_easy *data,
-                                       struct connectdata *conn)
-{
-#ifdef USE_WINDOWS_SSPI
-  /* Empty user: SSPI on Windows can make use of an "ambient"
-   * user from a "SecurityToken" associated with the current thread or
-   * process. This token can be switched at any time. We are therefore
-   * not able to find out reliably what token the connection really
-   * used, nor what token in the next connect attempt will use.
-   * To avoid TOCTOU attacks, do not reuse on empty credentials
-   * UNLESS this connection is the one used by this transfer before. */
-  if(!Curl_creds_has_user(conn_creds) &&
-     (data->state.lastconnect_id != conn->connection_id))
-    return FALSE;
-#else
-  (void)conn_creds;
-  (void)data;
-  (void)conn;
-#endif
-  return TRUE;
-}
-#endif /* USE_SPNEGO || USE_NTLM */
-
 #ifdef USE_NTLM
 static bool url_match_auth_ntlm(struct connectdata *conn,
                                 struct url_conn_match *m)
@@ -932,9 +907,6 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
     if(!m->want_ntlm_http ||
        !Curl_creds_same(conn->creds, m->data->state.creds) ||
        !Curl_peer_equal(conn->creds_origin, m->data->state.origin))
-      return FALSE;
-    /* Empty credentials need more careful matching for WINDOWS_SSPI */
-    if(!url_allow_sspi_empty_creds(conn->creds, m->data, conn))
       return FALSE;
   }
   else if(m->want_ntlm_http) {
@@ -951,9 +923,6 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
   if(conn->proxy_ntlm_state != NTLMSTATE_NONE) {
     if(!m->want_proxy_ntlm_http ||
        !Curl_creds_same(m->needle->http_proxy.creds, conn->http_proxy.creds))
-      return FALSE;
-    if(!url_allow_sspi_empty_creds(m->needle->http_proxy.creds,
-                                   m->data, conn))
       return FALSE;
   }
   else if(m->want_proxy_ntlm_http) {
@@ -997,8 +966,6 @@ static bool url_match_auth_nego(struct connectdata *conn,
        !Curl_creds_same(conn->creds, m->data->state.creds) ||
        !Curl_peer_equal(conn->creds_origin, m->data->state.origin))
       return FALSE;
-    if(!url_allow_sspi_empty_creds(conn->creds, m->data, conn))
-      return FALSE;
   }
   else if(m->want_nego_http) {
     /* Transfer wants Negotiate, connection is not using it.
@@ -1014,9 +981,6 @@ static bool url_match_auth_nego(struct connectdata *conn,
   if(conn->proxy_negotiate_state != GSS_AUTHNONE) {
     if(!m->want_proxy_nego_http ||
        !Curl_creds_same(m->needle->http_proxy.creds, conn->http_proxy.creds))
-      return FALSE;
-    if(!url_allow_sspi_empty_creds(m->needle->http_proxy.creds,
-                                   m->data, conn))
       return FALSE;
   }
   else if(m->want_proxy_nego_http) {


### PR DESCRIPTION
With the clarification that the application has to take extra care when changing an "ambient user" setting, remove the special check in connection matching that had been imperfect from the start.
