### PR TITLE
connection shutdown, fix for first ms

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -179,7 +179,7 @@ void Curl_conn_cf_discard_chain(struct Curl_cfilter **pcf,
 void Curl_conn_cf_discard_all(struct Curl_easy *data,
                               struct connectdata *conn, int8_t sockindex)
 {
-  conn->shutdown.start_ms[sockindex] = 0;
+  conn->shutdown.start_ms[sockindex] = -1;
   Curl_conn_cf_discard_chain(&conn->cfilter[sockindex], data);
 }
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -138,7 +138,7 @@ timediff_t Curl_shutdown_timeleft(struct Curl_easy *data,
 {
   timediff_t left_ms;
 
-  if(!conn->shutdown.start_ms[sockindex])
+  if(conn->shutdown.start_ms[sockindex] < 0)
     return 0; /* not started or no limits */
 
   left_ms = conn->shutdown.timeout_ms -
@@ -154,7 +154,7 @@ timediff_t Curl_conn_shutdown_timeleft(struct Curl_easy *data,
   int8_t i;
 
   for(i = 0; conn->shutdown.timeout_ms && (i < 2); ++i) {
-    if(!conn->shutdown.start_ms[i])
+    if(conn->shutdown.start_ms[i] < 0)
       continue;
     ms = Curl_shutdown_timeleft(data, conn, i);
     if(ms && (!left_ms || ms < left_ms))
@@ -165,12 +165,12 @@ timediff_t Curl_conn_shutdown_timeleft(struct Curl_easy *data,
 
 void Curl_shutdown_clear(struct Curl_easy *data, int8_t sockindex)
 {
-  data->conn->shutdown.start_ms[sockindex] = 0;
+  data->conn->shutdown.start_ms[sockindex] = -1;
 }
 
 bool Curl_shutdown_started(struct connectdata *conn, int8_t sockindex)
 {
-  return conn->shutdown.start_ms[sockindex] > 0;
+  return conn->shutdown.start_ms[sockindex] >= 0;
 }
 
 /*

--- a/lib/url.c
+++ b/lib/url.c
@@ -1185,15 +1185,15 @@ static struct connectdata *allocate_conn(struct Curl_easy *data,
 
   /* and we setup a few fields in case we end up actually using this struct */
 
+  conn->created = *pnow;
   conn->sock[FIRSTSOCKET] = CURL_SOCKET_BAD;     /* no file descriptor */
   conn->sock[SECONDARYSOCKET] = CURL_SOCKET_BAD; /* no file descriptor */
   conn->recv_idx = 0; /* default for receiving transfer data */
   conn->send_idx = 0; /* default for sending transfer data */
   conn->connection_id = -1;    /* no ID */
   conn->attached_xfers = 0;
-
-  /* Remember time this connection started */
-  conn->created = *pnow;
+  conn->shutdown.start_ms[FIRSTSOCKET] =
+    conn->shutdown.start_ms[SECONDARYSOCKET] = -1;
 
 #ifndef CURL_DISABLE_FTP
   conn->bits.ftp_use_epsv = data->set.ftp_use_epsv;

--- a/tests/unit/unit2606.c
+++ b/tests/unit/unit2606.c
@@ -131,6 +131,9 @@ static void t2606_run(struct Curl_easy *data, const struct t2606_case *tc)
   abort_if(!conn, "could not allocate a connection");
 
   conn->created = curlx_now();
+  conn->shutdown.start_ms[FIRSTSOCKET] =
+    conn->shutdown.start_ms[SECONDARYSOCKET] = -1;
+
   memset(&ctx0, 0, sizeof(ctx0));
   memset(&ctx1, 0, sizeof(ctx1));
   ctx0.sock = 42;


### PR DESCRIPTION
When a connection needed to start shutdown in the first millisecond since its creation, the changed `start_ms` indicator did not change.

Initialize `start_ms` with -1 so that 0ms are treated as a shutdown start.

