### PR TITLE
ossl_verifyhost: remove assumption of null termination of ASN1_STRING.

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2166,7 +2166,7 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
 
         if((cnlen <= 0) || !cn)
           result = CURLE_OUT_OF_MEMORY;
-        else if((size_t)cnlen != strlen((char *)cn)) {
+        else if(memchr(cn, '\0', cnlen)) {
           /* there was a null-terminator before the end of string, this
              cannot match and we return failure! */
           failf(data, "SSL: illegal cert name field");
@@ -2184,12 +2184,12 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
     }
     else if(!Curl_cert_hostcheck((const char *)cn, cnlen,
                                  peer->origin->hostname, hostlen)) {
-      failf(data, "SSL: certificate subject name '%s' does not match "
-            "target hostname '%s'", cn, peer->origin->user_hostname);
+      failf(data, "SSL: certificate subject name '%.*s' does not match "
+            "target hostname '%s'", cnlen, cn, peer->origin->user_hostname);
       result = CURLE_PEER_FAILED_VERIFICATION;
     }
     else {
-      infof(data, " common name: %s (matched)", cn);
+      infof(data, " common name: %.*s (matched)", cnlen, cn);
     }
     if(free_cn)
       OPENSSL_free(cn);


### PR DESCRIPTION
This only affects hosts where the deprecated CN is used for matching DNS names, instead of the modern way, which is by using a dNSName-typed SAN.

A similar change but for certs that store the hostname in the SAN (as they should nowadays) was in https://github.com/curl/curl/commit/543adc4de024dda4f3b8f368893c7d01a3cf0ea8.

Fixes https://github.com/curl/curl/issues/22822.