### PR TITLE
digest: check peer equality for staleness

### DIFF
--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -41,7 +41,7 @@ static void digest_flush_stale(struct Curl_easy *data,
                                struct Curl_creds *creds)
 {
   bool flush = FALSE;
-  if(digest->origin && !Curl_peer_same_destination(peer, digest->origin)) {
+  if(digest->origin && !Curl_peer_equal(peer, digest->origin)) {
     CURL_TRC_M(data, "http_digest, reset on peer change to %s:%u",
                peer->hostname, peer->port);
     flush = TRUE;


### PR DESCRIPTION
Check that current peer is *equal* from last peer's state information. This accomodates also scheme changes, which the previous check did not.
