### PR TITLE
doh: drop assert from doh_resp_decode_httpsrr()

### DIFF
--- a/lib/vdns/doh.c
+++ b/lib/vdns/doh.c
@@ -998,7 +998,6 @@ UNITTEST CURLcode doh_resp_decode_httpsrr(struct Curl_easy *data,
     len -= plen;
     expected_min_pcode = pcode + 1;
   }
-  DEBUGASSERT(!len);
   *hrr = lhrr;
   return CURLE_OK;
 err:


### PR DESCRIPTION
When the incoming DNS packet is broken, there might be bytes left at the end that the parser ignores so let's not assert on that.

Reported-by: Max Dymond

