### PR TITLE
CURLOPT_SHARE.md: remove bad explanation for cookie sharing

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLOPT_SHARE.md
@@ -33,11 +33,6 @@ itself. This enables several curl handles to share data. If the curl handles
 are used simultaneously in multiple threads, you **must** use the locking
 methods in the share handle. See curl_share_setopt(3) for details.
 
-If you add a share that is set to share cookies, your easy handle uses that
-cookie cache and get the cookie engine enabled. If you stop sharing an object
-that was using cookies (or change to another object that does not share
-cookies), the easy handle gets its cookie engine disabled.
-
 Data that the share object is not set to share is dealt with the usual way, as
 if no share was used.
 


### PR DESCRIPTION
- Remove it because the correct explanation is already documented in CURL_LOCK_DATA_COOKIE (CURLSHOPT_SHARE.md).

Prior to this change the doc said if you share cookies that the cookie engine is enabled. That is no longer true since d0a7ee3f (precedes curl 7.67.0).

Reported-by: Artem Prilutskiy

Ref: https://curl.se/libcurl/c/CURLSHOPT_SHARE.html#CURLLOCKDATACOOKIE

Fixes https://github.com/curl/curl/issues/22788
Closes #xxxxx

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
