### PR TITLE
schannel: auto_client_cert conn matching

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -780,7 +780,7 @@ static CURLcode schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                        "names in server certificates."));
   }
 
-  if(!ssl_config->auto_client_cert) {
+  if(!conn_config->auto_client_cert) {
     flags &= ~(DWORD)SCH_CRED_USE_DEFAULT_CREDS;
     flags |= SCH_CRED_NO_DEFAULT_CREDS;
     infof(data, "schannel: disabled automatic use of client certificate");
@@ -978,7 +978,7 @@ static CURLcode schannel_connect_step1(struct Curl_cfilter *cf,
     ISC_REQ_SEQUENCE_DETECT | ISC_REQ_REPLAY_DETECT |
     ISC_REQ_CONFIDENTIALITY | ISC_REQ_ALLOCATE_MEMORY |
     ISC_REQ_STREAM |
-    (!ssl_config->auto_client_cert ? ISC_REQ_USE_SUPPLIED_CREDS : 0);
+    (!conn_config->auto_client_cert ? ISC_REQ_USE_SUPPLIED_CREDS : 0);
 
   /* allocate memory for the security context handle */
   backend->ctxt = (struct Curl_schannel_ctxt *)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -850,7 +850,6 @@ static CURLcode schannel_connect_step1(struct Curl_cfilter *cf,
   struct schannel_ssl_backend_data *backend =
     (struct schannel_ssl_backend_data *)connssl->backend;
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   SecBuffer outbuf;
   SecBufferDesc outbuf_desc;
   SecBuffer inbuf;

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -145,6 +145,7 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
      (c1->verifypeer == c2->verifypeer) &&
      (c1->verifyhost == c2->verifyhost) &&
      (c1->verifystatus == c2->verifystatus) &&
+     (c1->auto_client_cert == c2->auto_client_cert) &&
      blobcmp(c1->cert_blob, c2->cert_blob) &&
      blobcmp(c1->ca_info_blob, c2->ca_info_blob) &&
      blobcmp(c1->issuercert_blob, c2->issuercert_blob) &&
@@ -196,6 +197,7 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
   dest->native_ca_store = source->native_ca_store;
   dest->cache_session = source->cache_session;
   dest->ssl_options = source->ssl_options;
+  dest->auto_client_cert = source->auto_client_cert;
 
   CLONE_BLOB(cert_blob);
   CLONE_BLOB(ca_info_blob);
@@ -228,14 +230,15 @@ static void ssl_easy_config_compl_options(struct Curl_peer *origin,
    * If not, we switch it on for supported backends if no custom
    * CA settings exist. */
   sslc->primary.native_ca_store = !!(options & CURLSSLOPT_NATIVE_CA);
+  sslc->primary.auto_client_cert =
+    Curl_peer_equal(origin, initial_origin) &&
+    !!(options & CURLSSLOPT_AUTO_CLIENT_CERT);
+
   sslc->enable_beast = !!(options & CURLSSLOPT_ALLOW_BEAST);
   sslc->no_partialchain = !!(options & CURLSSLOPT_NO_PARTIALCHAIN);
   sslc->no_revoke = !!(options & CURLSSLOPT_NO_REVOKE);
   sslc->revoke_best_effort = !!(options & CURLSSLOPT_REVOKE_BEST_EFFORT);
   sslc->earlydata = !!(options & CURLSSLOPT_EARLYDATA);
-
-  sslc->auto_client_cert = Curl_peer_equal(origin, initial_origin) &&
-                           !!(options & CURLSSLOPT_AUTO_CLIENT_CERT);
 }
 
 static char *ssl_easy_steal(struct Curl_easy *data, enum dupstring id)

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -57,6 +57,8 @@ struct ssl_primary_config {
   BIT(native_ca_store); /* use the native CA store of operating system */
   BIT(cache_session);    /* cache session or not */
   BIT(deep_copy);        /* members are deep copies, eg. owned here */
+  BIT(auto_client_cert);   /* automatically locate and use a client
+                              certificate for authentication (Schannel) */
 };
 
 struct ssl_config_data {
@@ -71,8 +73,6 @@ struct ssl_config_data {
   BIT(no_partialchain); /* do not accept partial certificate chains */
   BIT(revoke_best_effort); /* ignore SSL revocation offline/missing revocation
                               list errors */
-  BIT(auto_client_cert);   /* automatically locate and use a client
-                              certificate for authentication (Schannel) */
   BIT(custom_cafile); /* application has set custom CA file */
   BIT(custom_capath); /* application has set custom CA path */
   BIT(custom_cablob); /* application has set custom CA blob */


### PR DESCRIPTION
Move flag `auto_client_cert` into the connection SSL config struct so it is part of connection matching.

