### PR TITLE
curl: apply variable byte ranges to environment imports

### DIFF
--- a/docs/cmdline-opts/variable.md
+++ b/docs/cmdline-opts/variable.md
@@ -42,7 +42,7 @@ to include from the contents. For example, asking for offset "2-10" means
 offset two to offset ten, inclusive, resulting in 9 bytes in total. `2-2`
 means a single byte at offset 2. Not providing a second number implies to the
 end of data. The start offset cannot be larger than the end offset. Asking for
-a range that is outside of the file size makes the variable contents empty.
+a range that is outside of the source size makes the variable contents empty.
 For example, getting the first one hundred bytes from a given file:
 
     curl --variable "fraction[0-99]@filename"

--- a/src/var.c
+++ b/src/var.c
@@ -57,6 +57,22 @@ static const struct tool_var *varcontent(const char *name, size_t nlen)
   return NULL;
 }
 
+static void range_content(char **content, size_t *clen,
+                          curl_off_t startoffset, curl_off_t endoffset)
+{
+  if(startoffset || (endoffset != CURL_OFF_T_MAX)) {
+    if(startoffset >= (curl_off_t)*clen)
+      *clen = 0;
+    else {
+      /* make the end offset no larger than the last byte */
+      if(endoffset >= (curl_off_t)*clen)
+        endoffset = (curl_off_t)*clen - 1;
+      *clen = (size_t)(endoffset - startoffset) + 1;
+      *content += startoffset;
+    }
+  }
+}
+
 #define ENDOFFUNC(x) (((x) == '}') || ((x) == ':'))
 #define FUNCMATCH(ptr, name, len)                   \
   (!strncmp(ptr, name, len) && ENDOFFUNC((ptr)[len]))
@@ -464,22 +480,13 @@ ParameterError setvariable(const char *input)
     clen = strlen(line);
     /* this is the exact content */
     content = (char *)CURL_UNCONST(line);
-    if(startoffset || (endoffset != CURL_OFF_T_MAX)) {
-      if(startoffset >= (curl_off_t)clen)
-        clen = 0;
-      else {
-        /* make the end offset no larger than the last byte */
-        if(endoffset >= (curl_off_t)clen)
-          endoffset = clen - 1;
-        clen = (size_t)(endoffset - startoffset) + 1;
-        content += startoffset;
-      }
-    }
   }
   else {
     warnf("Bad --variable syntax, skipping: %s", input);
     return PARAM_OK;
   }
+  if(content && !contalloc)
+    range_content(&content, &clen, startoffset, endoffset);
   err = addvariable(name, nlen, content, clen, contalloc);
   if(err) {
     if(contalloc)

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -2130,7 +2130,9 @@ TESTCASES = \
   test5025 \
   test5026 \
   test5027 \
-  test5028
+  test5028 \
+  test5029 \
+  test5030
 
 EXTRA_DIST = \
   $(TESTCASES) \

--- a/tests/data/test5029
+++ b/tests/data/test5029
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+--variable
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<setenv>
+FOO_RANGE=abcdef
+FOO_RANGE_DEFAULT=abcdef
+</setenv>
+<name>
+--variable byte ranges on environment imports
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --variable "%FOO_RANGE[1-3]" --variable "%FOO_RANGE_DEFAULT[1-3]=fallback" --expand-data '{{FOO_RANGE}}-{{FOO_RANGE_DEFAULT}}'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes" nonewline="yes">
+POST /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 7
+Content-Type: application/x-www-form-urlencoded
+
+bcd-bcd
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test5030
+++ b/tests/data/test5030
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+--variable
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<setenv>
+FOO_RANGE_MISSING
+</setenv>
+<name>
+--variable byte range on a missing environment import fallback
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --variable "%FOO_RANGE_MISSING[1-3]=abcdef" --expand-data '{{FOO_RANGE_MISSING}}'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes" nonewline="yes">
+POST /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 3
+Content-Type: application/x-www-form-urlencoded
+
+bcd
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test5030
+++ b/tests/data/test5030
@@ -27,13 +27,13 @@ Content-Type: text/html
 http
 </server>
 <setenv>
-FOO_RANGE_MISSING
+CURL_TEST_FOO_RANGE_MISSING_5030
 </setenv>
 <name>
 --variable byte range on a missing environment import fallback
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER --variable "%FOO_RANGE_MISSING[1-3]=abcdef" --expand-data '{{FOO_RANGE_MISSING}}'
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --variable "%CURL_TEST_FOO_RANGE_MISSING_5030[1-3]=abcdef" --expand-data '{{CURL_TEST_FOO_RANGE_MISSING_5030}}'
 </command>
 </client>
 


### PR DESCRIPTION
`--variable` byte ranges are not applied when the source is an environment variable that already exists.

For example:

```shell
    FOO=abcdef curl \
      --variable '%FOO[1-3]' \
      --expand-data '{{FOO}}' \
      http://127.0.0.1:PORT/
```


Currently this expands to `abcdef`, while the same range is applied when the value comes from a literal fallback.

The reason is that `setvariable()` parses the byte range before importing the environment value, but the later dispatch skips the range handling when `content` is already set.

Apply the existing in-memory range handling to environment imports as well as literal assignments. File inputs continue to use `file2memory_range()`.
