### PR TITLE
test1679: unset `SSL_CERT_FILE`, use `TESTNUMBER`

### DIFF
--- a/tests/data/test1679
+++ b/tests/data/test1679
@@ -30,6 +30,9 @@ http
 <name>
 --libcurl resets SSL verification after --next
 </name>
+<setenv>
+SSL_CERT_FILE
+</setenv>
 <command>
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER --libcurl %LOGDIR/test%TESTNUMBER.c --insecure --next http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER
 </command>
@@ -54,7 +57,7 @@ $_ = '' if /CURLOPT_INTERLEAVEDATA/
 $_ = '' if /CURLOPT_SSH_KNOWNHOSTS/
 </stripfile>
 <file name="%LOGDIR/test%TESTNUMBER.c" mode="text">
-%includetext %SRCDIR/data/data1679.c%
+%includetext %SRCDIR/data/data%TESTNUMBER.c%
 </file>
 </verify>
 </testcase>


### PR DESCRIPTION
To fix a `SSL_CERT_FILE` env breaking the test. For example the
`ubuntu-24.04-firewall` runner image is setting this env.

Follow-up to 19d0f4acfa9df373e8e1f987c11b7165e1edac34 #22745

Cherry-picked from #22864
