### PR TITLE
docs: add the missing .html to the url-encode book link

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -306,7 +306,7 @@ Post a simple `name` and `phone` guestbook.
 
     curl -d "name=Rafael%20Sagula&phone=3320780" https://www.example.com/guest.cgi
 
-Or automatically [URL encode the data](https://everything.curl.dev/http/post/url-encode).
+Or automatically [URL encode the data](https://everything.curl.dev/http/post/url-encode.html).
 
     curl --data-urlencode "name=Rafael Sagula&phone=3320780"
       https://www.example.com/guest.cgi


### PR DESCRIPTION
The link in `docs/MANUAL.md` line 309 points at
`https://everything.curl.dev/http/post/url-encode`, which returns 404. The
page is served at `url-encode.html`.

Requested both: without the suffix 404, with it 200. It is the only
everything.curl.dev link under `docs/`, so nothing else needs the same change.

I used Claude Code to find this; I verified both URLs myself before reporting.