### PR TITLE
curl_fopen: keep the 0600 temp file when fchmod fails; define HAVE_FCHMOD for OS/400

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -51,6 +51,11 @@ libcurl creates the file to store the alt-svc cache in using default file
 permissions, meaning that on *nix systems you may need to restrict your umask
 to prevent other users on the same system to access the file.
 
+When the file already exists and is owned by the same user and group, libcurl
+rewrites it with the permissions the existing file has, without applying the
+umask again. Change the mode of the existing file to change what a rewrite
+produces.
+
 # DEFAULT
 
 NULL. The alt-svc cache is not read nor written to file.

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
@@ -62,6 +62,11 @@ libcurl creates the file to store cookies using default file permissions,
 meaning that on *nix systems you may need to restrict your umask to prevent
 other users on the same system to access the file.
 
+When the file already exists and is owned by the same user and group, libcurl
+rewrites it with the permissions the existing file has, without applying the
+umask again. Change the mode of the existing file to change what a rewrite
+produces.
+
 # DEFAULT
 
 NULL

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -77,6 +77,11 @@ libcurl creates the file to store HSTS data in using default file permissions,
 meaning that on *nix systems you may need to restrict your umask to prevent
 other users on the same system to access the file.
 
+When the file already exists and is owned by the same user and group, libcurl
+rewrites it with the permissions the existing file has, without applying the
+umask again. Change the mode of the existing file to change what a rewrite
+produces.
+
 # %PROTOCOLS%
 
 # EXAMPLE

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -55,6 +55,9 @@
 /* if you have <dirent.h> */
 #define HAVE_DIRENT_H
 
+/* Define to 1 if you have the fchmod function. */
+#define HAVE_FCHMOD             1
+
 /* Define to 1 if you have the fcntl function. */
 #define HAVE_FCNTL              1
 

--- a/lib/curl_fopen.c
+++ b/lib/curl_fopen.c
@@ -28,6 +28,7 @@
 
 #include "urldata.h"
 #include "rand.h"
+#include "curl_trc.h"
 #include "curl_fopen.h"
 
 /* The dirslash() function breaks a null-terminated pathname string into
@@ -142,9 +143,11 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
     curlx_struct_stat nsb;
     if((curlx_fstat(fd, &nsb) != -1) &&
        (nsb.st_uid == sb.st_uid) && (nsb.st_gid == sb.st_gid)) {
-      /* if the user and group are the same, clone the original mode */
+      /* if the user and group are the same, clone the original mode. A
+         failure is not fatal: the file keeps the private 0600 mode it was
+         created with, which is never more permissive than the clone. */
       if(fchmod(fd, sb.st_mode) == -1)
-        goto fail;
+        infof(data, "fchmod on %s failed, keeping mode 0600", tempstore);
     }
   }
 #endif


### PR DESCRIPTION
Repo: curl/curl · base: 83b7ad083d4252c11e7e897436ef073029c65de0 ("curl_fopen: restore the uid and gid checks") · branch: charles-fix-curl

## Title

curl_fopen: do not fail the save when fchmod() fails, add HAVE_FCHMOD to OS/400

## Body

83b7ad0 recreates the temp file with mode 0600 and then, when the existing file has the same
uid and gid, clones its mode with `fchmod(fd, sb.st_mode)`; any fchmod error takes the `fail`
path, which returns CURLE_WRITE_ERROR and unlinks the temp file. Because Curl_fopen() has
already opened the destination with `fopen(filename, "w")` to fstat it, the destination is
truncated at that point, so an fchmod failure does not just skip the save: it leaves the
existing cookie jar / HSTS / Alt-Svc file at 0 bytes (reproduced on macOS with a DYLD
interposer that makes fchmod return EPERM: 67-byte jar -> 0 bytes, `repro/`). Filesystems that
create files but reject mode changes (FAT-family, CIFS without unix extensions, some FUSE
mounts) trigger this on every rewrite.

The fix keeps the fchmod failure non-fatal: the temp file stays at the 0600 it was created
with, which is never more permissive than the mode being cloned, and an `infof()` line records
it. Second, `lib/config-os400.h` is hand-maintained and did not get `HAVE_FCHMOD`, so OS/400
builds compile without the clone block and silently rewrite every existing file as 0600 where
the previous code cloned the mode via open(); the define is added (IBM i provides fchmod()).
Third, the three option docs say to restrict the umask, which only covers the creation of a new
file; a sentence is added stating that an existing file's permissions are kept on rewrite.

Not changed: the umask is intentionally not re-applied to the cloned mode. fchmod() cannot
honor umask portably without a process-wide `umask()` round-trip, which is unsafe in a library,
and "keep the existing file's mode" is the 2022 design (20f9dd6bae) that 83b7ad0 restores.

Separate, pre-existing issue worth its own report: the `fopen(filename, "w")` probe truncates
the destination before the temp file exists, so *any* later failure (rand, OOM, open, fdopen)
destroys the old file. The temp-and-rename design was meant to prevent exactly that.

## Severity

- fchmod-fatal: low-medium. Environment dependent, but the consequence is loss of the existing
  file, not just a skipped save.
- OS/400 HAVE_FCHMOD: low. Niche platform; silent tightening to 0600 on rewrite.
- umask/docs: low. Doc clarification only.
- Truncate-before-temp (not fixed here): medium; data loss on failure paths; pre-existing.

## Verification

- `repro/repro_fchmod_fail.sh <libdir> <src>`: head -> "save ABORTED; the existing jar was left
  truncated" (0 bytes), fix -> jar rewritten, mode 0600 kept (test-before.log / test-after.log).
- Normal path unchanged: with fchmod working, an existing 0644 jar is rewritten as 0644.
- `cmake -DCURL_WERROR=ON` build clean; `scripts/checksrc.pl` clean on both changed lib files.
- OS/400 cannot be compiled here; the define was checked by inspection only.
- Upstream `lib/curl_fopen.c` and `lib/config-os400.h` on `master` were byte-identical to this
  case head at the time of writing.