### PR TITLE
clang-tidy: disable readability-redundant-parentheses

### DIFF
--- a/.clang-tidy.yml
+++ b/.clang-tidy.yml
@@ -48,7 +48,7 @@ Checks:
   - readability-redundant-control-flow
   - readability-redundant-declaration
   - readability-redundant-function-ptr-dereference
-  - readability-redundant-parentheses
+  # - readability-redundant-parentheses
   - readability-redundant-preprocessor
   - readability-suspicious-call-argument
   - readability-uppercase-literal-suffix


### PR DESCRIPTION
It is an opinion and a judgement call I think is better left for humans.

Ref: #22803 where this suddenly showed up for code not added in the PR.
