### PR TITLE
tests: Test certificates with embedded zero bytes

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -598,3 +598,29 @@ class TestSSLUse:
         ])
         # CURLE_PEER_FAILED_VERIFICATION or CURLE_SSL_CACERT_BADFILE
         assert r.exit_code in [60, 77], f'{r.dump_logs()}'
+
+    @pytest.mark.parametrize("proto", Env.http_protos())
+    def test_17_23_embedded_zero(self, env: Env, proto, httpd, nghttpx):
+        httpd.set_domain1_cred_name('embedded-zero')
+        httpd.reload_if_config_changed()
+        if proto == 'h3':
+            nghttpx.set_cred_name('embedded-zero')
+            nghttpx.reload_if_config_changed()
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo'
+        r = curl.http_get(url=url, alpn_proto=proto)
+        # CURLE_PEER_FAILED_VERIFICATION
+        assert r.exit_code == 60, f'{r.dump_logs()}'
+
+    @pytest.mark.parametrize("proto", Env.http_protos())
+    def test_17_24_embedded_zero_wildcard(self, env: Env, proto, httpd, nghttpx):
+        httpd.set_domain1_cred_name('embedded-zero-wildcard')
+        httpd.reload_if_config_changed()
+        if proto == 'h3':
+            nghttpx.set_cred_name('embedded-zero-wildcard')
+            nghttpx.reload_if_config_changed()
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo'
+        r = curl.http_get(url=url, alpn_proto=proto)
+        # CURLE_PEER_FAILED_VERIFICATION
+        assert r.exit_code == 60, f'{r.dump_logs()}'

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -609,8 +609,8 @@ class TestSSLUse:
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo'
         r = curl.http_get(url=url, alpn_proto=proto)
-        # CURLE_PEER_FAILED_VERIFICATION
-        assert r.exit_code == 60, f'{r.dump_logs()}'
+        # CURLE_SSL_CONNECT_ERROR or CURLE_PEER_FAILED_VERIFICATION
+        assert r.exit_code in [35, 60], f'{r.dump_logs()}'
 
     @pytest.mark.parametrize("proto", Env.http_protos())
     def test_17_24_embedded_zero_wildcard(self, env: Env, proto, httpd, nghttpx):
@@ -622,5 +622,5 @@ class TestSSLUse:
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo'
         r = curl.http_get(url=url, alpn_proto=proto)
-        # CURLE_PEER_FAILED_VERIFICATION
-        assert r.exit_code == 60, f'{r.dump_logs()}'
+        # CURLE_SSL_CONNECT_ERROR or CURLE_PEER_FAILED_VERIFICATION
+        assert r.exit_code in [35, 60], f'{r.dump_logs()}'

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -218,6 +218,16 @@ class EnvConfig:
                     CertificateSpec(name="user1", client=True),
                 ],
             ),
+            CertificateSpec(
+                name='embedded-zero',
+                domains=[f'{self.domain1}\0actually.{self.domain2}'],
+                key_type='rsa2048',
+            ),
+            CertificateSpec(
+                name='embedded-zero-wildcard',
+                domains=[f'*.{self.tld}\0actually.{self.domain2}'],
+                key_type='rsa2048',
+            ),
         ]
 
         self.openssl = "openssl"


### PR DESCRIPTION
The code removed from https://github.com/curl/curl/pull/22767 was part of a mess from when cURL once that strings in certificates were C strings and did not have embedded zeros. See these historical commits:

* c0e8bed5bf7a7e56897e492a4dcc399621939995
* 0b66efac9cb0b606d943870237f689d71ba798f7
* 781b82baf5e481964d67971848e4f363915ef789

Since it seems there was never a test for any of this, fill in some of these missing tests now.

(I was working on a fix for the same strlen issue but never got around to uploading it. Since #22767 has since landed, I figure I may as well contribute the tests.)
