### PR TITLE
http2: remove assert in ingress processing

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1901,10 +1901,6 @@ static CURLcode h2_progress_ingress(struct Curl_cfilter *cf,
         Curl_multi_mark_dirty(data);
       break;
     }
-    else if(!stream) {
-      DEBUGASSERT(0);
-      break;
-    }
 
     result = Curl_cf_recv_bufq(cf->next, data, &ctx->inbufq, 0, &nread);
     if(result) {


### PR DESCRIPTION
Remove the assert that every `data` triggering ingress processing has an opened HTTP/2 stream. This is not true for connection shutdown processing, at the least.

Reported-By: cmeister (fuzz-master)

