### PR TITLE
http proxy: some code cleanups

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -72,12 +72,13 @@ struct h1_tunnel_state {
   BIT(close_connection);
   BIT(maybe_folded);
   BIT(leading_unfold);
+  BIT(udp_tunnel);
 };
 
 /* Persistent context for the H1-PROXY filter */
 struct cf_h1_proxy_ctx {
+  struct Curl_peer *peer;
   struct h1_tunnel_state *ts;
-  BIT(udp_tunnel);
 };
 
 static bool tunnel_is_established(struct h1_tunnel_state *ts)
@@ -93,7 +94,7 @@ static bool tunnel_is_failed(struct h1_tunnel_state *ts)
 static bool h1_proxy_is_udp(struct Curl_cfilter *cf)
 {
   struct cf_h1_proxy_ctx *pctx = cf->ctx;
-  return (pctx->udp_tunnel ? TRUE : FALSE);
+  return (bool)(pctx->ts && pctx->ts->udp_tunnel);
 }
 
 static CURLcode tunnel_reinit(struct Curl_cfilter *cf,
@@ -232,6 +233,7 @@ static CURLcode start_CONNECT(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
                               struct h1_tunnel_state *ts)
 {
+  struct cf_h1_proxy_ctx *pctx = cf->ctx;
   struct httpreq *req = NULL;
   int http_minor;
   CURLcode result;
@@ -241,9 +243,10 @@ static CURLcode start_CONNECT(struct Curl_cfilter *cf,
      and we do not really use the newly cloned URL here then. Free it. */
   curlx_safefree(data->req.newurl);
 
-  result = Curl_http_proxy_create_tunnel_request(&req, cf, data, ts->dest,
-                                                  PROXY_HTTP_V1,
-                                                  h1_proxy_is_udp(cf));
+  result = Curl_http_proxy_create_tunnel_request(&req, cf, data,
+                                                 pctx->peer, ts->dest,
+                                                 PROXY_HTTP_V1,
+                                                 h1_proxy_is_udp(cf));
   if(result)
     goto out;
 
@@ -299,91 +302,6 @@ out:
   return result;
 }
 
-static CURLcode on_resp_header_udp(struct Curl_cfilter *cf,
-                                   struct Curl_easy *data,
-                                   struct h1_tunnel_state *ts,
-                                   const char *header)
-{
-  CURLcode result = CURLE_OK;
-  struct SingleRequest *k = &data->req;
-
-  if(checkprefix("Proxy-authenticate:", header) && (407 == k->httpcode)) {
-
-    bool proxy = (k->httpcode == 407);
-    char *auth = Curl_copy_header_value(header);
-    if(!auth)
-      return CURLE_OUT_OF_MEMORY;
-
-    CURL_TRC_CF(data, cf, "CONNECT-UDP: fwd auth header '%s'", header);
-    result = Curl_http_input_auth(data, proxy, auth);
-
-    curlx_free(auth);
-
-    if(result)
-      return result;
-  }
-  else if(checkprefix("Content-Length:", header)) {
-    if(k->httpcode / 100 == 2 || k->httpcode == 101) {
-      infof(data, "Ignoring Content-Length in CONNECT-UDP %03d response",
-            k->httpcode);
-    }
-    else {
-      const char *p = header + CURL_CSTRLEN("Content-Length:");
-      if(curlx_str_numblanks(&p, &ts->cl)) {
-        failf(data, "Unsupported Content-Length value");
-        return CURLE_WEIRD_SERVER_REPLY;
-      }
-    }
-  }
-  else if(checkprefix("Transfer-Encoding:", header)) {
-    if(k->httpcode / 100 == 2 || k->httpcode == 101) {
-      infof(data, "Ignoring Transfer-Encoding in "
-            "CONNECT-UDP %03d response", k->httpcode);
-    }
-    else if(Curl_compareheader(header,
-                               STRCONST("Transfer-Encoding:"),
-                               STRCONST("chunked"))) {
-      CURL_TRC_CF(data, cf, "CONNECT-UDP Response --> "
-                  "Transfer-Encoding: chunked");
-      ts->chunked_encoding = TRUE;
-      /* reset our chunky engine */
-      Curl_httpchunk_reset(data, &ts->ch, TRUE);
-    }
-  }
-  else if(checkprefix("Capsule-protocol:", header)) {
-    if(Curl_compareheader(header,
-                           STRCONST("Capsule-protocol:"),
-                           STRCONST("?1"))) {
-      CURL_TRC_CF(data, cf, "CONNECT-UDP Response --> Capsule-protocol: ?1");
-    }
-  }
-  else if(Curl_compareheader(header,
-                              STRCONST("Connection:"), STRCONST("close"))) {
-    ts->close_connection = TRUE;
-    CURL_TRC_CF(data, cf, "CONNECT-UDP Response --> Connection: close");
-  }
-  else if(Curl_compareheader(header,
-                             STRCONST("Proxy-Connection:"),
-                             STRCONST("close"))) {
-    ts->close_connection = TRUE;
-    CURL_TRC_CF(data, cf,
-                "CONNECT-UDP Response --> Proxy-Connection: close");
-  }
-  else if(!strncmp(header, "HTTP/1.", 7) &&
-           ((header[7] == '0') || (header[7] == '1')) &&
-           (header[8] == ' ') &&
-           ISDIGIT(header[9]) && ISDIGIT(header[10]) && ISDIGIT(header[11]) &&
-           !ISDIGIT(header[12])) {
-    /* store the HTTP code from the proxy */
-    data->info.httpproxycode = k->httpcode =
-      ((header[9] - '0') * 100) +
-      ((header[10] - '0') * 10) +
-      (header[11] - '0');
-    CURL_TRC_CF(data, cf, "CONNECT-UDP Response --> %d", k->httpcode);
-  }
-  return result;
-}
-
 static CURLcode on_resp_header(struct Curl_cfilter *cf,
                                struct Curl_easy *data,
                                struct h1_tunnel_state *ts,
@@ -391,7 +309,7 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
 {
   CURLcode result = CURLE_OK;
   struct SingleRequest *k = &data->req;
-  (void)cf;
+  bool is_udp = h1_proxy_is_udp(cf);
 
   if(checkprefix("Proxy-authenticate:", header) && (407 == k->httpcode)) {
 
@@ -400,7 +318,8 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
     if(!auth)
       return CURLE_OUT_OF_MEMORY;
 
-    CURL_TRC_CF(data, cf, "CONNECT: fwd auth header '%s'", header);
+    CURL_TRC_CF(data, cf, "CONNECT%s: fwd auth header '%s'",
+                is_udp ? "-UDP" : "", header);
     result = Curl_http_input_auth(data, proxy, auth);
 
     curlx_free(auth);
@@ -413,8 +332,8 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
       /* A client MUST ignore any Content-Length or Transfer-Encoding
          header fields received in a successful response to CONNECT.
          "Successful" described as: 2xx (Successful). RFC 7231 4.3.6 */
-      infof(data, "Ignoring Content-Length in CONNECT %03d response",
-            k->httpcode);
+      infof(data, "Ignoring Content-Length in CONNECT%s %03d response",
+            is_udp ? "-UDP" : "", k->httpcode);
     }
     else {
       const char *p = header + CURL_CSTRLEN("Content-Length:");
@@ -425,29 +344,41 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
     }
   }
   else if(Curl_compareheader(header,
-                             STRCONST("Connection:"), STRCONST("close")))
+                             STRCONST("Connection:"), STRCONST("close"))) {
+    CURL_TRC_CF(data, cf, "CONNECT%s Connection: close", is_udp ? "-UDP" : "");
     ts->close_connection = TRUE;
+  }
   else if(checkprefix("Transfer-Encoding:", header)) {
     if(k->httpcode / 100 == 2) {
       /* A client MUST ignore any Content-Length or Transfer-Encoding
          header fields received in a successful response to CONNECT.
          "Successful" described as: 2xx (Successful). RFC 7231 4.3.6 */
       infof(data, "Ignoring Transfer-Encoding in "
-            "CONNECT %03d response", k->httpcode);
+            "CONNECT%s %03d response", is_udp ? "-UDP" : "", k->httpcode);
     }
     else if(Curl_compareheader(header,
                                STRCONST("Transfer-Encoding:"),
                                STRCONST("chunked"))) {
-      infof(data, "CONNECT responded chunked");
+      CURL_TRC_CF(data, cf, "CONNECT%s response chunked",
+                  is_udp ? "-UDP" : "");
       ts->chunked_encoding = TRUE;
-      /* reset our chunky engine */
       Curl_httpchunk_reset(data, &ts->ch, TRUE);
+    }
+  }
+  else if(is_udp && checkprefix("Capsule-protocol:", header)) {
+    if(Curl_compareheader(header,
+                           STRCONST("Capsule-protocol:"),
+                           STRCONST("?1"))) {
+      CURL_TRC_CF(data, cf, "CONNECT-UDP Response --> Capsule-protocol: ?1");
     }
   }
   else if(Curl_compareheader(header,
                              STRCONST("Proxy-Connection:"),
-                             STRCONST("close")))
+                             STRCONST("close"))) {
+    CURL_TRC_CF(data, cf, "CONNECT%s Proxy-Connection: close",
+                is_udp ? "-UDP" : "");
     ts->close_connection = TRUE;
+  }
   else if(!strncmp(header, "HTTP/1.", 7) &&
           ((header[7] == '0') || (header[7] == '1')) &&
           (header[8] == ' ') &&
@@ -456,6 +387,8 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
     /* store the HTTP code from the proxy */
     data->info.httpproxycode = k->httpcode = ((header[9] - '0') * 100) +
       ((header[10] - '0') * 10) + (header[11] - '0');
+    CURL_TRC_CF(data, cf, "CONNECT%s HTTP status %d",
+                is_udp ? "-UDP" : "", k->httpcode);
   }
   return result;
 }
@@ -527,13 +460,7 @@ static CURLcode single_header(struct Curl_cfilter *cf,
     return result;
   }
 
-  if(h1_proxy_is_udp(cf)) {
-    result = on_resp_header_udp(cf, data, ts, linep);
-  }
-  else {
-    result = on_resp_header(cf, data, ts, linep);
-  }
-
+  result = on_resp_header(cf, data, ts, linep);
   if(result)
     return result;
 
@@ -802,12 +729,8 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
   /* 2xx response, SUCCESS! */
   /* 101 Switching Protocol for CONNECT-UDP */
   h1_tunnel_go_state(cf, ts, H1_TUNNEL_ESTABLISHED, data);
-  if(h1_proxy_is_udp(cf))
-    infof(data, "CONNECT-UDP tunnel established, response %d",
-                                    data->info.httpproxycode);
-  else
-    infof(data, "CONNECT tunnel established, response %d",
-                                    data->info.httpproxycode);
+  infof(data, "CONNECT%s tunnel established, response %d",
+        h1_proxy_is_udp(cf) ? "-UDP" : "", data->info.httpproxycode);
   result = CURLE_OK;
 
 out:
@@ -903,9 +826,14 @@ static bool cf_h1_proxy_data_pending(struct Curl_cfilter *cf,
 static void cf_h1_proxy_destroy(struct Curl_cfilter *cf,
                                 struct Curl_easy *data)
 {
+  struct cf_h1_proxy_ctx *pctx = cf->ctx;
+
   CURL_TRC_CF(data, cf, "destroy");
-  cf_tunnel_free(cf, data);
-  curlx_safefree(cf->ctx);
+  if(pctx) {
+    cf_tunnel_free(cf, data);
+    Curl_peer_unlink(&pctx->peer);
+    curlx_safefree(cf->ctx);
+  }
 }
 
 static CURLcode cf_h1_proxy_query(struct Curl_cfilter *cf,
@@ -954,6 +882,7 @@ struct Curl_cftype Curl_cft_h1_proxy = {
 
 CURLcode Curl_cf_h1_proxy_insert_after(struct Curl_cfilter *cf_at,
                                        struct Curl_easy *data,
+                                       struct Curl_peer *peer,
                                        struct Curl_peer *dest,
                                        int httpversion,
                                        bool udp_tunnel)
@@ -975,6 +904,7 @@ CURLcode Curl_cf_h1_proxy_insert_after(struct Curl_cfilter *cf_at,
     goto out;
   }
   Curl_peer_link(&ts->dest, dest);
+  ts->udp_tunnel = udp_tunnel;
   ts->httpversion = httpversion;
   curlx_dyn_init(&ts->rcvbuf, DYN_PROXY_CONNECT_HEADERS);
   curlx_dyn_init(&ts->request_data, DYN_HTTP_REQUEST);
@@ -985,7 +915,7 @@ CURLcode Curl_cf_h1_proxy_insert_after(struct Curl_cfilter *cf_at,
     result = CURLE_OUT_OF_MEMORY;
     goto out;
   }
-  pctx->udp_tunnel = udp_tunnel;
+  Curl_peer_link(&pctx->peer, peer);
   pctx->ts = ts;
   result = Curl_cf_create(&cf, &Curl_cft_h1_proxy, pctx);
   if(result) {

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -919,6 +919,7 @@ CURLcode Curl_cf_h1_proxy_insert_after(struct Curl_cfilter *cf_at,
   pctx->ts = ts;
   result = Curl_cf_create(&cf, &Curl_cft_h1_proxy, pctx);
   if(result) {
+    Curl_peer_unlink(&pctx->peer);
     curlx_free(pctx);
     goto out;
   }

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -328,7 +328,12 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
       return result;
   }
   else if(checkprefix("Content-Length:", header)) {
-    if(k->httpcode / 100 == 2) {
+    if(k->httpcode < 300) {
+      if(k->httpcode < 200) {
+        /* Informational 1xx responses cannot carry a body. RFC 9110 15.2 */
+        failf(data, "Invalid Content-Length: in %03d response", k->httpcode);
+        return CURLE_WEIRD_SERVER_REPLY;
+      }
       /* A client MUST ignore any Content-Length or Transfer-Encoding
          header fields received in a successful response to CONNECT.
          "Successful" described as: 2xx (Successful). RFC 7231 4.3.6 */
@@ -349,7 +354,13 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
     ts->close_connection = TRUE;
   }
   else if(checkprefix("Transfer-Encoding:", header)) {
-    if(k->httpcode / 100 == 2) {
+    if(k->httpcode < 300) {
+      if(k->httpcode < 200) {
+        /* Informational 1xx responses cannot carry a body. RFC 9110 15.2 */
+        failf(data, "Invalid Transfer-Encoding: in %03d response",
+              k->httpcode);
+        return CURLE_WEIRD_SERVER_REPLY;
+      }
       /* A client MUST ignore any Content-Length or Transfer-Encoding
          header fields received in a successful response to CONNECT.
          "Successful" described as: 2xx (Successful). RFC 7231 4.3.6 */

--- a/lib/cf-h1-proxy.h
+++ b/lib/cf-h1-proxy.h
@@ -31,6 +31,7 @@ struct Curl_peer;
 
 CURLcode Curl_cf_h1_proxy_insert_after(struct Curl_cfilter *cf_at,
                                        struct Curl_easy *data,
+                                       struct Curl_peer *peer,
                                        struct Curl_peer *dest,
                                        int httpversion,
                                        bool udp_tunnel);

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -184,6 +184,7 @@ struct cf_h2_proxy_ctx {
   struct bufq inbufq;  /* network receive buffer */
   struct bufq outbufq; /* network send buffer */
 
+  struct Curl_peer *peer; /* proxy we talk to */
   struct Curl_peer *dest; /* where to tunnel to */
   struct tunnel_stream tunnel; /* our tunnel CONNECT stream */
   int32_t goaway_error;
@@ -208,6 +209,7 @@ static void cf_h2_proxy_ctx_clear(struct cf_h2_proxy_ctx *ctx)
   }
   Curl_bufq_free(&ctx->inbufq);
   Curl_bufq_free(&ctx->outbufq);
+  Curl_peer_unlink(&ctx->peer);
   Curl_peer_unlink(&ctx->dest);
   tunnel_stream_clear(&ctx->tunnel);
   memset(ctx, 0, sizeof(*ctx));
@@ -770,7 +772,8 @@ static CURLcode submit_CONNECT(struct Curl_cfilter *cf,
   CURLcode result;
   struct httpreq *req = NULL;
 
-  result = Curl_http_proxy_create_tunnel_request(&req, cf, data, ctx->dest,
+  result = Curl_http_proxy_create_tunnel_request(&req, cf, data,
+                                                 ctx->peer, ctx->dest,
                                                   PROXY_HTTP_V2,
                                                   (bool)ctx->udp_tunnel);
   if(result)
@@ -1484,6 +1487,7 @@ struct Curl_cftype Curl_cft_h2_proxy = {
 
 CURLcode Curl_cf_h2_proxy_insert_after(struct Curl_cfilter *cf,
                                        struct Curl_easy *data,
+                                       struct Curl_peer *peer,
                                        struct Curl_peer *dest,
                                        bool udp_tunnel)
 {
@@ -1495,6 +1499,7 @@ CURLcode Curl_cf_h2_proxy_insert_after(struct Curl_cfilter *cf,
   ctx = curlx_calloc(1, sizeof(*ctx));
   if(!ctx)
     goto out;
+  Curl_peer_link(&ctx->peer, peer);
   Curl_peer_link(&ctx->dest, dest);
   ctx->udp_tunnel = udp_tunnel;
 

--- a/lib/cf-h2-proxy.h
+++ b/lib/cf-h2-proxy.h
@@ -29,6 +29,7 @@
 
 CURLcode Curl_cf_h2_proxy_insert_after(struct Curl_cfilter *cf,
                                        struct Curl_easy *data,
+                                       struct Curl_peer *peer,
                                        struct Curl_peer *dest,
                                        bool udp_tunnel);
 

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -197,6 +197,7 @@ static int proxy_http_ver_major(proxy_http_ver ver)
 static CURLcode http_proxy_create_CONNECT(struct httpreq **preq,
                                           struct Curl_cfilter *cf,
                                           struct Curl_easy *data,
+                                          struct Curl_peer *peer,
                                           struct Curl_peer *dest,
                                           proxy_http_ver ver)
 {
@@ -206,6 +207,7 @@ static CURLcode http_proxy_create_CONNECT(struct httpreq **preq,
   CURLcode result;
   struct httpreq *req = NULL;
 
+  (void)peer;
   authority = curl_maprintf("%s%s%s:%u",
                             dest->ipv6 ? "[" : "",
                             dest->hostname,
@@ -216,7 +218,7 @@ static CURLcode http_proxy_create_CONNECT(struct httpreq **preq,
     goto out;
   }
 
-  result = Curl_http_req_make(&req, "CONNECT", CURL_CSTRLEN("CONNECT"),
+  result = Curl_http_req_make(&req, STRCONST("CONNECT"),
                               NULL, 0, authority, strlen(authority),
                               NULL, 0);
   if(result)
@@ -274,17 +276,16 @@ out:
 static CURLcode http_proxy_create_CONNECTUDP(struct httpreq **preq,
                                              struct Curl_cfilter *cf,
                                              struct Curl_easy *data,
+                                             struct Curl_peer *peer,
                                              struct Curl_peer *dest,
                                              proxy_http_ver ver)
 {
   const char *proxy_scheme = "http", *ua;
-  const char *proxy_host = cf->conn->http_proxy.peer->hostname;
   int httpversion = proxy_http_ver_major(ver);
   char *authority = NULL;
   char *path = NULL;
   char *encoded_host = NULL;
   struct httpreq *req = NULL;
-  bool proxy_ipv6_ip;
   CURLcode result;
 
   if(cf->conn->http_proxy.proxytype == CURLPROXY_HTTPS ||
@@ -292,13 +293,11 @@ static CURLcode http_proxy_create_CONNECTUDP(struct httpreq **preq,
      cf->conn->http_proxy.proxytype == CURLPROXY_HTTPS3)
     proxy_scheme = "https";
 
-  proxy_ipv6_ip = cf->conn->http_proxy.peer->ipv6 != 0;
-
   authority = curl_maprintf("%s%s%s:%d",
-                            proxy_ipv6_ip ? "[" : "",
-                            proxy_host,
-                            proxy_ipv6_ip ? "]" : "",
-                            cf->conn->http_proxy.peer->port);
+                            peer->ipv6 ? "[" : "",
+                            peer->hostname,
+                            peer->ipv6 ? "]" : "",
+                            peer->port);
   if(!authority) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -349,7 +348,7 @@ static CURLcode http_proxy_create_CONNECTUDP(struct httpreq **preq,
       goto out;
   }
   else if(ver == PROXY_HTTP_V2 || ver == PROXY_HTTP_V3) {
-    result = Curl_http_req_make(&req, "CONNECT", CURL_CSTRLEN("CONNECT"),
+    result = Curl_http_req_make(&req, STRCONST("CONNECT"),
                                 proxy_scheme, strlen(proxy_scheme),
                                 authority, strlen(authority),
                                 path, strlen(path));
@@ -440,28 +439,20 @@ out:
 
 CURLcode Curl_http_proxy_create_tunnel_request(
     struct httpreq **preq, struct Curl_cfilter *cf,
-    struct Curl_easy *data, struct Curl_peer *dest,
+    struct Curl_easy *data, struct Curl_peer *peer, struct Curl_peer *dest,
     proxy_http_ver ver, bool udp_tunnel)
 {
-  CURLcode result;
-
-  if(udp_tunnel)
-    result = http_proxy_create_CONNECTUDP(preq, cf, data, dest, ver);
-  else
-    result = http_proxy_create_CONNECT(preq, cf, data, dest, ver);
+  CURLcode result = udp_tunnel ?
+    http_proxy_create_CONNECTUDP(preq, cf, data, peer, dest, ver) :
+    http_proxy_create_CONNECT(preq, cf, data, peer, dest, ver);
   if(result)
     return result;
 
-  if(udp_tunnel)
-    infof(data, "Establishing %s proxy UDP tunnel to %s:%u",
-          (ver == PROXY_HTTP_V2) ? "HTTP/2" :
-          (ver == PROXY_HTTP_V3) ? "HTTP/3" : "HTTP",
-          dest->user_hostname, dest->port);
-  else
-    infof(data, "Establishing %s proxy tunnel to %s",
-          (ver == PROXY_HTTP_V2) ? "HTTP/2" :
-          (ver == PROXY_HTTP_V3) ? "HTTP/3" : "HTTP",
-          (*preq)->authority);
+  infof(data, "Establishing %s proxy %stunnel to %s:%u",
+        (ver == PROXY_HTTP_V2) ? "HTTP/2" :
+        (ver == PROXY_HTTP_V3) ? "HTTP/3" : "HTTP",
+        udp_tunnel ? "UDP " : "",
+        dest->user_hostname, dest->port);
   return CURLE_OK;
 }
 
@@ -478,10 +469,8 @@ CURLcode Curl_http_proxy_inspect_tunnel_response(
   DEBUGASSERT(resp);
 
   header_count = Curl_dynhds_count(&resp->headers);
-  if(udp_tunnel)
-    infof(data, "CONNECT-UDP Response Status %d", resp->status);
-  else
-    infof(data, "CONNECT Response Status %d", resp->status);
+  infof(data, "CONNECT%s Response Status %d",
+        udp_tunnel ? "-UDP" : "", resp->status);
   infof(data, "Response Headers (%zu total):", header_count);
   for(i = 0; i < header_count; i++) {
     struct dynhds_entry *entry = Curl_dynhds_getn(&resp->headers, i);
@@ -558,14 +547,13 @@ static CURLcode http_proxy_cf_connect(struct Curl_cfilter *cf,
   struct cf_proxy_ctx *ctx = cf->ctx;
   CURLcode result;
   bool udp_tunnel = TRNSPRT_IS_DGRAM(ctx->tunnel_transport);
-  const char *tunnel_type = udp_tunnel ? "CONNECT-UDP" : "CONNECT";
 
   if(cf->connected) {
     *done = TRUE;
     return CURLE_OK;
   }
 
-  CURL_TRC_CF(data, cf, "%s", tunnel_type);
+  CURL_TRC_CF(data, cf, "CONNECT%s", udp_tunnel ? "-UDP" : "");
 connect_sub:
   /* in case of h3_proxy, cf->next will be NULL initially */
   if(cf->next) {
@@ -584,10 +572,11 @@ connect_sub:
     }
 
     if(alpn)
-      infof(data, "%s: '%s' negotiated", tunnel_type, alpn);
+      infof(data, "CONNECT%s: '%s' negotiated",
+            udp_tunnel ? "-UDP" : "", alpn);
     else if(!alpn) {
       /* No ALPN, proxytype rules. Fake ALPN */
-      infof(data, "%s: no ALPN negotiated", tunnel_type);
+      infof(data, "CONNECT%s: no ALPN negotiated", udp_tunnel ? "-UDP" : "");
       switch(ctx->proxytype) {
       case CURLPROXY_HTTP_1_0:
         alpn = "http/1.0";
@@ -606,8 +595,8 @@ connect_sub:
 
     if(!strcmp(alpn, "http/1.0")) {
       CURL_TRC_CF(data, cf, "installing subfilter for HTTP/1.0");
-      result = Curl_cf_h1_proxy_insert_after(cf, data, ctx->tunnel_peer, 10,
-                                             udp_tunnel);
+      result = Curl_cf_h1_proxy_insert_after(cf, data, ctx->peer,
+                                             ctx->tunnel_peer, 10, udp_tunnel);
       if(result)
         goto out;
     }
@@ -615,7 +604,8 @@ connect_sub:
       int httpversion = (ctx->proxytype == CURLPROXY_HTTP_1_0) ? 10 : 11;
       CURL_TRC_CF(data, cf, "installing subfilter for HTTP/1.%d",
                   httpversion % 10);
-      result = Curl_cf_h1_proxy_insert_after(cf, data, ctx->tunnel_peer,
+      result = Curl_cf_h1_proxy_insert_after(cf, data, ctx->peer,
+                                             ctx->tunnel_peer,
                                              httpversion, udp_tunnel);
       if(result)
         goto out;
@@ -623,8 +613,8 @@ connect_sub:
 #ifdef USE_NGHTTP2
     else if(!strcmp(alpn, "h2")) {
       CURL_TRC_CF(data, cf, "installing subfilter for HTTP/2");
-      result = Curl_cf_h2_proxy_insert_after(cf, data, ctx->tunnel_peer,
-                                             udp_tunnel);
+      result = Curl_cf_h2_proxy_insert_after(cf, data, ctx->peer,
+                                             ctx->tunnel_peer, udp_tunnel);
       if(result)
         goto out;
     }
@@ -641,7 +631,8 @@ connect_sub:
     }
 #endif /* USE_PROXY_HTTP3 && USE_NGHTTP3 && USE_NGTCP2 && USE_OPENSSL */
     else {
-      failf(data, "%s: negotiated ALPN '%s' not supported", tunnel_type, alpn);
+      failf(data, "CONNECT%s: negotiated ALPN '%s' not supported",
+            udp_tunnel ? "-UDP" : "", alpn);
       result = CURLE_COULDNT_CONNECT;
       goto out;
     }

--- a/lib/http_proxy.h
+++ b/lib/http_proxy.h
@@ -53,7 +53,7 @@ typedef enum {
 /* Create CONNECT or CONNECT-UDP request */
 CURLcode Curl_http_proxy_create_tunnel_request(
     struct httpreq **preq, struct Curl_cfilter *cf,
-    struct Curl_easy *data, struct Curl_peer *dest,
+    struct Curl_easy *data, struct Curl_peer *peer, struct Curl_peer *dest,
     proxy_http_ver ver, bool udp_tunnel);
 
 /* Inspect tunnel response for H2/H3 proxy (capsule-protocol, auth) */

--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -57,7 +57,7 @@ typedef enum {
 } h3_tunnel_state;
 
 struct h3_tunnel_stream {
-  struct Curl_peer *peer;  /* where the tunnel goes to */
+  struct Curl_peer *dest;  /* where the tunnel goes to */
   struct http_resp *resp;
   struct bufq recvbuf;
   char *authority;
@@ -69,19 +69,19 @@ struct h3_tunnel_stream {
 };
 
 static CURLcode h3_tunnel_stream_init(struct h3_tunnel_stream *ts,
-                                      struct Curl_peer *peer,
+                                      struct Curl_peer *dest,
                                       bool udp)
 {
   ts->state = H3_TUNNEL_INIT;
-  Curl_peer_link(&ts->peer, peer);
+  Curl_peer_link(&ts->dest, dest);
   Curl_bufq_init2(&ts->recvbuf, H3_STREAM_CHUNK_SIZE,
                   PROXY_H3_STREAM_RECV_CHUNKS, BUFQ_OPT_SOFT_LIMIT);
   ts->udp = udp;
   /* host:port with IPv6 support */
-  ts->authority = curl_maprintf("%s%s%s:%u", peer->ipv6 ? "[" : "",
-                                peer->hostname,
-                                peer->ipv6 ? "]" : "",
-                                peer->port);
+  ts->authority = curl_maprintf("%s%s%s:%u", dest->ipv6 ? "[" : "",
+                                dest->hostname,
+                                dest->ipv6 ? "]" : "",
+                                dest->port);
   if(!ts->authority)
     return CURLE_OUT_OF_MEMORY;
 
@@ -101,7 +101,7 @@ static void h3_tunnel_stream_reset(struct h3_tunnel_stream *ts)
 
 static void h3_tunnel_stream_cleanup(struct h3_tunnel_stream *ts)
 {
-  Curl_peer_unlink(&ts->peer);
+  Curl_peer_unlink(&ts->dest);
   Curl_bufq_free(&ts->recvbuf);
   Curl_http_resp_free(ts->resp);
   curlx_safefree(ts->authority);
@@ -1044,13 +1044,13 @@ static CURLcode cf_h3_proxy_submit_CONNECT(struct Curl_cfilter *cf,
                                            struct Curl_easy *data,
                                            struct h3_tunnel_stream *ts)
 {
+  struct cf_h3_proxy_ctx *ctx = cf->ctx;
   CURLcode result;
   struct httpreq *req = NULL;
 
-  result = Curl_http_proxy_create_tunnel_request(&req, cf, data,
-                                                  ts->peer,
-                                                  PROXY_HTTP_V3,
-                                                  (bool)ts->udp);
+  result = Curl_http_proxy_create_tunnel_request(
+    &req, cf, data, ctx->ngtcp2_ctx.ssl_peer.peer,
+    ts->dest, PROXY_HTTP_V3, (bool)ts->udp);
   if(!result)
     result = Curl_creader_set_null(data);
   if(!result)


### PR DESCRIPTION
- dedup code for CONNECT/CONNECT-UDP
- pass proxy peer to h1/h2 filters for use in CONNECT reuqests (UDP needs it)

