### PR TITLE
h2proxy: remember goaway "last_stream_id"

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -187,7 +187,7 @@ struct cf_h2_proxy_ctx {
   struct Curl_peer *dest; /* where to tunnel to */
   struct tunnel_stream tunnel; /* our tunnel CONNECT stream */
   int32_t goaway_error;
-  int32_t last_stream_id;
+  int32_t remote_max_sid;
   BIT(conn_closed);
   BIT(rcvd_goaway);
   BIT(sent_goaway);
@@ -500,6 +500,11 @@ static int proxy_h2_on_frame_recv(nghttp2_session *session,
       break;
     case NGHTTP2_GOAWAY:
       ctx->rcvd_goaway = TRUE;
+      ctx->remote_max_sid = frame->goaway.last_stream_id;
+      if(data) {
+        infof(data, "received GOAWAY, error=%u, last_stream=%d",
+              frame->goaway.error_code, ctx->remote_max_sid);
+      }
       break;
     default:
       break;
@@ -911,6 +916,7 @@ static CURLcode cf_h2_proxy_ctx_init(struct Curl_cfilter *cf,
 
   Curl_bufq_init(&ctx->inbufq, PROXY_H2_CHUNK_SIZE, PROXY_H2_NW_RECV_CHUNKS);
   Curl_bufq_init(&ctx->outbufq, PROXY_H2_CHUNK_SIZE, PROXY_H2_NW_SEND_CHUNKS);
+  ctx->remote_max_sid = 2147483647;
 
   if(tunnel_stream_init(&ctx->tunnel, ctx->dest))
     goto out;
@@ -1187,7 +1193,7 @@ static CURLcode tunnel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     else if(ctx->tunnel.reset ||
             (ctx->conn_closed && Curl_bufq_is_empty(&ctx->inbufq)) ||
             (ctx->rcvd_goaway &&
-             ctx->last_stream_id < ctx->tunnel.stream_id)) {
+             ctx->remote_max_sid < ctx->tunnel.stream_id)) {
       result = CURLE_RECV_ERROR;
     }
     else

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -916,7 +916,7 @@ static CURLcode cf_h2_proxy_ctx_init(struct Curl_cfilter *cf,
 
   Curl_bufq_init(&ctx->inbufq, PROXY_H2_CHUNK_SIZE, PROXY_H2_NW_RECV_CHUNKS);
   Curl_bufq_init(&ctx->outbufq, PROXY_H2_CHUNK_SIZE, PROXY_H2_NW_SEND_CHUNKS);
-  ctx->remote_max_sid = 2147483647;
+  ctx->remote_max_sid = INT32_MAX;
 
   if(tunnel_stream_init(&ctx->tunnel, ctx->dest))
     goto out;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -179,7 +179,7 @@ static void cf_h2_ctx_init(struct cf_h2_ctx *ctx, bool via_h1_upgrade)
   Curl_bufq_initp(&ctx->outbufq, &ctx->stream_bufcp, H2_NW_SEND_CHUNKS, 0);
   curlx_dyn_init(&ctx->scratch, CURL_MAX_HTTP_HEADER);
   Curl_uint32_hash_init(&ctx->streams, 63, h2_stream_hash_free);
-  ctx->remote_max_sid = 2147483647;
+  ctx->remote_max_sid = INT32_MAX;
   ctx->via_h1_upgrade = via_h1_upgrade;
   ctx->initialized = TRUE;
 }


### PR DESCRIPTION
In the HTTP/2 proxy filter, remember the server announced "last_stream_id" form a GOAWAY frame, so that error handling does not report a perfectly fine stream as broken.

Reported-By: cmeister2

