### PR TITLE
expire/progress handling, do less clock calls

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -52,7 +52,6 @@ struct cf_hc_baller {
   const char *name;
   struct Curl_cfilter *cf;
   CURLcode result;
-  struct curltime started;
   int reply_ms;
   uint8_t transport;
   enum alpnid alpn_id;
@@ -173,7 +172,6 @@ static void cf_hc_baller_init(struct cf_hc_baller *b,
   struct Curl_cfilter *save = cf->next;
 
   cf->next = NULL;
-  b->started = *Curl_pgrs_now(data);
   b->result = Curl_cf_setup_insert_after(cf, data, b->transport,
                                          CURL_CF_SSL_ENABLE);
   b->cf = cf->next;
@@ -238,7 +236,8 @@ static CURLcode baller_connected(struct Curl_cfilter *cf,
 }
 
 static bool time_to_start_baller2(struct Curl_cfilter *cf,
-                                  struct Curl_easy *data)
+                                  struct Curl_easy *data,
+                                  const struct curltime *pnow)
 {
   struct cf_hc_ctx *ctx = cf->ctx;
   timediff_t elapsed_ms;
@@ -253,7 +252,7 @@ static bool time_to_start_baller2(struct Curl_cfilter *cf,
     return TRUE;
   }
 
-  elapsed_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &ctx->started);
+  elapsed_ms = curlx_ptimediff_ms(pnow, &ctx->started);
   if(elapsed_ms >= ctx->hard_eyeballs_timeout_ms) {
     CURL_TRC_CF(data, cf, "%s inconclusive after %" FMT_TIMEDIFF_T ", "
                 "starting %s", ctx->ballers[0].name,
@@ -479,6 +478,7 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
 {
   struct cf_hc_ctx *ctx = cf->ctx;
   CURLcode result = CURLE_OK;
+  const struct curltime *pnow = NULL;
 
   if(cf->connected) {
     *done = TRUE;
@@ -513,10 +513,12 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
       goto out;
     }
     cf_hc_set_baller2(cf, data);
-    ctx->started = *Curl_pgrs_now(data);
+    pnow = Curl_pgrs_now(data);
+    ctx->started = *pnow;
     cf_hc_baller_init(&ctx->ballers[0], cf, data);
     if((ctx->baller_count > 1) || !ctx->ballers_complete) {
-      Curl_expire(data, ctx->soft_eyeballs_timeout_ms, EXPIRE_ALPN_EYEBALLS);
+      Curl_expire_set(data, EXPIRE_ALPN_EYEBALLS,
+                      ctx->soft_eyeballs_timeout_ms, pnow);
     }
     ctx->state = CF_HC_CONNECT;
     FALLTHROUGH();
@@ -533,7 +535,8 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
       }
     }
 
-    if(time_to_start_baller2(cf, data)) {
+    pnow = Curl_pgrs_now(data);
+    if(time_to_start_baller2(cf, data, pnow)) {
       cf_hc_baller_init(&ctx->ballers[1], cf, data);
     }
 

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -165,7 +165,6 @@ struct cf_ip_attempt {
   struct Curl_sockaddr_ex addr;
   struct Curl_cfilter *cf;           /* current sub-cfilter connecting */
   cf_ip_connect_create *cf_create;
-  struct curltime started;           /* start of current attempt */
   CURLcode result;
   int ai_family;
   uint8_t transport_peer;
@@ -277,7 +276,6 @@ struct cf_ip_ballers {
   struct Curl_peer *peer;
   struct Curl_peer *tunnel_peer;
   cf_ip_connect_create *cf_create;   /* for creating cf */
-  struct curltime started;
   struct curltime last_attempt_started;
   timediff_t attempt_delay_ms;
   int last_attempt_ai_family;
@@ -399,6 +397,7 @@ static CURLcode cf_ip_ballers_run(struct cf_ip_ballers *bs,
   bool do_more;
   timediff_t next_expire_ms;
   uint32_t inconclusive, ongoing;
+  const struct curltime *pnow = NULL;
   VERBOSE(int i);
 
   if(bs->winner)
@@ -439,9 +438,8 @@ evaluate:
                 "%u ongoing, %u inconclusive", ongoing, inconclusive);
 
   /* no attempt connected yet, start another one? */
+  pnow = Curl_pgrs_now(data);
   if(!ongoing) {
-    if(!bs->started.tv_sec && !bs->started.tv_usec)
-      bs->started = *Curl_pgrs_now(data);
     do_more = TRUE;
   }
   else {
@@ -451,7 +449,7 @@ evaluate:
       more_possible = cf_ai_iter_has_more(&bs->ipv6_iter, data);
 #endif
     do_more = more_possible &&
-      (curlx_ptimediff_ms(Curl_pgrs_now(data), &bs->last_attempt_started) >=
+      (curlx_ptimediff_ms(pnow, &bs->last_attempt_started) >=
        bs->attempt_delay_ms);
     if(do_more)
       CURL_TRC_CF(data, cf, "happy eyeballs timeout expired, "
@@ -511,7 +509,7 @@ evaluate:
       while(*panchor)
         panchor = &(*panchor)->next;
       *panchor = a;
-      bs->last_attempt_started = *Curl_pgrs_now(data);
+      bs->last_attempt_started = *pnow;
       bs->last_attempt_ai_family = ai_family;
       /* and run everything again */
       goto evaluate;
@@ -520,7 +518,7 @@ evaluate:
       /* tried all addresses, no success but some where inconclusive.
        * Let's restart the inconclusive ones. */
       timediff_t since_ms =
-        curlx_ptimediff_ms(Curl_pgrs_now(data), &bs->last_attempt_started);
+        curlx_ptimediff_ms(pnow, &bs->last_attempt_started);
       timediff_t delay_ms = bs->attempt_delay_ms - since_ms;
       if(delay_ms <= 0) {
         CURL_TRC_CF(data, cf, "all attempts inconclusive, restarting one");
@@ -533,7 +531,7 @@ evaluate:
           CURL_TRC_CF(data, cf, "restarted baller %d -> %d", i, (int)result);
           if(result) /* serious failure */
             goto out;
-          bs->last_attempt_started = *Curl_pgrs_now(data);
+          bs->last_attempt_started = *pnow;
           goto evaluate;
         }
         DEBUGASSERT(0); /* should not come here */
@@ -542,7 +540,7 @@ evaluate:
         /* let's wait some more before restarting */
         infof(data, "connect attempts inconclusive, retrying "
                     "in %" FMT_TIMEDIFF_T "ms", delay_ms);
-        Curl_expire(data, delay_ms, EXPIRE_HAPPY_EYEBALLS);
+        Curl_expire_set(data, EXPIRE_HAPPY_EYEBALLS, delay_ms, pnow);
       }
       /* attempt timeout for restart has not expired yet */
       goto out;
@@ -579,8 +577,10 @@ out:
 #endif
     if(more_possible) {
       timediff_t expire_ms, elapsed_ms;
-      elapsed_ms =
-        curlx_ptimediff_ms(Curl_pgrs_now(data), &bs->last_attempt_started);
+
+      if(!pnow)
+        pnow = Curl_pgrs_now(data);
+      elapsed_ms = curlx_ptimediff_ms(pnow, &bs->last_attempt_started);
       expire_ms = CURLMAX(bs->attempt_delay_ms - elapsed_ms, 0);
       next_expire_ms = CURLMIN(next_expire_ms, expire_ms);
       if(next_expire_ms <= 0) {
@@ -589,7 +589,7 @@ out:
       }
       CURL_TRC_CF(data, cf, "next HAPPY_EYEBALLS timeout in %" FMT_TIMEDIFF_T
                   "ms", next_expire_ms);
-      Curl_expire(data, next_expire_ms, EXPIRE_HAPPY_EYEBALLS);
+      Curl_expire_set(data, EXPIRE_HAPPY_EYEBALLS, next_expire_ms, pnow);
     }
   }
   return result;
@@ -671,7 +671,6 @@ struct cf_ip_happy_ctx {
   cf_ip_connect_create *cf_create;
   cf_connect_state state;
   struct cf_ip_ballers ballers;
-  struct curltime started;
   BIT(dns_resolved);
 };
 
@@ -763,7 +762,6 @@ static CURLcode cf_ip_happy_init(struct Curl_cfilter *cf,
 
   CURL_TRC_CF(data, cf, "init ip ballers for transport %u",
               ctx->ballers.transport_peer);
-  ctx->started = *Curl_pgrs_now(data);
   return CURLE_OK;
 }
 

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -563,7 +563,8 @@ out:
     bool more_possible;
 
     /* when do we need to be called again? */
-    next_expire_ms = Curl_timeleft_ms(data);
+    pnow = Curl_pgrs_now(data);
+    next_expire_ms = Curl_timeleft_now_ms(data, pnow);
     if(next_expire_ms < 0) {
       failf(data, "Connection timeout after %" FMT_OFF_T " ms",
             Curl_pgrs_since_ms(data, NULL, TIMER_STARTSINGLE));
@@ -578,8 +579,6 @@ out:
     if(more_possible) {
       timediff_t expire_ms, elapsed_ms;
 
-      if(!pnow)
-        pnow = Curl_pgrs_now(data);
       elapsed_ms = curlx_ptimediff_ms(pnow, &bs->last_attempt_started);
       expire_ms = CURLMAX(bs->attempt_delay_ms - elapsed_ms, 0);
       next_expire_ms = CURLMIN(next_expire_ms, expire_ms);

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -118,16 +118,17 @@ void Curl_shutdown_start(struct Curl_easy *data, int8_t sockindex,
                          int timeout_ms)
 {
   struct connectdata *conn = data->conn;
+  const struct curltime *pnow = Curl_pgrs_now(data);
 
   DEBUGASSERT(conn);
-  conn->shutdown.start[sockindex] = *Curl_pgrs_now(data);
+  conn->shutdown.start[sockindex] = *pnow;
   conn->shutdown.timeout_ms = (timeout_ms > 0) ?
     (timediff_t)timeout_ms :
     ((data->set.shutdowntimeout > 0) ?
      data->set.shutdowntimeout : DEFAULT_SHUTDOWN_TIMEOUT_MS);
   /* Set a timer, unless we operate on the admin handle */
   if(data->mid)
-    Curl_expire(data, conn->shutdown.timeout_ms, EXPIRE_SHUTDOWN);
+    Curl_expire_set(data, EXPIRE_SHUTDOWN, conn->shutdown.timeout_ms, pnow);
   CURL_TRC_M(data, "shutdown start on%s connection",
              sockindex ? " secondary" : "");
 }

--- a/lib/http.c
+++ b/lib/http.c
@@ -1523,7 +1523,8 @@ static CURLcode cr_exp100_read(struct Curl_easy *data,
                  "timeout %dms", data->set.expect_100_timeout));
     ctx->state = EXP100_AWAITING_CONTINUE;
     ctx->start = *Curl_pgrs_now(data);
-    Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
+    Curl_expire_set(data, EXPIRE_100_TIMEOUT,
+                    data->set.expect_100_timeout, &ctx->start);
     *nread = 0;
     *eos = FALSE;
     return CURLE_OK;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1997,7 +1997,7 @@ static CURLcode mspeed_check(struct Curl_easy *data)
       if(data->mstate != MSTATE_RATELIMITING) {
         multistate(data, MSTATE_RATELIMITING);
       }
-      Curl_expire(data, CURLMAX(send_ms, recv_ms), EXPIRE_TOOFAST);
+      Curl_expire_set(data, EXPIRE_TOOFAST, CURLMAX(send_ms, recv_ms), pnow);
       Curl_multi_clear_dirty(data);
       CURL_TRC_M(data, "[RLIMIT] waiting %" FMT_TIMEDIFF_T "ms",
                  CURLMAX(send_ms, recv_ms));
@@ -2012,7 +2012,7 @@ static CURLcode mspeed_check(struct Curl_easy *data)
         timediff_t next_ms = CURLMIN(send_ms, recv_ms);
         if(!next_ms)
           next_ms = CURLMAX(send_ms, recv_ms);
-        Curl_expire(data, next_ms, EXPIRE_TOOFAST);
+        Curl_expire_set(data, EXPIRE_TOOFAST, next_ms, pnow);
         CURL_TRC_M(data, "[RLIMIT] next token update in %" FMT_TIMEDIFF_T "ms",
                    next_ms);
       }
@@ -2503,14 +2503,16 @@ static CURLMcode multistate_init(struct Curl_easy *data, CURLcode *result)
 
 static CURLMcode multistate_setup(struct Curl_easy *data)
 {
-  Curl_pgrsTime(data, TIMER_STARTSINGLE);
+  const struct curltime *pnow = Curl_pgrs_now(data);
+  Curl_pgrsTimeWas(data, TIMER_STARTSINGLE, *pnow);
   if(data->set.timeout)
-    Curl_expire(data, data->set.timeout, EXPIRE_TIMEOUT);
+    Curl_expire_set(data, EXPIRE_TIMEOUT, data->set.timeout, pnow);
   if(data->set.connecttimeout)
     /* Since a connection might go to pending and back to CONNECT several
        times before it actually takes off, we need to set the timeout once
        in SETUP before we enter CONNECT the first time. */
-    Curl_expire(data, data->set.connecttimeout, EXPIRE_CONNECTTIMEOUT);
+    Curl_expire_set(data, EXPIRE_CONNECTTIMEOUT,
+                    data->set.connecttimeout, pnow);
 
   multistate(data, MSTATE_CONNECT);
   return CURLM_CALL_MULTI_PERFORM;
@@ -3745,8 +3747,9 @@ static CURLMcode multi_set_timeout(struct Curl_easy *data,
  *
  * Expire replaces a former timeout using the same id if already set.
  */
-void Curl_expire(struct Curl_easy *data,
-                 timediff_t milli, expire_id eid)
+void Curl_expire_set(struct Curl_easy *data,
+                     expire_id eid, timediff_t ms,
+                     const struct curltime *pnow)
 {
   struct Curl_multi *multi = data->multi;
   struct expire_timers *timeouts = &data->state.timeouts;
@@ -3758,14 +3761,14 @@ void Curl_expire(struct Curl_easy *data,
   if(!multi)
     return;
   DEBUGASSERT(eid < EXPIRE_LAST);
-  if(milli > INT_MAX)
+  if(ms > INT_MAX)
     /* Cap ridiculous timeouts, 31-bit ms is still 3.5 weeks. When the time
        goes to the user, it must fit in this size. */
-    milli = INT_MAX;
+    ms = INT_MAX;
 
-  set = *Curl_pgrs_now(data);
-  set.tv_sec += (time_t)(milli / 1000); /* may be a 64 to 32-bit conversion */
-  set.tv_usec += (int)(milli % 1000) * 1000;
+  set = *pnow;
+  set.tv_sec += (time_t)(ms / 1000); /* may be a 64 to 32-bit conversion */
+  set.tv_usec += (int)(ms % 1000) * 1000;
   if(set.tv_usec >= 1000000) {
     set.tv_sec++;
     set.tv_usec -= 1000000;
@@ -3791,6 +3794,12 @@ void Curl_expire(struct Curl_easy *data,
   /* Insert the new timer expiry since it is our local minimum. */
   Curl_timeouts_add(&multi->timeouts, data,
                     timeouts->offset_us[timeouts->first]);
+}
+
+void Curl_expire(struct Curl_easy *data,
+                 timediff_t milli, expire_id eid)
+{
+  Curl_expire_set(data, eid, milli, Curl_pgrs_now(data));
 }
 
 /*

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -28,6 +28,9 @@
  */
 
 void Curl_expire(struct Curl_easy *data, timediff_t milli, expire_id eid);
+void Curl_expire_set(struct Curl_easy *data,
+                     expire_id eid, timediff_t ms,
+                     const struct curltime *pnow);
 void Curl_expire_clear(struct Curl_easy *data, expire_id eid);
 void Curl_expire_clear_all(struct Curl_easy *data);
 CURLMcode Curl_update_timer(struct Curl_multi *multi) WARN_UNUSED_RESULT;

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -163,7 +163,7 @@ UNITTEST CURLcode pgrs_speedcheck(struct Curl_easy *data,
 
   /* since low speed limit is enabled, set the expire timer to make this
      connection's speed get checked again in a second */
-  Curl_expire(data, 1000, EXPIRE_SPEEDCHECK);
+  Curl_expire_set(data, EXPIRE_SPEEDCHECK, 1000, pnow);
 
   return CURLE_OK;
 }
@@ -721,14 +721,20 @@ CURLcode Curl_pgrsUpdateX(struct Curl_easy *data,
   return pgrs_update(data, pnow);
 }
 
-CURLcode Curl_pgrsCheck(struct Curl_easy *data)
+CURLcode Curl_pgrsCheckX(struct Curl_easy *data,
+                         const struct curltime *pnow)
 {
   CURLcode result;
 
-  result = pgrs_update(data, Curl_pgrs_now(data));
+  result = pgrs_update(data, pnow);
   if(!result && !data->req.done)
-    result = pgrs_speedcheck(data, Curl_pgrs_now(data));
+    result = pgrs_speedcheck(data, pnow);
   return result;
+}
+
+CURLcode Curl_pgrsCheck(struct Curl_easy *data)
+{
+  return Curl_pgrsCheckX(data, Curl_pgrs_now(data));
 }
 
 /*

--- a/lib/progress.h
+++ b/lib/progress.h
@@ -62,6 +62,7 @@ CURLcode Curl_pgrsUpdateX(struct Curl_easy *data, const struct curltime *pnow);
 void Curl_pgrsUpdate_nometer(struct Curl_easy *data);
 /* perform progress update with callbacks and speed checks */
 CURLcode Curl_pgrsCheck(struct Curl_easy *data);
+CURLcode Curl_pgrsCheckX(struct Curl_easy *data, const struct curltime *pnow);
 
 /* Inform progress/speedcheck about receive/send pausing */
 void Curl_pgrsRecvPause(struct Curl_easy *data, bool enable);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -354,6 +354,7 @@ static CURLcode sendrecv_ul(struct Curl_easy *data)
 CURLcode Curl_sendrecv(struct Curl_easy *data)
 {
   struct SingleRequest *k = &data->req;
+  const struct curltime *pnow = NULL;
   CURLcode result = CURLE_OK;
 
   if(Curl_xfer_is_blocked(data)) {
@@ -376,12 +377,9 @@ CURLcode Curl_sendrecv(struct Curl_easy *data)
       goto out;
   }
 
-  result = Curl_pgrsCheck(data);
-  if(result)
-    goto out;
-
+  pnow = Curl_pgrs_now(data);
   if(CURL_REQ_WANT_IO(data)) {
-    if(Curl_timeleft_ms(data) < 0) {
+    if(Curl_timeleft_now_ms(data, pnow) < 0) {
       if(k->size != -1) {
         failf(data, "Operation timed out after %" FMT_TIMEDIFF_T
               " milliseconds with %" FMT_OFF_T " out of %"
@@ -417,7 +415,7 @@ CURLcode Curl_sendrecv(struct Curl_easy *data)
   if(!CURL_REQ_WANT_IO(data))
     data->req.done = TRUE;
 
-  result = Curl_pgrsUpdate(data);
+  result = Curl_pgrsCheckX(data, pnow);
 
 out:
   if(result)

--- a/lib/vdns/asyn-thrdd.c
+++ b/lib/vdns/asyn-thrdd.c
@@ -702,7 +702,7 @@ CURLcode Curl_async_pollset(struct Curl_easy *data,
     const struct curltime *pnow = Curl_pgrs_now(data);
 #ifndef ENABLE_INTERNAL_WAKEUP
     timediff_t stutter_ms, elapsed_ms;
-    elapsed_ms = curlx_ptimediff_ms(pnow), &async->start);
+    elapsed_ms = curlx_ptimediff_ms(pnow, &async->start);
     if(elapsed_ms < 3)
       stutter_ms = 1;
     else if(elapsed_ms <= 50)

--- a/lib/vdns/asyn-thrdd.c
+++ b/lib/vdns/asyn-thrdd.c
@@ -699,9 +699,10 @@ CURLcode Curl_async_pollset(struct Curl_easy *data,
 #endif
 
   if(!async->done) {
+    const struct curltime *pnow = Curl_pgrs_now(data);
 #ifndef ENABLE_INTERNAL_WAKEUP
     timediff_t stutter_ms, elapsed_ms;
-    elapsed_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &async->start);
+    elapsed_ms = curlx_ptimediff_ms(pnow), &async->start);
     if(elapsed_ms < 3)
       stutter_ms = 1;
     else if(elapsed_ms <= 50)
@@ -721,7 +722,7 @@ CURLcode Curl_async_pollset(struct Curl_easy *data,
       timeout_ms = CURLMIN(100, timeout_ms);
     }
 #endif
-    Curl_expire(data, timeout_ms, EXPIRE_ASYNC_NAME);
+    Curl_expire_set(data, EXPIRE_ASYNC_NAME, timeout_ms, pnow);
   }
   return CURLE_OK;
 }

--- a/lib/vdns/cf-dns.c
+++ b/lib/vdns/cf-dns.c
@@ -254,6 +254,7 @@ static bool cf_dns_ready_to_connect(struct Curl_cfilter *cf,
     return TRUE;
 #ifdef USE_CURL_ASYNC
   else if(CURL_DNSQ_IS_ADDR(ctx->dns_queries)) {
+    const struct curltime *pnow;
     timediff_t remain_ms;
     /* For Happy Eyeballing, we can start on either A or AAAA resolves,
      * but AAAA is preferred. We enforce a small delay for missing
@@ -262,14 +263,15 @@ static bool cf_dns_ready_to_connect(struct Curl_cfilter *cf,
      * an answer (e.g. a negative one). */
     if(Curl_resolv_has_answers(data, ctx->resolv_id, CURL_DNSQ_AAAA))
       return TRUE;
+    pnow = Curl_pgrs_now(data);
     remain_ms = ctx->he_aaaa_await_ms -
-                Curl_resolv_elapsed_ms(data, ctx->resolv_id);
+                Curl_resolv_elapsed_ms(data, ctx->resolv_id, pnow);
     if(remain_ms <= 0)
       return TRUE;
     CURL_TRC_CF(data, cf, "[%s] still waiting %" FMT_TIMEDIFF_T
                 "ms for AAAA result",
                 Curl_resolv_query_str(ctx->dns_queries), remain_ms);
-    Curl_expire(data, remain_ms, EXPIRE_HAPPY_EYEBALLS);
+    Curl_expire_set(data, EXPIRE_HAPPY_EYEBALLS, remain_ms, pnow);
     return FALSE;
   }
   else {

--- a/lib/vdns/hostip.c
+++ b/lib/vdns/hostip.c
@@ -470,12 +470,13 @@ static CURLcode hostip_resolv_take_result(struct Curl_easy *data,
 }
 
 timediff_t Curl_resolv_elapsed_ms(struct Curl_easy *data,
-                                  uint32_t resolv_id)
+                                  uint32_t resolv_id,
+                                  const struct curltime *pnow)
 {
   struct Curl_resolv_async *async = Curl_async_get(data, resolv_id);
   if(!async)
     return CURL_TIMEOUT_RESOLVE_MS;
-  return curlx_ptimediff_ms(Curl_pgrs_now(data), &async->start);
+  return curlx_ptimediff_ms(pnow, &async->start);
 }
 
 bool Curl_resolv_has_answers(struct Curl_easy *data,

--- a/lib/vdns/hostip.h
+++ b/lib/vdns/hostip.h
@@ -140,7 +140,8 @@ void Curl_resolv_destroy(struct Curl_easy *data, uint32_t resolv_id);
 /* How much time has gone by since start of resolve.
  * Returns CURL_TIMEOUT_RESOLVE_MS if `resolv_id` is no longer valid. */
 timediff_t Curl_resolv_elapsed_ms(struct Curl_easy *data,
-                                  uint32_t resolv_id);
+                                  uint32_t resolv_id,
+                                  const struct curltime *pnow);
 
 /* Return TRUE if `resolv_id` has answers (positive or negative) to
  * all queries in `dns_queries`.
@@ -178,7 +179,7 @@ bool Curl_resolv_knows_https(struct Curl_easy *data, uint32_t resolv_id);
 #define Curl_resolv_shutdown_all(x)      Curl_nop_stmt
 #define Curl_resolv_destroy_all(x)       Curl_nop_stmt
 #define Curl_resolv_take_result(x, y, z) CURLE_NOT_BUILT_IN
-#define Curl_resolv_elapsed_ms(x, y)     CURL_TIMEOUT_RESOLVE_MS
+#define Curl_resolv_elapsed_ms(x, y, z)  CURL_TIMEOUT_RESOLVE_MS
 #define Curl_resolv_has_answers(x, y, z) TRUE
 #define Curl_resolv_get_ai(x, y, z, a)   NULL
 #define Curl_resolv_get_https(x, y)      NULL

--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -1351,26 +1351,26 @@ void Curl_cf_ngtcp2_io_ctx_init(struct cf_ngtcp2_io_ctx *io_ctx,
                                 struct Curl_easy *data)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  const struct curltime *pnow = Curl_pgrs_now(data);
 
   io_ctx->cf = cf;
   io_ctx->data = data;
+  io_ctx->now = *Curl_pgrs_now(data);
   ngtcp2_path_storage_zero(&io_ctx->ps);
-  Curl_vquic_ctx_set_time(&ctx->q, pnow);
-  io_ctx->ts = ((ngtcp2_tstamp)pnow->tv_sec * NGTCP2_SECONDS) +
-               ((ngtcp2_tstamp)pnow->tv_usec * NGTCP2_MICROSECONDS);
+  Curl_vquic_ctx_set_time(&ctx->q, &io_ctx->now);
+  io_ctx->ts = ((ngtcp2_tstamp)io_ctx->now.tv_sec * NGTCP2_SECONDS) +
+               ((ngtcp2_tstamp)io_ctx->now.tv_usec * NGTCP2_MICROSECONDS);
 }
 
 void Curl_cf_ngtcp2_io_ctx_update_time(struct Curl_easy *data,
-                                       struct cf_ngtcp2_io_ctx *pktx,
+                                       struct cf_ngtcp2_io_ctx *io_ctx,
                                        struct Curl_cfilter *cf)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  const struct curltime *pnow = Curl_pgrs_now(data);
 
-  Curl_vquic_ctx_update_time(&ctx->q, pnow);
-  pktx->ts = ((ngtcp2_tstamp)pnow->tv_sec * NGTCP2_SECONDS) +
-             ((ngtcp2_tstamp)pnow->tv_usec * NGTCP2_MICROSECONDS);
+  io_ctx->now = *Curl_pgrs_now(data);
+  Curl_vquic_ctx_update_time(&ctx->q, &io_ctx->now);
+  io_ctx->ts = ((ngtcp2_tstamp)io_ctx->now.tv_sec * NGTCP2_SECONDS) +
+               ((ngtcp2_tstamp)io_ctx->now.tv_usec * NGTCP2_MICROSECONDS);
 }
 
 #if NGTCP2_VERSION_NUM < 0x011100
@@ -1547,7 +1547,7 @@ CURLcode Curl_cf_ngtcp2_progress_egress(struct Curl_cfilter *cf,
   result = Curl_vquic_flush(cf, data, &ctx->q);
   if(result) {
     if(result == CURLE_AGAIN) {
-      Curl_expire(data, 1, EXPIRE_QUIC);
+      Curl_expire_set(data, EXPIRE_QUIC, 1, &pktx->now);
       return CURLE_OK;
     }
     return result;
@@ -1599,7 +1599,7 @@ CURLcode Curl_cf_ngtcp2_progress_egress(struct Curl_cfilter *cf,
                                             gsolen, nread, nread);
         if(result) {
           if(result == CURLE_AGAIN) {
-            Curl_expire(data, 1, EXPIRE_QUIC);
+            Curl_expire_set(data, EXPIRE_QUIC, 1, &pktx->now);
             return CURLE_OK;
           }
           return result;
@@ -1621,7 +1621,7 @@ CURLcode Curl_cf_ngtcp2_progress_egress(struct Curl_cfilter *cf,
     result = Curl_vquic_send(cf, data, &ctx->q, gsolen);
     if(result) {
       if(result == CURLE_AGAIN) {
-        Curl_expire(data, 1, EXPIRE_QUIC);
+        Curl_expire_set(data, EXPIRE_QUIC, 1, &pktx->now);
         return CURLE_OK;
       }
       return result;
@@ -1827,8 +1827,9 @@ CURLcode Curl_cf_ngtcp2_cmn_set_expiry(struct Curl_cfilter *cf,
       if(timeout % NGTCP2_MILLISECONDS) {
         timeout += NGTCP2_MILLISECONDS;
       }
-      Curl_expire(data, (timediff_t)(timeout / NGTCP2_MILLISECONDS),
-                  EXPIRE_QUIC);
+      Curl_expire_set(data, EXPIRE_QUIC,
+                      (timediff_t)(timeout / NGTCP2_MILLISECONDS),
+                      &pktx->now);
     }
   }
   return CURLE_OK;

--- a/lib/vquic/cf-ngtcp2-cmn.h
+++ b/lib/vquic/cf-ngtcp2-cmn.h
@@ -204,6 +204,7 @@ void Curl_cf_ngtcp2_cmn_conn_close(struct Curl_cfilter *cf,
 struct cf_ngtcp2_io_ctx {
   struct Curl_cfilter *cf;
   struct Curl_easy *data;
+  struct curltime now;
   ngtcp2_tstamp ts;
   ngtcp2_path_storage ps;
 };
@@ -212,7 +213,7 @@ void Curl_cf_ngtcp2_io_ctx_init(struct cf_ngtcp2_io_ctx *io_ctx,
                                 struct Curl_cfilter *cf,
                                 struct Curl_easy *data);
 void Curl_cf_ngtcp2_io_ctx_update_time(struct Curl_easy *data,
-                                       struct cf_ngtcp2_io_ctx *pktx,
+                                       struct cf_ngtcp2_io_ctx *io_ctx,
                                        struct Curl_cfilter *cf);
 
 CURLcode Curl_cf_ngtcp2_progress_egress(struct Curl_cfilter *cf,


### PR DESCRIPTION
Save clock system calls by passing obtained timestamps to expire and progress calls.

transfer: remove duplicate progress call
cf-ip-happy: remove timestamps never used
cf-https-connect: remove timestamps never used


