### PR TITLE
docs: correct cookie sharing description

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLOPT_SHARE.md
@@ -33,10 +33,10 @@ itself. This enables several curl handles to share data. If the curl handles
 are used simultaneously in multiple threads, you **must** use the locking
 methods in the share handle. See curl_share_setopt(3) for details.
 
-If you add a share that is set to share cookies, your easy handle uses that
-cookie cache and get the cookie engine enabled. If you stop sharing an object
-that was using cookies (or change to another object that does not share
-cookies), the easy handle gets its cookie engine disabled.
+If you add a share that is set to share cookies, cookie data is shared across
+the easy handles using this shared object. Note that this does not activate an
+easy handle's cookie handling. You can do that separately by using
+CURLOPT_COOKIEFILE(3) for example.
 
 Data that the share object is not set to share is dealt with the usual way, as
 if no share was used.


### PR DESCRIPTION
The CURLOPT_SHARE documentation incorrectly says that sharing cookies enables the cookie engine and disables it when sharing stops. This conflicts with the implementation, CURLSHOPT_SHARE documentation, and the example on this page. Clarify that sharing supplies the cookie cache, while cookie handling must be enabled separately with CURLOPT_COOKIEFILE.

Fixes #22788

Validation: make -C docs/libcurl check; git diff --check.