### PR TITLE
tests: raise some alloc limits

### DIFF
--- a/tests/data/test1
+++ b/tests/data/test1
@@ -48,7 +48,7 @@ Accept: */*
 
 </protocol>
 <limits>
-Allocations: 135
+Allocations: 136
 Maximum allocated: 136000
 </limits>
 </verify>

--- a/tests/data/test1
+++ b/tests/data/test1
@@ -48,7 +48,7 @@ Accept: */*
 
 </protocol>
 <limits>
-Allocations: 136
+Allocations: 140
 Maximum allocated: 136000
 </limits>
 </verify>

--- a/tests/data/test440
+++ b/tests/data/test440
@@ -75,7 +75,7 @@ https://this.hsts.example./%TESTNUMBER
 7
 </errorcode>
 <limits>
-Allocations: 160
+Allocations: 172
 </limits>
 </verify>
 </testcase>

--- a/tests/data/test767
+++ b/tests/data/test767
@@ -49,7 +49,7 @@ Accept: */*
 
 </protocol>
 <limits>
-Allocations: 135
+Allocations: 141
 Maximum allocated: 136000
 </limits>
 </verify>


### PR DESCRIPTION
Due to the SSH setopts, limits have increased on some tests

Failures like in: https://github.com/curl/curl/actions/runs/34106380684/job/101692347326?pr=22857
