### PR TITLE
GHA/curl-for-win: upload artifact as `curl.exe` (without using zip)

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -180,8 +180,8 @@ jobs:
         with:
           name: 'curl-windows-snapshot-tool'
           retention-days: 5
-          archive: false
           path: curl-*-*-*/curl*
+          archive: false
 
   win-gcc-zlibold-x64:
     name: 'Windows gcc zlib-classic (x64)'

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -181,6 +181,7 @@ jobs:
           name: 'curl-windows-snapshot-tool'
           retention-days: 5
           path: curl-*-*-*/curl*
+          archive: false
 
   win-gcc-zlibold-x64:
     name: 'Windows gcc zlib-classic (x64)'

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -180,8 +180,8 @@ jobs:
         with:
           name: 'curl-windows-snapshot-tool'
           retention-days: 5
-          path: curl-*-*-*/curl*
           archive: false
+          path: curl-*-*-*/curl*
 
   win-gcc-zlibold-x64:
     name: 'Windows gcc zlib-classic (x64)'


### PR DESCRIPTION
To make it easier to run local tests.

Example:
https://github.com/curl/curl/actions/runs/34158040472?pr=22863
https://github.com/curl/curl/actions/runs/34158040472/artifacts/10031671842

Ref: https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/
