### PR TITLE
warnless: dedupe Intel compiler warning suppression pragmas

### DIFF
--- a/lib/curlx/warnless.c
+++ b/lib/curlx/warnless.c
@@ -48,22 +48,18 @@
 #define CURL_MASK_USIZE_T ((size_t)~0)
 #define CURL_MASK_SSIZE_T (CURL_MASK_USIZE_T >> 1)
 
-/*
- * unsigned long to unsigned char
- */
-unsigned char curlx_ultouc(unsigned long ulnum)
-{
 #ifdef __INTEL_COMPILER
 #pragma warning(push)
 #pragma warning(disable:810) /* conversion may lose significant bits */
 #endif
 
+/*
+ * unsigned long to unsigned char
+ */
+unsigned char curlx_ultouc(unsigned long ulnum)
+{
   DEBUGASSERT(ulnum <= (unsigned long)CURL_MASK_UCHAR);
   return (unsigned char)(ulnum & (unsigned long)CURL_MASK_UCHAR);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -71,17 +67,8 @@ unsigned char curlx_ultouc(unsigned long ulnum)
  */
 int curlx_uztosi(size_t uznum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(uznum <= (size_t)CURL_MASK_SINT);
   return (int)(uznum & (size_t)CURL_MASK_SINT);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -89,19 +76,10 @@ int curlx_uztosi(size_t uznum)
  */
 unsigned long curlx_uztoul(size_t uznum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
 #if ULONG_MAX < SIZE_MAX
   DEBUGASSERT(uznum <= (size_t)CURL_MASK_ULONG);
 #endif
   return (unsigned long)(uznum & (size_t)CURL_MASK_ULONG);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -109,19 +87,10 @@ unsigned long curlx_uztoul(size_t uznum)
  */
 unsigned int curlx_uztoui(size_t uznum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
 #if UINT_MAX < SIZE_MAX
   DEBUGASSERT(uznum <= (size_t)CURL_MASK_UINT);
 #endif
   return (unsigned int)(uznum & (size_t)CURL_MASK_UINT);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -129,20 +98,11 @@ unsigned int curlx_uztoui(size_t uznum)
  */
 int curlx_sltosi(long slnum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(slnum >= 0);
 #if INT_MAX < LONG_MAX
   DEBUGASSERT((unsigned long)slnum <= (unsigned long)CURL_MASK_SINT);
 #endif
   return (int)(slnum & (long)CURL_MASK_SINT);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -150,20 +110,11 @@ int curlx_sltosi(long slnum)
  */
 unsigned int curlx_sltoui(long slnum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(slnum >= 0);
 #if UINT_MAX < LONG_MAX
   DEBUGASSERT((unsigned long)slnum <= (unsigned long)CURL_MASK_UINT);
 #endif
   return (unsigned int)(slnum & (long)CURL_MASK_UINT);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -171,18 +122,9 @@ unsigned int curlx_sltoui(long slnum)
  */
 unsigned short curlx_sltous(long slnum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(slnum >= 0);
   DEBUGASSERT((unsigned long)slnum <= (unsigned long)CURL_MASK_USHORT);
   return (unsigned short)(slnum & (long)CURL_MASK_USHORT);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -190,17 +132,8 @@ unsigned short curlx_sltous(long slnum)
  */
 ssize_t curlx_uztosz(size_t uznum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(uznum <= (size_t)CURL_MASK_SSIZE_T);
   return (ssize_t)(uznum & (size_t)CURL_MASK_SSIZE_T);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -208,17 +141,8 @@ ssize_t curlx_uztosz(size_t uznum)
  */
 size_t curlx_sotouz(curl_off_t sonum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(sonum >= 0);
   return (size_t)(sonum & (curl_off_t)CURL_MASK_USIZE_T);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -226,20 +150,11 @@ size_t curlx_sotouz(curl_off_t sonum)
  */
 int curlx_sztosi(ssize_t sznum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(sznum >= 0);
 #if INT_MAX < SSIZE_MAX
   DEBUGASSERT((size_t)sznum <= (size_t)CURL_MASK_SINT);
 #endif
   return (int)(sznum & (ssize_t)CURL_MASK_SINT);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -247,17 +162,8 @@ int curlx_sztosi(ssize_t sznum)
  */
 unsigned short curlx_uitous(unsigned int uinum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(uinum <= (unsigned int)CURL_MASK_USHORT);
   return (unsigned short)(uinum & (unsigned int)CURL_MASK_USHORT);
-
-#ifdef __INTEL_COMPILER
-#pragma warning(pop)
-#endif
 }
 
 /*
@@ -265,18 +171,13 @@ unsigned short curlx_uitous(unsigned int uinum)
  */
 size_t curlx_sitouz(int sinum)
 {
-#ifdef __INTEL_COMPILER
-#pragma warning(push)
-#pragma warning(disable:810) /* conversion may lose significant bits */
-#endif
-
   DEBUGASSERT(sinum >= 0);
   return (size_t)sinum;
+}
 
 #ifdef __INTEL_COMPILER
 #pragma warning(pop)
 #endif
-}
 
 size_t curlx_uitouz(unsigned int uinum)
 {


### PR DESCRIPTION
<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
