### PR TITLE
digest: parse without storing 'value' in local buffer

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -65,7 +65,8 @@ bool Curl_auth_digest_get_pair(const char *str, struct Curl_str *value,
   bool starts_with_quote = FALSE;
   bool escape = FALSE;
 
-  if(curlx_str_until(&str, value, DIGEST_MAX_VALUE_LENGTH, '='))
+  if(curlx_str_until(&str, value, DIGEST_MAX_VALUE_LENGTH, '=') ||
+     curlx_str_single(&str, '='))
     /* eek, no match */
     return FALSE;
 

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -57,19 +57,15 @@
 #define DIGEST_QOP_VALUE_STRING_AUTH_CONF "auth-conf"
 #endif
 
-bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
-                               const char **endptr)
+bool Curl_auth_digest_get_pair(const char *str, struct Curl_str *value,
+                               char *content, const char **endptr)
 {
   int c;
   size_t content_length = 0;
   bool starts_with_quote = FALSE;
   bool escape = FALSE;
 
-  for(c = DIGEST_MAX_VALUE_LENGTH - 1; (*str && (*str != '=') && c--);)
-    *value++ = *str++;
-  *value = 0;
-
-  if('=' != *str++)
+  if(curlx_str_until(&str, value, DIGEST_MAX_VALUE_LENGTH, '='))
     /* eek, no match */
     return FALSE;
 
@@ -538,47 +534,46 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
   Curl_auth_digest_cleanup(digest);
 
   for(;;) {
-    char value[DIGEST_MAX_VALUE_LENGTH];
+    struct Curl_str value;
     char content[DIGEST_MAX_CONTENT_LENGTH];
 
     /* Pass all additional spaces here */
-    while(*chlg && ISBLANK(*chlg))
-      chlg++;
+    curlx_str_passblanks(&chlg);
 
     /* Extract a value=content pair */
-    if(Curl_auth_digest_get_pair(chlg, value, content, &chlg)) {
-      if(curl_strequal(value, "nonce")) {
+    if(Curl_auth_digest_get_pair(chlg, &value, content, &chlg)) {
+      if(curlx_str_casecompare(&value, "nonce")) {
         curlx_free(digest->nonce);
         digest->nonce = curlx_strdup(content);
         if(!digest->nonce)
           return CURLE_OUT_OF_MEMORY;
       }
-      else if(curl_strequal(value, "stale")) {
+      else if(curlx_str_casecompare(&value, "stale")) {
         if(curl_strequal(content, "true")) {
           digest->stale = TRUE;
           digest->nc = 1; /* we make a new nonce now */
         }
       }
-      else if(curl_strequal(value, "realm")) {
+      else if(curlx_str_casecompare(&value, "realm")) {
         curlx_free(digest->realm);
         digest->realm = curlx_strdup(content);
         if(!digest->realm)
           return CURLE_OUT_OF_MEMORY;
       }
-      else if(curl_strequal(value, "opaque")) {
+      else if(curlx_str_casecompare(&value, "opaque")) {
         curlx_free(digest->opaque);
         digest->opaque = curlx_strdup(content);
         if(!digest->opaque)
           return CURLE_OUT_OF_MEMORY;
       }
-      else if(curl_strequal(value, "qop")) {
+      else if(curlx_str_casecompare(&value, "qop")) {
         const char *token = content;
         struct Curl_str out;
         bool foundAuth = FALSE;
         bool foundAuthInt = FALSE;
         /* Pass leading spaces */
-        while(*token && ISBLANK(*token))
-          token++;
+        curlx_str_passblanks(&token);
+
         while(!curlx_str_until(&token, &out, 32, ',')) {
           if(curlx_str_casecompare(&out, DIGEST_QOP_VALUE_STRING_AUTH))
             foundAuth = TRUE;
@@ -587,8 +582,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
             foundAuthInt = TRUE;
           if(curlx_str_single(&token, ','))
             break;
-          while(*token && ISBLANK(*token))
-            token++;
+          curlx_str_passblanks(&token);
         }
 
         /* Select only auth or auth-int. Otherwise, ignore */
@@ -605,7 +599,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
             return CURLE_OUT_OF_MEMORY;
         }
       }
-      else if(curl_strequal(value, "algorithm")) {
+      else if(curlx_str_casecompare(&value, "algorithm")) {
         curlx_free(digest->algorithm);
         digest->algorithm = curlx_strdup(content);
         if(!digest->algorithm)
@@ -636,7 +630,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
         else
           return CURLE_BAD_CONTENT_ENCODING;
       }
-      else if(curl_strequal(value, "userhash")) {
+      else if(curlx_str_casecompare(&value, "userhash")) {
         if(curl_strequal(content, "true")) {
           digest->userhash = TRUE;
         }
@@ -649,12 +643,10 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
       break; /* We are done here */
 
     /* Pass all additional spaces here */
-    while(*chlg && ISBLANK(*chlg))
-      chlg++;
+    curlx_str_passblanks(&chlg);
 
     /* Allow the list to be comma-separated */
-    if(',' == *chlg)
-      chlg++;
+    (void)curlx_str_single(&chlg, ',');
   }
 
   /* We had a nonce since before, and we got another one now without

--- a/lib/vauth/digest.h
+++ b/lib/vauth/digest.h
@@ -31,8 +31,8 @@
 #define DIGEST_MAX_CONTENT_LENGTH         1024
 
 /* This is used to extract the realm from a challenge message */
-bool Curl_auth_digest_get_pair(const char *str, char *value, char *content,
-                               const char **endptr);
+bool Curl_auth_digest_get_pair(const char *str, struct Curl_str *value,
+                               char *content, const char **endptr);
 
 #endif
 

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -34,6 +34,7 @@
 #include "curlx/multibyte.h"
 #include "curl_trc.h"
 #include "curlx/strdup.h"
+#include "curlx/strparse.h"
 #include "strcase.h"
 #include "strerror.h"
 

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -250,16 +250,15 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
   /* If domain is blank or unset, check challenge message for realm */
   if(!identity->Domain || !identity->DomainLength) {
     for(;;) {
-      char value[DIGEST_MAX_VALUE_LENGTH];
+      struct Curl_str value;
       char content[DIGEST_MAX_CONTENT_LENGTH];
 
       /* Pass all additional spaces here */
-      while(*chlg && ISBLANK(*chlg))
-        chlg++;
+      curlx_str_passblanks(&chlg);
 
       /* Extract a value=content pair */
-      if(Curl_auth_digest_get_pair(chlg, value, content, &chlg)) {
-        if(curl_strequal(value, "realm")) {
+      if(Curl_auth_digest_get_pair(chlg, &value, content, &chlg)) {
+        if(curlx_str_casecompare(&value, "realm")) {
 
           /* Setup identity's domain and length */
           domain.tchar_ptr = curlx_convert_UTF8_to_tchar(content);
@@ -287,12 +286,10 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
         break; /* We are done here */
 
       /* Pass all additional spaces here */
-      while(*chlg && ISBLANK(*chlg))
-        chlg++;
+      curlx_str_passblanks(&chlg);
 
       /* Allow the list to be comma-separated */
-      if(',' == *chlg)
-        chlg++;
+      (void)curlx_str_single(&chlg, ',');
     }
   }
 
@@ -325,16 +322,16 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 
     /* Check for the 'stale' directive */
     for(;;) {
-      char value[DIGEST_MAX_VALUE_LENGTH];
+      struct Curl_str value;
       char content[DIGEST_MAX_CONTENT_LENGTH];
 
       while(*p && ISBLANK(*p))
         p++;
 
-      if(!Curl_auth_digest_get_pair(p, value, content, &p))
+      if(!Curl_auth_digest_get_pair(p, &value, content, &p))
         break;
 
-      if(curl_strequal(value, "stale") &&
+      if(curlx_str_casecompare(&value, "stale") &&
          curl_strequal(content, "true")) {
         stale = TRUE;
         break;


### PR DESCRIPTION
Use of curlx_str_ functions avoids having a copy.

