### PR TITLE
digest.h: add forward declaration

### DIFF
--- a/lib/vauth/digest.h
+++ b/lib/vauth/digest.h
@@ -30,6 +30,8 @@
 #define DIGEST_MAX_VALUE_LENGTH           256
 #define DIGEST_MAX_CONTENT_LENGTH         1024
 
+struct Curl_str;
+
 /* This is used to extract the realm from a challenge message */
 bool Curl_auth_digest_get_pair(const char *str, struct Curl_str *value,
                                char *content, const char **endptr);


### PR DESCRIPTION
Fixing (seen in CM openssl libssh2 sync-resolver valgrind 1 +analyzer):
```
In file included from /home/runner/work/curl/curl/lib/vauth/digest.c:32:
lib/vauth/digest.h:34:56: error: ‘struct Curl_str’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   34 | bool Curl_auth_digest_get_pair(const char *str, struct Curl_str *value,
      |                                                        ^~~~~~~~
lib/vauth/digest.c:60:6: error: conflicting types for ‘Curl_auth_digest_get_pair’; have ‘_Bool(const char *, struct Curl_str *, char *, const char **)’
   60 | bool Curl_auth_digest_get_pair(const char *str, struct Curl_str *value,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/33891130575/job/101082778404#step:43:159

Bug: https://github.com/curl/curl/pull/22221#issuecomment-5551359468
Follow-up to 9be5c6849225f2dbb3bf60249998c33575dd0910 #22831

---

Not sure why the GCC analyzer triggers this. Which in turn disables typechecks, so one
of these is a suspect reason.
