### PR TITLE
Fix preprocessor check for old Darwin versions

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -564,6 +564,7 @@ static size_t vquic_msghdr_get_udp_gro(struct msghdr *msg)
 }
 #endif /* (HAVE_SENDMMSG || HAVE_SENDMSG) && !HAVE_APPLE_MSG_X */
 
+/* IP_RECVTOS was added in the macOS 10.13 SDK */
 #if (defined(HAVE_SENDMMSG) || defined(HAVE_SENDMSG) || \
   defined(HAVE_APPLE_MSG_X)) && \
   ((defined(__APPLE__) && defined(IP_RECVTOS)) || \

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -567,8 +567,8 @@ static size_t vquic_msghdr_get_udp_gro(struct msghdr *msg)
 #if (defined(HAVE_SENDMMSG) || defined(HAVE_SENDMSG) || \
   defined(HAVE_APPLE_MSG_X)) && \
   ((defined(__APPLE__) && defined(IP_RECVTOS)) || \
-  (!defined(__APPLE__) && defined(IP_TOS))) \
-  && defined(IPTOS_ECN_MASK)
+   (!defined(__APPLE__) && defined(IP_TOS))) && \
+  defined(IPTOS_ECN_MASK)
 static uint8_t vquic_msghdr_get_ecn(struct msghdr *msg, int family)
 {
   struct cmsghdr *cmsg;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -566,7 +566,8 @@ static size_t vquic_msghdr_get_udp_gro(struct msghdr *msg)
 
 #if (defined(HAVE_SENDMMSG) || defined(HAVE_SENDMSG) || \
   defined(HAVE_APPLE_MSG_X)) && \
-  (defined(IP_RECVTOS) || defined(IP_TOS)) && defined(IPTOS_ECN_MASK)
+  ((defined(__APPLE__) && defined(IP_RECVTOS)) || (!defined(__APPLE__) && defined(IP_TOS))) \
+  && defined(IPTOS_ECN_MASK)
 static uint8_t vquic_msghdr_get_ecn(struct msghdr *msg, int family)
 {
   struct cmsghdr *cmsg;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -566,7 +566,8 @@ static size_t vquic_msghdr_get_udp_gro(struct msghdr *msg)
 
 #if (defined(HAVE_SENDMMSG) || defined(HAVE_SENDMSG) || \
   defined(HAVE_APPLE_MSG_X)) && \
-  ((defined(__APPLE__) && defined(IP_RECVTOS)) || (!defined(__APPLE__) && defined(IP_TOS))) \
+  ((defined(__APPLE__) && defined(IP_RECVTOS)) || \
+  (!defined(__APPLE__) && defined(IP_TOS))) \
   && defined(IPTOS_ECN_MASK)
 static uint8_t vquic_msghdr_get_ecn(struct msghdr *msg, int family)
 {


### PR DESCRIPTION
Older versions of Darwin (macOS, iOS, tvOS, etc) before macOS 10.13 don't have `IP_RECVTOS`, but they still get this code because they do have `IP_TOS`.  This makes the preprocessor check for this code more thorough to allow curl to compile on older Darwin versions again.