### PR TITLE
share link: forget connection

### DIFF
--- a/lib/curl_share.c
+++ b/lib/curl_share.c
@@ -457,6 +457,10 @@ CURLcode Curl_share_easy_link(struct Curl_easy *data,
   if(share) {
     bool locked = share_lock_acquire(share, data);
 
+    /* Forget an identifier from the previously used connection cache. */
+    if((share->specifier & (1 << CURL_LOCK_DATA_CONNECT)))
+      data->state.lastconnect_id = -1;
+
     share_ref_inc(share);
     data->share = share;
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -2087,6 +2087,7 @@ TESTCASES = \
   test3228 \
   test3229 \
   test3230 \
+  test3231 \
   \
   test3300 \
   test3301 \

--- a/tests/data/test3231
+++ b/tests/data/test3231
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+HTTP
+CONNECT_ONLY
+CURLOPT_SHARE
+</keywords>
+</info>
+
+# Server-side
+<reply>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+CONNECT_ONLY forgets connection when attaching a shared pool
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -327,5 +327,6 @@ TESTS_C = \
   lib3105.c \
   lib3207.c \
   lib3208.c \
+  lib3231.c \
   lib5000.c \
   lib5004.c

--- a/tests/libtest/lib3231.c
+++ b/tests/libtest/lib3231.c
@@ -1,0 +1,110 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "first.h"
+
+static CURLcode test_lib3231(const char *URL)
+{
+  CURL *easy_a = NULL;
+  CURL *easy_b = NULL;
+  CURLSH *share = NULL;
+  CURLSHcode shresult;
+  CURLcode result = CURLE_OK;
+  curl_socket_t socket_a = CURL_SOCKET_BAD;
+  curl_socket_t socket_b = CURL_SOCKET_BAD;
+  curl_socket_t socket_after = CURL_SOCKET_BAD;
+  curl_off_t conn_id = -1;
+  size_t sent = 0;
+
+  global_init(CURL_GLOBAL_ALL);
+
+  share = curl_share_init();
+  if(!share) {
+    result = TEST_ERR_FAILURE;
+    goto test_cleanup;
+  }
+
+  shresult = curl_share_setopt(share, CURLSHOPT_SHARE,
+                               CURL_LOCK_DATA_CONNECT);
+  if(shresult != CURLSHE_OK) {
+    result = TEST_ERR_FAILURE;
+    goto test_cleanup;
+  }
+
+  easy_init(easy_a);
+  easy_setopt(easy_a, CURLOPT_URL, URL);
+  easy_setopt(easy_a, CURLOPT_CONNECT_ONLY, 1L);
+  result = curl_easy_perform(easy_a);
+  if(result)
+    goto test_cleanup;
+  result = curl_easy_getinfo(easy_a, CURLINFO_ACTIVESOCKET, &socket_a);
+  if(result)
+    goto test_cleanup;
+
+  easy_init(easy_b);
+  easy_setopt(easy_b, CURLOPT_SHARE, share);
+  easy_setopt(easy_b, CURLOPT_URL, URL);
+  easy_setopt(easy_b, CURLOPT_CONNECT_ONLY, 1L);
+  result = curl_easy_perform(easy_b);
+  if(result)
+    goto test_cleanup;
+  result = curl_easy_getinfo(easy_b, CURLINFO_ACTIVESOCKET, &socket_b);
+  if(result)
+    goto test_cleanup;
+
+  if(socket_a == CURL_SOCKET_BAD || socket_b == CURL_SOCKET_BAD ||
+     socket_a == socket_b) {
+    curl_mfprintf(stderr, "failed to create two distinct connections\n");
+    result = TEST_ERR_FAILURE;
+    goto test_cleanup;
+  }
+
+  easy_setopt(easy_a, CURLOPT_SHARE, share);
+  result = curl_easy_getinfo(easy_a, CURLINFO_CONN_ID, &conn_id);
+  if(result)
+    goto test_cleanup;
+  result = curl_easy_getinfo(easy_a, CURLINFO_ACTIVESOCKET, &socket_after);
+  if(result)
+    goto test_cleanup;
+
+  if(conn_id != -1 || socket_after != CURL_SOCKET_BAD) {
+    curl_mfprintf(stderr, "connection survived a connection pool change\n");
+    result = TEST_ERR_FAILURE;
+    goto test_cleanup;
+  }
+
+  result = curl_easy_send(easy_a, "x", 1, &sent);
+  if(result != CURLE_UNSUPPORTED_PROTOCOL || sent) {
+    curl_mfprintf(stderr, "raw send used a connection from the new pool\n");
+    result = TEST_ERR_FAILURE;
+    goto test_cleanup;
+  }
+  result = CURLE_OK;
+
+test_cleanup:
+  curl_easy_cleanup(easy_a);
+  curl_easy_cleanup(easy_b);
+  curl_share_cleanup(share);
+  curl_global_cleanup();
+  return result;
+}


### PR DESCRIPTION
When an easy handle completes a CONNECT_ONLY operation using its private
connection cache, it retains lastconnect_id so raw send and receive calls can
find that connection. Attaching a share with CURL_LOCK_DATA_CONNECT changes
the cache used by later lookups. Since connection IDs are local to each cache,
the old ID can resolve a different connection in the shared cache.

Invalidate lastconnect_id when linking a connection-sharing share. This
mirrors the unlink-side fix in fe2d3591c / #22718.

Test 3231 creates distinct CONNECT_ONLY connections in private and shared
caches, attaches the share to the private handle, and verifies that the old
connection ID and socket are no longer exposed and curl_easy_send cannot use a
connection from the new cache.

Follow-up to https://hackerone.com/reports/3971585

This follow-up was identified with AI-assisted code analysis and was manually
reproduced, reviewed, and tested.