### PR TITLE
clang-tidy: enable check `bugprone-assignment-in-selection-statement`

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -14,6 +14,7 @@ Checks:
   - -clang-diagnostic-nullability-extension
   - bugprone-assert-side-effect
   - bugprone-assignment-in-if-condition
+  - bugprone-assignment-in-selection-statement
   - bugprone-chained-comparison
   - bugprone-dynamic-static-initializers
   - bugprone-invalid-enum-default-initialization


### PR DESCRIPTION
Supported by clang-tidy 23.1.0+.

Ref: https://clang.llvm.org/extra/clang-tidy/checks/bugprone/assignment-in-selection-statement.html

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
