### PR TITLE
HTTP-CONNECT: do not react to 401 responses

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -307,8 +307,7 @@ static CURLcode on_resp_header_udp(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OK;
   struct SingleRequest *k = &data->req;
 
-  if((checkprefix("WWW-Authenticate:", header) && (401 == k->httpcode)) ||
-     (checkprefix("Proxy-authenticate:", header) && (407 == k->httpcode))) {
+  if(checkprefix("Proxy-authenticate:", header) && (407 == k->httpcode)) {
 
     bool proxy = (k->httpcode == 407);
     char *auth = Curl_copy_header_value(header);
@@ -394,8 +393,7 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
   struct SingleRequest *k = &data->req;
   (void)cf;
 
-  if((checkprefix("WWW-Authenticate:", header) && (401 == k->httpcode)) ||
-     (checkprefix("Proxy-authenticate:", header) && (407 == k->httpcode))) {
+  if(checkprefix("Proxy-authenticate:", header) && (407 == k->httpcode)) {
 
     bool proxy = (k->httpcode == 407);
     char *auth = Curl_copy_header_value(header);

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -489,10 +489,7 @@ CURLcode Curl_http_proxy_inspect_tunnel_response(
       infof(data, "  %s: %s", entry->name, entry->value);
   }
 
-  if(resp->status == 401) {
-    auth_reply = Curl_dynhds_cget(&resp->headers, "WWW-Authenticate");
-  }
-  else if(resp->status == 407) {
+  if(resp->status == 407) {
     auth_reply = Curl_dynhds_cget(&resp->headers, "Proxy-Authenticate");
   }
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -1918,6 +1918,8 @@ TESTCASES = \
   test2118 \
   test2119 \
   \
+  test2173 \
+  \
   test2200 \
   test2201 \
   test2202 \

--- a/tests/data/test2173
+++ b/tests/data/test2173
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP CONNECT
+HTTP Basic auth
+proxytunnel
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data>
+<connect crlf="headers">
+HTTP/1.1 401 Tricking You
+WWW-Authenticate: Basic
+
+</connect>
+<datacheck crlf="headers">
+HTTP/1.1 401 Tricking You
+WWW-Authenticate: Basic
+
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+http-proxy
+</server>
+<name>
+HTTP over proxy-tunnel with site wrong 401 response
+</name>
+<command>
+http://test.%TESTNUMBER:%HTTPPORT/we/want/that/page/%TESTNUMBER -p -x %HOSTIP:%PROXYPORT --user 'iam:my:;self' --anyauth
+</command>
+<features>
+proxy
+</features>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<proxy crlf="headers">
+CONNECT test.%TESTNUMBER:%HTTPPORT HTTP/1.1
+Host: test.%TESTNUMBER:%HTTPPORT
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+</proxy>
+<protocol crlf="headers">
+</protocol>
+<errorcode>
+7
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
When a proxy answers with a 401 on a CONNECT, ignore Authentication headers and fail the connect.

Add test2173 to verify.

