### PR TITLE
openssl: Remove the common name fallback

### DIFF
--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
@@ -42,9 +42,9 @@ When CURLOPT_DOH_SSL_VERIFYHOST(3) is 2, the SSL certificate provided by
 the DoH server must indicate that the server name is the same as the server
 name to which you meant to connect to, or the connection fails.
 
-curl considers the DoH server the intended one when the Common Name field or a
-Subject Alternate Name field in the certificate matches the hostname in the
-DoH URL to which you told curl to connect.
+curl considers the DoH server the intended one when a name in the Subject
+Alternate Name field in the certificate matches the hostname in the DoH URL to
+which you told curl to connect.
 
 When the *verify* value is set to 1L it is treated the same as 2L. However
 for consistency with the other *VERIFYHOST* options we suggest use 2 and

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
@@ -41,9 +41,9 @@ When CURLOPT_PROXY_SSL_VERIFYHOST(3) is 2, the proxy certificate must
 indicate that the server is the proxy to which you meant to connect to, or the
 connection fails.
 
-curl considers the proxy the intended one when the Common Name field or a
-Subject Alternate Name field in the certificate matches the hostname in the
-proxy string which you told curl to use.
+curl considers the proxy the intended one when a name in the Subject Alternate
+Name field in the certificate matches the hostname in the proxy string which you
+told curl to use.
 
 If *verify* value is set to 1:
 

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -42,9 +42,9 @@ indicate that it was made for the hostname or address curl connects to, or the
 connection fails. The certificate has to have the same name as is used in the
 URL you operate against.
 
-curl considers the server the intended one when the Common Name field or a
-Subject Alternate Name field in the certificate matches the hostname in the
-URL to which you told curl to connect.
+curl considers the server the intended one when a name in the Subject Alternate
+Name field in the certificate matches the hostname in the URL to which you told
+curl to connect.
 
 When the *verify* value is 0, the connection succeeds regardless of the names
 in the certificate. Use that ability with caution.

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1432,9 +1432,9 @@ typedef enum {
    */
   CURLOPT(CURLOPT_HTTPGET, CURLOPTTYPE_LONG, 80),
 
-  /* Set if we should verify the Common name from the peer certificate in SSL
-   * handshake, set 1 to check existence, 2 to ensure that it matches the
-   * provided hostname. */
+  /* Set to 1 or 2 to check if some name in the peer certificate in the SSL
+     handshake matches the provided hostname. Set to 0 to disable this security
+     check. It is enabled by default. */
   CURLOPT(CURLOPT_SSL_VERIFYHOST, CURLOPTTYPE_LONG, 81),
 
   /* Specify which filename to write all known cookies in after completed
@@ -2031,9 +2031,9 @@ typedef enum {
      set 1 to verify. */
   CURLOPT(CURLOPT_PROXY_SSL_VERIFYPEER, CURLOPTTYPE_LONG, 248),
 
-  /* Set if we should verify the Common name from the proxy certificate in SSL
-   * handshake, set 1 to check existence, 2 to ensure that it matches
-   * the provided hostname. */
+  /* Set to 1 or 2 to check if some name in the proxy certificate in the SSL
+     handshake matches the provided hostname. Set to 0 to disable this security
+     check. It is enabled by default. */
   CURLOPT(CURLOPT_PROXY_SSL_VERIFYHOST, CURLOPTTYPE_LONG, 249),
 
   /* What version to specifically try to use for proxy.

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1989,25 +1989,10 @@ static void ossl_close_all(struct Curl_easy *data)
 
 /* ====================================================== */
 
-/* Quote from RFC2818 section 3.1 "Server Identity"
-
-   If a subjectAltName extension of type dNSName is present, that MUST
-   be used as the identity. Otherwise, the (most specific) Common Name
-   field in the Subject field of the certificate MUST be used. Although
-   the use of the Common Name is existing practice, it is deprecated and
-   Certification Authorities are encouraged to use the dNSName instead.
-
-   Matching is performed using the matching rules specified by
-   [RFC2459]. If more than one identity of a given type is present in
-   the certificate (e.g., more than one dNSName name, a match in any one
-   of the set is considered acceptable.) Names may contain the wildcard
-   character * which is considered to match any single domain name
-   component or component fragment. E.g., *.a.com matches foo.a.com but
-   not bar.foo.a.com. f*.com matches foo.com but not bar.com.
-
-   In some cases, the URI is specified as an IP address rather than a
-   hostname. In this case, the iPAddress subjectAltName must be present
-   in the certificate and must exactly match the IP in the URI.
+/* See RFC9525. Historically, this function checked both subjectAltName and
+   the Common Name in the Subject field. This was deprecated since RFC2818.
+   Checking it was downgraded to a SHOULD in RFC6125 and finally removed in
+   RFC9525.
 
    This function is now used from ngtcp2 (QUIC) as well.
  */
@@ -2026,8 +2011,6 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
   struct in_addr addr;
 #endif
   CURLcode result = CURLE_OK;
-  bool dNSName = FALSE; /* if a dNSName field exists in the cert */
-  bool iPAddress = FALSE; /* if an iPAddress field exists in the cert */
   size_t hostlen = strlen(peer->origin->hostname);
 
   (void)conn;
@@ -2076,11 +2059,6 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
       /* get a handle to alternative name number i */
       const GENERAL_NAME *check = sk_GENERAL_NAME_value(altnames, i);
 
-      if(check->type == GEN_DNS)
-        dNSName = TRUE;
-      else if(check->type == GEN_IPADD)
-        iPAddress = TRUE;
-
       /* only check alternatives of the same type the target is */
       if(check->type == target) {
         /* get data and length */
@@ -2116,7 +2094,7 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
   if(matched)
     /* an alternative name matched */
     ;
-  else if(dNSName || iPAddress) {
+  else {
     const char *tname = (peer->type == CURL_SSL_PEER_DNS) ? "hostname" :
                         (peer->type == CURL_SSL_PEER_IPV4) ?
                         "IPv4 address" : "IPv6 address";
@@ -2125,74 +2103,6 @@ static CURLcode ossl_verifyhost(struct Curl_easy *data,
     failf(data, "SSL: no alternative certificate subject name matches "
           "target %s '%s'", tname, peer->origin->user_hostname);
     result = CURLE_PEER_FAILED_VERIFICATION;
-  }
-  else {
-    /* we have to look to the last occurrence of a commonName in the
-       distinguished one to get the most significant one. */
-    int i = -1;
-    unsigned char *cn = NULL;
-    int cnlen = 0;
-    bool free_cn = FALSE;
-
-    /* The following is done because of a bug in 0.9.6b */
-    const X509_NAME *name = X509_get_subject_name(server_cert);
-    if(name) {
-      int j;
-      while((j = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0)
-        i = j;
-    }
-
-    /* we have the name entry and we now convert this to a string
-       that we can use for comparison. Doing this we support BMPstring,
-       UTF8, etc. */
-
-    if(i >= 0) {
-      const ASN1_STRING *tmp =
-        X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
-
-      /* In OpenSSL 0.9.7d and earlier, ASN1_STRING_to_UTF8 fails if the input
-         is already UTF-8 encoded. We check for this case and copy the raw
-         string manually to avoid the problem. This code can be made
-         conditional in the future when OpenSSL has been fixed. */
-      if(tmp) {
-        if(ASN1_STRING_type(tmp) == V_ASN1_UTF8STRING) {
-          cnlen = ASN1_STRING_length(tmp);
-          cn = (unsigned char *)CURL_UNCONST(ASN1_STRING_get0_data(tmp));
-        }
-        else { /* not a UTF8 name */
-          cnlen = ASN1_STRING_to_UTF8(&cn, tmp);
-          free_cn = TRUE;
-        }
-
-        if((cnlen <= 0) || !cn)
-          result = CURLE_OUT_OF_MEMORY;
-        else if(memchr(cn, '\0', cnlen)) {
-          /* there was a null-terminator before the end of string, this
-             cannot match and we return failure! */
-          failf(data, "SSL: illegal cert name field");
-          result = CURLE_PEER_FAILED_VERIFICATION;
-        }
-      }
-    }
-
-    if(result)
-      /* error already detected, pass through */
-      ;
-    else if(!cn) {
-      failf(data, "SSL: unable to obtain common name from peer certificate");
-      result = CURLE_PEER_FAILED_VERIFICATION;
-    }
-    else if(!Curl_cert_hostcheck((const char *)cn, cnlen,
-                                 peer->origin->hostname, hostlen)) {
-      failf(data, "SSL: certificate subject name '%.*s' does not match "
-            "target hostname '%s'", cnlen, cn, peer->origin->user_hostname);
-      result = CURLE_PEER_FAILED_VERIFICATION;
-    }
-    else {
-      infof(data, " common name: %.*s (matched)", cnlen, cn);
-    }
-    if(free_cn)
-      OPENSSL_free(cn);
   }
 
   return result;

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -624,3 +624,20 @@ class TestSSLUse:
         r = curl.http_get(url=url, alpn_proto=proto)
         # CURLE_SSL_CONNECT_ERROR or CURLE_PEER_FAILED_VERIFICATION
         assert r.exit_code in [35, 60], f'{r.dump_logs()}'
+
+    @pytest.mark.parametrize("proto", Env.http_protos())
+    def test_17_25_no_common_name_fallback(self, env: Env, proto, httpd, nghttpx):
+        if env.curl_uses_lib('mbedtls') or \
+           env.curl_uses_lib('gnutls') or \
+           env.curl_uses_lib('wolfssl'):
+            pytest.skip("TLS library has not yet been updated for RFC 9525")
+        httpd.set_domain1_cred_name('domain-in-common-name-only')
+        httpd.reload_if_config_changed()
+        if proto == 'h3':
+            nghttpx.set_cred_name('domain-in-common-name-only')
+            nghttpx.reload_if_config_changed()
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo'
+        r = curl.http_get(url=url, alpn_proto=proto)
+        # CURLE_PEER_FAILED_VERIFICATION
+        assert r.exit_code == 60, f'{r.dump_logs()}'

--- a/tests/http/testenv/certs.py
+++ b/tests/http/testenv/certs.py
@@ -91,7 +91,8 @@ class CertificateSpec:
                  valid_to: timedelta = timedelta(days=89),
                  client: bool = False,
                  check_valid: bool = True,
-                 sub_specs: Optional[List['CertificateSpec']] = None):
+                 sub_specs: Optional[List['CertificateSpec']] = None,
+                 domain_in_common_name_only: bool = False):
         self._name = name
         self.domains = domains
         self.client = client
@@ -102,6 +103,7 @@ class CertificateSpec:
         self.valid_to = valid_to
         self.sub_specs = sub_specs
         self.check_valid = check_valid
+        self.domain_in_common_name_only = domain_in_common_name_only
 
     @property
     def name(self) -> Optional[str]:
@@ -386,7 +388,8 @@ class TestCA:
         if spec.domains and len(spec.domains):
             return TestCA._make_server_credentials(name=spec.name, domains=spec.domains,
                                                    issuer=issuer, valid_from=valid_from,
-                                                   valid_to=valid_to, key_type=key_type)
+                                                   valid_to=valid_to, key_type=key_type,
+                                                   domain_in_common_name_only=spec.domain_in_common_name_only)
         if spec.client:
             return TestCA._make_client_credentials(name=spec.name, issuer=issuer,
                                                    email=spec.email, valid_from=valid_from,
@@ -468,7 +471,8 @@ class TestCA:
         )
 
     @staticmethod
-    def _add_leaf_usages(csr: Any, domains: List[str], issuer: Credentials) -> Any:
+    def _add_leaf_usages(csr: Any, domains: List[str], issuer: Credentials,
+                         domain_in_common_name_only: bool = False) -> Any:
         names = []
         for name in domains:
             m = re.match(r'dns:(.+)', name)
@@ -480,7 +484,7 @@ class TestCA:
                 except ValueError:
                     names.append(x509.DNSName(name))
 
-        return csr.add_extension(
+        csr = csr.add_extension(
             x509.BasicConstraints(ca=False, path_length=None),
             critical=True,
         ).add_extension(
@@ -488,9 +492,12 @@ class TestCA:
                 issuer.certificate.extensions.get_extension_for_class(
                     x509.SubjectKeyIdentifier).value),
             critical=False
-        ).add_extension(
-            x509.SubjectAlternativeName(names), critical=True,
-        ).add_extension(
+        )
+        if not domain_in_common_name_only:
+            csr = csr.add_extension(
+                x509.SubjectAlternativeName(names), critical=True,
+            )
+        return csr.add_extension(
             x509.ExtendedKeyUsage([
                 ExtendedKeyUsageOID.SERVER_AUTH,
             ]),
@@ -549,13 +556,22 @@ class TestCA:
                                  key_type: Any,
                                  valid_from: timedelta = timedelta(days=-1),
                                  valid_to: timedelta = timedelta(days=89),
+                                 domain_in_common_name_only: bool = False,
                                  ) -> Credentials:
         pkey = _private_key(key_type=key_type)
-        subject = TestCA._make_x509_name(common_name=name, parent=issuer.subject)
+        common_name = name
+        if domain_in_common_name_only:
+            if len(domains) != 1:
+                raise CertError("domain_in_common_name_only requires exactly one domain")
+            # Use the first domain as the common name, instead of `name`. This allows
+            # `name` still be a unique name for reconfiguring the server.
+            common_name = domains[0]
+        subject = TestCA._make_x509_name(common_name=common_name, parent=issuer.subject)
         csr = TestCA._make_csr(subject=subject,
                                issuer_subject=issuer.certificate.subject, pkey=pkey,
                                valid_from_delta=valid_from, valid_until_delta=valid_to)
-        csr = TestCA._add_leaf_usages(csr, domains=domains, issuer=issuer)
+        csr = TestCA._add_leaf_usages(csr, domains=domains, issuer=issuer,
+                                      domain_in_common_name_only=domain_in_common_name_only)
         cert = csr.sign(private_key=issuer.private_key,
                         algorithm=hashes.SHA256(),
                         backend=default_backend())

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -219,14 +219,20 @@ class EnvConfig:
                 ],
             ),
             CertificateSpec(
-                name='embedded-zero',
-                domains=[f'{self.domain1}\0actually.{self.domain2}'],
-                key_type='rsa2048',
+                name="embedded-zero",
+                domains=[f"{self.domain1}\0actually.{self.domain2}"],
+                key_type="rsa2048",
             ),
             CertificateSpec(
-                name='embedded-zero-wildcard',
-                domains=[f'*.{self.tld}\0actually.{self.domain2}'],
-                key_type='rsa2048',
+                name="embedded-zero-wildcard",
+                domains=[f"*.{self.tld}\0actually.{self.domain2}"],
+                key_type="rsa2048",
+            ),
+            CertificateSpec(
+                name="domain-in-common-name-only",
+                domains=[self.domain1],
+                key_type="rsa2048",
+                domain_in_common_name_only=True,
             ),
         ]
 


### PR DESCRIPTION
(I only tested locally against OpenSSL. It's quite likely that CI will complain about about other backends. Those seem to ask the backends to do the check and I wasn't sure off-hand which one they do. I'll do a couple iterations on this PR as the CI results come in and round this out.)

This was deprecated since RFC2818. Checking it was downgraded to a SHOULD in RFC6125 and finally removed in RFC9525.

See also https://github.com/curl/curl/pull/22824#issuecomment-5544166058

While updating docs and comments, I noticed that the header comment for CURLOPT_SSL_VERIFYHOST is out of date w.r.t. 1 and 2 being merged, so I've fixed that to match the .md files.

(Also fix the quotes from my recent PR to env.py to match the surrounding ones. I didn't rebase that change across the reformatting quite correctly.)