### PR TITLE
request: clear the http code before doing next request

### DIFF
--- a/lib/request.c
+++ b/lib/request.c
@@ -33,6 +33,7 @@
 #include "transfer.h"
 #include "url.h"
 #include "curlx/strparse.h"
+#include "getinfo.h"
 
 void Curl_req_init(struct SingleRequest *req)
 {
@@ -69,6 +70,7 @@ CURLcode Curl_req_soft_reset(struct SingleRequest *req,
   curlx_safefree(req->hd_proxy_auth);
 #endif
 
+  data->info.httpcode = 0;
   result = Curl_client_start(data);
   if(result)
     return result;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -2101,6 +2101,7 @@ TESTCASES = \
   test4000 \
   test4001 \
   test4644 \
+  test4656 \
   test5000 \
   test5001 \
   test5002 \

--- a/tests/data/test4656
+++ b/tests/data/test4656
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP CONNECT
+HTTP proxy
+</keywords>
+</info>
+
+# Server-side
+<reply>
+
+<data crlf="headers" nocheck="yes">
+HTTP/1.1 301 OK
+Location: %TESTNUMBER0002
+Content-Length: 0
+Connection: close
+
+</data>
+
+<data2 crlf="headers" nocheck="yes">
+HTTP/1.1 200 OK swsclose
+Content-Length: 18
+
+final destination
+</data2>
+
+<connect crlf="headers">
+HTTP/1.1 200 welcome dear
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Disposition: attachment; filename="proxy-chosen.bin"
+
+</connect>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+IPv6
+proxy
+</features>
+<server>
+http-proxy
+http
+https
+</server>
+<name>
+HTTPS over proxy with CONNECT redirected and -OJ
+</name>
+<command option="no-output,no-include">
+https://remotesite:%HTTPSPORT/%TESTNUMBER -L -O -J -x %HOSTIP:%PROXYPORT --insecure --output-dir=%LOGDIR
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<proxy crlf="headers">
+CONNECT remotesite:%HTTPSPORT HTTP/1.1
+Host: remotesite:%HTTPSPORT
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+CONNECT remotesite:%HTTPSPORT HTTP/1.1
+Host: remotesite:%HTTPSPORT
+User-Agent: curl/%VERSION
+Proxy-Connection: Keep-Alive
+
+</proxy>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: remotesite:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: remotesite:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<file name="%LOGDIR/%TESTNUMBER0002">
+final destination
+</file>
+</verify>
+</testcase>


### PR DESCRIPTION
To prevent it from "leaking" over from the previous, potentially misleading users.

Add test4656 to verify

Reported-by: Stanislav Fort

