### PR TITLE
connectdata: use less curltime

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -179,8 +179,7 @@ void Curl_conn_cf_discard_chain(struct Curl_cfilter **pcf,
 void Curl_conn_cf_discard_all(struct Curl_easy *data,
                               struct connectdata *conn, int8_t sockindex)
 {
-  struct curltime *pt = &conn->shutdown.start[sockindex];
-  memset(pt, 0, sizeof(*pt));
+  conn->shutdown.start_ms[sockindex] = 0;
   Curl_conn_cf_discard_chain(&conn->cfilter[sockindex], data);
 }
 

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -315,9 +315,9 @@ static struct connectdata *cpool_bundle_get_oldest_idle(
   const struct curltime *pnow)
 {
   struct Curl_llist_node *curr;
-  timediff_t highscore = -1;
-  timediff_t score;
   struct connectdata *oldest_idle = NULL;
+  timediff_t unused_ms;
+  timediff_t oldest_ms = -1;
   struct connectdata *conn;
 
   curr = Curl_llist_head(&bundle->conns);
@@ -326,10 +326,9 @@ static struct connectdata *cpool_bundle_get_oldest_idle(
 
     if(!CONN_INUSE(conn)) {
       /* Set higher score for the age passed since the connection was used */
-      score = curlx_ptimediff_ms(pnow, &conn->lastused);
-
-      if(score > highscore) {
-        highscore = score;
+      unused_ms = curlx_ptimediff_ms(pnow, &conn->created) - conn->lastused_ms;
+      if(unused_ms > oldest_ms) {
+        oldest_ms = unused_ms;
         oldest_idle = conn;
       }
     }
@@ -362,7 +361,7 @@ static struct connectdata *cpool_get_oldest_idle(struct cpool *cpool,
       conn = Curl_node_elem(curr);
       if(CONN_INUSE(conn) || conn->bits.close || conn->bits.connect_only)
         continue;
-      idle_ms = curlx_ptimediff_ms(pnow, &conn->lastused);
+      idle_ms = curlx_ptimediff_ms(pnow, &conn->created) - conn->lastused_ms;
       if((idle_ms >= min_age_ms) && (idle_ms > oldest_idle_ms)) {
         oldest_idle_ms = idle_ms;
         oldest_idle = conn;
@@ -641,10 +640,11 @@ static bool cpool_foreach(struct Curl_easy *data,
 bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
                               struct connectdata *conn)
 {
-  unsigned int maxconnects;
-  struct connectdata *oldest_idle = NULL;
   struct cpool *cpool = cpool_get_instance(data);
+  struct connectdata *oldest_idle = NULL;
+  const struct curltime *pnow = NULL;
   struct Curl_easy *admin;
+  unsigned int maxconnects;
   bool kept = TRUE;
   timediff_t min_age_ms = 0;
 
@@ -664,7 +664,9 @@ bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
   }
 
   /* remember times, connection had been used just before */
-  conn->lastchecked = conn->lastupkeep = conn->lastused = *Curl_pgrs_now(data);
+  pnow = Curl_pgrs_now(data);
+  conn->lastchecked_ms = conn->lastupkeep_ms = conn->lastused_ms =
+    curlx_ptimediff_ms(pnow, &conn->created);
   if(cpool && maxconnects) {
     /* may be called form a callback already under lock */
     bool do_lock = !CPOOL_IS_LOCKED(cpool);
@@ -676,7 +678,7 @@ bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
       infof(data, "Connection pool is full, closing the oldest of %zu/%u",
             cpool->num_conn, maxconnects);
 
-      oldest_idle = cpool_get_oldest_idle(cpool, &conn->lastused, min_age_ms);
+      oldest_idle = cpool_get_oldest_idle(cpool, pnow, min_age_ms);
       kept = (oldest_idle != conn);
       if(oldest_idle) {
         cpool_evict_conn(cpool, admin, oldest_idle);
@@ -792,11 +794,11 @@ static int conn_upkeep(struct cpool *cpool,
   const struct curltime *pnow = Curl_pgrs_now(admin);
 
   (void)param;
-  if(curlx_ptimediff_ms(pnow, &conn->lastupkeep) >=
+  if((curlx_ptimediff_ms(pnow, &conn->created) - conn->lastupkeep_ms) >=
      admin->set.upkeep_interval_ms) {
     CURLcode result;
 
-    conn->lastupkeep = *pnow;
+    conn->lastupkeep_ms = curlx_ptimediff_ms(pnow, &conn->created);
     /* briefly attach for action */
     Curl_attach_connection(admin, conn, FALSE);
     result = Curl_conn_keep_alive(admin, conn);
@@ -918,7 +920,7 @@ static bool cpool_conn_maxage(struct Curl_easy *data,
   timediff_t age_ms;
 
   if(data->set.conn_max_idle_ms) {
-    age_ms = curlx_ptimediff_ms(pnow, &conn->lastused);
+    age_ms = curlx_ptimediff_ms(pnow, &conn->created) - conn->lastused_ms;
     if(age_ms > data->set.conn_max_idle_ms) {
       infof(data, "Too old connection (%" FMT_TIMEDIFF_T
             " ms idle, max idle is %" FMT_TIMEDIFF_T " ms), disconnect it",
@@ -951,7 +953,7 @@ bool Curl_cpool_conn_seems_healthy(struct connectdata *conn,
   DEBUGASSERT(!data->conn);
   if(!CONN_INUSE(conn) && cpool_conn_maxage(data, conn, pnow)) /* too old? */
     return FALSE;
-  if(curlx_ptimediff_ms(pnow, &conn->lastchecked) < 1000)
+  if((curlx_ptimediff_ms(pnow, &conn->created) - conn->lastchecked_ms) < 1000)
     return TRUE;
 
   admin = Curl_get_admin(data);
@@ -977,7 +979,7 @@ bool Curl_cpool_conn_seems_healthy(struct connectdata *conn,
   }
 
   if(healthy)
-    conn->lastchecked = *pnow;
+    conn->lastchecked_ms = curlx_ptimediff_ms(pnow, &conn->created);
   return healthy;
 }
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -121,7 +121,8 @@ void Curl_shutdown_start(struct Curl_easy *data, int8_t sockindex,
   const struct curltime *pnow = Curl_pgrs_now(data);
 
   DEBUGASSERT(conn);
-  conn->shutdown.start[sockindex] = *pnow;
+  conn->shutdown.start_ms[sockindex] =
+    curlx_ptimediff_ms(pnow, &conn->created);
   conn->shutdown.timeout_ms = (timeout_ms > 0) ?
     (timediff_t)timeout_ms :
     ((data->set.shutdowntimeout > 0) ?
@@ -139,13 +140,12 @@ timediff_t Curl_shutdown_timeleft(struct Curl_easy *data,
 {
   timediff_t left_ms;
 
-  if(!conn->shutdown.start[sockindex].tv_sec ||
-     (conn->shutdown.timeout_ms <= 0))
+  if(!conn->shutdown.start_ms[sockindex])
     return 0; /* not started or no limits */
 
   left_ms = conn->shutdown.timeout_ms -
-            curlx_ptimediff_ms(Curl_pgrs_now(data),
-                               &conn->shutdown.start[sockindex]);
+            (curlx_ptimediff_ms(Curl_pgrs_now(data), &conn->created) -
+             conn->shutdown.start_ms[sockindex]);
   return left_ms ? left_ms : -1;
 }
 
@@ -156,7 +156,7 @@ timediff_t Curl_conn_shutdown_timeleft(struct Curl_easy *data,
   int8_t i;
 
   for(i = 0; conn->shutdown.timeout_ms && (i < 2); ++i) {
-    if(!conn->shutdown.start[i].tv_sec)
+    if(!conn->shutdown.start_ms[i])
       continue;
     ms = Curl_shutdown_timeleft(data, conn, i);
     if(ms && (!left_ms || ms < left_ms))
@@ -167,14 +167,12 @@ timediff_t Curl_conn_shutdown_timeleft(struct Curl_easy *data,
 
 void Curl_shutdown_clear(struct Curl_easy *data, int8_t sockindex)
 {
-  struct curltime *pt = &data->conn->shutdown.start[sockindex];
-  memset(pt, 0, sizeof(*pt));
+  data->conn->shutdown.start_ms[sockindex] = 0;
 }
 
 bool Curl_shutdown_started(struct connectdata *conn, int8_t sockindex)
 {
-  const struct curltime *pt = &conn->shutdown.start[sockindex];
-  return (pt->tv_sec > 0) || (pt->tv_usec > 0);
+  return conn->shutdown.start_ms[sockindex] > 0;
 }
 
 /*
@@ -381,7 +379,8 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
        * socket and ip related information. */
       Curl_conn_cntrl_update_info(data, data->conn);
       conn_report_stats(data, sockindex);
-      data->conn->lastupkeep = *Curl_pgrs_now(data);
+      data->conn->lastupkeep_ms =
+        curlx_ptimediff_ms(Curl_pgrs_now(data), &data->conn->created);
       VERBOSE(result = conn_connect_trace(data, cf));
       VERBOSE(Curl_conn_trc_filters(data, sockindex, "connected"));
       Curl_conn_remove_setup_filters(data, sockindex);

--- a/lib/url.c
+++ b/lib/url.c
@@ -2443,7 +2443,7 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
 {
   CURLcode result;
   struct connectdata *conn = NULL;
-  const struct curltime *pnow = Curl_pgrs_now(data);
+  const struct curltime *pnow = NULL;
   *pconnected = FALSE;
 
   /* Set the request to virgin state based on transfer settings */
@@ -2459,6 +2459,8 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
   }
 
   /* Get or create a connection for the transfer. */
+  pnow = Curl_pgrs_now(data);
+  Curl_pgrsTimeWas(data, TIMER_POSTQUEUE, *pnow);
   result = url_find_or_create_conn(data, pnow);
   conn = data->conn;
   if(result)
@@ -2469,7 +2471,6 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
     goto out;
   }
 
-  Curl_pgrsTimeWas(data, TIMER_POSTQUEUE, *pnow);
   if(conn->bits.reuse) {
     if(conn->attached_xfers > 1)
       /* multiplexed */

--- a/lib/url.c
+++ b/lib/url.c
@@ -1178,7 +1178,8 @@ static bool url_attach_existing(struct Curl_easy *data,
 /*
  * Allocate and initialize a new connectdata object.
  */
-static struct connectdata *allocate_conn(struct Curl_easy *data)
+static struct connectdata *allocate_conn(struct Curl_easy *data,
+                                         const struct curltime *pnow)
 {
   struct connectdata *conn = curlx_calloc(1, sizeof(struct connectdata));
   if(!conn)
@@ -1194,7 +1195,7 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
   conn->attached_xfers = 0;
 
   /* Remember time this connection started */
-  conn->lastused = conn->lastupkeep = conn->created = *Curl_pgrs_now(data);
+  conn->created = *pnow;
 
 #ifndef CURL_DISABLE_FTP
   conn->bits.ftp_use_epsv = data->set.ftp_use_epsv;
@@ -2002,6 +2003,7 @@ static void conn_meta_freeentry(void *p)
 }
 
 static CURLcode url_create_needle(struct Curl_easy *data,
+                                  const struct curltime *pnow,
                                   struct connectdata **pneedle)
 {
   struct connectdata *needle = NULL;
@@ -2010,7 +2012,7 @@ static CURLcode url_create_needle(struct Curl_easy *data,
 
   /* Allocate a temporary connection data struct (needle) and fill in for
      comparison purposes. */
-  needle = allocate_conn(data);
+  needle = allocate_conn(data, pnow);
   if(!needle) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -2240,7 +2242,8 @@ out:
  *   a suitable connection has not determined its multiplex capability.
  * - a fatal error
  */
-static CURLcode url_find_or_create_conn(struct Curl_easy *data)
+static CURLcode url_find_or_create_conn(struct Curl_easy *data,
+                                        const struct curltime *pnow)
 {
   struct connectdata *needle = NULL;
   bool waitpipe = FALSE;
@@ -2249,7 +2252,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data)
   /* create the template connection for transfer data. Use this needle to
    * find an existing connection or, if none exists, convert needle
    * to a full connection and attach it to data. */
-  result = url_create_needle(data, &needle);
+  result = url_create_needle(data, pnow, &needle);
   if(result)
     goto out;
   DEBUGASSERT(needle);
@@ -2440,7 +2443,7 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
 {
   CURLcode result;
   struct connectdata *conn = NULL;
-
+  const struct curltime *pnow = Curl_pgrs_now(data);
   *pconnected = FALSE;
 
   /* Set the request to virgin state based on transfer settings */
@@ -2456,7 +2459,7 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
   }
 
   /* Get or create a connection for the transfer. */
-  result = url_find_or_create_conn(data);
+  result = url_find_or_create_conn(data, pnow);
   conn = data->conn;
   if(result)
     goto out;
@@ -2466,7 +2469,7 @@ CURLcode Curl_connect(struct Curl_easy *data, bool *pconnected)
     goto out;
   }
 
-  Curl_pgrsTime(data, TIMER_POSTQUEUE);
+  Curl_pgrsTimeWas(data, TIMER_POSTQUEUE, *pnow);
   if(conn->bits.reuse) {
     if(conn->attached_xfers > 1)
       /* multiplexed */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -295,7 +295,7 @@ struct connectdata {
   /* timediff_t are deltas from `created`*/
   timediff_t lastused_ms; /* when returned to the connection pool as idle */
   timediff_t lastchecked_ms; /* when last checked alive status */
-  timediff_t  lastupkeep_ms; /* when last done conn_upkeep */
+  timediff_t lastupkeep_ms; /* when last done conn_upkeep */
 
 #ifndef CURL_DISABLE_PROXY
   struct proxy_info socks_proxy;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -292,9 +292,10 @@ struct connectdata {
   char *destination; /* hostname+port, used in conncache */
 
   struct curltime created; /* creation time */
-  struct curltime lastused; /* when returned to the connection pool as idle */
-  struct curltime lastchecked; /* when last checked alive status */
-  struct curltime lastupkeep; /* when last done conn_upkeep */
+  /* timediff_t are deltas from `created`*/
+  timediff_t lastused_ms; /* when returned to the connection pool as idle */
+  timediff_t lastchecked_ms; /* when last checked alive status */
+  timediff_t  lastupkeep_ms; /* when last done conn_upkeep */
 
 #ifndef CURL_DISABLE_PROXY
   struct proxy_info socks_proxy;
@@ -311,7 +312,7 @@ struct connectdata {
 #define CONN_SOCK_IDX_VALID(i)    (((i) >= 0) && ((i) < 2))
 
   struct {
-    struct curltime start[2]; /* when filter shutdown started */
+    timediff_t start_ms[2]; /* when filter shutdown started */
     timediff_t timeout_ms; /* 0 means no timeout */
   } shutdown;
 

--- a/tests/unit/unit2606.c
+++ b/tests/unit/unit2606.c
@@ -130,6 +130,7 @@ static void t2606_run(struct Curl_easy *data, const struct t2606_case *tc)
   conn = curlx_calloc(1, sizeof(*conn));
   abort_if(!conn, "could not allocate a connection");
 
+  conn->created = curlx_now();
   memset(&ctx0, 0, sizeof(ctx0));
   memset(&ctx1, 0, sizeof(ctx1));
   ctx0.sock = 42;
@@ -142,7 +143,7 @@ static void t2606_run(struct Curl_easy *data, const struct t2606_case *tc)
     Curl_conn_cf_add(data, conn, FIRSTSOCKET, cf0);
     cf0->connected = tc->c0_connected;
     if(tc->c0_shutdown)
-      conn->shutdown.start[FIRSTSOCKET] = curlx_now();
+      conn->shutdown.start_ms[FIRSTSOCKET] = 100;
   }
 
   if(tc->has_c1) {
@@ -152,7 +153,7 @@ static void t2606_run(struct Curl_easy *data, const struct t2606_case *tc)
       Curl_conn_cf_add(data, conn, SECONDARYSOCKET, cf1);
       cf1->connected = tc->c1_connected;
       if(tc->c1_shutdown)
-        conn->shutdown.start[SECONDARYSOCKET] = curlx_now();
+        conn->shutdown.start_ms[SECONDARYSOCKET] = 100;
     }
   }
 


### PR DESCRIPTION
Replace several curltime members with timediff_t in connectdata.

Everyone needs a shrink!

