### PR TITLE
multi: store timeout epoch as whole seconds

### DIFF
--- a/lib/splay.c
+++ b/lib/splay.c
@@ -30,8 +30,9 @@
 void Curl_timeouts_init(struct Curl_timeouts *timeouts,
                         const struct curltime *ptime_base)
 {
+  struct curltime time_base = ptime_base ? *ptime_base : curlx_now();
   timeouts->tree = NULL;
-  timeouts->time_base = ptime_base ? *ptime_base : curlx_now();
+  timeouts->time_base_sec = time_base.tv_sec;
 }
 
 bool Curl_timeouts_has(struct Curl_easy *data)
@@ -43,7 +44,10 @@ bool Curl_timeouts_has(struct Curl_easy *data)
 timediff_t Curl_timeouts_offset_us(struct Curl_timeouts *timeouts,
                                    const struct curltime *pts)
 {
-  return curlx_ptimediff_us(pts, &timeouts->time_base);
+  struct curltime time_base;
+  time_base.tv_sec = timeouts->time_base_sec;
+  time_base.tv_usec = 0;
+  return curlx_ptimediff_us(pts, &time_base);
 }
 
 int Curl_timeouts_next_ms(struct Curl_timeouts *timeouts,

--- a/lib/splay.h
+++ b/lib/splay.h
@@ -41,7 +41,7 @@ struct Curl_tree {
 
 struct Curl_timeouts {
   struct Curl_tree *tree;
-  struct curltime time_base;
+  time_t time_base_sec;
 };
 
 void Curl_timeouts_init(struct Curl_timeouts *timeouts,

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -54,6 +54,49 @@ static void splayprint(struct Curl_tree *t, int d, char output)
   splayprint(t->smaller, d + 1, output);
 }
 
+static void test_timeouts_nonzero_usec_base(void)
+{
+  struct Curl_timeouts timeouts;
+  struct Curl_tree node;
+  struct curltime base;
+  struct curltime deadline;
+  struct curltime now;
+  timediff_t original_deadline_offset;
+  timediff_t original_now_offset;
+  timediff_t deadline_offset;
+  timediff_t now_offset;
+  timediff_t expire_offset;
+  uint32_t mid;
+  int timeout_ms;
+
+  base.tv_sec = 10;
+  base.tv_usec = 750000;
+  deadline.tv_sec = 12;
+  deadline.tv_usec = 250000;
+  now.tv_sec = 11;
+  now.tv_usec = 100000;
+
+  original_deadline_offset = curlx_ptimediff_us(&deadline, &base);
+  original_now_offset = curlx_ptimediff_us(&now, &base);
+
+  Curl_timeouts_init(&timeouts, &base);
+  deadline_offset = Curl_timeouts_offset_us(&timeouts, &deadline);
+  now_offset = Curl_timeouts_offset_us(&timeouts, &now);
+
+  fail_unless(deadline_offset - original_deadline_offset == base.tv_usec,
+              "deadline offset did not shift by the base microseconds");
+  fail_unless(now_offset - original_now_offset == base.tv_usec,
+              "now offset did not shift by the base microseconds");
+
+  memset(&node, 0, sizeof(node));
+  timeouts.tree = Curl_splayinsert(deadline_offset, timeouts.tree, &node, 42);
+  timeout_ms = Curl_timeouts_next_ms(&timeouts, &now, &expire_offset, &mid);
+
+  fail_unless(timeout_ms == 1150, "timeout changed with whole-second base");
+  fail_unless(expire_offset == deadline_offset, "wrong expiry offset");
+  fail_unless(mid == 42, "wrong timeout id");
+}
+
 static CURLcode test_unit1309(const char *arg)
 {
   UNITTEST_BEGIN_SIMPLE
@@ -157,6 +200,8 @@ static CURLcode test_unit1309(const char *arg)
   }
 
   fail_unless(!root, "tree not empty when it should be");
+
+  test_timeouts_nonzero_usec_base();
 
   UNITTEST_END_SIMPLE
 }


### PR DESCRIPTION
The timeout splay tree stores its keys as offsets from a fixed epoch. Dropping the epoch's microseconds shifts every offset by the same constant, which cancels when calculating timeout deltas.

Writing the reconstructed whole-second epoch as `base'`, the remaining timeout is unchanged:

```text
(deadline - base') - (now - base')
  = deadline - now
  = (deadline - base) - (now - base)
```

Every deadline offset is also shifted by the same constant, so their ordering is preserved.

Store only the epoch's seconds and reconstruct a zero-microsecond curltime for offset calculations. This reduces Curl_timeouts and Curl_multi by eight bytes on 64-bit builds without changing timeout ordering or durations.
