### PR TITLE
clang-tidy: merge nested `if()`s

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -8,6 +8,7 @@
 Checks:
   - clang-analyzer-*
   - -clang-analyzer-optin.performance.Padding
+  - -clang-analyzer-core.NullDereference  # became noisy in 23.1.0
   - -clang-analyzer-security.ArrayBound  # due to false positives with clang-tidy 21.1.0+
   - -clang-analyzer-security.insecureAPI.bzero  # for FD_ZERO() (seen on macOS)
   - -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling

--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -48,6 +48,7 @@ Checks:
   - readability-redundant-control-flow
   - readability-redundant-declaration
   - readability-redundant-function-ptr-dereference
+  - readability-redundant-nested-if
   # - readability-redundant-parentheses
   - readability-redundant-preprocessor
   - readability-suspicious-call-argument

--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -8,7 +8,6 @@
 Checks:
   - clang-analyzer-*
   - -clang-analyzer-optin.performance.Padding
-  - -clang-analyzer-core.NullDereference  # became noisy in 23.1.0
   - -clang-analyzer-security.ArrayBound  # due to false positives with clang-tidy 21.1.0+
   - -clang-analyzer-security.insecureAPI.bzero  # for FD_ZERO() (seen on macOS)
   - -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling

--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -49,7 +49,7 @@ Checks:
   - readability-redundant-control-flow
   - readability-redundant-declaration
   - readability-redundant-function-ptr-dereference
-  - readability-redundant-nested-if
+  # readability-redundant-nested-if  # would need local suppression in a handful of cases
   # - readability-redundant-parentheses
   - readability-redundant-preprocessor
   - readability-suspicious-call-argument

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -273,6 +273,11 @@ if(PICKY_COMPILER)
           )
         endif()
       endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 23.1))
+        list(APPEND _picky_enable
+          -Wlifetime-safety                # clang 23.1
+        )
+      endif()
     else()  # gcc
       # Enable based on compiler version
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.3)

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -273,11 +273,6 @@ if(PICKY_COMPILER)
           )
         endif()
       endif()
-      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 23.1))
-        list(APPEND _picky_enable
-          -Wlifetime-safety                # clang 23.1
-        )
-      endif()
     else()  # gcc
       # Enable based on compiler version
       if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 4.3)

--- a/docs/examples/multi-double.c
+++ b/docs/examples/multi-double.c
@@ -80,11 +80,9 @@ int main(void)
 
         do {
           msg = curl_multi_info_read(multi, &queued);
-          if(msg) {
-            if(msg->msg == CURLMSG_DONE) {
-              /* a transfer ended */
-              fprintf(stderr, "Transfer completed\n");
-            }
+          if(msg && msg->msg == CURLMSG_DONE) {
+            /* a transfer ended */
+            fprintf(stderr, "Transfer completed\n");
           }
         } while(msg);
       }

--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -77,10 +77,9 @@ retry:
      * in chunks, however. */
     if(meta->flags & CURLWS_PONG) {
       int same = 0;
-      if(rlen == strlen(expected_payload)) {
-        if(!memcmp(expected_payload, buffer, rlen))
-          same = 1;
-      }
+      if(rlen == strlen(expected_payload) &&
+         !memcmp(expected_payload, buffer, rlen))
+        same = 1;
       fprintf(stderr, "ws: received PONG with %s payload back\n",
               same ? "same" : "different");
     }

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -527,8 +527,7 @@ static int proxy_h2_on_frame_recv(nghttp2_session *session,
     /* Only final status code signals the end of header */
     CURL_TRC_CF(data, cf, "[%d] got http status: %d",
                 stream_id, ctx->tunnel.resp->status);
-    if(!ctx->tunnel.has_final_response &&
-       ctx->tunnel.resp->status / 100 != 1)
+    if(!ctx->tunnel.has_final_response && ctx->tunnel.resp->status / 100 != 1)
       ctx->tunnel.has_final_response = TRUE;
     break;
   case NGHTTP2_WINDOW_UPDATE:

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -527,11 +527,9 @@ static int proxy_h2_on_frame_recv(nghttp2_session *session,
     /* Only final status code signals the end of header */
     CURL_TRC_CF(data, cf, "[%d] got http status: %d",
                 stream_id, ctx->tunnel.resp->status);
-    if(!ctx->tunnel.has_final_response) {
-      if(ctx->tunnel.resp->status / 100 != 1) {
-        ctx->tunnel.has_final_response = TRUE;
-      }
-    }
+    if(!ctx->tunnel.has_final_response &&
+       ctx->tunnel.resp->status / 100 != 1)
+      ctx->tunnel.has_final_response = TRUE;
     break;
   case NGHTTP2_WINDOW_UPDATE:
     if(CURL_REQ_WANT_SEND(data)) {

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -259,14 +259,13 @@ static bool time_to_start_baller2(struct Curl_cfilter *cf,
                 ctx->hard_eyeballs_timeout_ms, ctx->ballers[1].name);
     return TRUE;
   }
-  else if(elapsed_ms >= ctx->soft_eyeballs_timeout_ms) {
-    if(cf_hc_baller_reply_ms(&ctx->ballers[0], data) < 0) {
-      CURL_TRC_CF(data, cf, "%s has not seen any data after %"
-                  FMT_TIMEDIFF_T "ms, starting %s",
-                  ctx->ballers[0].name, ctx->soft_eyeballs_timeout_ms,
-                  ctx->ballers[1].name);
-      return TRUE;
-    }
+  else if(elapsed_ms >= ctx->soft_eyeballs_timeout_ms &&
+          cf_hc_baller_reply_ms(&ctx->ballers[0], data) < 0) {
+    CURL_TRC_CF(data, cf, "%s has not seen any data after %"
+                FMT_TIMEDIFF_T "ms, starting %s",
+                ctx->ballers[0].name, ctx->soft_eyeballs_timeout_ms,
+                ctx->ballers[1].name);
+    return TRUE;
   }
   return FALSE;
 }

--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -652,10 +652,9 @@ static int cf_ip_ballers_min_reply_ms(struct cf_ip_ballers *bs,
 
   for(a = bs->running; a; a = a->next) {
     if(a->cf && !a->cf->cft->query(a->cf, data, CF_QUERY_CONNECT_REPLY_MS,
-                                   &breply_ms, NULL)) {
-      if(breply_ms >= 0 && (reply_ms < 0 || breply_ms < reply_ms))
-        reply_ms = breply_ms;
-    }
+                                   &breply_ms, NULL) &&
+       breply_ms >= 0 && (reply_ms < 0 || breply_ms < reply_ms))
+      reply_ms = breply_ms;
   }
   return reply_ms;
 }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -698,14 +698,14 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
      * converted to an IP address and would fail Curl_if2ip. Try to
      * use it straight away.
      */
-    /* This is often "errno 1, error: Operation not permitted" if you are
-     * not running as root or another suitable privileged user. If it
-     * succeeds it means the parameter was a valid interface and not an IP
-     * address. Return immediately.
-     */
     if(iface &&
        setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
                   iface, (curl_socklen_t)strlen(iface) + 1) == 0 &&
+       /* This is often "errno 1, error: Operation not permitted" if you are
+        * not running as root or another suitable privileged user. If it
+        * succeeds it means the parameter was a valid interface and not an IP
+        * address. Return immediately.
+        */
        !host_input) {
       infof(data, "socket successfully bound to interface '%s'", iface);
       return CURLE_OK;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -688,29 +688,27 @@ static CURLcode bindlocal(struct Curl_easy *data, struct connectdata *conn,
     if2ip_result_t if2ip_result = IF2IP_NOT_FOUND;
 
 #ifdef SO_BINDTODEVICE
-    if(iface) {
-      /*
-       * This binds the local socket to a particular interface. This will
-       * force even requests to other local interfaces to go out the external
-       * interface. Only bind to the interface when specified as interface,
-       * not as a hostname or ip address.
-       *
-       * The interface might be a VRF, eg: vrf-blue, which means it cannot be
-       * converted to an IP address and would fail Curl_if2ip. Try to
-       * use it straight away.
-       */
-      if(setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
-                    iface, (curl_socklen_t)strlen(iface) + 1) == 0) {
-        /* This is often "errno 1, error: Operation not permitted" if you are
-         * not running as root or another suitable privileged user. If it
-         * succeeds it means the parameter was a valid interface and not an IP
-         * address. Return immediately.
-         */
-        if(!host_input) {
-          infof(data, "socket successfully bound to interface '%s'", iface);
-          return CURLE_OK;
-        }
-      }
+    /*
+     * This binds the local socket to a particular interface. This will
+     * force even requests to other local interfaces to go out the external
+     * interface. Only bind to the interface when specified as interface,
+     * not as a hostname or ip address.
+     *
+     * The interface might be a VRF, eg: vrf-blue, which means it cannot be
+     * converted to an IP address and would fail Curl_if2ip. Try to
+     * use it straight away.
+     */
+    /* This is often "errno 1, error: Operation not permitted" if you are
+     * not running as root or another suitable privileged user. If it
+     * succeeds it means the parameter was a valid interface and not an IP
+     * address. Return immediately.
+     */
+    if(iface &&
+       setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
+                  iface, (curl_socklen_t)strlen(iface) + 1) == 0 &&
+       !host_input) {
+      infof(data, "socket successfully bound to interface '%s'", iface);
+      return CURLE_OK;
     }
 #endif
     if(!host_input) {

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -50,10 +50,8 @@ enum alpnid Curl_alpn2alpnid(const unsigned char *name, size_t len)
     if(!memcmp(name, "h3", 2))
       return ALPN_h3;
   }
-  else if(len == 8) {
-    if(!memcmp(name, "http/1.1", 8))
-      return ALPN_h1;
-  }
+  else if(len == 8 && !memcmp(name, "http/1.1", 8))
+    return ALPN_h1;
   return ALPN_none; /* unknown, probably rubbish input */
 }
 

--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -403,13 +403,12 @@ void Curl_cshutdn_add(struct cshutdn *cshutdn,
     cshutdn_destroy_oldest(cshutdn, NULL);
   }
 
-  if(cshutdn->multi->socket_cb) {
-    if(cshutdn_update_ev(cshutdn, conn)) {
-      CURL_TRC_M(admin, "[SHUTDOWN] update events failed, discarding #%"
-                 FMT_OFF_T, conn->connection_id);
-      Curl_conn_terminate(admin, conn, FALSE);
-      return;
-    }
+  if(cshutdn->multi->socket_cb &&
+     cshutdn_update_ev(cshutdn, conn)) {
+    CURL_TRC_M(admin, "[SHUTDOWN] update events failed, discarding #%"
+               FMT_OFF_T, conn->connection_id);
+    Curl_conn_terminate(admin, conn, FALSE);
+    return;
   }
 
   Curl_llist_append(&cshutdn->list, conn, &conn->cshutdn_node);

--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -403,8 +403,7 @@ void Curl_cshutdn_add(struct cshutdn *cshutdn,
     cshutdn_destroy_oldest(cshutdn, NULL);
   }
 
-  if(cshutdn->multi->socket_cb &&
-     cshutdn_update_ev(cshutdn, conn)) {
+  if(cshutdn->multi->socket_cb && cshutdn_update_ev(cshutdn, conn)) {
     CURL_TRC_M(admin, "[SHUTDOWN] update events failed, discarding #%"
                FMT_OFF_T, conn->connection_id);
     Curl_conn_terminate(admin, conn, FALSE);

--- a/lib/curl_share.c
+++ b/lib/curl_share.c
@@ -379,10 +379,9 @@ CURLSHcode Curl_share_lock_share(struct Curl_share *share,
   if(!share)
     return CURLSHE_INVALID;
 
-  if(share->specifier & (unsigned int)(1 << type)) {
-    if(share->lockfunc) /* only call this if set! */
-      share->lockfunc(data, type, accesstype, share->clientdata);
-  }
+  if(share->specifier & (unsigned int)(1 << type) &&
+     share->lockfunc) /* only call this if set! */
+    share->lockfunc(data, type, accesstype, share->clientdata);
   /* else if we do not share this, pretend successful lock */
 
   return CURLSHE_OK;
@@ -401,10 +400,9 @@ CURLSHcode Curl_share_unlock_share(struct Curl_share *share,
   if(!share)
     return CURLSHE_INVALID;
 
-  if(share->specifier & (unsigned int)(1 << type)) {
-    if(share->unlockfunc) /* only call this if set! */
-      share->unlockfunc(data, type, share->clientdata);
-  }
+  if(share->specifier & (unsigned int)(1 << type) &&
+     share->unlockfunc) /* only call this if set! */
+    share->unlockfunc(data, type, share->clientdata);
 
   return CURLSHE_OK;
 }

--- a/lib/curlx/inet_pton.c
+++ b/lib/curlx/inet_pton.c
@@ -121,9 +121,8 @@ static int inet_pton6(const char *src, unsigned char *dst)
   endp = tp + IN6ADDRSZ;
   colonp = NULL;
   /* Leading :: requires some special handling. */
-  if(*src == ':')
-    if(*++src != ':')
-      return 0;
+  if(*src == ':' && *++src != ':')
+    return 0;
   curtok = src;
   saw_xdigit = 0;
   val = 0;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1239,8 +1239,8 @@ CURLcode curl_easy_pause(CURL *curl, int action)
       }
     }
 
-    /* pause/unpausing may result in multi event changes */
     if(!result && changed && !data->state.done && data->multi &&
+       /* pause/unpausing may result in multi event changes */
        Curl_multi_ev_assess_xfer(data->multi, data))
       result = CURLE_ABORTED_BY_CALLBACK;
   }

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1239,10 +1239,10 @@ CURLcode curl_easy_pause(CURL *curl, int action)
       }
     }
 
-    if(!result && changed && !data->state.done && data->multi)
-      /* pause/unpausing may result in multi event changes */
-      if(Curl_multi_ev_assess_xfer(data->multi, data) && !result)
-        result = CURLE_ABORTED_BY_CALLBACK;
+    /* pause/unpausing may result in multi event changes */
+    if(!result && changed && !data->state.done && data->multi &&
+       Curl_multi_ev_assess_xfer(data->multi, data) && !result)
+      result = CURLE_ABORTED_BY_CALLBACK;
   }
 out:
   CURL_EAPI_LEAVE(&guard);

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1234,10 +1234,8 @@ CURLcode curl_easy_pause(CURL *curl, int action)
       if(data->multi) {
         Curl_multi_mark_dirty(data); /* make it run */
         /* On changes, tell application to update its timers. */
-        if(changed) {
-          if(Curl_update_timer(data->multi) && !result)
-            result = CURLE_ABORTED_BY_CALLBACK;
-        }
+        if(changed && Curl_update_timer(data->multi) && !result)
+          result = CURLE_ABORTED_BY_CALLBACK;
       }
     }
 

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1241,7 +1241,7 @@ CURLcode curl_easy_pause(CURL *curl, int action)
 
     /* pause/unpausing may result in multi event changes */
     if(!result && changed && !data->state.done && data->multi &&
-       Curl_multi_ev_assess_xfer(data->multi, data) && !result)
+       Curl_multi_ev_assess_xfer(data->multi, data))
       result = CURLE_ABORTED_BY_CALLBACK;
   }
 out:

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -822,10 +822,10 @@ CURLcode Curl_getformdata(CURL *data,
       }
 
       /* Set fake filename. */
-      if(!result && post->showfilename)
-        if(post->more || (post->flags & (HTTPPOST_FILENAME | HTTPPOST_BUFFER |
-                                         HTTPPOST_CALLBACK)))
-          result = curl_mime_filename(part, post->showfilename);
+      if(!result && post->showfilename &&
+         (post->more || (post->flags & (HTTPPOST_FILENAME | HTTPPOST_BUFFER |
+                                        HTTPPOST_CALLBACK))))
+        result = curl_mime_filename(part, post->showfilename);
     }
   }
 

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -258,9 +258,9 @@ static CURLFORMcode formadd_check(struct FormInfo *first_form,
     }
     if(name && form->namelength && memchr(name, 0, form->namelength))
       return CURL_FORMADD_NULL;
-    /* Note that there is small risk that form->name is NULL here if the app
-       passed in a bad combo, so we check for that. */
     if(!(form->flags & HTTPPOST_PTRNAME) &&
+       /* Note that there is small risk that form->name is NULL here if the app
+          passed in a bad combo, so we check for that. */
        forminfo_copyfield(&form->name, form->namelength))
       return CURL_FORMADD_MEMORY;
     if(!(form->flags & (HTTPPOST_FILENAME | HTTPPOST_READFILE |

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -256,16 +256,13 @@ static CURLFORMcode formadd_check(struct FormInfo *first_form,
       if(Curl_bufref_memdup0(&form->contenttype, type, strlen(type)))
         return CURL_FORMADD_MEMORY;
     }
-    if(name && form->namelength) {
-      if(memchr(name, 0, form->namelength))
-        return CURL_FORMADD_NULL;
-    }
-    if(!(form->flags & HTTPPOST_PTRNAME)) {
-      /* Note that there is small risk that form->name is NULL here if the app
-         passed in a bad combo, so we check for that. */
-      if(forminfo_copyfield(&form->name, form->namelength))
-        return CURL_FORMADD_MEMORY;
-    }
+    if(name && form->namelength && memchr(name, 0, form->namelength))
+      return CURL_FORMADD_NULL;
+    /* Note that there is small risk that form->name is NULL here if the app
+       passed in a bad combo, so we check for that. */
+    if(!(form->flags & HTTPPOST_PTRNAME) &&
+       forminfo_copyfield(&form->name, form->namelength))
+      return CURL_FORMADD_MEMORY;
     if(!(form->flags & (HTTPPOST_FILENAME | HTTPPOST_READFILE |
                         HTTPPOST_PTRCONTENTS | HTTPPOST_PTRBUFFER |
                         HTTPPOST_CALLBACK))) {

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -265,10 +265,9 @@ static CURLFORMcode formadd_check(struct FormInfo *first_form,
       return CURL_FORMADD_MEMORY;
     if(!(form->flags & (HTTPPOST_FILENAME | HTTPPOST_READFILE |
                         HTTPPOST_PTRCONTENTS | HTTPPOST_PTRBUFFER |
-                        HTTPPOST_CALLBACK))) {
-      if(forminfo_copyfield(&form->value, (size_t)form->contentslength))
-        return CURL_FORMADD_MEMORY;
-    }
+                        HTTPPOST_CALLBACK)) &&
+       forminfo_copyfield(&form->value, (size_t)form->contentslength))
+      return CURL_FORMADD_MEMORY;
     post = httppost_add(form, post, httppost, last_post);
 
     if(!post)

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2673,13 +2673,11 @@ static CURLcode ftp_state_size_resp(struct Curl_easy *data,
     if(curlx_str_number(&fdigit, &filesize, CURL_OFF_T_MAX))
       filesize = -1; /* size remain unknown */
   }
-  else if(ftpcode == 550) { /* "No such file or directory" */
-    /* allow a SIZE failure for (resumed) uploads, when probing what command
-       to use */
-    if(instate != FTP_STOR_SIZE) {
-      failf(data, "The file does not exist");
-      return CURLE_REMOTE_FILE_NOT_FOUND;
-    }
+  /* allow a SIZE failure for (resumed) uploads, when probing what command
+     to use */
+  else if(ftpcode == 550 && instate != FTP_STOR_SIZE) { /* "No such file or directory" */
+    failf(data, "The file does not exist");
+    return CURLE_REMOTE_FILE_NOT_FOUND;
   }
 
   if(instate == FTP_SIZE) {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2673,9 +2673,10 @@ static CURLcode ftp_state_size_resp(struct Curl_easy *data,
     if(curlx_str_number(&fdigit, &filesize, CURL_OFF_T_MAX))
       filesize = -1; /* size remain unknown */
   }
-  /* allow a SIZE failure for (resumed) uploads, when probing what command
-     to use */
-  else if(ftpcode == 550 && instate != FTP_STOR_SIZE) { /* "No such file or directory" */
+  else if(ftpcode == 550 && /* "No such file or directory" */
+          /* allow a SIZE failure for (resumed) uploads, when probing what
+             command to use */
+          instate != FTP_STOR_SIZE) {
     failf(data, "The file does not exist");
     return CURLE_REMOTE_FILE_NOT_FOUND;
   }

--- a/lib/http.c
+++ b/lib/http.c
@@ -2546,13 +2546,12 @@ static CURLcode http_add_content_hds(struct Curl_easy *data,
       }
     }
 #endif
-    if(httpreq == HTTPREQ_POST) {
-      if(!Curl_checkheaders(data, STRCONST("Content-Type"))) {
-        result = curlx_dyn_addn(r, STRCONST("Content-Type: application/"
-                                            "x-www-form-urlencoded\r\n"));
-        if(result)
-          goto out;
-      }
+    if(httpreq == HTTPREQ_POST &&
+       !Curl_checkheaders(data, STRCONST("Content-Type"))) {
+      result = curlx_dyn_addn(r, STRCONST("Content-Type: application/"
+                                          "x-www-form-urlencoded\r\n"));
+      if(result)
+        goto out;
     }
     result = addexpect(data, r, httpversion, &announced_exp100);
     if(result)

--- a/lib/http.c
+++ b/lib/http.c
@@ -616,19 +616,18 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data)
   }
   else if((data->req.httpcode < 300) &&
           !data->state.authhost.done &&
-          data->req.authneg) {
+          data->req.authneg &&
+          (data->state.httpreq != HTTPREQ_GET) &&
+          (data->state.httpreq != HTTPREQ_HEAD)) {
     /* no (known) authentication available,
        authentication is not "done" yet and
        no authentication seems to be required and
        we did not try HEAD or GET */
-    if((data->state.httpreq != HTTPREQ_GET) &&
-       (data->state.httpreq != HTTPREQ_HEAD)) {
-      /* clone URL */
-      data->req.newurl = Curl_bufref_dup(&data->state.url);
-      if(!data->req.newurl)
-        return CURLE_OUT_OF_MEMORY;
-      data->state.authhost.done = TRUE;
-    }
+    /* clone URL */
+    data->req.newurl = Curl_bufref_dup(&data->state.url);
+    if(!data->req.newurl)
+      return CURLE_OUT_OF_MEMORY;
+    data->state.authhost.done = TRUE;
   }
   if(http_should_fail(data, data->req.httpcode)) {
     failf(data, "The requested URL returned error: %d",

--- a/lib/http.c
+++ b/lib/http.c
@@ -2745,10 +2745,10 @@ static CURLcode http_firstwrite(struct Curl_easy *data)
     return CURLE_RANGE_ERROR;
   }
 
-  /* A time condition has been set AND no ranges have been requested. This
-     seems to be what chapter 13.3.4 of RFC 2616 defines to be the correct
-     action for an HTTP/1.1 client */
   if(data->set.timecondition && !data->state.range &&
+     /* A time condition has been set AND no ranges have been requested. This
+        seems to be what chapter 13.3.4 of RFC 2616 defines to be the correct
+        action for an HTTP/1.1 client */
      !Curl_meets_timecondition(data, k->timeofdoc)) {
     k->done = TRUE;
     /* We are simulating an HTTP 304 from server so we return

--- a/lib/http.c
+++ b/lib/http.c
@@ -2747,22 +2747,20 @@ static CURLcode http_firstwrite(struct Curl_easy *data)
     return CURLE_RANGE_ERROR;
   }
 
-  if(data->set.timecondition && !data->state.range) {
-    /* A time condition has been set AND no ranges have been requested. This
-       seems to be what chapter 13.3.4 of RFC 2616 defines to be the correct
-       action for an HTTP/1.1 client */
-
-    if(!Curl_meets_timecondition(data, k->timeofdoc)) {
-      k->done = TRUE;
-      /* We are simulating an HTTP 304 from server so we return
-         what should have been returned from the server */
-      data->info.httpcode = 304;
-      infof(data, "Simulate an HTTP 304 response");
-      /* we abort the transfer before it is completed == we ruin the
-         reuse ability. Close the connection */
-      streamclose(conn);
-      return CURLE_OK;
-    }
+  /* A time condition has been set AND no ranges have been requested. This
+     seems to be what chapter 13.3.4 of RFC 2616 defines to be the correct
+     action for an HTTP/1.1 client */
+  if(data->set.timecondition && !data->state.range &&
+     !Curl_meets_timecondition(data, k->timeofdoc)) {
+    k->done = TRUE;
+    /* We are simulating an HTTP 304 from server so we return
+       what should have been returned from the server */
+    data->info.httpcode = 304;
+    infof(data, "Simulate an HTTP 304 response");
+    /* we abort the transfer before it is completed == we ruin the
+       reuse ability. Close the connection */
+    streamclose(conn);
+    return CURLE_OK;
   } /* we have a time condition */
 
   return CURLE_OK;

--- a/lib/http.c
+++ b/lib/http.c
@@ -617,12 +617,12 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data)
   else if((data->req.httpcode < 300) &&
           !data->state.authhost.done &&
           data->req.authneg &&
+          /* no (known) authentication available,
+             authentication is not "done" yet and
+             no authentication seems to be required and
+             we did not try HEAD or GET */
           (data->state.httpreq != HTTPREQ_GET) &&
           (data->state.httpreq != HTTPREQ_HEAD)) {
-    /* no (known) authentication available,
-       authentication is not "done" yet and
-       no authentication seems to be required and
-       we did not try HEAD or GET */
     /* clone URL */
     data->req.newurl = Curl_bufref_dup(&data->state.url);
     if(!data->req.newurl)

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -186,10 +186,8 @@ static CURLcode split_to_dyn_array(const char *source,
   if(segment_length) {
     curlx_dyn_init(&db[index], segment_length + 1);
     result = curlx_dyn_addn(&db[index], &source[start], segment_length);
-    if(!result) {
-      if(++num_splits == MAX_QUERY_COMPONENTS)
-        result = CURLE_TOO_LARGE;
-    }
+    if(!result && ++num_splits == MAX_QUERY_COMPONENTS)
+      result = CURLE_TOO_LARGE;
   }
 fail:
   *num_splits_out = num_splits;

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -523,10 +523,8 @@ static CURLcode make_headers(struct Curl_easy *data,
     if(tmp)
       *tmp = 0;
 
-    if(l != head) {
-      if(curlx_dyn_add(signed_headers, ";"))
-        goto fail;
-    }
+    if(l != head && curlx_dyn_add(signed_headers, ";"))
+      goto fail;
     if(curlx_dyn_add(signed_headers, l->data))
       goto fail;
   }

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -688,10 +688,8 @@ UNITTEST CURLcode canon_path(const char *q, size_t len,
   else
     result = curlx_dyn_addn(new_path, q, len);
 
-  if(!result) {
-    if(curlx_dyn_len(new_path) == 0)
-      result = curlx_dyn_add(new_path, "/");
-  }
+  if(!result && curlx_dyn_len(new_path) == 0)
+    result = curlx_dyn_add(new_path, "/");
 
   return result;
 }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -877,11 +877,8 @@ static CURLcode imap_perform_append(struct Curl_easy *data,
     result = Curl_mime_prepare_headers(data, postp, NULL,
                                        NULL, MIMESTRATEGY_MAIL);
 
-    if(!result)
-      if(!Curl_checkheaders(data, STRCONST("Mime-Version")))
-        result = Curl_mime_add_header(&postp->curlheaders,
-                                      "Mime-Version: 1.0");
-
+    if(!result && !Curl_checkheaders(data, STRCONST("Mime-Version")))
+      result = Curl_mime_add_header(&postp->curlheaders, "Mime-Version: 1.0");
     if(!result)
       result = Curl_creader_set_mime(data, postp);
     if(result)

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -2205,17 +2205,16 @@ static CURLcode imap_disconnect(struct Curl_easy *data,
 {
   struct imap_conn *imapc = Curl_conn_meta_get(conn, CURL_META_IMAP_CONN);
 
-  if(imapc) {
-    /* We cannot send quit unconditionally. If this connection is stale or
-       bad in any way (pingpong has pending data to send),
-       sending quit and waiting around here will make the
-       disconnect wait in vain and cause more problems than we need to. */
-    if(!dead_connection && conn->bits.protoconnstart &&
-       !Curl_pp_needs_flush(data, &imapc->pp)) {
-      if(!imap_perform_logout(data, imapc))
-        (void)imap_block_statemach(data, imapc, TRUE); /* ignore errors */
-    }
-  }
+  /* We cannot send quit unconditionally. If this connection is stale or
+     bad in any way (pingpong has pending data to send),
+     sending quit and waiting around here will make the
+     disconnect wait in vain and cause more problems than we need to. */
+  if(imapc &&
+     !dead_connection && conn->bits.protoconnstart &&
+     !Curl_pp_needs_flush(data, &imapc->pp) &&
+     !imap_perform_logout(data, imapc))
+    (void)imap_block_statemach(data, imapc, TRUE); /* ignore errors */
+
   return CURLE_OK;
 }
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1206,11 +1206,10 @@ static bool is_custom_fetch_listing(struct IMAP *imap)
     const char *p = imap->custom_params;
     return is_custom_fetch_listing_match(p);
   }
-  else if(curl_strequal(imap->custom, "UID") && imap->custom_params) {
-    if(curl_strnequal(imap->custom_params, " FETCH ", 7)) {
-      const char *p = imap->custom_params + 6;
-      return is_custom_fetch_listing_match(p);
-    }
+  else if(curl_strequal(imap->custom, "UID") && imap->custom_params &&
+          curl_strnequal(imap->custom_params, " FETCH ", 7)) {
+    const char *p = imap->custom_params + 6;
+    return is_custom_fetch_listing_match(p);
   }
   return FALSE;
 }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -2201,11 +2201,11 @@ static CURLcode imap_disconnect(struct Curl_easy *data,
 {
   struct imap_conn *imapc = Curl_conn_meta_get(conn, CURL_META_IMAP_CONN);
 
-  /* We cannot send quit unconditionally. If this connection is stale or
-     bad in any way (pingpong has pending data to send),
-     sending quit and waiting around here will make the
-     disconnect wait in vain and cause more problems than we need to. */
   if(imapc &&
+     /* We cannot send quit unconditionally. If this connection is stale or
+        bad in any way (pingpong has pending data to send),
+        sending quit and waiting around here will make the
+        disconnect wait in vain and cause more problems than we need to. */
      !dead_connection && conn->bits.protoconnstart &&
      !Curl_pp_needs_flush(data, &imapc->pp) &&
      !imap_perform_logout(data, imapc))

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -931,12 +931,11 @@ static CURLcode imap_perform_append(struct Curl_easy *data,
     }
 
     for(i = 0; ulflag[i].bit; i++) {
-      if(data->set.upload_flags & ulflag[i].bit) {
-        if((curlx_dyn_len(&flags) > 2 && curlx_dyn_add(&flags, " ")) ||
-           curlx_dyn_add(&flags, "\\") ||
-           curlx_dyn_add(&flags, ulflag[i].flag))
-          goto cleanup;
-      }
+      if(data->set.upload_flags & ulflag[i].bit &&
+         ((curlx_dyn_len(&flags) > 2 && curlx_dyn_add(&flags, " ")) ||
+          curlx_dyn_add(&flags, "\\") ||
+          curlx_dyn_add(&flags, ulflag[i].flag)))
+        goto cleanup;
     }
 
     if(curlx_dyn_add(&flags, ")"))

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1810,9 +1810,9 @@ CURLcode Curl_mime_prepare_headers(struct Curl_easy *data,
       boundary = mime->boundary;
   }
   else if(contenttype && !customct &&
-          content_type_match(contenttype, STRCONST("text/plain")))
-    if(strategy == MIMESTRATEGY_MAIL || !part->filename)
-      contenttype = NULL;
+          content_type_match(contenttype, STRCONST("text/plain")) &&
+          (strategy == MIMESTRATEGY_MAIL || !part->filename))
+    contenttype = NULL;
 
   /* Issue content-disposition header only if not already set by caller. */
   if(!search_header(part->userheaders, STRCONST("Content-Disposition"))) {

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1706,13 +1706,15 @@ static CURLcode add_content_disposition(struct Curl_easy *data,
                                         const char *contenttype,
                                         enum mimestrategy strategy)
 {
-  if(!disposition)
-    if(part->filename || part->name ||
-       (contenttype && !curl_strnequal(contenttype, "multipart/", 10)))
-      disposition = DISPOSITION_DEFAULT;
+  if(!disposition &&
+     (part->filename || part->name ||
+      (contenttype && !curl_strnequal(contenttype, "multipart/", 10))))
+    disposition = DISPOSITION_DEFAULT;
+
   if(disposition && curl_strequal(disposition, "attachment") &&
      !part->name && !part->filename)
     disposition = NULL;
+
   if(disposition) {
     CURLcode result = CURLE_OK;
     char *name = NULL;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1401,11 +1401,9 @@ static CURLMcode multi_winsock_select(struct Curl_multi *multi,
       mask |= FD_WRITE | FD_CONNECT | FD_CLOSE;
       reset_socket_fdwrite(cpfds->pfds[i].fd);
     }
-    if(mask) {
-      if(WSAEventSelect(cpfds->pfds[i].fd, multi->wsa_event, mask)) {
-        mresult = CURLM_OUT_OF_MEMORY;
-        goto out;
-      }
+    if(mask && WSAEventSelect(cpfds->pfds[i].fd, multi->wsa_event, mask)) {
+      mresult = CURLM_OUT_OF_MEMORY;
+      goto out;
     }
   }
 

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1621,10 +1621,9 @@ static CURLcode pop3_disconnect(struct Curl_easy *data,
      disconnect wait in vain and cause more problems than we need to. */
 
   if(!dead_connection && conn->bits.protoconnstart &&
-     !Curl_pp_needs_flush(data, &pop3c->pp)) {
-    if(!pop3_perform_quit(data, conn))
-      (void)pop3_block_statemach(data, conn, TRUE); /* ignore errors on QUIT */
-  }
+     !Curl_pp_needs_flush(data, &pop3c->pp) &&
+     !pop3_perform_quit(data, conn))
+    (void)pop3_block_statemach(data, conn, TRUE); /* ignore errors on QUIT */
 
   /* Disconnect from the server */
   Curl_pp_disconnect(&pop3c->pp);

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -697,9 +697,8 @@ static CURLcode pop3_perform_authentication(struct Curl_easy *data,
     /* Calculate the SASL login details */
     result = Curl_sasl_start(&pop3c->sasl, data, FALSE, &progress);
 
-    if(!result)
-      if(progress == SASL_INPROGRESS)
-        pop3_state(data, POP3_AUTH);
+    if(!result && progress == SASL_INPROGRESS)
+      pop3_state(data, POP3_AUTH);
   }
 
   if(!result && progress == SASL_IDLE) {

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -410,16 +410,14 @@ static CURLcode rtsp_setup_request(struct Curl_easy *data,
      data->state.use_range &&
      ((rtspreq == RTSPREQ_PLAY) ||
       (rtspreq == RTSPREQ_PAUSE) ||
-      (rtspreq == RTSPREQ_RECORD))) {
-
-    /* Check to see if there is a range set in the custom headers */
-    if(!Curl_checkheaders(data, STRCONST("Range")) && data->state.range) {
-      result = rtsp_header_alloc("Range",
-                                 data->state.range,
-                                 &data->state.rangeline);
-      if(!result)
-        b->range = data->state.rangeline;
-    }
+      (rtspreq == RTSPREQ_RECORD)) &&
+     /* Check to see if there is a range set in the custom headers */
+     !Curl_checkheaders(data, STRCONST("Range")) && data->state.range) {
+    result = rtsp_header_alloc("Range",
+                               data->state.range,
+                               &data->state.rangeline);
+    if(!result)
+      b->range = data->state.rangeline;
   }
   return result;
 }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -933,12 +933,10 @@ static CURLcode rtsp_parse_transport(struct Curl_easy *data,
       if(!curlx_str_number(&p, &chan1, 255)) {
         unsigned char *rtp_channel_mask = data->state.rtp_channel_mask;
         chan2 = chan1;
-        if(!curlx_str_single(&p, '-')) {
-          if(curlx_str_number(&p, &chan2, 255)) {
-            infof(data, "Unable to read the interleaved parameter from "
-                  "Transport header: [%s]", transport);
-            chan2 = chan1;
-          }
+        if(!curlx_str_single(&p, '-') && curlx_str_number(&p, &chan2, 255)) {
+          infof(data, "Unable to read the interleaved parameter from "
+                "Transport header: [%s]", transport);
+          chan2 = chan1;
         }
         for(chan = chan1; chan <= chan2; chan++) {
           int idx = (int)chan / 8;

--- a/lib/select.c
+++ b/lib/select.c
@@ -385,10 +385,8 @@ static CURLcode cpfds_add_sock(struct curl_pollfds *cpfds,
     }
   }
   /* not folded, add new entry */
-  if(cpfds->n >= cpfds->count) {
-    if(cpfds_increase(cpfds, 100))
-      return CURLE_OUT_OF_MEMORY;
-  }
+  if(cpfds->n >= cpfds->count && cpfds_increase(cpfds, 100))
+    return CURLE_OUT_OF_MEMORY;
   cpfds->pfds[cpfds->n].fd = sock;
   cpfds->pfds[cpfds->n].events = events;
   ++cpfds->n;

--- a/lib/select.c
+++ b/lib/select.c
@@ -412,10 +412,8 @@ CURLcode Curl_pollfds_add_ps(struct curl_pollfds *cpfds,
       events |= POLLIN;
     if(ps->actions[i] & CURL_POLL_OUT)
       events |= POLLOUT;
-    if(events) {
-      if(cpfds_add_sock(cpfds, ps->sockets[i], events, TRUE))
-        return CURLE_OUT_OF_MEMORY;
-    }
+    if(events && cpfds_add_sock(cpfds, ps->sockets[i], events, TRUE))
+      return CURLE_OUT_OF_MEMORY;
   }
   return CURLE_OK;
 }

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1917,10 +1917,9 @@ static CURLcode smtp_disconnect(struct Curl_easy *data,
      disconnect wait in vain and cause more problems than we need to. */
 
   if(!dead_connection && conn->bits.protoconnstart &&
-     !Curl_pp_needs_flush(data, &smtpc->pp)) {
-    if(!smtp_perform_quit(data, smtpc))
-      (void)smtp_block_statemach(data, smtpc, TRUE); /* ignore on QUIT */
-  }
+     !Curl_pp_needs_flush(data, &smtpc->pp) &&
+     !smtp_perform_quit(data, smtpc))
+    (void)smtp_block_statemach(data, smtpc, TRUE); /* ignore on QUIT */
 
   CURL_TRC_SMTP(data, "smtp_disconnect(), finished");
   return CURLE_OK;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1016,11 +1016,8 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data,
     result = Curl_mime_prepare_headers(data, postp, NULL,
                                        NULL, MIMESTRATEGY_MAIL);
 
-    if(!result)
-      if(!Curl_checkheaders(data, STRCONST("Mime-Version")))
-        result = Curl_mime_add_header(&postp->curlheaders,
-                                      "Mime-Version: 1.0");
-
+    if(!result && !Curl_checkheaders(data, STRCONST("Mime-Version")))
+      result = Curl_mime_add_header(&postp->curlheaders, "Mime-Version: 1.0");
     if(!result)
       result = Curl_creader_set_mime(data, postp);
     if(result)

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -274,10 +274,8 @@ static CURLcode smtp_parse_address(struct Curl_easy *data, const char *fqma,
 
   if(fqma[0] != '<') {
     length = strlen(dup);
-    if(length) {
-      if(dup[length - 1] == '>')
-        dup[length - 1] = '\0';
-    }
+    if(length && dup[length - 1] == '>')
+      dup[length - 1] = '\0';
   }
   else {
     addressend = strrchr(dup, '>');

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1414,13 +1414,12 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     }
     } /* switch */
 
-    if(data->set.timeout) {
-      if(curlx_ptimediff_ms(Curl_pgrs_now(data), &conn->created) >=
-         data->set.timeout) {
-        failf(data, "Time-out");
-        result = CURLE_OPERATION_TIMEDOUT;
-        keepon = FALSE;
-      }
+    if(data->set.timeout &&
+       curlx_ptimediff_ms(Curl_pgrs_now(data), &conn->created) >=
+       data->set.timeout) {
+      failf(data, "Time-out");
+      result = CURLE_OPERATION_TIMEDOUT;
+      keepon = FALSE;
     }
   }
 
@@ -1533,13 +1532,12 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
       break;
     } /* poll switch statement */
 
-    if(data->set.timeout) {
-      if(curlx_ptimediff_ms(Curl_pgrs_now(data), &conn->created) >=
-         data->set.timeout) {
-        failf(data, "Time-out");
-        result = CURLE_OPERATION_TIMEDOUT;
-        keepon = FALSE;
-      }
+    if(data->set.timeout &&
+       curlx_ptimediff_ms(Curl_pgrs_now(data), &conn->created) >=
+       data->set.timeout) {
+      failf(data, "Time-out");
+      result = CURLE_OPERATION_TIMEDOUT;
+      keepon = FALSE;
     }
 
     if(!result) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -1380,15 +1380,14 @@ static CURLcode url_set_data_creds_netrc(struct Curl_easy *data,
       goto out;
     }
     else if(ncreds_out) {
-      if(!(data->state.origin->scheme->flags & PROTOPT_USERPWDCTRL)) {
-        /* if the protocol cannot handle control codes in credentials, make
-           sure there are none */
-        if(str_has_ctrl(ncreds_out->user) ||
-           str_has_ctrl(ncreds_out->passwd)) {
-          failf(data, "control code detected in .netrc credentials");
-          result = CURLE_READ_ERROR;
-          goto out;
-        }
+      if(!(data->state.origin->scheme->flags & PROTOPT_USERPWDCTRL) &&
+         /* if the protocol cannot handle control codes in credentials, make
+            sure there are none */
+         (str_has_ctrl(ncreds_out->user) ||
+          str_has_ctrl(ncreds_out->passwd))) {
+        failf(data, "control code detected in .netrc credentials");
+        result = CURLE_READ_ERROR;
+        goto out;
       }
       CURL_TRC_M(data, "netrc: using credentials for %s as %s",
                  data->state.origin->hostname, ncreds_out->user);

--- a/lib/url.c
+++ b/lib/url.c
@@ -611,7 +611,7 @@ static bool url_match_connect_config(struct connectdata *conn,
      m->data->set.ipver != conn->ip_version)
     return FALSE;
 
-  if(m->needle->localdev || m->needle->localport) {
+  if((m->needle->localdev || m->needle->localport) &&
     /* If we are bound to a specific local end (IP+port), we must not reuse a
        random other one, although if we did not ask for a particular one we
        can reuse one that was bound.
@@ -622,12 +622,11 @@ static bool url_match_connect_config(struct connectdata *conn,
        this matching will assume that reuses of bound connections will most
        likely also reuse the exact same binding parameters and missing out a
        few edge cases should not hurt anyone much. */
-    if((conn->localport != m->needle->localport) ||
-       (conn->localportrange != m->needle->localportrange) ||
-       (m->needle->localdev &&
-        (!conn->localdev || strcmp(conn->localdev, m->needle->localdev))))
-      return FALSE;
-  }
+    ((conn->localport != m->needle->localport) ||
+     (conn->localportrange != m->needle->localportrange) ||
+     (m->needle->localdev &&
+      (!conn->localdev || strcmp(conn->localdev, m->needle->localdev)))))
+    return FALSE;
 
   if(!m->needle->via_peer != !conn->via_peer)
     /* do not mix connections that use the "connect to host" feature and

--- a/lib/url.c
+++ b/lib/url.c
@@ -868,16 +868,15 @@ static bool url_match_destination(struct connectdata *conn,
   if(!Curl_peer_same_destination(m->needle->via_peer, conn->via_peer))
     return FALSE;
 
-  if(m->needle->origin->scheme != conn->origin->scheme) {
+  if(m->needle->origin->scheme != conn->origin->scheme &&
     /* `needle` and `conn` not having the same scheme.
      * This is allowed for the same family *if* conn is using TLS.
      * - IMAP+STARTTLS works for IMAPS.
      * - IMAPS works for IMAP. */
-    if(get_protocol_family(conn->origin->scheme) !=
-       m->needle->scheme->protocol) {
-      return FALSE;
-    }
-  }
+     get_protocol_family(conn->origin->scheme) !=
+     m->needle->scheme->protocol)
+    return FALSE;
+
   /* Scheme mismatch is acceptable, compare hostname/port */
   return Curl_peer_same_destination(m->needle->origin, conn->origin);
 }

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1479,15 +1479,13 @@ static CURLUcode urlget_format(const CURLU *u, CURLUPart what,
       part = punyversion;
     }
   }
-  else if(depunyfy) {
-    if(Curl_is_ASCII_name(u->host)) {
-      char *unpunified = NULL;
-      uc = host_encode(part, &unpunified);
-      curlx_free(part);
-      if(uc)
-        return uc;
-      part = unpunified;
-    }
+  else if(depunyfy && Curl_is_ASCII_name(u->host)) {
+    char *unpunified = NULL;
+    uc = host_encode(part, &unpunified);
+    curlx_free(part);
+    if(uc)
+      return uc;
+    part = unpunified;
   }
   *partp = part;
   return CURLUE_OK;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1026,8 +1026,7 @@ static int enginecheck(struct Curl_easy *data,
 
   /* Implicitly use pkcs11 engine if none was provided and the
    * key_file is a PKCS#11 URI */
-  if(!data->state.engine &&
-     is_pkcs11_uri(key_file) &&
+  if(!data->state.engine && is_pkcs11_uri(key_file) &&
      ossl_set_engine(data, "pkcs11") != CURLE_OK)
     return 0;
 
@@ -1078,8 +1077,7 @@ static int providercheck(struct Curl_easy *data,
   char error_buffer[256];
   /* Implicitly use pkcs11 provider if none was provided and the
    * key_file is a PKCS#11 URI */
-  if(!data->state.provider_loaded &&
-     is_pkcs11_uri(key_file) &&
+  if(!data->state.provider_loaded && is_pkcs11_uri(key_file) &&
      ossl_set_provider(data, "pkcs11") != CURLE_OK) {
     return 0;
   }
@@ -1163,8 +1161,7 @@ static int engineload(struct Curl_easy *data,
   char error_buffer[256];
   /* Implicitly use pkcs11 engine if none was provided and the
    * cert_file is a PKCS#11 URI */
-  if(!data->state.engine &&
-     is_pkcs11_uri(cert_file) &&
+  if(!data->state.engine && is_pkcs11_uri(cert_file) &&
      ossl_set_engine(data, "pkcs11") != CURLE_OK)
     return 0;
 
@@ -1229,8 +1226,7 @@ static int providerload(struct Curl_easy *data,
   char error_buffer[256];
   /* Implicitly use pkcs11 provider if none was provided and the
    * cert_file is a PKCS#11 URI */
-  if(!data->state.provider_loaded &&
-     is_pkcs11_uri(cert_file) &&
+  if(!data->state.provider_loaded && is_pkcs11_uri(cert_file) &&
      ossl_set_provider(data, "pkcs11") != CURLE_OK)
     return 0;
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1076,7 +1076,6 @@ static int providercheck(struct Curl_easy *data,
 {
 #ifdef OPENSSL_HAS_PROVIDERS
   char error_buffer[256];
-
   /* Implicitly use pkcs11 provider if none was provided and the
    * key_file is a PKCS#11 URI */
   if(!data->state.provider_loaded &&
@@ -1162,7 +1161,6 @@ static int engineload(struct Curl_easy *data,
 /* ENGINE_CTRL_GET_CMD_FROM_NAME supported by OpenSSL, LibreSSL <=3.8.3 */
 #if defined(USE_OPENSSL_ENGINE) && defined(ENGINE_CTRL_GET_CMD_FROM_NAME)
   char error_buffer[256];
-
   /* Implicitly use pkcs11 engine if none was provided and the
    * cert_file is a PKCS#11 URI */
   if(!data->state.engine &&
@@ -1231,13 +1229,10 @@ static int providerload(struct Curl_easy *data,
   char error_buffer[256];
   /* Implicitly use pkcs11 provider if none was provided and the
    * cert_file is a PKCS#11 URI */
-  if(!data->state.provider_loaded) {
-    if(is_pkcs11_uri(cert_file)) {
-      if(ossl_set_provider(data, "pkcs11") != CURLE_OK) {
-        return 0;
-      }
-    }
-  }
+  if(!data->state.provider_loaded &&
+     is_pkcs11_uri(cert_file) &&
+     ossl_set_provider(data, "pkcs11") != CURLE_OK)
+    return 0;
 
   if(data->state.provider_loaded) {
     /* Load the certificate from the provider */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1166,15 +1166,13 @@ static int engineload(struct Curl_easy *data,
 /* ENGINE_CTRL_GET_CMD_FROM_NAME supported by OpenSSL, LibreSSL <=3.8.3 */
 #if defined(USE_OPENSSL_ENGINE) && defined(ENGINE_CTRL_GET_CMD_FROM_NAME)
   char error_buffer[256];
+
   /* Implicitly use pkcs11 engine if none was provided and the
    * cert_file is a PKCS#11 URI */
-  if(!data->state.engine) {
-    if(is_pkcs11_uri(cert_file)) {
-      if(ossl_set_engine(data, "pkcs11") != CURLE_OK) {
-        return 0;
-      }
-    }
-  }
+  if(!data->state.engine &&
+     is_pkcs11_uri(cert_file) &&
+     ossl_set_engine(data, "pkcs11") != CURLE_OK)
+    return 0;
 
   if(data->state.engine) {
     static const char cmd_name[] = "LOAD_CERT_CTRL";

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1026,13 +1026,10 @@ static int enginecheck(struct Curl_easy *data,
 
   /* Implicitly use pkcs11 engine if none was provided and the
    * key_file is a PKCS#11 URI */
-  if(!data->state.engine) {
-    if(is_pkcs11_uri(key_file)) {
-      if(ossl_set_engine(data, "pkcs11") != CURLE_OK) {
-        return 0;
-      }
-    }
-  }
+  if(!data->state.engine &&
+     is_pkcs11_uri(key_file) &&
+     ossl_set_engine(data, "pkcs11") != CURLE_OK)
+    return 0;
 
   if(data->state.engine) {
     UI_METHOD *ui_method = UI_create_method("curl user interface");

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1079,14 +1079,13 @@ static int providercheck(struct Curl_easy *data,
 {
 #ifdef OPENSSL_HAS_PROVIDERS
   char error_buffer[256];
+
   /* Implicitly use pkcs11 provider if none was provided and the
    * key_file is a PKCS#11 URI */
-  if(!data->state.provider_loaded) {
-    if(is_pkcs11_uri(key_file)) {
-      if(ossl_set_provider(data, "pkcs11") != CURLE_OK) {
-        return 0;
-      }
-    }
+  if(!data->state.provider_loaded &&
+     is_pkcs11_uri(key_file) &&
+     ossl_set_provider(data, "pkcs11") != CURLE_OK) {
+    return 0;
   }
 
   if(data->state.provider_loaded) {

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -970,11 +970,6 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             fi
           fi
 
-          dnl clang 23 or later
-          if test "$compiler_num" -ge "2301"; then
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [lifetime-safety])
-          fi
-
           case "$CFLAGS" in
             *-std=c89*|*-std=c90*|*-std=gnu89*|*-std=gnu90*)
               if test "$compiler_num" -ge "300"; then

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -970,6 +970,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             fi
           fi
 
+          dnl clang 23 or later
+          if test "$compiler_num" -ge "2301"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [lifetime-safety])
+          fi
+
           case "$CFLAGS" in
             *-std=c89*|*-std=c90*|*-std=gnu89*|*-std=gnu90*)
               if test "$compiler_num" -ge "300"; then

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -262,8 +262,8 @@ static long tlsversion(unsigned char mintls,
 {
   long tlsver = 0;
   if(!mintls && /* minimum is at default */
-     maxtls && (maxtls < 3)) { /* minimum is set to default,
-                                  which we want to be 1.2 */
+     /* minimum is set to default, which we want to be 1.2 */
+     maxtls && (maxtls < 3)) {
       /* max is set lower than 1.2 and minimum is default, change minimum to
          the same as max */
       mintls = maxtls;

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -261,9 +261,9 @@ static long tlsversion(unsigned char mintls,
                        unsigned char maxtls)
 {
   long tlsver = 0;
-  if(!mintls) { /* minimum is at default */
-    /* minimum is set to default, which we want to be 1.2 */
-    if(maxtls && (maxtls < 3))
+  if(!mintls && /* minimum is at default */
+     maxtls && (maxtls < 3)) { /* minimum is set to default,
+                                  which we want to be 1.2 */
       /* max is set lower than 1.2 and minimum is default, change minimum to
          the same as max */
       mintls = maxtls;

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -225,10 +225,10 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
     case CURLINFO_DATA_IN:
     case CURLINFO_SSL_DATA_IN:
     case CURLINFO_SSL_DATA_OUT:
-      /* if the data is output to a tty and we are sending this debug trace
-         to stderr or stdout, we do not display the alert about the data not
-         being shown as the data _is_ shown then not via this function */
       if(!traced_data &&
+         /* if the data is output to a tty and we are sending this debug trace
+            to stderr or stdout, we do not display the alert about the data not
+            being shown as the data _is_ shown then not via this function */
          (!global->isatty ||
           ((output != tool_stderr) && (output != stdout)))) {
         if(!newl)

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -225,18 +225,17 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
     case CURLINFO_DATA_IN:
     case CURLINFO_SSL_DATA_IN:
     case CURLINFO_SSL_DATA_OUT:
-      if(!traced_data) {
-        /* if the data is output to a tty and we are sending this debug trace
-           to stderr or stdout, we do not display the alert about the data not
-           being shown as the data _is_ shown then not via this function */
-        if(!global->isatty ||
-           ((output != tool_stderr) && (output != stdout))) {
-          if(!newl)
-            log_line_start(output, timebuf, idsbuf, type);
-          curl_mfprintf(output, "[%zu bytes data]\n", size);
-          newl = FALSE;
-          traced_data = TRUE;
-        }
+      /* if the data is output to a tty and we are sending this debug trace
+         to stderr or stdout, we do not display the alert about the data not
+         being shown as the data _is_ shown then not via this function */
+      if(!traced_data &&
+         (!global->isatty ||
+          ((output != tool_stderr) && (output != stdout)))) {
+        if(!newl)
+          log_line_start(output, timebuf, idsbuf, type);
+        curl_mfprintf(output, "[%zu bytes data]\n", size);
+        newl = FALSE;
+        traced_data = TRUE;
       }
       break;
     default: /* nada */

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -347,10 +347,9 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   else
 #endif
   {
-    if(per->hdrcbdata.headlist) {
-      if(tool_write_headers(&per->hdrcbdata, outs->stream))
-        return CURL_WRITEFUNC_ERROR;
-    }
+    if(per->hdrcbdata.headlist &&
+       tool_write_headers(&per->hdrcbdata, outs->stream))
+      return CURL_WRITEFUNC_ERROR;
     rc = fwrite(buffer, sz, nmemb, outs->stream);
   }
 

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -240,10 +240,8 @@ static int tool_mime_stdin_seek(void *instream, curl_off_t offset, int whence)
   }
   if(offset < 0)
     return CURL_SEEKFUNC_CANTSEEK;
-  if(!sip->data) {
-    if(curlx_fseek(stdin, offset + sip->origin, SEEK_SET))
-      return CURL_SEEKFUNC_CANTSEEK;
-  }
+  if(!sip->data && curlx_fseek(stdin, offset + sip->origin, SEEK_SET))
+    return CURL_SEEKFUNC_CANTSEEK;
   sip->curpos = offset;
   return CURL_SEEKFUNC_OK;
 }

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -382,15 +382,13 @@ static char *get_param_word(char **str, char **end_pos, char endchar)
   if(*ptr == '"') {
     ++ptr;
     while(*ptr) {
-      if(*ptr == '\\') {
-        if(ptr[1] == '\\' || ptr[1] == '"') {
-          /* remember the first escape position */
-          if(!escape)
-            escape = ptr;
-          /* skip escape of back-slash or double-quote */
-          ptr += 2;
-          continue;
-        }
+      if(*ptr == '\\' && (ptr[1] == '\\' || ptr[1] == '"')) {
+        /* remember the first escape position */
+        if(!escape)
+          escape = ptr;
+        /* skip escape of back-slash or double-quote */
+        ptr += 2;
+        continue;
       }
       if(*ptr == '"') {
         bool trailing_data = FALSE;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -3189,10 +3189,8 @@ ParameterError parse_args(int argc, argv_item_t argv[])
     }
   }
 
-  if(!err && config->content_disposition) {
-    if(config->resume_from_current)
-      err = PARAM_CONTDISP_RESUME_FROM;
-  }
+  if(!err && config->content_disposition && config->resume_from_current)
+    err = PARAM_CONTDISP_RESUME_FROM;
 
   if(err &&
      err != PARAM_HELP_REQUESTED &&

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1001,12 +1001,10 @@ static ParameterError set_data(cmdline_t cmd,
   if(cmd == C_JSON)
     config->jsoned = TRUE;
 
-  if(curlx_dyn_len(&config->postdata)) {
-    /* skip separator append for --json */
-    if(!err && (cmd != C_JSON) &&
-       curlx_dyn_addn(&config->postdata, "&", 1))
-      err = PARAM_NO_MEM;
-  }
+  /* skip separator append for --json */
+  if(curlx_dyn_len(&config->postdata) && !err && (cmd != C_JSON) &&
+     curlx_dyn_addn(&config->postdata, "&", 1))
+    err = PARAM_NO_MEM;
 
   if(!err && curlx_dyn_addn(&config->postdata, postdata, size))
     err = PARAM_NO_MEM;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2812,10 +2812,8 @@ static ParameterError opt_string(struct OperationConfig *config,
     break;
   case C_HOSTPUBMD5: /* --hostpubmd5 */
     err = getstr(&config->hostpubmd5, nextarg, DENY_BLANK);
-    if(!err) {
-      if(!config->hostpubmd5 || strlen(config->hostpubmd5) != 32)
-        err = PARAM_BAD_USE;
-    }
+    if(!err && (!config->hostpubmd5 || strlen(config->hostpubmd5) != 32))
+      err = PARAM_BAD_USE;
     break;
   case C_HOSTPUBSHA256: /* --hostpubsha256 */
     err = getstr(&config->hostpubsha256, nextarg, DENY_BLANK);

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -669,10 +669,9 @@ CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
     pat = &glob->pattern[i];
     switch(pat->type) {
     case GLOB_SET:
-      if(pat->c.set.elem) {
-        if(curlx_dyn_add(&glob->buf, pat->c.set.elem[pat->c.set.idx]))
-          return CURLE_OUT_OF_MEMORY;
-      }
+      if(pat->c.set.elem &&
+         curlx_dyn_add(&glob->buf, pat->c.set.elem[pat->c.set.idx]))
+        return CURLE_OUT_OF_MEMORY;
       break;
     case GLOB_ASCII: {
       char letter = (char)pat->c.ascii.letter;

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -676,13 +676,11 @@ static void output_header(struct per_transfer *per,
     size_t seplen = 0;
     size_t vlen = end - ptr;
     instr = memchr(ptr, ':', vlen);
-    if(instr) {
-      /* instructions follow */
-      if(!strncmp(&instr[1], "all:", 4)) {
-        sep = &instr[5];
-        seplen = end - sep;
-        vlen -= (seplen + 5);
-      }
+    /* instructions follow */
+    if(instr && !strncmp(&instr[1], "all:", 4)) {
+      sep = &instr[5];
+      seplen = end - sep;
+      vlen -= (seplen + 5);
     }
     if(vlen < sizeof(hname)) {
       memcpy(hname, ptr, vlen);

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -228,12 +228,10 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
             len = curlx_dyn_len(&buf);
             if(len) {
               char *ptr = curlx_dyn_ptr(&buf);
-              if(ptr[len - 1] != '\n') {
-                /* add a newline to make things look better */
-                if(curlx_dyn_addn(&buf, "\n", 1)) {
-                  error = TRUE;
-                  break;
-                }
+              /* add a newline to make things look better */
+              if(ptr[len - 1] != '\n' && curlx_dyn_addn(&buf, "\n", 1)) {
+                error = TRUE;
+                break;
               }
             }
           }

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -286,11 +286,9 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
     case VAR_INPUT_URLEQUERY:
     case VAR_INPUT_URLEFRAGMENT:
     case VAR_INPUT_URLEZONEID:
-      if(per->url) {
-        if(!urlpart(per, wovar->id, &strinfo)) {
-          freestr = strinfo;
-          valid = TRUE;
-        }
+      if(per->url && !urlpart(per, wovar->id, &strinfo)) {
+        freestr = strinfo;
+        valid = TRUE;
       }
       break;
     default:

--- a/src/var.c
+++ b/src/var.c
@@ -423,11 +423,10 @@ ParameterError setvariable(const char *input)
     if(curlx_str_number(&line, &startoffset, CURL_OFF_T_MAX) ||
        curlx_str_single(&line, '-'))
       return PARAM_VAR_SYNTAX;
-    if(curlx_str_single(&line, ']')) {
-      if(curlx_str_number(&line, &endoffset, CURL_OFF_T_MAX) ||
-         curlx_str_single(&line, ']'))
-        return PARAM_VAR_SYNTAX;
-    }
+    if(curlx_str_single(&line, ']') &&
+       (curlx_str_number(&line, &endoffset, CURL_OFF_T_MAX) ||
+        curlx_str_single(&line, ']')))
+      return PARAM_VAR_SYNTAX;
     if(startoffset > endoffset)
       return PARAM_VAR_SYNTAX;
   }

--- a/src/var.c
+++ b/src/var.c
@@ -113,11 +113,9 @@ static ParameterError varfunc(char *c, /* content */
     else if(FUNCMATCH(f, FUNC_JSON, FUNC_JSON_LEN)) {
       f += FUNC_JSON_LEN;
       curlx_dyn_reset(out);
-      if(clen) {
-        if(jsonquoted(c, clen, out, FALSE)) {
-          err = PARAM_NO_MEM;
-          break;
-        }
+      if(clen && jsonquoted(c, clen, out, FALSE)) {
+        err = PARAM_NO_MEM;
+        break;
       }
     }
     else if(FUNCMATCH(f, FUNC_URL, FUNC_URL_LEN)) {

--- a/tests/libtest/cli_h2_pausing.c
+++ b/tests/libtest/cli_h2_pausing.c
@@ -260,15 +260,14 @@ static CURLcode test_cli_h2_pausing(const char *URL)
     while((msg = curl_multi_info_read(multi, &msgs_left)) != NULL) {
       if(msg->msg == CURLMSG_DONE) {
         for(i = 0; i < CURL_ARRAYSIZE(handles); i++) {
-          if(msg->easy_handle == handles[i].curl) {
-            if(handles[i].paused != 1 || !handles[i].resumed) {
-              curl_mfprintf(stderr, "ERROR: [%zu] done, paused=%d, "
-                            "resumed=%d, result %d - wtf?\n", i,
-                            handles[i].paused,
-                            handles[i].resumed, (int)msg->data.result);
-              result = (CURLcode)1;
-              goto cleanup;
-            }
+          if(msg->easy_handle == handles[i].curl &&
+             (handles[i].paused != 1 || !handles[i].resumed)) {
+            curl_mfprintf(stderr, "ERROR: [%zu] done, paused=%d, "
+                          "resumed=%d, result %d - wtf?\n", i,
+                          handles[i].paused,
+                          handles[i].resumed, (int)msg->data.result);
+            result = (CURLcode)1;
+            goto cleanup;
           }
         }
       }

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1785,13 +1785,11 @@ static int setget_parts(bool has_utf8)
                         (int)uc, (int)setget_parts_list[i].pcode);
           error++;
         }
-        if(!uc) {
-          if(checkparts(urlp,
-                        setget_parts_list[i].set,
-                        setget_parts_list[i].out,
-                        setget_parts_list[i].getflags))
-            error++;        /* add */
-        }
+        if(!uc && checkparts(urlp,
+                             setget_parts_list[i].set,
+                             setget_parts_list[i].out,
+                             setget_parts_list[i].getflags))
+          error++; /* add */
       }
       else if(rc != CURLUE_OK) {
         curl_mfprintf(stderr, "Set parts\nin: %s\nreturned %d (expected %d)\n",

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -60,16 +60,15 @@ static bool is_chain_in_order(struct curl_certinfo *cert_info)
       curl_mprintf("  subject: %s\n", subject);
       curl_mprintf("  issuer: %s\n", issuer);
 
-      if(last_issuer) {
-        /* If the last certificate's issuer matches the current certificate's
-         * subject, then the chain is in order */
-        if(strcmp(last_issuer, subject)) {
-          curl_mfprintf(stderr,
-                        "cert %d issuer does not match cert %d subject\n",
-                        cert - 1, cert);
-          curl_mfprintf(stderr, "certificate chain is not in order\n");
-          return FALSE;
-        }
+      if(last_issuer &&
+         /* If the last certificate's issuer matches the current certificate's
+          * subject, then the chain is in order */
+         strcmp(last_issuer, subject)) {
+        curl_mfprintf(stderr,
+                      "cert %d issuer does not match cert %d subject\n",
+                      cert - 1, cert);
+        curl_mfprintf(stderr, "certificate chain is not in order\n");
+        return FALSE;
       }
     }
 

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -116,11 +116,9 @@ static CURLcode test_lib3102(const char *URL)
     struct curl_certinfo *cert_info = NULL;
     /* Get the certificate information */
     result = curl_easy_getinfo(curl, CURLINFO_CERTINFO, &cert_info);
-    if(!result) {
-      /* Check to see if the certificate chain is ordered correctly */
-      if(!is_chain_in_order(cert_info))
-        result = TEST_ERR_FAILURE;
-    }
+    /* Check to see if the certificate chain is ordered correctly */
+    if(!result && !is_chain_in_order(cert_info))
+      result = TEST_ERR_FAILURE;
   }
 
 test_cleanup:

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -361,12 +361,11 @@ static CURLcode testone(const char *URL, int timer_fail_at, int socket_fail_at)
     }
 
     if(timeout.tv_sec != (time_t)-1 &&
-       t530_getMicroSecondTimeout(&timeout) == 0) {
-      /* curl's timer has elapsed. */
-      if(socket_action(multi, CURL_SOCKET_TIMEOUT, 0, "timeout")) {
-        result = TEST_ERR_BAD_TIMEOUT;
-        goto test_cleanup;
-      }
+       t530_getMicroSecondTimeout(&timeout) == 0 &&
+       /* curl's timer has elapsed. */
+       socket_action(multi, CURL_SOCKET_TIMEOUT, 0, "timeout")) {
+      result = TEST_ERR_BAD_TIMEOUT;
+      goto test_cleanup;
     }
 
     abort_on_test_timeout();

--- a/tests/libtest/lib556.c
+++ b/tests/libtest/lib556.c
@@ -76,15 +76,14 @@ again:
       /* busy-read like crazy */
       result = curl_easy_recv(curl, buf, sizeof(buf), &nread);
 
-      if(nread) {
-        /* send received stuff to stdout */
-        if((size_t)write(STDOUT_FILENO, buf, nread) != nread) {
-          char errbuf[STRERROR_LEN];
-          curl_mfprintf(stderr, "write() failed: errno %d (%s)\n",
-                        errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
-          result = TEST_ERR_FAILURE;
-          break;
-        }
+      if(nread &&
+         /* send received stuff to stdout */
+         (size_t)write(STDOUT_FILENO, buf, nread) != nread) {
+        char errbuf[STRERROR_LEN];
+        curl_mfprintf(stderr, "write() failed: errno %d (%s)\n",
+                      errno, curlx_strerror(errno, errbuf, sizeof(errbuf)));
+        result = TEST_ERR_FAILURE;
+        break;
       }
 
     } while((result == CURLE_OK && nread) || (result == CURLE_AGAIN));

--- a/tests/libtest/lib758.c
+++ b/tests/libtest/lib758.c
@@ -455,12 +455,11 @@ static CURLcode t758_one(const char *URL, int timer_fail_at,
     }
 
     if(timeout.tv_sec != (time_t)-1 &&
-       t758_getMicroSecondTimeout(&timeout) == 0) {
-      /* curl's timer has elapsed. */
-      if(t758_saction(multi, CURL_SOCKET_TIMEOUT, 0, "timeout")) {
-        result = TEST_ERR_BAD_TIMEOUT;
-        goto test_cleanup;
-      }
+       t758_getMicroSecondTimeout(&timeout) == 0 &&
+       /* curl's timer has elapsed. */
+       t758_saction(multi, CURL_SOCKET_TIMEOUT, 0, "timeout")) {
+      result = TEST_ERR_BAD_TIMEOUT;
+      goto test_cleanup;
     }
 
     abort_on_test_timeout();

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -703,15 +703,13 @@ static bool socksd_incoming(curl_socket_t listenfd)
     }
     for(i = 0; i < 2; i++) {
       struct perclient *cp = &c[i];
-      if(cp->used) {
-        if(tunnel(cp, &fds_read)) {
-          logmsg("SOCKS transfer completed. Bytes: < %zu > %zu",
-                 cp->fromremote, cp->fromclient);
-          sclose(cp->clientfd);
-          sclose(cp->remotefd);
-          cp->used = FALSE;
-          clients--;
-        }
+      if(cp->used && tunnel(cp, &fds_read)) {
+        logmsg("SOCKS transfer completed. Bytes: < %zu > %zu",
+               cp->fromremote, cp->fromclient);
+        sclose(cp->clientfd);
+        sclose(cp->remotefd);
+        cp->used = FALSE;
+        clients--;
       }
     }
   } while(clients);

--- a/tests/unit/unit1627.c
+++ b/tests/unit/unit1627.c
@@ -128,11 +128,9 @@ static CURLcode test_unit1627(const char *arg)
     for(i = 0; i < CURL_ARRAYSIZE(okay); i++) {
       char buffer[32];
       const struct Curl_scheme *get = Curl_get_scheme(okay[i]);
-      if(get) {
-        /* verify that we got the correct scheme */
-        if(!curl_strequal(get->name, okay[i]))
-          get = NULL;
-      }
+      /* verify that we got the correct scheme */
+      if(get && !curl_strequal(get->name, okay[i]))
+        get = NULL;
       if(!get) {
         curl_mprintf("Input: %s, expected okay\n", okay[i]);
         break;

--- a/tests/unit/unit1675.c
+++ b/tests/unit/unit1675.c
@@ -227,14 +227,13 @@ static CURLcode test_unit1675(const char *arg)
                         uc ? "error" : hostname);
           fails++;
         }
-        if(!uc && tests[i].out_zone) {
-          if(!u.zoneid || strcmp(u.zoneid, tests[i].out_zone)) {
-            curl_mfprintf(stderr, "ipv6_parse('%s') zone failed:"
-                          " expected '%s', got '%s'\n",
-                          tests[i].in, tests[i].out_zone,
-                          u.zoneid ? u.zoneid : "(null)");
-            fails++;
-          }
+        if(!uc && tests[i].out_zone &&
+           (!u.zoneid || strcmp(u.zoneid, tests[i].out_zone))) {
+          curl_mfprintf(stderr, "ipv6_parse('%s') zone failed:"
+                        " expected '%s', got '%s'\n",
+                        tests[i].in, tests[i].out_zone,
+                        u.zoneid ? u.zoneid : "(null)");
+          fails++;
         }
       }
       else if(!uc) {

--- a/tests/unit/unit2603.c
+++ b/tests/unit/unit2603.c
@@ -80,12 +80,10 @@ static void parse_success(const struct tcase *t)
       fail("error consuming");
     }
     in_consumed += nread;
-    if(nread != buflen) {
-      if(!p.done) {
-        curl_mfprintf(stderr, "only %zu/%zu consumed for: '%s'\n",
-                      nread, buflen, buf);
-        fail("not all consumed");
-      }
+    if(nread != buflen && !p.done) {
+      curl_mfprintf(stderr, "only %zu/%zu consumed for: '%s'\n",
+                    nread, buflen, buf);
+      fail("not all consumed");
     }
   }
 


### PR DESCRIPTION
Reported by clang-tidy 23.1.0+ via `readability-redundant-nested-if`.

Do not enforce at this time, due to a handful of places where it 1) 
applies  conditionally for non-debug builds (cf-h2-proxy.c), 2)
decreases readability (cookie.c, probably could be fixed by using temp
variables or code refactor), 3) breaks code structure (protocol.c).

Ref: https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-nested-if.html

---

https://github.com/curl/curl/pull/22793/files?w=1
