### PR TITLE
tool_cb_wrt: try up to .9999 when no-clobbering

### DIFF
--- a/docs/cmdline-opts/no-clobber.md
+++ b/docs/cmdline-opts/no-clobber.md
@@ -18,7 +18,7 @@ Example:
 When used in conjunction with the --output, --remote-header-name,
 --remote-name, or --remote-name-all options, curl avoids overwriting files
 that already exist. Instead, a dot and a number gets appended to the name of
-the file that would be created, up to filename.100 after which it does not
+the file that would be created, up to filename.9999 after which it does not
 create any file.
 
 Note that this is the negated option name documented. You can thus use

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -64,13 +64,24 @@ bool tool_create_output_file(struct OutStruct *outs,
       int next_num = 1;
       struct dynbuf fbuffer;
       char *newfile;
+      int max_num = MAX_CLOBBER_ATTEMPTS;
+#ifdef DEBUGBUILD
+      char *p = curl_getenv("CURL_MAX_CLOBBER");
+      if(p) {
+        const char *pp = p;
+        curl_off_t val;
+        if(!curlx_str_number(&pp, &val, 100000))
+          max_num = (int)val;
+        curl_free(p);
+      }
+#endif
       curlx_dyn_init(&fbuffer, 1025);
       /* !checksrc! disable ERRNOVAR 1 */
       while(fd == -1 && /* have not successfully opened a file */
             /* because we keep having files that already exist */
             (errno == EEXIST || errno == EISDIR) &&
             /* and we have not reached the retry limit */
-            (next_num < MAX_CLOBBER_ATTEMPTS)) {
+            (next_num < max_num)) {
         curlx_dyn_reset(&fbuffer);
         if(curlx_dyn_addf(&fbuffer, "%s.%d", fname, next_num))
           return FALSE;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -34,6 +34,8 @@
 #define OPENMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
 #endif
 
+#define MAX_CLOBBER_ATTEMPTS 9999
+
 /* create/open a local file for writing, return TRUE on success */
 bool tool_create_output_file(struct OutStruct *outs,
                              struct OperationConfig *config)
@@ -65,9 +67,10 @@ bool tool_create_output_file(struct OutStruct *outs,
       curlx_dyn_init(&fbuffer, 1025);
       /* !checksrc! disable ERRNOVAR 1 */
       while(fd == -1 && /* have not successfully opened a file */
-            (errno == EEXIST || errno == EISDIR) &&
             /* because we keep having files that already exist */
-            next_num < 100 /* and we have not reached the retry limit */) {
+            (errno == EEXIST || errno == EISDIR) &&
+            /* and we have not reached the retry limit */
+            (next_num < MAX_CLOBBER_ATTEMPTS)) {
         curlx_dyn_reset(&fbuffer);
         if(curlx_dyn_addf(&fbuffer, "%s.%d", fname, next_num))
           return FALSE;

--- a/tests/data/test1683
+++ b/tests/data/test1683
@@ -30,7 +30,11 @@ http
 </server>
 <features>
 http
+Debug
 </features>
+<setenv>
+CURL_MAX_CLOBBER=100
+</setenv>
 <command option="no-output">
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -o %LOGDIR/exist%TESTNUMBER --no-clobber
 </command>


### PR DESCRIPTION
Previously it gave up after 100.

Some users use this feature when downloading large number of files in a glob range and then 100 is on the small side.
