### PR TITLE
tool_operate: use the real upload size when stdin is a regular file

### DIFF
--- a/docs/KNOWN_BUGS.md
+++ b/docs/KNOWN_BUGS.md
@@ -84,27 +84,6 @@ See [curl issue 10073](https://github.com/curl/curl/issues/10073)
 
 See [curl issue 12063](https://github.com/curl/curl/issues/12063)
 
-# Command line
-
-## `-T /dev/stdin` may upload with an incorrect content length
-
-`-T` stats the path to figure out its size in bytes to use it as
-`Content-Length` if it is a regular file.
-
-The problem with that is that on BSD and some other UNIX systems (not Linux),
-open(path) may not give you a file descriptor with a 0 offset from the start
-of the file.
-
-See [curl issue 12177](https://github.com/curl/curl/issues/12177)
-
-## `-T -` always uploads chunked
-
-When the `<` shell operator is used. curl should realize that stdin is a
-regular file in this case, and that it can do a non-chunked upload, like it
-would do if you used `-T` file.
-
-See [curl issue 12171](https://github.com/curl/curl/issues/12171)
-
 # Build and portability issues
 
 ## OS400 port requires deprecated IBM library

--- a/docs/cmdline-opts/upload-file.md
+++ b/docs/cmdline-opts/upload-file.md
@@ -39,6 +39,11 @@ Alternately, the filename `.` (a single period) may be specified instead of
 `-` to use stdin in non-blocking mode to allow reading server output while
 stdin is being uploaded.
 
+If stdin is a regular file, for example when a shell redirect is used, curl
+knows the upload size beforehand and uses it for the transfer. Otherwise, an
+upload from stdin is done with an unknown size, which for HTTP/1.1 means a
+chunked transfer. (Added in 8.23.0)
+
 If this option is used with an HTTP(S) URL, the PUT method is used.
 
 You can specify one --upload-file for each URL on the command line. Each

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -243,6 +243,20 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
   return n;
 }
 
+/* Return the number of bytes that remain to read of a regular file,
+   counting from the current file position, or -1 if it cannot be
+   determined. On several systems (not Linux), opening /dev/stdin or
+   /dev/fd/N returns a file descriptor that shares file position with the
+   original descriptor, so the position is not necessarily zero. */
+UNITTEST curl_off_t regfile_size_left(int fd, curl_off_t filesize)
+{
+  curl_off_t pos = (curl_off_t)curl_lseek(fd, 0, SEEK_CUR);
+  if(pos >= 0)
+    return (pos < filesize) ? filesize - pos : 0;
+  /* with an unknown position, treat the size as unknown */
+  return -1;
+}
+
 static CURLcode pre_transfer(struct per_transfer *per)
 {
   curl_off_t uploadfilesize = -1;
@@ -297,23 +311,32 @@ static CURLcode pre_transfer(struct per_transfer *per)
 
     /* we ignore file size for char/block devices, sockets, etc. */
     if(S_ISREG(fileinfo.st_mode))
-      uploadfilesize = fileinfo.st_size;
+      uploadfilesize = regfile_size_left(per->infd,
+                                         (curl_off_t)fileinfo.st_size);
+  }
+  else if(per->uploadfile && !strcmp(per->uploadfile, "-")) {
+    /* when stdin is a regular file, the upload size is known and the
+       transfer does not need to use an unknown size */
+    if(!curlx_fstat(STDIN_FILENO, &fileinfo) && S_ISREG(fileinfo.st_mode))
+      uploadfilesize = regfile_size_left(STDIN_FILENO,
+                                         (curl_off_t)fileinfo.st_size);
+  }
 
 #ifdef DEBUGBUILD
-    /* allow dedicated test cases to override */
-    {
-      const char *ev = getenv("CURL_UPLOAD_SIZE");
-      if(ev) {
-        curl_off_t sz;
-        curlx_str_number(&ev, &sz, CURL_OFF_T_MAX);
-        uploadfilesize = sz;
-      }
+  /* allow dedicated test cases to override */
+  if(per->uploadfile) {
+    const char *ev = getenv("CURL_UPLOAD_SIZE");
+    if(ev) {
+      curl_off_t sz;
+      curlx_str_number(&ev, &sz, CURL_OFF_T_MAX);
+      uploadfilesize = sz;
     }
+  }
 #endif
 
-    if(uploadfilesize != -1)
-      my_setopt_offt(per->curl, CURLOPT_INFILESIZE_LARGE, uploadfilesize);
-  }
+  if(uploadfilesize != -1)
+    my_setopt_offt(per->curl, CURLOPT_INFILESIZE_LARGE, uploadfilesize);
+
   per->uploadfilesize = uploadfilesize;
   per->start = curlx_now();
   return result;

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -25,6 +25,10 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
+#ifdef UNITTESTS
+UNITTEST curl_off_t regfile_size_left(int fd, curl_off_t filesize);
+#endif
+
 #include "tool_cb_hdr.h"
 #include "tool_cb_prg.h"
 #include "tool_cfgable.h"

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -1700,6 +1700,7 @@ TESTCASES = \
   test1676 \
   test1677 \
   test1678 \
+  test1679 \
   test1680 \
   test1681 \
   test1682 \

--- a/tests/data/test1068
+++ b/tests/data/test1068
@@ -5,7 +5,6 @@
 <keywords>
 HTTP
 HTTP PUT
-chunked Transfer-Encoding
 </keywords>
 </info>
 
@@ -44,14 +43,9 @@ PUT /bzz/%TESTNUMBER HTTP/1.1%CR
 Host: %HOSTIP:%HTTPPORT%CR
 User-Agent: curl/%VERSION%CR
 Accept: */*%CR
-Transfer-Encoding: chunked%CR
-Expect: 100-continue%CR
+Content-Length: 19%CR
 %CR
-13%CR
 more than one byte
-%CR
-0%CR
-%CR
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test1069
+++ b/tests/data/test1069
@@ -21,7 +21,7 @@ http
 HTTP 1.0 PUT from stdin with no content length
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/bzz/%TESTNUMBER -T - -0
+http://%HOSTIP:%HTTPPORT/bzz/%TESTNUMBER -T . -0
 </command>
 <stdin>
 this data cannot be sent

--- a/tests/data/test1072
+++ b/tests/data/test1072
@@ -34,14 +34,18 @@ Connection: close
 <server>
 http
 </server>
+# `-T .` on Windows relays stdin through a thread and a socket. The rewind
+# for the authentication retry then does not work: mingw builds error out
+# with 65, msvc builds hang.
 <features>
+!win32
 crypto
 </features>
 <name>
 HTTP chunked PUT to HTTP 1.0 server with authorization
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T - -u testuser:testpass --anyauth
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T . -u testuser:testpass --anyauth
 </command>
 <stdin>
 This is data we upload with PUT

--- a/tests/data/test1073
+++ b/tests/data/test1073
@@ -31,11 +31,17 @@ Connection: close
 <server>
 http
 </server>
+# `-T .` on Windows relays stdin through a thread and a socket. The rewind
+# for following the redirect then does not work: mingw builds error out
+# with 65, msvc builds hang.
+<features>
+!win32
+</features>
 <name>
 HTTP chunked PUT to HTTP 1.0 server with redirect
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T - -L
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T . -L
 </command>
 <stdin>
 This is data we upload with PUT

--- a/tests/data/test1679
+++ b/tests/data/test1679
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+unittest
+upload
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+unittest
+</features>
+<name>
+unit tests for regfile_size_left
+</name>
+<tool>
+tool%TESTNUMBER
+</tool>
+</client>
+</testcase>

--- a/tests/data/test60
+++ b/tests/data/test60
@@ -4,7 +4,6 @@
 <keywords>
 HTTP
 HTTP PUT
-chunked Transfer-Encoding
 </keywords>
 </info>
 
@@ -43,15 +42,9 @@ PUT /bzz/%TESTNUMBER HTTP/1.1%CR
 Host: %HOSTIP:%HTTPPORT%CR
 User-Agent: curl/%VERSION%CR
 Accept: */*%CR
-Transfer-Encoding: chunked%CR
 Content-Length: 1%CR
-Expect: 100-continue%CR
 %CR
-13%CR
 more than one byte
-%CR
-0%CR
-%CR
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test98
+++ b/tests/data/test98
@@ -43,7 +43,6 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 14
-Expect: 100-continue
 
 data on stdin
 </protocol>

--- a/tests/tunit/Makefile.inc
+++ b/tests/tunit/Makefile.inc
@@ -35,4 +35,5 @@ TESTS_C = \
   tool1621.c \
   tool1622.c \
   tool1623.c \
+  tool1679.c \
   tool1720.c

--- a/tests/tunit/tool1679.c
+++ b/tests/tunit/tool1679.c
@@ -1,0 +1,87 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "unitcheck.h"
+#include "tool_operate.h"
+
+#include "curlx/fopen.h"
+
+static CURLcode test_tool1679(const char *arg)
+{
+  UNITTEST_BEGIN_SIMPLE
+
+  /* regfile_size_left() must return the number of bytes that remain to
+     read from the current file position, since a descriptor for
+     /dev/stdin or /dev/fd/N can arrive with a nonzero position */
+
+  static const char content[] = "0123456789abcdefghijklmnopqrstu";
+  static const char *fname = "tool1679.txt";
+  const curl_off_t fsize = (curl_off_t)strlen(content); /* 31 bytes */
+
+  struct positions {
+    curl_off_t seek_to;
+    curl_off_t expected;
+  };
+
+  static const struct positions tests[] = {
+    { 0, 31 },   /* at the start: everything remains */
+    { 10, 21 },  /* middle: the remainder */
+    { 30, 1 },   /* on the last byte */
+    { 31, 0 },   /* at EOF: nothing remains */
+    { 40, 0 }    /* beyond EOF: nothing remains */
+  };
+
+  FILE *fp = curlx_fopen(fname, "wb");
+  size_t i;
+  int fd;
+
+  abort_unless(fp != NULL, "cannot create test file");
+  fail_unless(fwrite(content, 1, (size_t)fsize, fp) == (size_t)fsize,
+              "short write");
+  curlx_fclose(fp);
+
+  fd = curlx_open(fname, O_RDONLY | CURL_O_BINARY);
+  abort_unless(fd != -1, "cannot open test file");
+
+  for(i = 0; i < CURL_ARRAYSIZE(tests); i++) {
+    curl_off_t left;
+    fail_unless(curl_lseek(fd, tests[i].seek_to, SEEK_SET) != LSEEK_ERROR,
+                "lseek failed");
+    left = regfile_size_left(fd, fsize);
+    if(left != tests[i].expected) {
+      curl_mprintf("seek to %" CURL_FORMAT_CURL_OFF_T " expected %"
+                   CURL_FORMAT_CURL_OFF_T " remaining, got %"
+                   CURL_FORMAT_CURL_OFF_T "\n",
+                   tests[i].seek_to, tests[i].expected, left);
+      fail("wrong remaining size");
+    }
+    /* the helper must not move the file position */
+    fail_unless((curl_off_t)curl_lseek(fd, 0, SEEK_CUR) == tests[i].seek_to,
+                "file position moved");
+  }
+
+  curlx_close(fd);
+  remove(fname);
+
+  UNITTEST_END_SIMPLE
+}


### PR DESCRIPTION
`-T -` always uploaded with an unknown size, which for HTTP/1.1 means a chunked transfer, even when stdin is a regular file with a known size, like when a shell redirect is used.

`-T /dev/stdin` used the file size but ignored the current file position. On systems where opening /dev/stdin or /dev/fd/N shares file position with the original descriptor (BSD derivatives, macOS), a nonzero position made curl announce a bigger upload than the data it could read, and the transfer failed with CURLE_READ_ERROR after a short body.

Fix both by counting the remaining bytes of a regular file from its current position (`regfile_size_left()` in tool_operate.c), used for named files and for stdin alike. When the position cannot be determined the size stays unknown. Uploads from pipes and the non-blocking `-T .` mode keep using an unknown size.

Tests:
- new tool unit test 1679 covers the remaining-bytes calculation at nonzero file positions, the half of the fix that runtests cannot reach since the harness always redirects stdin at offset zero; it fails against the previous calculation
- 60, 98, 1068: stdin-from-file uploads now send `Content-Length` (and no `Expect: 100-continue` for small uploads), same as `-T file`
- 1069, 1072, 1073: switched to `-T .` so they keep exercising the unknown-size HTTP/1.0 failure path (error 25)
- 1072 and 1073 are excluded on Windows: the `-T .` stdin relay (thread + socket) cannot rewind for the auth retry or redirect there. mingw builds return 65 (CURLE_SEND_FAIL_REWIND), msvc builds hang until the CI job timeout. That looks like an existing Windows quirk of `-T .` with retried uploads that these tests newly exposed; I can file it separately if wanted
- the `CURL_UPLOAD_SIZE` debug override now applies to stdin uploads too

Removes both KNOWN_BUGS "Command line" entries and mentions the behavior in the --upload-file documentation.

Verified with a CMake debug build on macOS 26 arm64:
- before/after: `curl -T - URL < 32-byte-file` sent chunked, now sends `Content-Length: 32`; `{ dd bs=1 count=16 of=/dev/null; curl -T /dev/stdin URL; } < 32-byte-file` sent `Content-Length: 32` and failed with exit 26, now sends `Content-Length: 16` and succeeds; a piped `-T -` stays chunked
- `runtests.pl -a` full local suite green apart from known-flaky timing tests under parallel load, which pass serially
- `scripts/checksrc.pl` clean on all touched files

Fixes #12171
Fixes #12177

Developed with AI assistance (Claude Code); reproduced, verified and reviewed by me.