### PR TITLE
CURLOPT_FORBID_REUSE.md: has no effect on multiplexed transfers

### DIFF
--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
@@ -36,7 +36,7 @@ it does as it can seriously impact performance.
 
 When set for a transfer that is done multiplexed on a shared connection (like
 when using HTTP/2 and HTTP/3), this option prevents new transfers to get added
-to the connection but all existing ones will be allowed to complete.
+to the connection but all existing ones are allowed to complete.
 
 Set to 0 to have libcurl keep the connection open for possible later reuse
 (default behavior).

--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
@@ -28,11 +28,14 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FORBID_REUSE, long close);
 
 # DESCRIPTION
 
-Pass a long. Set *close* to 1 to make libcurl explicitly close the
-connection when done with the transfer. Normally, libcurl keeps all
-connections alive when done with one transfer in case a succeeding one follows
-that can reuse them. This option should be used with caution and only if you
-understand what it does as it can seriously impact performance.
+Pass a long. Set *close* to 1 to make libcurl explicitly close the connection
+when done with the transfer. Normally, libcurl keeps all connections alive
+when done with one transfer in case a succeeding one follows that can reuse
+them. This option should be used with caution and only if you understand what
+it does as it can seriously impact performance.
+
+This option does not have any effect on multiplexed transfers, like those
+using HTTP/2 or HTTP/3.
 
 Set to 0 to have libcurl keep the connection open for possible later reuse
 (default behavior).

--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
@@ -34,8 +34,9 @@ when done with one transfer in case a succeeding one follows that can reuse
 them. This option should be used with caution and only if you understand what
 it does as it can seriously impact performance.
 
-This option does not have any effect on multiplexed transfers, like those
-using HTTP/2 or HTTP/3.
+When set for a transfer that is done multiplexed on a shared connection (like
+when using HTTP/2 and HTTP/3), this option prevents new transfers to get added
+to the connection but all existing ones will be allowed to complete.
 
 Set to 0 to have libcurl keep the connection open for possible later reuse
 (default behavior).

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -941,6 +941,8 @@ void Curl_attach_connection(struct Curl_easy *data,
   DEBUGASSERT(conn);
   DEBUGASSERT(conn->attached_xfers < UINT32_MAX);
   data->conn = conn;
+  if(data->set.reuse_forbid)
+    conn->bits.no_reuse = TRUE;  /* connection should not be reused */
   if(matched)
     data->state.lastconnect_id = conn->connection_id;
   else

--- a/lib/url.c
+++ b/lib/url.c
@@ -2316,11 +2316,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
     VERBOSE(bool tls_upgraded = (!(needle->given->flags & PROTOPT_SSL) &&
                                  Curl_conn_is_ssl(conn, FIRSTSOCKET)));
 
-    conn->bits.reuse = TRUE;  /* this is a reused connection */
-
-    if(data->set.reuse_forbid)
-      conn->bits.no_reuse = TRUE;  /* connection should not be reused again */
-
+    conn->bits.reuse = TRUE;
     url_conn_reuse_adjust(data, needle);
 
 #ifndef CURL_DISABLE_PROXY

--- a/lib/url.c
+++ b/lib/url.c
@@ -2316,7 +2316,11 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
     VERBOSE(bool tls_upgraded = (!(needle->given->flags & PROTOPT_SSL) &&
                                  Curl_conn_is_ssl(conn, FIRSTSOCKET)));
 
-    conn->bits.reuse = TRUE;
+    conn->bits.reuse = TRUE;  /* this is a reused connection */
+
+    if(data->set.reuse_forbid)
+      conn->bits.no_reuse = TRUE;  /* connection should not be reused again */
+
     url_conn_reuse_adjust(data, needle);
 
 #ifndef CURL_DISABLE_PROXY


### PR DESCRIPTION
Discussion: https://curl.se/mail/lib-2026-09/0006.html