### PR TITLE
mprintf: add a fast path for trivial formats

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1058,6 +1058,194 @@ static bool out_pointer(void *userp,
   return FALSE;
 }
 
+/* TRUE if the format is literal text plus unadorned %s, %c, %d, %u and %%,
+   and stays inside the limits the general path enforces.
+
+   This takes only the format string. It holds no argument list, so it needs no
+   copy, and it is small enough to inline. A format it declines therefore costs
+   a short loop and no call. */
+/* Width of an integer conversion, matching the flags parsefmt() sets. */
+#define MP_W_NONE 0
+#define MP_W_LONG 1
+#define MP_W_LL   2
+
+/* Consume an optional length modifier on an integer conversion, exactly as
+   parsefmt() classifies it: l -> long, ll -> long long, z -> long or long long
+   by the size of size_t, and on Windows I32 -> long, I64 -> long long.
+   Advance *pp past whatever it consumed and return the width. A byte that is
+   not one of these is not a modifier: *pp is left alone and MP_W_NONE is
+   returned, so a bare %d still reads as MP_W_NONE. */
+static int mp_lenmod(const char **pp)
+{
+  const char *p = *pp;
+  switch(*p) {
+  case 'l':
+    if(p[1] == 'l') {
+      *pp = p + 2;
+      return MP_W_LL;
+    }
+    *pp = p + 1;
+    return MP_W_LONG;
+  case 'z':
+    *pp = p + 1;
+#if SIZEOF_SIZE_T > SIZEOF_LONG
+    return MP_W_LL;
+#else
+    return MP_W_LONG;
+#endif
+#ifdef _WIN32
+  case 'I':
+    if((p[1] == '6') && (p[2] == '4')) {
+      *pp = p + 3;
+      return MP_W_LL;
+    }
+    if((p[1] == '3') && (p[2] == '2')) {
+      *pp = p + 3;
+      return MP_W_LONG;
+    }
+    break;
+#endif
+  default:
+    break;
+  }
+  return MP_W_NONE;
+}
+
+/* TRUE if the format is literal text plus %s, %c, %%, and %d/%u with an
+   optional l/ll/z/I length modifier -- the conversions the general path reads
+   as int, long, long long or size_t. Stays inside the general path's limits.
+   Takes only the format string, so it needs no argument list and inlines. */
+static bool format_is_simple(const char *format)
+{
+  const char *p = format;
+  int nargs = 0;
+  int nsegs = 1; /* conservative upper bound on general-path segments */
+
+  while(*p) {
+    if(*p != '%') {
+      p++;
+      continue;
+    }
+    p++;
+    if(*p == '%') {
+      nsegs++;
+      p++;
+      continue;
+    }
+    if((*p == 's') || (*p == 'c')) {
+      if(++nargs > MAX_PARAMETERS)
+        return FALSE;
+      nsegs++;
+      p++;
+      continue;
+    }
+    (void)mp_lenmod(&p);
+    if((*p == 'd') || (*p == 'u')) {
+      if(++nargs > MAX_PARAMETERS)
+        return FALSE;
+      nsegs++;
+      p++;
+      continue;
+    }
+    return FALSE; /* not ours */
+  }
+  /* the general path treats too many segments as an error, so do not succeed
+     where it would fail */
+  return nsegs <= MAX_SEGMENTS;
+}
+
+/* Emits a format that format_is_simple() accepted, and skips the parsefmt()
+   segment and input arrays. Returns TRUE, with *donep updated. Call this only
+   after format_is_simple() returns TRUE: it does not check the format. */
+static bool format_simple(void *userp,
+                          int (*stream)(unsigned char, void *),
+                          mp_streamn streamn,
+                          const char *format, va_list args, int *donep)
+{
+  const char *p;
+
+  p = format;
+  while(*p) {
+    if(*p != '%') {
+      const char *seg = p;
+      while(*p && (*p != '%'))
+        p++;
+      if(stream_run(userp, stream, streamn, (const unsigned char *)seg,
+                    (size_t)(p - seg), donep))
+        goto out;
+      continue;
+    }
+    p++;
+    if(*p == '%') {
+      p++;
+      if(stream('%', userp))
+        goto out;
+      (*donep)++;
+    }
+    else if(*p == 's') {
+      const char *str = va_arg(args, const char *);
+      size_t len;
+      p++;
+      if(!str) {
+        str = nilstr;
+        len = sizeof(nilstr) - 1;
+      }
+      else
+        len = strlen(str);
+      if(stream_run(userp, stream, streamn, (const unsigned char *)str,
+                    len, donep))
+        goto out;
+    }
+    else if(*p == 'c') {
+      p++;
+      if(stream((unsigned char)va_arg(args, int), userp))
+        goto out;
+      (*donep)++;
+    }
+    else {
+      /* %d/%u with an optional l/ll/z/I modifier. The width and the va_arg
+         type match the general path (parsefmt + its argument switch). */
+      char nbuf[24]; /* 20 digits for a 64-bit value, a sign, and slack */
+      char *end = &nbuf[sizeof(nbuf)];
+      char *w = end;
+      bool neg = FALSE;
+      uint64_t uv;
+      int width = mp_lenmod(&p);
+      char conv = *p++;
+      if(conv == 'd') {
+        int64_t sv;
+        if(width == MP_W_LL)
+          sv = va_arg(args, int64_t);
+        else if(width == MP_W_LONG)
+          sv = (int64_t)va_arg(args, long);
+        else
+          sv = (int64_t)va_arg(args, int);
+        neg = (sv < 0);
+        uv = neg ? (0 - (uint64_t)sv) : (uint64_t)sv;
+      }
+      else {
+        if(width == MP_W_LL)
+          uv = va_arg(args, uint64_t);
+        else if(width == MP_W_LONG)
+          uv = (uint64_t)va_arg(args, unsigned long);
+        else
+          uv = (uint64_t)va_arg(args, unsigned int);
+      }
+      do {
+        *--w = (char)('0' + (uv % 10));
+        uv /= 10;
+      } while(uv);
+      if(neg)
+        *--w = '-';
+      if(stream_run(userp, stream, streamn, (const unsigned char *)w,
+                    (size_t)(end - w), donep))
+        goto out;
+    }
+  }
+out:
+  return TRUE;
+}
+
 /*
  * formatf() - the general printf function.
  *
@@ -1092,6 +1280,10 @@ static int formatf(void *userp, /* untouched by format(), sent to the
   struct outsegment output[MAX_SEGMENTS];
   struct va_input input[MAX_PARAMETERS];
   char work[BUFFSIZE + 2];
+
+  if(format_is_simple(format) &&
+     format_simple(userp, stream, streamn, format, ap_save, &done))
+    return done;
 
   /* Parse the format string */
   if(parsefmt(format, output, input, &ocount, &icount, ap_save))

--- a/tests/libtest/lib1398.c
+++ b/tests/libtest/lib1398.c
@@ -217,6 +217,117 @@ static CURLcode test_lib1398(const char *arg)
   );
   fail_unless(rc == 128, "return code should be 128");
 
+  /* Literal text plus unadorned %s, %c, %d, %u and %% goes through the
+     fast path in mprintf.c; adding a width does not. Formatting the same
+     arguments both ways must produce the same bytes.
+
+     A width of 1 changes no output here: out_string() subtracts the string
+     length from the width before padding and the %c and integer paths do
+     likewise, so a non-empty conversion leaves nothing to pad. */
+  {
+    char fast[600];
+    char gen[600];
+    /* 512 bytes, one byte longer than the staging buffer. Built here rather
+       than written as a literal: C90 requires support for only 509
+       characters in a string literal, and that limit applies after
+       concatenation. */
+    char lstr[513];
+    int rcf, rcg;
+
+    memset(lstr, 'x', sizeof(lstr) - 1);
+    lstr[sizeof(lstr) - 1] = '\0';
+
+    /* a request line */
+    rcf = curl_msnprintf(fast, sizeof(fast), "%s %s HTTP/1.1\r\n",
+                         "POST", "/path");
+    rcg = curl_msnprintf(gen, sizeof(gen), "%1s %1s HTTP/1.1\r\n",
+                         "POST", "/path");
+    fail_unless(rcf == rcg, "fast and general lengths differ");
+    fail_unless(!strcmp(fast, gen), "fast and general output differ");
+    fail_unless(!strcmp(fast, "POST /path HTTP/1.1\r\n"), "wrong output");
+
+    /* %d, including the value whose negation overflows */
+    rcf = curl_msnprintf(fast, sizeof(fast), "[%d][%d][%d]",
+                         0, -1, INT_MIN);
+    rcg = curl_msnprintf(gen, sizeof(gen), "[%1d][%1d][%1d]",
+                         0, -1, INT_MIN);
+    fail_unless(rcf == rcg, "fast and general lengths differ");
+    fail_unless(!strcmp(fast, gen), "fast and general output differ");
+
+    /* %u at the top of its range */
+    rcf = curl_msnprintf(fast, sizeof(fast), "[%u][%u]", 0U, UINT_MAX);
+    rcg = curl_msnprintf(gen, sizeof(gen), "[%1u][%1u]", 0U, UINT_MAX);
+    fail_unless(rcf == rcg, "fast and general output differ");
+    fail_unless(!strcmp(fast, gen), "fast and general output differ");
+
+    /* %c and a literal percent next to conversions */
+    rcf = curl_msnprintf(fast, sizeof(fast), "%c%%%c 100%%", 'o', 'k');
+    rcg = curl_msnprintf(gen, sizeof(gen), "%1c%%%1c 100%%", 'o', 'k');
+    fail_unless(rcf == rcg, "fast and general lengths differ");
+    fail_unless(!strcmp(fast, gen), "fast and general output differ");
+    fail_unless(!strcmp(fast, "o%k 100%"), "wrong output");
+
+    /* a NULL %s renders as (nil) on both paths */
+    rcf = curl_msnprintf(fast, sizeof(fast), "[%s]", (char *)NULL);
+    rcg = curl_msnprintf(gen, sizeof(gen), "[%1s]", (char *)NULL);
+    fail_unless(rcf == rcg, "fast and general lengths differ");
+    fail_unless(!strcmp(fast, gen), "fast and general output differ");
+    fail_unless(!strcmp(fast, "[(nil)]"), "wrong output");
+
+    /* an empty %s, where a width would legitimately differ */
+    rcf = curl_msnprintf(fast, sizeof(fast), "[%s]", "");
+    fail_unless(rcf == 2, "return code should be 2");
+    fail_unless(!strcmp(fast, "[]"), "wrong output");
+
+    /* long enough to flush the staging buffer mid-format */
+    rcf = curl_msnprintf(fast, sizeof(fast), "%s", lstr);
+    rcg = curl_msnprintf(gen, sizeof(gen), "%1s", lstr);
+    fail_unless(rcf == rcg, "fast and general lengths differ");
+    fail_unless(!strcmp(fast, gen), "fast and general output differ");
+    fail_unless(rcf == (int)(sizeof(lstr) - 1), "wrong length");
+
+    /* off_t / size_t conversions the fast path now accepts: %lld %ld %llu
+       %lu %zu, at the boundaries where a wrong va_arg width or sign shows. A
+       '1' width forces the general path. %zd and %ld share the signed path
+       with %lld, and %zu shares the z width, so the two together cover %zd. */
+    {
+      long long ll = -9223372036854775807LL - 1; /* INT64_MIN */
+      unsigned long long ull = 18446744073709551615ULL; /* UINT64_MAX */
+      long lv = -1234567L;
+      unsigned long ulv = 4000000000UL;
+      size_t zv = (size_t)-1; /* SIZE_MAX */
+
+      rcf = curl_msnprintf(fast, sizeof(fast), "[%lld][%llu]", ll, ull);
+      rcg = curl_msnprintf(gen, sizeof(gen), "[%1lld][%1llu]", ll, ull);
+      fail_unless(rcf == rcg, "fast and general lengths differ");
+      fail_unless(!strcmp(fast, gen), "fast and general output differ");
+
+      rcf = curl_msnprintf(fast, sizeof(fast), "[%ld][%lu]", lv, ulv);
+      rcg = curl_msnprintf(gen, sizeof(gen), "[%1ld][%1lu]", lv, ulv);
+      fail_unless(rcf == rcg, "fast and general lengths differ");
+      fail_unless(!strcmp(fast, gen), "fast and general output differ");
+
+      rcf = curl_msnprintf(fast, sizeof(fast), "[%zu]", zv);
+      rcg = curl_msnprintf(gen, sizeof(gen), "[%1zu]", zv);
+      fail_unless(rcf == rcg, "fast and general lengths differ");
+      fail_unless(!strcmp(fast, gen), "fast and general output differ");
+
+      /* the curl_off_t form that lib/http.c emits on every request body */
+      rcf = curl_msnprintf(fast, sizeof(fast),
+                           "Content-Length: %" CURL_FORMAT_CURL_OFF_T "\r\n",
+                           (curl_off_t)5368709120LL);
+      fail_unless(rcf == 28, "wrong length");
+      fail_unless(!strcmp(fast, "Content-Length: 5368709120\r\n"),
+                  "wrong output");
+    }
+
+    /* truncation into a short buffer */
+    rcf = curl_msnprintf(fast, 8, "%s%d", "abc", 4567);
+    rcg = curl_msnprintf(gen, 8, "%1s%1d", "abc", 4567);
+    fail_unless(rcf == rcg, "fast and general lengths differ");
+    fail_unless(!strcmp(fast, gen), "fast and general output differ");
+  }
+
   UNITTEST_END_SIMPLE
 }
 


### PR DESCRIPTION
`formatf()` parses every format into a segment array and an argument array in 2 passes. But many formats in curl are simple: literal text plus `%s`, `%c`, `%%`, and `%d`/`%u` with an optional length modifier. Those formats can be processed quickly in one pass with neither array.

This PR adds 3 functions:

1. `format_is_simple()` takes only the format string and returns TRUE if the fast path can emit it. It holds no argument list, so it needs no copy, and it inlines.
2. `format_simple()` emits a format that `format_is_simple()` accepted.
3. `mp_lenmod()`, shared helper used by both to make sure they both know which modifiers qualify for the fast path.

The accepted integer conversions are `%d` and `%u` with an optional `l`, `ll`, `z`, or (on Windows) `I32`/`I64` length modifier. That is `int`, `long`, `long long` and `size_t` — which is what `curl_off_t` and `size_t` resolve to. Everything else — a width, a precision, a float, a pointer, `%n` — falls through to the general parser, which is unchanged.

### Benchmarking

Harness: https://github.com/ron-kuper/curlbench

Base is master at `75e85f0e86`. Median of five interleaved passes, first discarded, pinned to one CPU, governor pinned to `performance` where the part has one. Every row carries a control for code layout noise: dead `__attribute__((used))` code that never runs, so it only moves addresses.

| | Cortex-A55 | 250 MHz e300c3 |
|---|---|---|
| `curl_maprintf()` of `Content-Length: <off_t>` | −20.1% | −19.4% |
| `curl_msnprintf()` of `"%s:%d"` | −55% | −67% |
| `curl_msnprintf()` of `"%s: %s\r\n"` | −54% | −47% |
| `curl_maprintf()` of a request line | −32% | −28% |

Repeat noise is 0.3% or less on both parts, every case. I left x86-64 out: the desktop available to me could not produce a resolvable figure for this set.

**A format the fast path still declines** costs a little, because the predicate scans the literal text before it reaches the conversion it cannot take. On a format with a width and a length modifier, that is about +2% on the A55 and about +1% on the e300c3, above the layout control on both. This is the general parser's own workload plus the scan; nothing regresses that the fast path does not also accept.

### Testing

Built with `--enable-debug --enable-warnings --disable-unity`:

- `make -C tests nonflaky-test`: **1618 of 1618 reported OK**.
- Tests 1398 (`curl_msnprintf`), 557 (`curl_mprintf`), 1395, 1397, 1399, 1502, 1506 pass on their own.
- A separate build with `CFLAGS=-std=gnu89 --enable-warnings --enable-werror` (which adds `-pedantic-errors`) builds the library and the test tree clean.
- `scripts/checksrc.pl` clean on both files, no new warnings.

`test1398` gains an equivalence check for every accepted conversion. A width of `1` makes a format ineligible for the fast path without changing what it prints, so the test formats the same arguments both ways and compares the bytes. It covers `%s` (including NULL and empty), `%c`, `%%`, `%d` at `INT_MIN`, `%u` at `UINT_MAX`, `%lld` at `INT64_MIN`, `%llu` at `UINT64_MAX`, `%ld`/`%lu`, `%zu` at `SIZE_MAX`, the `Content-Length` off_t shape, output long enough to force a flush, and truncation into a short buffer.

### AI disclosure

I used an AI assistant on this work: for the benchmark harness, for reading the generated code, and for checking the measurements and the argument-reading against the general path. The change, the reasoning and the measurements are mine, and I verified every claim here myself.
