### PR TITLE
build: Convert HAS_TIME_T_UNSIGNED to a compile-time check

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -388,3 +388,13 @@ int main(void)
   return 0;
 }
 #endif
+
+#ifdef HAVE_TIME_T_UNSIGNED
+#include <time.h>
+static int time_t_is_unsigned[((time_t)-1 > 0) ? 1 : -1];
+int main(void)
+{
+  (void)time_t_is_unsigned;
+  return 0;
+}
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1798,16 +1798,7 @@ if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
     }" HAVE_WRITABLE_ARGV)
 endif()
 
-if(NOT CMAKE_CROSSCOMPILING)
-  include(CheckCSourceRuns)
-  check_c_source_runs("
-    #include <time.h>
-    int main(void)
-    {
-      time_t t = -1;
-      return t < 0;
-    }" HAVE_TIME_T_UNSIGNED)
-endif()
+curl_internal_test(HAVE_TIME_T_UNSIGNED)
 
 curl_internal_test(HAVE_GLIBC_STRERROR_R)
 curl_internal_test(HAVE_POSIX_STRERROR_R)

--- a/configure.ac
+++ b/configure.ac
@@ -4157,21 +4157,20 @@ case $host_os in
     ;;
   *)
     AC_MSG_CHECKING([if time_t is unsigned])
-    CURL_RUN_IFELSE(
-      [
-      #include <time.h>
-      int main(void)
-      {
-        time_t t = -1;
-        return t < 0;
-      }
-      ],[
+    AC_COMPILE_IFELSE([
+      AC_LANG_SOURCE([[
+        #include <time.h>
+        static int time_t_is_unsigned[((time_t)-1 > 0) ? 1 : -1];
+        int main(void)
+        {
+          (void)time_t_is_unsigned;
+          return 0;
+        }
+      ]])
+    ],[
       AC_MSG_RESULT([yes])
       AC_DEFINE(HAVE_TIME_T_UNSIGNED, 1, [Define this if time_t is unsigned])
     ],[
-      AC_MSG_RESULT([no])
-    ],[
-      dnl cross-compiling, most systems are signed
       AC_MSG_RESULT([no])
     ])
     ;;


### PR DESCRIPTION
`(time_t)-1 > 0` is a constant expression. Checking this at compile time instead of running a program (a) is faster, and (b) can be checked when cross-compiling.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
