### PR TITLE
appveyor: fix description, drop redundant env

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ environment:
       CMAKE_GENERATOR: 'Visual Studio 16 2019'
       CMAKE_GENERATE: '-A x64 -DCURL_USE_OPENSSL=ON -DCURL_DISABLE_VERBOSE_STRINGS=ON'
 
-    - job_name: 'CM VS2026, Debug, x64, OpenSSL 3.5 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'
+    - job_name: 'CM VS2026, Debug, x64, OpenSSL 3.6 + Schannel, Static, Unicode, Build-tests & examples, clang-cl'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2026'
       CMAKE_VERSION: 4.2.1
       CMAKE_SHA256: dfc2b2afac257555e3b9ce375b12b2883964283a366c17fec96cf4d17e4f1677
@@ -98,7 +98,6 @@ environment:
     - job_name: 'CM VS2022, Release, x64, Schannel, Shared, Unicode, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       CMAKE_GENERATOR: 'Visual Studio 17 2022'
-      ENABLE_UNICODE: 'ON'
       CMAKE_GENERATE: '-A x64 -DENABLE_UNICODE=ON -DENABLE_DEBUG=OFF'
 
     - job_name: 'CM VS2026, Debug, x64, !ssl, Static, Build-tests'


### PR DESCRIPTION
- drop redundant Unicode setting.
  Follow-up to 41198e09b66bd5f99fcec9fe9f0d562f70559309 #20390

- sync OpenSSL version in description with actual.
  Follow-up to 81cdf4d8e5be60bf3fe498c823c34a42f2b08294 #21939

Reported-by: Jay Satiro
Ref: #22653
