### PR TITLE
openssl/gtls: reject CRLfile with native CA store, matching rustls

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -541,6 +541,13 @@ static CURLcode gtls_populate_creds(struct Curl_cfilter *cf,
   if(creds_are_empty)
     infof(data, "  no trust anchors configured");
 
+#ifdef USE_APPLE_SECTRUST
+  if(config->CRLfile && config->native_ca_store) {
+    failf(data, "gnutls: CRL file not supported with native CA store; "
+          "the platform verifier has no CRL attachment API");
+    return CURLE_NOT_BUILT_IN;
+  }
+#endif
   if(config->CRLfile) {
     /* set the CRL list file */
     rc = gnutls_certificate_set_x509_crl_file(creds, config->CRLfile,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3105,6 +3105,13 @@ static CURLcode ossl_populate_x509_store(struct Curl_cfilter *cf,
     return result;
 
   /* Does not make sense to load a CRL file without peer verification */
+#ifdef USE_APPLE_SECTRUST
+  if(ssl_crlfile && conn_config->native_ca_store) {
+    failf(data, "openssl: CRL file not supported with native CA store; "
+          "the platform verifier has no CRL attachment API");
+    return CURLE_NOT_BUILT_IN;
+  }
+#endif
   if(ssl_crlfile) {
     /* tell OpenSSL where to find CRL file that is used to check certificate
      * revocation */


### PR DESCRIPTION
Same fix as rustls (#21614): the Apple SecTrust fallback has no CRL attachment API, so fail with CURLE_NOT_BUILT_IN instead of silently ignoring CRLfile.