### PR TITLE
url match, no force reuse and candidates

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -716,7 +716,9 @@ bool Curl_cpool_find(struct Curl_easy *data,
   if(bundle) {
     if(data->state.lastconnect_id >= 0) {
       /* Try to find the previously used connection in this bundle
-       * and if it still matches, use that one. */
+       * and if it still matches, use that one. This assures that
+       * an authentication involving several requests is using
+       * the same connection again. */
       curr = Curl_llist_head(&bundle->conns);
       while(curr) {
         conn = Curl_node_elem(curr);
@@ -734,7 +736,10 @@ bool Curl_cpool_find(struct Curl_easy *data,
       while(curr) {
         conn = Curl_node_elem(curr);
         curr = Curl_node_next(curr);
-        if(conn_cb(conn, userdata)) {
+        /* Already tried a matching connection above. No need to
+         * invoke callback again for this one. */
+        if((data->state.lastconnect_id != conn->connection_id) &&
+           conn_cb(conn, userdata)) {
           found = TRUE;
           break;
         }

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -701,6 +701,8 @@ bool Curl_cpool_find(struct Curl_easy *data,
 {
   struct cpool *cpool = cpool_get_instance(data);
   struct cpool_bundle *bundle;
+  struct Curl_llist_node *curr;
+  struct connectdata *conn;
   bool found = FALSE;
 
   DEBUGASSERT(cpool);
@@ -712,15 +714,30 @@ bool Curl_cpool_find(struct Curl_easy *data,
   bundle = Curl_hash_pick(&cpool->dest2bundle,
                           destination, strlen(destination) + 1);
   if(bundle) {
-    struct Curl_llist_node *curr = Curl_llist_head(&bundle->conns);
-    while(curr) {
-      struct connectdata *conn = Curl_node_elem(curr);
-      /* Get next node now. callback might discard current */
-      curr = Curl_node_next(curr);
+    if(data->state.lastconnect_id >= 0) {
+      /* Try to find the previously used connection in this bundle
+       * and if it still matches, use that one. */
+      curr = Curl_llist_head(&bundle->conns);
+      while(curr) {
+        conn = Curl_node_elem(curr);
+        curr = Curl_node_next(curr);
+        if(data->state.lastconnect_id == conn->connection_id) {
+          if(conn_cb(conn, userdata))
+            found = TRUE;
+          break;
+        }
+      }
+    }
 
-      if(conn_cb(conn, userdata)) {
-        found = TRUE;
-        break;
+    if(!found) {
+      curr = Curl_llist_head(&bundle->conns);
+      while(curr) {
+        conn = Curl_node_elem(curr);
+        curr = Curl_node_next(curr);
+        if(conn_cb(conn, userdata)) {
+          found = TRUE;
+          break;
+        }
       }
     }
   }

--- a/lib/url.c
+++ b/lib/url.c
@@ -765,7 +765,8 @@ static bool url_match_proxy_use(struct connectdata *conn,
 
 #ifndef CURL_DISABLE_HTTP
 static bool url_match_http_multiplex(struct connectdata *conn,
-                                     struct url_conn_match *m)
+                                     struct url_conn_match *m,
+                                     bool *pwait_pipe)
 {
   if(m->may_multiplex &&
      (m->data->state.http_neg.allowed & (CURL_HTTP_V2x | CURL_HTTP_V3x)) &&
@@ -774,7 +775,7 @@ static bool url_match_http_multiplex(struct connectdata *conn,
     if(m->data->set.pipewait) {
       infof(m->data, "Server upgrade does not support multiplex yet, wait");
       m->found = NULL;
-      m->wait_pipe = TRUE;
+      *pwait_pipe = TRUE;
       return TRUE; /* stop searching, we want to wait */
     }
     infof(m->data, "Server upgrade cannot be used");
@@ -816,8 +817,8 @@ static bool url_match_http_version(struct connectdata *conn,
   return TRUE;
 }
 #else
-#define url_match_http_multiplex(c, m) ((void)(c), (void)(m), TRUE)
-#define url_match_http_version(c, m)   ((void)(c), (void)(m), TRUE)
+#define url_match_http_multiplex(c, m, w) ((void)(c), (void)(m), TRUE)
+#define url_match_http_version(c, m)      ((void)(c), (void)(m), TRUE)
 #endif
 
 static bool url_match_proto_config(struct connectdata *conn,
@@ -979,8 +980,7 @@ static bool url_match_auth_nego(struct connectdata *conn,
 static bool url_match_conn(struct connectdata *conn, void *userdata)
 {
   struct url_conn_match *m = userdata;
-  /* Check if `conn` can be used for transfer `m->data` */
-  m->wait_pipe = FALSE;
+  bool wait_pipe = FALSE;
 
   /* general connect config setting match? */
   if(!url_match_connect_config(conn, m))
@@ -1004,7 +1004,7 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
   if(!url_match_ssl_config(conn, m))
     return FALSE;
 
-  if(!url_match_http_multiplex(conn, m))
+  if(!url_match_http_multiplex(conn, m, &wait_pipe))
     return FALSE;
 
   if(!url_match_auth(conn, m))
@@ -1023,18 +1023,11 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
     return FALSE;
 
   /* The connection matches all conditions, but do we want to use it? */
-  if(m->wait_pipe) {
+  if(wait_pipe) {
     /* The connection fits, but it's multiplex state has not been determined
      * yet. Put the transfer into PENDING and wait for conn state change. */
     DEBUGASSERT(!m->found);
-    return TRUE;
-  }
-
-  if(m->data->state.lastconnect_id == conn->connection_id) {
-    /* This connection was used by `data` just before and it still
-     * matches. We definitely want to use this one again without any
-     * further max-age and health checks. */
-    m->found = conn;
+    m->wait_pipe = TRUE;
     return TRUE;
   }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -579,7 +579,6 @@ static bool ssh_config_matches(struct connectdata *one,
 
 struct url_conn_match {
   struct connectdata *found;
-  struct connectdata *candidate;
   struct Curl_easy *data;
   struct connectdata *needle;
   struct curltime now;
@@ -932,17 +931,8 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
 #endif
   return TRUE;
 }
-
-static bool url_match_is_ntlm_maybe(struct connectdata *conn,
-                                    struct url_conn_match *m)
-{
-  (void)conn;
-  return (m->want_ntlm_http || m->want_proxy_ntlm_http);
-}
-
 #else
 #define url_match_auth_ntlm(c, m) ((void)(c), (void)(m), TRUE)
-#define url_match_is_ntlm_maybe(c, m) ((void)(c), (void)(m), FALSE)
 #endif
 
 #ifdef USE_SPNEGO
@@ -982,17 +972,8 @@ static bool url_match_auth_nego(struct connectdata *conn,
 #endif
   return TRUE;
 }
-
-static bool url_match_is_nego_maybe(struct connectdata *conn,
-                                    struct url_conn_match *m)
-{
-  (void)conn;
-  return (m->want_nego_http || m->want_proxy_nego_http);
-}
-
 #else
 #define url_match_auth_nego(c, m) ((void)(c), (void)(m), TRUE)
-#define url_match_is_nego_maybe(c, m) ((void)(c), (void)(m), FALSE)
 #endif
 
 static bool url_match_conn(struct connectdata *conn, void *userdata)
@@ -1077,18 +1058,6 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
     return FALSE;
   }
 
-  if((m->data->state.lastconnect_id >= 0) &&
-     ((url_match_is_ntlm_maybe(conn, m) ||
-       url_match_is_nego_maybe(conn, m)))) {
-    /* NTLM/Negotiate ideally match a previously used connection again
-     * (and there was one). Because they do a multi-step dance to establish
-     * authentication and that only works on the same connection.
-     * This connection maybe used for NTLM/Negotiate, but it's not the
-     * last one used, so keep on looking. */
-    m->candidate = conn;
-    return FALSE;
-  }
-
   /* conn matches our needs. */
   m->found = conn;
   return TRUE;
@@ -1101,10 +1070,6 @@ static bool url_match_result(void *userdata)
     /* Attach it now while still under lock, so the connection does
      * no longer appear idle and can be reaped. */
     Curl_attach_connection(match->data, match->found, TRUE);
-    return TRUE;
-  }
-  if(match->candidate) {
-    Curl_attach_connection(match->data, match->candidate, TRUE);
     return TRUE;
   }
   else if(match->seen_single_use_conn && !match->seen_multiplex_conn) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -933,7 +933,7 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
   return TRUE;
 }
 
-static bool url_match_is_ntlm_mabye(struct connectdata *conn,
+static bool url_match_is_ntlm_maybe(struct connectdata *conn,
                                     struct url_conn_match *m)
 {
   (void)conn;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1077,8 +1077,9 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
     return FALSE;
   }
 
-  if(m->data->state.lastconnect_id >= 0 &&
-     (url_match_is_ntlm_maybe(conn, m) || url_match_is_nego_maybe(conn, m))) {
+  if((m->data->state.lastconnect_id >= 0) &&
+     ((url_match_is_ntlm_maybe(conn, m) ||
+       url_match_is_nego_maybe(conn, m)))) {
     /* NTLM/Negotiate ideally match a previously used connection again
      * (and there was one). Because they do a multi-step dance to establish
      * authentication and that only works on the same connection.

--- a/lib/url.c
+++ b/lib/url.c
@@ -579,6 +579,7 @@ static bool ssh_config_matches(struct connectdata *one,
 
 struct url_conn_match {
   struct connectdata *found;
+  struct connectdata *candidate;
   struct Curl_easy *data;
   struct connectdata *needle;
   struct curltime now;
@@ -593,7 +594,6 @@ struct url_conn_match {
   BIT(require_tls); /* Requires TLS use from a clear-text start, can only
                  * reuse connections that have TLS. */
   BIT(wait_pipe);
-  BIT(force_reuse);
   BIT(seen_pending_conn);
   BIT(seen_single_use_conn);
   BIT(seen_multiplex_conn);
@@ -909,8 +909,9 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
   }
   else if(m->want_ntlm_http) {
     /* Transfer wants NTLM, connection is not using it.
-     * Do not reuse when connection has credentials and they differ. */
-    if(conn->creds &&
+     * Do not reuse when connection credentials state is bound to an origin
+     * and it or creds differ. */
+    if(conn->creds_origin &&
        (!Curl_creds_same(conn->creds, m->data->state.creds) ||
         !Curl_peer_equal(conn->creds_origin, m->data->state.origin)))
       return FALSE;
@@ -929,28 +930,19 @@ static bool url_match_auth_ntlm(struct connectdata *conn,
       return FALSE;
   }
 #endif
-  if(m->want_ntlm_http || m->want_proxy_ntlm_http) {
-    /* Credentials are already checked, we may use this connection.
-     * With NTLM being weird as it is, we MUST use a
-     * connection where it has already been fully negotiated.
-     * If it has not, we keep on looking for a better one. */
-    m->found = conn;
-
-    if((m->want_ntlm_http &&
-       (conn->http_ntlm_state != NTLMSTATE_NONE)) ||
-        (m->want_proxy_ntlm_http &&
-         (conn->proxy_ntlm_state != NTLMSTATE_NONE))) {
-      /* We must use this connection, no other */
-      m->force_reuse = TRUE;
-      return TRUE;
-    }
-    /* Continue look up for a better connection */
-    return FALSE;
-  }
   return TRUE;
 }
+
+static bool url_match_is_ntlm_mabye(struct connectdata *conn,
+                                    struct url_conn_match *m)
+{
+  (void)conn;
+  return (m->want_ntlm_http || m->want_proxy_ntlm_http);
+}
+
 #else
 #define url_match_auth_ntlm(c, m) ((void)(c), (void)(m), TRUE)
+#define url_match_is_ntlm_maybe(c, m) ((void)(c), (void)(m), FALSE)
 #endif
 
 #ifdef USE_SPNEGO
@@ -967,8 +959,9 @@ static bool url_match_auth_nego(struct connectdata *conn,
   }
   else if(m->want_nego_http) {
     /* Transfer wants Negotiate, connection is not using it.
-     * Do not reuse when connection has credentials and they differ. */
-    if(conn->creds &&
+     * Do not reuse when connection credentials state is bound to an origin
+     * and it or creds differ. */
+    if(conn->creds_origin &&
        (!Curl_creds_same(conn->creds, m->data->state.creds) ||
         !Curl_peer_equal(conn->creds_origin, m->data->state.origin)))
       return FALSE;
@@ -987,31 +980,26 @@ static bool url_match_auth_nego(struct connectdata *conn,
       return FALSE;
   }
 #endif
-  if(m->want_nego_http || m->want_proxy_nego_http) {
-    /* Credentials are already checked, we may use this connection. We MUST
-     * use a connection where it has already been fully negotiated. If it has
-     * not, we keep on looking for a better one. */
-    m->found = conn;
-    if((m->want_nego_http &&
-        (conn->http_negotiate_state != GSS_AUTHNONE)) ||
-       (m->want_proxy_nego_http &&
-        (conn->proxy_negotiate_state != GSS_AUTHNONE))) {
-      /* We must use this connection, no other */
-      m->force_reuse = TRUE;
-      return TRUE;
-    }
-    return FALSE; /* get another */
-  }
   return TRUE;
 }
+
+static bool url_match_is_nego_maybe(struct connectdata *conn,
+                                    struct url_conn_match *m)
+{
+  (void)conn;
+  return (m->want_nego_http || m->want_proxy_nego_http);
+}
+
 #else
 #define url_match_auth_nego(c, m) ((void)(c), (void)(m), TRUE)
+#define url_match_is_nego_maybe(c, m) ((void)(c), (void)(m), FALSE)
 #endif
 
 static bool url_match_conn(struct connectdata *conn, void *userdata)
 {
   struct url_conn_match *m = userdata;
   /* Check if `conn` can be used for transfer `m->data` */
+  m->wait_pipe = FALSE;
 
   /* general connect config setting match? */
   if(!url_match_connect_config(conn, m))
@@ -1037,9 +1025,6 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
 
   if(!url_match_http_multiplex(conn, m))
     return FALSE;
-  else if(m->wait_pipe)
-    /* wait on multiplexing */
-    return TRUE;
 
   if(!url_match_auth(conn, m))
     return FALSE;
@@ -1049,16 +1034,28 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
 
   if(!url_match_auth_ntlm(conn, m))
     return FALSE;
-  else if(m->force_reuse)
-    return TRUE;
 
   if(!url_match_auth_nego(conn, m))
     return FALSE;
-  else if(m->force_reuse)
-    return TRUE;
 
   if(!url_match_multiplex_limits(conn, m))
     return FALSE;
+
+  /* The connection matches all conditions, but do we want to use it? */
+  if(m->wait_pipe) {
+    /* The connection fits, but it's multiplex state has not been determined
+     * yet. Put the transfer into PENDING and wait for conn state change. */
+    DEBUGASSERT(!m->found);
+    return TRUE;
+  }
+
+  if(m->data->state.lastconnect_id == conn->connection_id) {
+    /* This connection was used by `data` just before and it still
+     * matches. We definitely want to use this one again without any
+     * further max-age and health checks. */
+    m->found = conn;
+    return TRUE;
+  }
 
   if(m->data->set.conn_max_age_ms > 0) {
     timediff_t age_ms = curlx_ptimediff_ms(&m->now, &conn->created);
@@ -1080,6 +1077,17 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
     return FALSE;
   }
 
+  if(m->data->state.lastconnect_id >= 0 &&
+     (url_match_is_ntlm_maybe(conn, m) || url_match_is_nego_maybe(conn, m))) {
+    /* NTLM/Negotiate ideally match a previously used connection again
+     * (and there was one). Because they do a multi-step dance to establish
+     * authentication and that only works on the same connection.
+     * This connection maybe used for NTLM/Negotiate, but it's not the
+     * last one used, so keep on looking. */
+    m->candidate = conn;
+    return FALSE;
+  }
+
   /* conn matches our needs. */
   m->found = conn;
   return TRUE;
@@ -1094,6 +1102,10 @@ static bool url_match_result(void *userdata)
     Curl_attach_connection(match->data, match->found, TRUE);
     return TRUE;
   }
+  if(match->candidate) {
+    Curl_attach_connection(match->data, match->candidate, TRUE);
+    return TRUE;
+  }
   else if(match->seen_single_use_conn && !match->seen_multiplex_conn) {
     /* We have seen a single-use, existing connection to the destination and
      * no multiplexed one. It seems safe to assume that the server does
@@ -1105,7 +1117,6 @@ static bool url_match_result(void *userdata)
           "Found pending candidate for reuse and CURLOPT_PIPEWAIT is set");
     match->wait_pipe = TRUE;
   }
-  match->force_reuse = FALSE;
   return FALSE;
 }
 


### PR DESCRIPTION
Changes to connection matching for a transfer:

- When a transfer previously used a connection and that still exists in the connection bundle to search *and* that still matches, use exactly that one. This eliminates the `force_reuse` bit in match making.
- Always apply all match conditions before selecting a match.
- NTML/Negotiate: check for creds match when `conn->creds_origin` is present. This should be the safe indicator that authenticaion is happening for the connection (as compared to requests) and credentials then need to match for it.


