### PR TITLE
GHA/linux: enable egress firewall reporting in one job, disable MotD

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -212,7 +212,7 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
           actionlint --version
-          actionlint --ignore matrix --ignore ubuntu-26.04 .github/workflows/*.yml
+          actionlint --ignore matrix --ignore ubuntu-26.04 --ignore ubuntu-24.04-firewall .github/workflows/*.yml
 
       - name: 'shellcheck CI'
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -234,7 +234,6 @@ jobs:
           - name: 'openssl intel C89'
             image: ubuntu-24.04-firewall
             install_packages: libssh-dev
-            install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --with-libssh --enable-debug
 
           - name: 'openssl arm C89'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -476,7 +476,9 @@ jobs:
 
         run: |
           sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
+          sudo rm -f /etc/apt/apt.conf.d/20packagekit || true
           sudo rm -f /etc/apt/apt.conf.d/20snapd.conf || true
+          time sudo systemctl stop snapd.service || true
           echo '----------------------'
           cat /etc/apt/apt.conf.d/20packagekit || true
           echo '----------------------'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -476,18 +476,6 @@ jobs:
 
         run: |
           sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
-          sudo rm -f /etc/apt/apt.conf.d/20packagekit || true
-          sudo rm -f /etc/apt/apt.conf.d/20snapd.conf || true
-          time sudo systemctl stop snapd.service || true
-          echo '----------------------'
-          cat /etc/apt/apt.conf.d/20packagekit || true
-          echo '----------------------'
-          cat /etc/default/motd-news || true
-          echo '----------------------'
-          find /etc/apt/apt.conf.d/ || true
-          echo '----------------------'
-          sudo pro config set apt_news=false || true
-          echo '----------------------'
           ls -l /etc/apt/sources.list.d
           sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -232,6 +232,7 @@ jobs:
             generate: -DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF -DCURL_ENABLE_NTLM=ON
 
           - name: 'openssl intel C89'
+            image: ubuntu-24.04-firewall
             install_packages: libssh-dev
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --with-libssh --enable-debug

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -475,6 +475,8 @@ jobs:
             ${{ contains(matrix.build.install_steps, 'pytest') && 'apache2 apache2-dev libnghttp2-dev vsftpd dante-server' || '' }}
 
         run: |
+          rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf
+           rm -f /etc/apt/apt.conf.d/20snapd.conf
           echo '----------------------'
           cat /etc/default/motd-news || true
           echo '----------------------'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -474,8 +474,8 @@ jobs:
             ${{ contains(matrix.build.install_steps, 'pytest') && 'apache2 apache2-dev libnghttp2-dev vsftpd dante-server' || '' }}
 
         run: |
-          rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf
-           rm -f /etc/apt/apt.conf.d/20snapd.conf
+          sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
+          sudo rm -f /etc/apt/apt.conf.d/20snapd.conf || true
           echo '----------------------'
           cat /etc/default/motd-news || true
           echo '----------------------'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -475,6 +475,13 @@ jobs:
             ${{ contains(matrix.build.install_steps, 'pytest') && 'apache2 apache2-dev libnghttp2-dev vsftpd dante-server' || '' }}
 
         run: |
+          echo '----------------------'
+          cat /etc/default/motd-news || true
+          echo '----------------------'
+          find /etc/apt/apt.conf.d/ || true
+          echo '----------------------'
+          sudo pro config set apt_news=false || true
+          echo '----------------------'
           ls -l /etc/apt/sources.list.d
           sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
           sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,6 +81,7 @@ jobs:
             configure: --with-openssl=/home/runner/awslc --enable-ech --enable-ntlm --enable-smb
 
           - name: 'awslc'
+            image: ubuntu-24.04-firewall
             install_packages: libidn2-dev
             install_steps: awslc clean
             generate: -DOPENSSL_ROOT_DIR=/home/runner/awslc -DUSE_ECH=ON -DCMAKE_UNITY_BUILD=OFF -DCURL_DROP_UNUSED=ON -DCURL_PATCHSTAMP=test-patch -DCURL_ENABLE_NTLM=ON
@@ -232,8 +233,8 @@ jobs:
             generate: -DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF -DCURL_ENABLE_NTLM=ON
 
           - name: 'openssl intel C89'
-            image: ubuntu-24.04-firewall
             install_packages: libssh-dev
+            install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --with-libssh --enable-debug
 
           - name: 'openssl arm C89'
@@ -476,6 +477,8 @@ jobs:
         run: |
           sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
           sudo rm -f /etc/apt/apt.conf.d/20snapd.conf || true
+          echo '----------------------'
+          cat /etc/apt/apt.conf.d/20packagekit || true
           echo '----------------------'
           cat /etc/default/motd-news || true
           echo '----------------------'


### PR DESCRIPTION
In the 'CM awslc' job. It's a preview feature and needs downgrading to
Ubuntu 24.04. It uses a MitM proxy to record network access and causes
a 15-20% runtime increase according to documentation.

Notably it breaks pytests 50 and 51 (SCP/SFTP):
https://github.com/curl/curl/actions/runs/34165541078/job/101875730179?pr=22864

The observed performance impact is higher than documented, at 1m37s ->
2m6s. apt install steps takes 2x time, configure/build: +20-40%, running
tests: +10%. This makes this practical only for security critical jobs,
e.g. creating build artifacts or other lasting or external impact (once
URL filtering is supported/documented). Also useful for occasional
review and debugging.

Before: https://github.com/curl/curl/actions/runs/34192638355/job/101953659576
After: https://github.com/curl/curl/actions/runs/34201459582/job/101981056237?pr=22864

Also:
- GHA/checksrc: add actionlint exception for the firewalled runner image.
- GHA/linux: disable MotD (message of the day) Ubuntu feature, discovered
  via the firewall log, accessing `https://motd.ubuntu.com/aptnews.json`
  twice, during package install.

Ref: https://github.com/github-early-access/actions-native-egress-firewall

---

- [x] breaks pytests (50/51 SCP/SFTP). [could not figure out why, or a fix]
  https://github.com/curl/curl/actions/runs/34165541078/job/101875730179?pr=22864

log:
https://github.com/curl/curl/actions/runs/34165541078/artifacts/10034174663

Observations:
- MotD is accessed twice on Ubuntu runner machine startup.
  Seems completely unnecessary.
- snapcraft.io is accessed 10 times.

```
E             Disconnected from authenticating user runner 127.0.0.1 port 59750 [preauth]
E             Connection from 127.0.0.1 port 59754 on 127.0.0.1 port 49477 rdomain ""
E             Authentication refused: bad ownership or modes for directory /home/runner/work
E             Failed publickey for runner from 127.0.0.1 port 59754 ssh2: RSA SHA256:V485hnoh59Qa8pVkXDy75+tUN7W2Q0qXlD6e5J3eXT0
E             Received disconnect from 127.0.0.1 port 59754:11: Bye Bye [preauth]
E             Disconnected from authenticating user runner 127.0.0.1 port 59754 [preauth]
E             Connection from 127.0.0.1 port 59758 on 127.0.0.1 port 49477 rdomain ""
E             Authentication refused: bad ownership or modes for directory /home/runner/work
E             Failed publickey for runner from 127.0.0.1 port 59758 ssh2: RSA SHA256:V485hnoh59Qa8pVkXDy75+tUN7W2Q0qXlD6e5J3eXT0
E             Received disconnect from 127.0.0.1 port 59758:11: Bye Bye [preauth]
E             Disconnected from authenticating user runner 127.0.0.1 port 59758 [preauth]
E             Received signal 15; terminating.
E             >>--curl log ----------------------------------------------
E             22:15:49.377862 [0-x] * !!! WARNING !!!
E             22:15:49.377912 [0-x] * This is a debug build of libcurl, do not use in production.
E             22:15:49.377939 [0-x] * [DNS] added one.http.curl.se:49477:127.0.0.1 to cache
E             22:15:49.377971 [0-x] * SSH: public key file '/home/runner/work/curl/curl/tests/http/gen/gw0/sshd/id_user1_user_rsa_key.pub'
E             22:15:49.377977 [0-x] * SSH: private key file '/home/runner/work/curl/curl/tests/http/gen/gw0/sshd/id_user1_user_rsa_key'
E             22:15:49.378002 [0-0] * Hostname one.http.curl.se was found in DNS cache
E             22:15:49.378009 [0-0] * Host one.http.curl.se:49477 was resolved.
E             22:15:49.378015 [0-0] * IPv6: (none)
E             22:15:49.378023 [0-0] * IPv4: 127.0.0.1
E             22:15:49.378044 [0-0] *   Trying 127.0.0.1:49477...
E             22:15:49.378306 [0-0] * Established connection to one.http.curl.se (127.0.0.1 port 49477) from 127.0.0.1 port 59758 
E             22:15:49.378571 [0-0] * User: runner
E             22:15:49.394331 [0-0] * SSH authentication methods available: public key, 
E             22:15:49.394350 [0-0] * Authentication using SSH public key file
E             22:15:49.403416 [0-0] * closing connection #0
E             <<-------------------------------------------------------
```