### PR TITLE
multi_ntfy: replace enabled bitset with inline flags

### DIFF
--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -538,6 +538,7 @@ CURL_EXTERN CURLMcode curl_multi_waitfds(CURLM *m,
  */
 #define CURLMNOTIFY_INFO_READ    0
 #define CURLMNOTIFY_EASY_DONE    1
+#define CURLMNOTIFY_LAST         2 /* last, not used */
 
 /*
  * Callback to install via CURLMOPT_NOTIFYFUNCTION.

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -276,8 +276,7 @@ struct Curl_multi *Curl_multi_handle(uint32_t xfer_table_size,
   multi->wakeup_internal[1] = CURL_SOCKET_BAD;
 #endif
 
-  if(Curl_mntfy_resize(multi) ||
-     Curl_uint32_bset_resize(&multi->process, xfer_table_size) ||
+  if(Curl_uint32_bset_resize(&multi->process, xfer_table_size) ||
      Curl_uint32_bset_resize(&multi->pending, xfer_table_size) ||
      Curl_uint32_bset_resize(&multi->dirty, xfer_table_size) ||
      Curl_uint32_bset_resize(&multi->msgsent, xfer_table_size) ||

--- a/lib/multi_ntfy.c
+++ b/lib/multi_ntfy.c
@@ -29,6 +29,11 @@
 #include "multiif.h"
 #include "multi_ntfy.h"
 
+#if CURLMNOTIFY_LAST > 31
+#error "notification types must fit below the curl_multi_ntfy high flag bit"
+#endif
+
+#define CURL_MNTFY_TYPE_FLAG(type)  ((uint32_t)1 << (type))
 
 struct mntfy_entry {
   uint32_t mid;
@@ -108,7 +113,7 @@ static void mntfy_chunk_dispatch_all(struct Curl_multi *multi,
       e = &chunk->entries[chunk->r_offset];
       data = e->mid ? Curl_multi_get_easy(multi, e->mid) : multi->admin;
       /* only when notification has not been disabled in the meantime */
-      if(data && Curl_uint32_bset_contains(&multi->ntfy.enabled, e->type)) {
+      if(data && (multi->ntfy.flags & CURL_MNTFY_TYPE_FLAG(e->type))) {
         /* this may cause new notifications to be added! */
         CURL_TRC_M(multi->admin, "[NTFY] dispatch %u to xfer %u",
                    e->type, e->mid);
@@ -124,14 +129,6 @@ static void mntfy_chunk_dispatch_all(struct Curl_multi *multi,
 void Curl_mntfy_init(struct Curl_multi *multi)
 {
   memset(&multi->ntfy, 0, sizeof(multi->ntfy));
-  Curl_uint32_bset_init(&multi->ntfy.enabled);
-}
-
-CURLMcode Curl_mntfy_resize(struct Curl_multi *multi)
-{
-  if(Curl_uint32_bset_resize(&multi->ntfy.enabled, CURLMNOTIFY_EASY_DONE + 1))
-    return CURLM_OUT_OF_MEMORY;
-  return CURLM_OK;
 }
 
 void Curl_mntfy_cleanup(struct Curl_multi *multi)
@@ -142,22 +139,21 @@ void Curl_mntfy_cleanup(struct Curl_multi *multi)
     mnfty_chunk_destroy(chunk);
   }
   multi->ntfy.tail = NULL;
-  Curl_uint32_bset_destroy(&multi->ntfy.enabled);
 }
 
 CURLMcode Curl_mntfy_enable(struct Curl_multi *multi, unsigned int type)
 {
-  if(type > CURLMNOTIFY_EASY_DONE)
+  if(type >= CURLMNOTIFY_LAST)
     return CURLM_UNKNOWN_OPTION;
-  Curl_uint32_bset_add(&multi->ntfy.enabled, type);
+  multi->ntfy.flags |= CURL_MNTFY_TYPE_FLAG(type);
   return CURLM_OK;
 }
 
 CURLMcode Curl_mntfy_disable(struct Curl_multi *multi, unsigned int type)
 {
-  if(type > CURLMNOTIFY_EASY_DONE)
+  if(type >= CURLMNOTIFY_LAST)
     return CURLM_UNKNOWN_OPTION;
-  Curl_uint32_bset_remove(&multi->ntfy.enabled, (uint32_t)type);
+  multi->ntfy.flags &= ~CURL_MNTFY_TYPE_FLAG(type);
   return CURLM_OK;
 }
 
@@ -165,7 +161,8 @@ void Curl_mntfy_add(struct Curl_easy *data, unsigned int type)
 {
   struct Curl_multi *multi = data ? data->multi : NULL;
   if(multi && multi->ntfy.ntfy_cb && !multi->ntfy.failure &&
-     Curl_uint32_bset_contains(&multi->ntfy.enabled, (uint32_t)type)) {
+     type < CURLMNOTIFY_LAST &&
+     (multi->ntfy.flags & CURL_MNTFY_TYPE_FLAG(type))) {
     /* append to list of outstanding notifications */
     struct mntfy_chunk *tail = mntfy_non_full_tail(&multi->ntfy);
     CURL_TRC_M(data, "[NTFY] add %u for xfer %u", type, data->mid);
@@ -173,7 +170,7 @@ void Curl_mntfy_add(struct Curl_easy *data, unsigned int type)
       mntfy_chunk_append(tail, data, (uint32_t)type);
     else
       multi->ntfy.failure = CURLM_OUT_OF_MEMORY;
-    multi->ntfy.has_entries = TRUE;
+    multi->ntfy.flags |= CURL_MNTFY_FLAG_HAS_ENTRIES;
   }
 }
 
@@ -208,6 +205,6 @@ CURLMcode Curl_mntfy_dispatch_all(struct Curl_multi *multi)
     return mresult;
   }
   else
-    multi->ntfy.has_entries = FALSE;
+    multi->ntfy.flags &= ~CURL_MNTFY_FLAG_HAS_ENTRIES;
   return CURLM_OK;
 }

--- a/lib/multi_ntfy.h
+++ b/lib/multi_ntfy.h
@@ -23,7 +23,9 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#include "uint-bset.h"
+#include "curl_setup.h"
+
+#define CURL_MNTFY_FLAG_HAS_ENTRIES  ((uint32_t)1 << 31)
 
 struct Curl_easy;
 struct Curl_multi;
@@ -31,15 +33,13 @@ struct Curl_multi;
 struct curl_multi_ntfy {
   curl_notify_callback ntfy_cb;
   void *ntfy_cb_data;
-  struct uint32_bset enabled;
   struct mntfy_chunk *head;
   struct mntfy_chunk *tail;
+  uint32_t flags;
   CURLMcode failure;
-  BIT(has_entries);
 };
 
 void Curl_mntfy_init(struct Curl_multi *multi);
-CURLMcode Curl_mntfy_resize(struct Curl_multi *multi);
 void Curl_mntfy_cleanup(struct Curl_multi *multi);
 
 CURLMcode Curl_mntfy_enable(struct Curl_multi *multi, unsigned int type);
@@ -53,7 +53,8 @@ void Curl_mntfy_add(struct Curl_easy *data, unsigned int type);
       Curl_mntfy_add((d), (t));                       \
   } while(0)
 
-#define CURL_MNTFY_HAS_ENTRIES(m)       ((m)->ntfy.has_entries)
+#define CURL_MNTFY_HAS_ENTRIES(m) \
+  ((m)->ntfy.flags & CURL_MNTFY_FLAG_HAS_ENTRIES)
 
 CURLMcode Curl_mntfy_dispatch_all(struct Curl_multi *multi);
 


### PR DESCRIPTION
Store enabled notification types in the low bits of a uint32_t and use the high bit for the pending-entry state.

This reduces curl_multi_ntfy to 40 bytes and removes an allocation from multi-handle initialization.