### PR TITLE
GHA/non-native: re-enable FreeBSD riscv64

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -136,6 +136,9 @@ jobs:
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
+            echo '---------------'
+            ls -l /usr/local/etc/pkg/repos
+            echo '---------------'
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             if [ "${MATRIX_BUILD}" = 'autotools' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -136,7 +136,7 @@ jobs:
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
-            find /usr/local/etc/pkg/repos
+            find /usr/local/etc/pkg/repos || true
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             if [ "${MATRIX_BUILD}" = 'autotools' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -139,6 +139,10 @@ jobs:
             echo '---------------'
             ls -l /usr/local/etc/pkg/repos
             echo '---------------'
+            cat /usr/local/etc/pkg/repos/FreeBSD.conf
+            echo '---------------'
+            cat /usr/local/etc/pkg/repos/custom.conf
+            echo '---------------'
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             if [ "${MATRIX_BUILD}" = 'autotools' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -136,13 +136,7 @@ jobs:
           if [ "${MATRIX_OS}" = 'dragonflybsd' ]; then
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'freebsd' ]; then
-            echo '---------------'
-            ls -l /usr/local/etc/pkg/repos
-            echo '---------------'
-            cat /usr/local/etc/pkg/repos/FreeBSD.conf
-            echo '---------------'
-            cat /usr/local/etc/pkg/repos/custom.conf
-            echo '---------------'
+            find /usr/local/etc/pkg/repos
             sudo pkg install -y pkgconf brotli libnghttp2 ${MATRIX_INSTALL}
           elif [ "${MATRIX_OS}" = 'midnightbsd' ]; then
             if [ "${MATRIX_BUILD}" = 'autotools' ]; then

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -75,9 +75,9 @@ jobs:
               install: 'cmake-core ninja perl5 krb5-devel openldap26-client libidn2',
               options: '-DCURL_USE_GSSAPI=ON -DCMAKE_UNITY_BUILD=OFF' }
 
-          # { os: 'freebsd'     , version: '15.1',  build: 'cmake'    , arch: 'riscv64', cc: 'clang', desc: 'openssl !examples', tflags: 'HTTP --min=0 --subset=0/10 -R --seed',
-          #   install: 'cmake-core ninja perl5',
-          #   options: '-D_CURL_PREFILL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF -DCURL_DISABLE_HTTPSIG=OFF -DCURL_DISABLE_TYPECHECK=ON' }
+          - { os: 'freebsd'     , version: '15.1',  build: 'cmake'    , arch: 'riscv64', cc: 'clang', desc: 'openssl !examples', tflags: 'HTTP --min=0 --subset=0/10 -R --seed',
+              install: 'cmake-core ninja perl5',
+              options: '-D_CURL_PREFILL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF -DCURL_DISABLE_HTTPSIG=OFF -DCURL_DISABLE_TYPECHECK=ON' }
 
           - { os: 'freebsd'     , version: '14.3',  build: 'autotools', arch: 'arm64'  , cc: 'clang', desc: 'openssl !examples', tflags: 'skipall',
               install: 'autoconf automake libtool krb5-devel openldap26-client libidn2 stunnel',


### PR DESCRIPTION
It seems to be working again, with no change on the curl end.

Also: log the list of custom port sources.

Refs:
https://docs.freebsd.org/en/books/handbook/ports/
https://github.com/cross-platform-actions/freebsd-builder/commit/5d49278777bb3825aac3395d2dffc087f55ddf6d
https://github.com/cross-platform-actions/action/issues/166

Follow-up to 73f18365ab8e47912afcd5ee9404c7493d9d0fb2 #22760
