### PR TITLE
GHA: share apt/brew/pip install logic between workflows, related tidy-ups

### DIFF
--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -40,13 +40,11 @@ runs:
       env:
         HOMEBREW_NO_INSTALL_CLEANUP: '1'
         PACKAGES: ${{ inputs.brew }}
-      # Run this command with retries because of spurious failures seen
-      # while running the tests, for example
-      # https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
       run: |
         if [[ "$(uname)" != *'Darwin'* ]]; then
           brewroot='/home/linuxbrew/.linuxbrew/bin/'
         fi
+        # Run this command with retries because of spurious failures seen while running the tests.
         # shellcheck disable=SC2181
         while [[ $? == 0 ]]; do
           for i in 1 2 3; do

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -22,7 +22,6 @@ runs:
   steps:
     - name: 'install (apt)'
       if: ${{ inputs.apt }}
-      background: true
       shell: bash
       env:
         PACKAGES: ${{ inputs.apt }}
@@ -39,7 +38,6 @@ runs:
 
     - name: 'install (pip)'
       if: ${{ inputs.pip }}
-      background: true
       shell: bash
       env:
         PACKAGES: ${{ inputs.pip }}
@@ -49,7 +47,6 @@ runs:
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}
-      background: true
       shell: bash
       env:
         PACKAGES: ${{ inputs.brew }}
@@ -70,6 +67,3 @@ runs:
           done
           false Too many retries
         done
-
-    - name: 'wait-all'
-      wait-all:

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -9,13 +9,10 @@ description: 'Installs packages for local workflows'
 inputs:
   apt:
     description: 'Optional space-separated list of apt package names'
-    required: false
   brew:
     description: 'Optional space-separated list of Homebrew package names'
-    required: false
   pip:
     description: 'Optional requirements.txt filename'
-    required: false
 
 runs:
   using: 'composite'

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -1,0 +1,68 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+# https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action
+name: 'Install packages'
+description: 'Installs packages for local workflows'
+
+inputs:
+  apt:
+    description: 'Optional space-separated list of apt package names'
+    required: false
+  pip:
+    description: 'Optional requirements.txt filename'
+    required: false
+  brew:
+    description: 'Optional space-separated list of Homebrew package names'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'install (apt)'
+      if: ${{ inputs.apt }}
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.apt }}
+      run: |
+        # shellcheck disable=SC2001
+        PACKAGES="$(echo "${PACKAGES}" | sed 's/{.*}//g')"
+        ls -l /etc/apt/sources.list.d
+        sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
+        sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+        [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
+        sudo apt-get -o Dpkg::Use-Pty=0 update
+        sudo apt-get -o Dpkg::Use-Pty=0 install ${PACKAGES}
+
+    - name: 'install (pip)'
+      if: ${{ inputs.pip }}
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.pip }}
+      run: |
+          python3 -m venv ~/venv
+          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r ${PACKAGES}
+
+    - name: 'install (brew)'
+      if: ${{ inputs.brew }}
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.brew }}
+      # Run this command with retries because of spurious failures seen
+      # while running the tests, for example
+      # https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
+      run: |
+        [[ "$(uname)" != *'Darwin'* ]] && brewroot='/home/linuxbrew/.linuxbrew/bin/'
+        # shellcheck disable=SC2181
+        while [[ $? == 0 ]]; do
+          for i in 1 2 3; do
+            if ${brewroot}brew install ${PACKAGES}; then
+              break 2
+            else
+              echo "Error: wait to try again: $i"
+              sleep 10
+            fi
+          done
+          false Too many retries
+        done

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -12,7 +12,7 @@ inputs:
   brew:
     description: 'Optional space-separated list of Homebrew package names'
   pip:
-    description: 'Optional requirements.txt filename'
+    description: 'Optional pip command-line options'
 
 runs:
   using: 'composite'

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -43,7 +43,7 @@ runs:
         PACKAGES: ${{ inputs.pip }}
       run: |
           [ -d ~/venv ] || python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r ${PACKAGES}
+          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary ${PACKAGES}
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -42,7 +42,7 @@ runs:
       env:
         PACKAGES: ${{ inputs.pip }}
       run: |
-          python3 -m venv ~/venv
+          [ -d ~/venv ] || python3 -m venv ~/venv
           ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r ${PACKAGES}
 
     - name: 'install (brew)'

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -22,6 +22,7 @@ runs:
   steps:
     - name: 'install (apt)'
       if: ${{ inputs.apt }}
+      background: true
       shell: bash
       env:
         PACKAGES: ${{ inputs.apt }}
@@ -37,6 +38,7 @@ runs:
 
     - name: 'install (pip)'
       if: ${{ inputs.pip }}
+      background: true
       shell: bash
       env:
         PACKAGES: ${{ inputs.pip }}
@@ -46,6 +48,7 @@ runs:
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}
+      background: true
       shell: bash
       env:
         PACKAGES: ${{ inputs.brew }}
@@ -66,3 +69,6 @@ runs:
           done
           false Too many retries
         done
+
+    - name: 'wait-all'
+      wait-all:

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -68,5 +68,5 @@ runs:
       env:
         PACKAGES: ${{ inputs.pip }}
       run: |
-          [ -d ~/venv ] || python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary ${PACKAGES}
+        [ -d ~/venv ] || python3 -m venv ~/venv
+        ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary ${PACKAGES}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -10,11 +10,11 @@ inputs:
   apt:
     description: 'Optional space-separated list of apt package names'
     required: false
-  pip:
-    description: 'Optional requirements.txt filename'
-    required: false
   brew:
     description: 'Optional space-separated list of Homebrew package names'
+    required: false
+  pip:
+    description: 'Optional requirements.txt filename'
     required: false
 
 runs:
@@ -35,15 +35,6 @@ runs:
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
         sudo apt-get -o Dpkg::Use-Pty=0 update
         sudo apt-get -o Dpkg::Use-Pty=0 install ${PACKAGES}
-
-    - name: 'install (pip)'
-      if: ${{ inputs.pip }}
-      shell: bash
-      env:
-        PACKAGES: ${{ inputs.pip }}
-      run: |
-          [ -d ~/venv ] || python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary ${PACKAGES}
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}
@@ -70,3 +61,12 @@ runs:
           done
           false Too many retries
         done
+
+    - name: 'install (pip)'
+      if: ${{ inputs.pip }}
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.pip }}
+      run: |
+          [ -d ~/venv ] || python3 -m venv ~/venv
+          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary ${PACKAGES}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -26,8 +26,6 @@ runs:
       env:
         PACKAGES: ${{ inputs.apt }}
       run: |
-        # shellcheck disable=SC2001
-        PACKAGES="$(echo "${PACKAGES}" | sed 's/{.*}//g')"
         sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
         ls -l /etc/apt/sources.list.d
         sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -49,12 +49,15 @@ runs:
       if: ${{ inputs.brew }}
       shell: bash
       env:
+        HOMEBREW_NO_INSTALL_CLEANUP: '1'
         PACKAGES: ${{ inputs.brew }}
       # Run this command with retries because of spurious failures seen
       # while running the tests, for example
       # https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
       run: |
-        [[ "$(uname)" != *'Darwin'* ]] && brewroot='/home/linuxbrew/.linuxbrew/bin/'
+        if [[ "$(uname)" != *'Darwin'* ]]; then
+          brewroot='/home/linuxbrew/.linuxbrew/bin/'
+        fi
         # shellcheck disable=SC2181
         while [[ $? == 0 ]]; do
           for i in 1 2 3; do

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -29,6 +29,7 @@ runs:
       run: |
         # shellcheck disable=SC2001
         PACKAGES="$(echo "${PACKAGES}" | sed 's/{.*}//g')"
+        sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
         ls -l /etc/apt/sources.list.d
         sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
         sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt

--- a/.github/scripts/shellcheck-ci.sh
+++ b/.github/scripts/shellcheck-ci.sh
@@ -10,7 +10,7 @@ set -eu
 export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
 
 # GHA
-git ls-files '.github/workflows/*.yml' | while read -r f; do
+git ls-files '.github/workflows/*.yml' '.github/actions/*.yml' | while read -r f; do
   echo "Verifying ${f}..."
   {
     echo '#!/usr/bin/env bash'

--- a/.github/scripts/shellcheck-ci.sh
+++ b/.github/scripts/shellcheck-ci.sh
@@ -7,6 +7,8 @@
 
 set -eu
 
+cd -- "$(dirname "${0}")"/../..
+
 export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
 
 # GHA

--- a/.github/scripts/shellcheck-ci.sh
+++ b/.github/scripts/shellcheck-ci.sh
@@ -10,7 +10,7 @@ set -eu
 export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
 
 # GHA
-git ls-files '.github/workflows/*.yml' '.github/actions/*.yml' | while read -r f; do
+git ls-files '.github/actions/*.yml' '.github/workflows/*.yml' | while read -r f; do
   echo "Verifying ${f}..."
   {
     echo '#!/usr/bin/env bash'

--- a/.github/scripts/shellcheck-ci.sh
+++ b/.github/scripts/shellcheck-ci.sh
@@ -10,7 +10,7 @@ set -eu
 export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
 
 # GHA
-git ls-files '.github/actions/*.yml' '.github/workflows/*.yml' | while read -r f; do
+git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' | while read -r f; do
   echo "Verifying ${f}..."
   {
     echo '#!/usr/bin/env bash'

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -109,7 +109,7 @@ jobs:
         background: true
         run: .github/scripts/cleancmd.pl 'docs/*.md'
 
-      - name: 'install'
+      - name: 'install prereqs'
         timeout-minutes: 2
         uses: $/.github/actions/pkg-install
         with:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -111,13 +111,10 @@ jobs:
 
       - name: 'install'
         timeout-minutes: 2
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install aspell aspell-en
-          python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r .github/scripts/requirements-docs.txt
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: aspell aspell-en
+          pip: .github/scripts/requirements-docs.txt
 
       - name: 'trim all *.md files in docs/'
         wait-all:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -54,9 +54,9 @@ jobs:
         run: git ls-files '*.md' -z | xargs -0 -n1 .github/scripts/trimmarkdownheader.pl
 
       - name: 'install prereqs'
-        run: |
-          python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r .github/scripts/requirements-proselint.txt
+        uses: $/.github/actions/pkg-install
+        with:
+          pip: -r .github/scripts/requirements-proselint.txt
 
       - name: 'trim headers off all *.md files'
         wait-all:
@@ -114,7 +114,7 @@ jobs:
         uses: $/.github/actions/pkg-install
         with:
           apt: aspell aspell-en
-          pip: .github/scripts/requirements-docs.txt
+          pip: -r .github/scripts/requirements-docs.txt
 
       - name: 'trim all *.md files in docs/'
         wait-all:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -33,7 +33,6 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_INSTALL_CLEANUP: '1'
 
 jobs:
   checksrc:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -153,12 +153,9 @@ jobs:
     steps:
       - name: 'install pmccabe'
         timeout-minutes: 2
-        run: |
-          ls -l /etc/apt/sources.list.d
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install pmccabe
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: pmccabe
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -177,11 +174,9 @@ jobs:
     steps:
       - name: 'install prereqs'
         timeout-minutes: 2
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install libxml2-utils
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: libxml2-utils
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -197,7 +192,9 @@ jobs:
     steps:
       - name: 'install prereqs'
         timeout-minutes: 2
-        run: /home/linuxbrew/.linuxbrew/bin/brew install actionlint shellcheck zizmor
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: actionlint shellcheck zizmor
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -212,7 +212,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' dependabot.yml -z | xargs -0 -r zizmor --persona pedantic --
+          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' -z | xargs -0 -r zizmor --persona pedantic --
 
       - name: 'zizmor GHA (auditor, warning-only)'
         background: true
@@ -220,7 +220,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' dependabot.yml -z | xargs -0 -r zizmor --persona auditor -- || true
+          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' -z | xargs -0 -r zizmor --persona auditor -- || true
 
       - name: 'actionlint'
         background: true

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -212,7 +212,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          zizmor --persona pedantic .github/actions/*.yml .github/workflows/*.yml .github/dependabot.yml
+          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' dependabot.yml -z | xargs -0 -r zizmor --persona pedantic --
 
       - name: 'zizmor GHA (auditor, warning-only)'
         background: true
@@ -220,7 +220,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          zizmor --persona auditor .github/actions/*.yml .github/workflows/*.yml .github/dependabot.yml || true
+          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' dependabot.yml -z | xargs -0 -r zizmor --persona auditor -- || true
 
       - name: 'actionlint'
         background: true
@@ -228,7 +228,8 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
           actionlint --version
-          actionlint --ignore matrix \
+          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' -z | xargs -0 -r actionlint \
+            --ignore matrix \
             --ignore ubuntu-26.04 \
             --ignore ubuntu-24.04-firewall \
             --ignore 'unexpected key "background"' \
@@ -236,7 +237,7 @@ jobs:
             --ignore 'unexpected key "wait-all"' \
             --ignore 'must run script with "run" section' \
             --ignore 'invalid format because ref is missing' \
-            .github/actions/*.yml .github/workflows/*.yml
+            --
 
       - name: 'shellcheck CI'
         background: true

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -127,13 +127,6 @@ jobs:
           codespell --version
           .github/scripts/codespell.sh
 
-      - name: 'typos'
-        timeout-minutes: 2
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          typos --version
-          .github/scripts/typos.sh
-
   pytype:
     name: 'pytype'
     runs-on: ubuntu-24.04-arm  # pytype is discontinued and requires python 3.8-3.12

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -70,7 +70,9 @@ jobs:
       - name: 'install prereqs (typos)'
         background: true
         timeout-minutes: 2
-        run: /home/linuxbrew/.linuxbrew/bin/brew install typos-cli
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: typos-cli
 
       - name: 'install prereqs'
         run: |
@@ -124,6 +126,13 @@ jobs:
           source ~/venv/bin/activate
           codespell --version
           .github/scripts/codespell.sh
+
+      - name: 'typos'
+        timeout-minutes: 2
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          typos --version
+          .github/scripts/typos.sh
 
   pytype:
     name: 'pytype'

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -212,7 +212,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          zizmor --persona pedantic .github/workflows/*.yml .github/dependabot.yml
+          zizmor --persona pedantic .github/actions/*.yml .github/workflows/*.yml .github/dependabot.yml
 
       - name: 'zizmor GHA (auditor, warning-only)'
         background: true
@@ -220,7 +220,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          zizmor --persona auditor .github/workflows/*.yml .github/dependabot.yml || true
+          zizmor --persona auditor .github/actions/*.yml .github/workflows/*.yml .github/dependabot.yml || true
 
       - name: 'actionlint'
         background: true
@@ -236,7 +236,7 @@ jobs:
             --ignore 'unexpected key "wait-all"' \
             --ignore 'must run script with "run" section' \
             --ignore 'invalid format because ref is missing' \
-            .github/workflows/*.yml
+            .github/actions/*.yml .github/workflows/*.yml
 
       - name: 'shellcheck CI'
         background: true

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -66,7 +66,7 @@ jobs:
         background: true
         run: scripts/perlcheck.sh
 
-      - name: 'install prereqs (typos)'
+      - name: 'install typos-cli'
         background: true
         timeout-minutes: 2
         uses: $/.github/actions/pkg-install

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -74,11 +74,11 @@ jobs:
           brew: typos-cli
 
       - name: 'install prereqs'
-        run: |
-          python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary \
-            -r .github/scripts/requirements.txt \
-            -r tests/http/requirements.txt \
+        uses: $/.github/actions/pkg-install
+        with:
+          pip: |
+            -r .github/scripts/requirements.txt
+            -r tests/http/requirements.txt
             -r tests/requirements.txt
 
       - name: 'REUSE check'
@@ -135,11 +135,12 @@ jobs:
           persist-credentials: false
 
       - name: 'install prereqs'
-        run: |
-          python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary pytype==2024.10.11 \
-            -r .github/scripts/requirements.txt \
-            -r tests/http/requirements.txt \
+        uses: $/.github/actions/pkg-install
+        with:
+          pip: |
+            pytype==2024.10.11
+            -r .github/scripts/requirements.txt
+            -r tests/http/requirements.txt
             -r tests/requirements.txt
 
       - name: 'check'

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -212,7 +212,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' -z | xargs -0 -r zizmor --persona pedantic --
+          git ls-files '.github/actions/**/*.yml' '.github/dependabot.yml' '.github/workflows/*.yml' -z | xargs -0 -r zizmor --persona pedantic --
 
       - name: 'zizmor GHA (auditor, warning-only)'
         background: true
@@ -220,7 +220,7 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' -z | xargs -0 -r zizmor --persona auditor -- || true
+          git ls-files '.github/actions/**/*.yml' '.github/dependabot.yml' '.github/workflows/*.yml' -z | xargs -0 -r zizmor --persona auditor -- || true
 
       - name: 'actionlint'
         background: true

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -228,7 +228,7 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           export SHELLCHECK_OPTS='--exclude=1090,1091,2086,2153 --enable=avoid-nullary-conditions,deprecate-which'
           actionlint --version
-          git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' -z | xargs -0 -r actionlint \
+          actionlint \
             --ignore matrix \
             --ignore ubuntu-26.04 \
             --ignore ubuntu-24.04-firewall \
@@ -237,7 +237,7 @@ jobs:
             --ignore 'unexpected key "wait-all"' \
             --ignore 'must run script with "run" section' \
             --ignore 'invalid format because ref is missing' \
-            --
+            .github/workflows/*.yml
 
       - name: 'shellcheck CI'
         background: true

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -233,6 +233,7 @@ jobs:
             --ignore 'unexpected key "wait"' \
             --ignore 'unexpected key "wait-all"' \
             --ignore 'must run script with "run" section' \
+            --ignore 'invalid format because ref is missing' \
             .github/workflows/*.yml
 
       - name: 'shellcheck CI'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           brew: c-ares gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
           apt: >-
-            libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev \
+            libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev
             libnghttp2-dev libldap-dev libkrb5-dev libgnutls28-dev libwolfssl-dev
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,7 +76,7 @@ jobs:
       - name: 'install prereqs'
         if: ${{ matrix.platform == 'Linux' }}
         timeout-minutes: 2
-        uses: ./.github/actions/pkg-install
+        uses: $/.github/actions/pkg-install
         with:
           brew: c-ares gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
           apt: >-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,15 +76,12 @@ jobs:
       - name: 'install prereqs'
         if: ${{ matrix.platform == 'Linux' }}
         timeout-minutes: 2
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install \
+        uses: ./.github/actions/pkg-install
+        with:
+          brew: c-ares gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
+          apt: >-
             libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev \
             libnghttp2-dev libldap-dev libkrb5-dev libgnutls28-dev libwolfssl-dev
-          /home/linuxbrew/.linuxbrew/bin/brew install ca-certificates || true
-          /home/linuxbrew/.linuxbrew/bin/brew install c-ares gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,10 +77,8 @@ jobs:
         timeout-minutes: 2
         uses: $/.github/actions/pkg-install
         with:
+          apt: libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev libnghttp2-dev libldap-dev libkrb5-dev libgnutls28-dev libwolfssl-dev
           brew: c-ares gsasl libnghttp3 libngtcp2 mbedtls rustls-ffi
-          apt: >-
-            libpsl-dev libbrotli-dev libidn2-dev libssh2-1-dev libssh-dev
-            libnghttp2-dev libldap-dev libkrb5-dev libgnutls28-dev libwolfssl-dev
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,6 @@ permissions: {}
 
 env:
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_INSTALL_CLEANUP: '1'
 
 jobs:
   gha_python:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -41,7 +41,6 @@ permissions: {}
 env:
   CURL_CI: github
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_INSTALL_CLEANUP: '1'
 
 jobs:
   check-linux:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -90,19 +90,9 @@ jobs:
     steps:
       - name: 'install packages'
         timeout-minutes: 2
-        run: |
-          # shellcheck disable=SC2181
-          while [[ $? == 0 ]]; do
-            for i in 1 2 3; do
-              if brew install automake libtool; then
-                break 2
-              else
-                echo "Error: wait to try again: $i"
-                sleep 10
-              fi
-            done
-            false Too many retries
-          done
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: automake libtool
 
       - name: 'toolchain versions'
         run: echo '::group::brew packages installed'; ls -l /opt/homebrew/opt; echo '::endgroup::'

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -147,11 +147,9 @@ jobs:
     steps:
       - name: 'install packages'
         timeout-minutes: 1
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: gcc-mingw-w64-x86-64-win32
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -87,7 +87,7 @@ jobs:
     name: 'macOS'
     runs-on: macos-latest
     steps:
-      - name: 'install packages'
+      - name: 'install prereqs'
         timeout-minutes: 2
         uses: $/.github/actions/pkg-install
         with:
@@ -144,7 +144,7 @@ jobs:
     env:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
-      - name: 'install packages'
+      - name: 'install prereqs'
         timeout-minutes: 1
         uses: $/.github/actions/pkg-install
         with:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -283,27 +283,28 @@ jobs:
             perl mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
 
       - name: 'install prereqs'
-        timeout-minutes: 3
+        if: ${{ !contains(matrix.image, 'windows') }}
+        timeout-minutes: 2
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: ${{ contains(matrix.image, 'macos') && 'libpsl openssl' || '' }}
+          apt: ${{ contains(matrix.image, 'ubuntu') && 'libpsl-dev libssl-dev' || '' }}
+
+      - name: 'install cmake'
+        timeout-minutes: 2
         run: |
+          cd ~
           if [[ "${MATRIX_IMAGE}" = *'windows'* ]]; then
-            cd ~
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --location --proto-redir =https "https://github.com/Kitware/CMake/releases/download/v${OLD_CMAKE_VERSION}/cmake-${OLD_CMAKE_VERSION}-win64-x64.zip" --output pkg.bin
             sha256sum pkg.bin && sha256sum pkg.bin | grep -qwF -- "${OLD_CMAKE_SHA256_WIN_INTEL}" && unzip -q pkg.bin && rm -f pkg.bin
             printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-win64-x64/bin/cmake.exe > ~/old-cmake-path.txt
           elif [[ "${MATRIX_IMAGE}" = *'ubuntu'* ]]; then
-            sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-            sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-            sudo apt-get -o Dpkg::Use-Pty=0 update
-            sudo apt-get -o Dpkg::Use-Pty=0 install libpsl-dev libssl-dev
-            cd ~
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --location --proto-redir =https "https://github.com/Kitware/CMake/releases/download/v${OLD_CMAKE_VERSION}/cmake-${OLD_CMAKE_VERSION}-Linux-aarch64.tar.gz" --output pkg.bin
             sha256sum pkg.bin | tee /dev/stderr | grep -qwF -- "${OLD_CMAKE_SHA256_LINUX_ARM}" && tar -xzf pkg.bin && rm -f pkg.bin
             printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-Linux-aarch64/bin/cmake > ~/old-cmake-path.txt
           else
-            brew install libpsl openssl
-            cd ~
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --location --proto-redir =https "https://github.com/Kitware/CMake/releases/download/v${OLD_CMAKE_VERSION}/cmake-${OLD_CMAKE_VERSION}-macos-universal.tar.gz" --output pkg.bin
             sha256sum pkg.bin | tee /dev/stderr | grep -qwF -- "${OLD_CMAKE_SHA256_MACOS_UNI}" && tar -xzf pkg.bin && rm -f pkg.bin

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -289,7 +289,7 @@ jobs:
           brew: ${{ contains(matrix.image, 'macos') && 'libpsl openssl' || '' }}
           apt: ${{ contains(matrix.image, 'ubuntu') && 'libpsl-dev libssl-dev' || '' }}
 
-      - name: 'install cmake'
+      - name: 'install prereqs (cmake)'
         timeout-minutes: 2
         run: |
           cd ~

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -24,7 +24,6 @@ permissions: {}
 env:
   CURL_TEST_MIN: 1500
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_INSTALL_CLEANUP: '1'
   MAKEFLAGS: -j 5
 
 jobs:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -278,16 +278,15 @@ jobs:
           update: false
           cache: false
           path-type: inherit
-          install: >-
-            perl mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
+          install: perl mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
 
       - name: 'install prereqs'
         if: ${{ !contains(matrix.image, 'windows') }}
         timeout-minutes: 2
         uses: $/.github/actions/pkg-install
         with:
-          brew: ${{ contains(matrix.image, 'macos') && 'libpsl openssl' || '' }}
           apt: ${{ contains(matrix.image, 'ubuntu') && 'libpsl-dev libssl-dev' || '' }}
+          brew: ${{ contains(matrix.image, 'macos') && 'libpsl openssl' || '' }}
 
       - name: 'install prereqs (cmake)'
         timeout-minutes: 2

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -223,16 +223,14 @@ jobs:
       - name: 'install build prereqs'
         if: ${{ steps.settings.outputs.needs-build }}
         timeout-minutes: 2
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install \
-            libtool autoconf automake pkgconf \
-            libbrotli-dev libzstd-dev zlib1g-dev \
-            libev-dev \
-            libuv1-dev \
-            libc-ares-dev \
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: >-
+            libtool autoconf automake pkgconf
+            libbrotli-dev libzstd-dev zlib1g-dev
+            libev-dev
+            libuv1-dev
+            libc-ares-dev
             libp11-kit-dev autopoint bison gperf gtk-doc-tools libtasn1-bin  # for GnuTLS
 
       - name: 'build awslc'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -431,7 +431,6 @@ jobs:
     env:
       CURL_TRACE_PKG_CONFIG: '1'
       MATRIX_BUILD: ${{ matrix.build.generate && 'cmake' || 'autotools' }}
-      MATRIX_INSTALL_PACKAGES: '${{ matrix.build.install_packages }}'
     strategy:
       fail-fast: false
       matrix:
@@ -576,21 +575,15 @@ jobs:
     steps:
       - name: 'install prereqs'
         timeout-minutes: 2
-        env:
-          INSTALL_PACKAGES: >-
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: >-
+            libtool autoconf automake pkgconf
+            libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libidn2-0-dev libldap-dev libuv1-dev valgrind
             ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') && 'stunnel4 ' || '' }}
             ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') &&
               'apache2 apache2-dev libnghttp2-dev vsftpd dante-server libev-dev' || '' }}
-
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install \
-            libtool autoconf automake pkgconf \
-            libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libidn2-0-dev libldap-dev libuv1-dev valgrind \
-            ${INSTALL_PACKAGES} \
-            ${MATRIX_INSTALL_PACKAGES}
+            ${{ matrix.build.install_packages }}
 
       - name: 'cache awslc'
         if: ${{ contains(matrix.build.name, 'awslc') }}

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -874,9 +874,9 @@ jobs:
 
       - name: 'install pytest prereqs'
         if: ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') }}
-        run: |
-          [ -d ~/venv ] || python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/http/requirements.txt
+        uses: $/.github/actions/pkg-install
+        with:
+          pip: -r tests/http/requirements.txt
 
       - name: 'run pytest (event based)'
         if: ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   label:
     name: 'Labeler'
-    image: ubuntu-24.04-firewall
+    runs-on: ubuntu-24.04-firewall
     permissions:
       contents: read        # To comply with https://github.com/actions/labeler documentation
       pull-requests: write  # To edit labels on PRs

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   label:
     name: 'Labeler'
-    runs-on: ubuntu-slim
+    image: ubuntu-24.04-firewall
     permissions:
       contents: read        # To comply with https://github.com/actions/labeler documentation
       pull-requests: write  # To edit labels on PRs

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,6 @@ env:
   CURL_CI: github
   CURL_TEST_MIN: 1660
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_INSTALL_CLEANUP: '1'
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   AWSLC_VERSION: 5.5.0
   # renovate: datasource=github-tags depName=google/boringssl versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -468,40 +468,25 @@ jobs:
       - name: 'install prereqs'
         if: ${{ matrix.build.container == null && !contains(matrix.build.name, 'i686') }}
         timeout-minutes: 3
-        env:
-          INSTALL_PACKAGES_BREW: '${{ matrix.build.install_steps_brew }}'
-          INSTALL_PACKAGES: >-
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: ${{ matrix.build.install_steps_brew }}
+          apt: >-
+            libtool autoconf automake pkgconf
+            libpsl-dev zlib1g-dev libbrotli-dev libzstd-dev
             ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') && 'stunnel4' || '' }}
             ${{ contains(matrix.build.install_steps, 'pytest') && 'apache2 apache2-dev libnghttp2-dev vsftpd dante-server' || '' }}
-
-        run: |
-          sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
-          ls -l /etc/apt/sources.list.d
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install \
-            libtool autoconf automake pkgconf \
-            libpsl-dev zlib1g-dev libbrotli-dev libzstd-dev \
-            ${INSTALL_PACKAGES} \
-            ${MATRIX_INSTALL_PACKAGES}
-          if [ -n "${INSTALL_PACKAGES_BREW}" ]; then
-            /home/linuxbrew/.linuxbrew/bin/brew install ca-certificates || true
-            /home/linuxbrew/.linuxbrew/bin/brew install ${INSTALL_PACKAGES_BREW}
-          fi
+            ${{ matrix.build.install_packages }}
 
       - name: 'install prereqs (i686)'
         if: ${{ contains(matrix.build.name, 'i686') }}
         timeout-minutes: 2
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo dpkg --add-architecture i386
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install \
-            libtool autoconf automake pkgconf stunnel4 \
-            libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \
-            ${MATRIX_INSTALL_PACKAGES}
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: >-
+            libtool autoconf automake pkgconf stunnel4
+            libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386
+            ${{ matrix.build.install_packages }}
 
       - name: 'install prereqs (alpine)'
         if: ${{ startsWith(matrix.build.container, 'alpine') }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -970,9 +970,9 @@ jobs:
 
       - name: 'install pytest prereqs'
         if: ${{ contains(matrix.build.install_steps, 'pytest') }}
-        run: |
-          [ -d ~/venv ] || python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/http/requirements.txt
+        uses: $/.github/actions/pkg-install
+        with:
+          pip: -r tests/http/requirements.txt
 
       - name: 'run pytest'
         if: ${{ contains(matrix.build.install_steps, 'pytest') }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,7 +80,6 @@ jobs:
             configure: --with-openssl=/home/runner/awslc --enable-ech --enable-ntlm --enable-smb
 
           - name: 'awslc'
-            image: ubuntu-24.04-firewall
             install_packages: libidn2-dev
             install_steps: awslc clean
             generate: -DOPENSSL_ROOT_DIR=/home/runner/awslc -DUSE_ECH=ON -DCMAKE_UNITY_BUILD=OFF -DCURL_DROP_UNUSED=ON -DCURL_PATCHSTAMP=test-patch -DCURL_ENABLE_NTLM=ON

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -586,9 +586,9 @@ jobs:
 
       - name: 'install pytest prereqs'
         if: ${{ contains(matrix.build.install_steps, 'pytest') }}
-        run: |
-          [ -d ~/venv ] || python3 -m venv ~/venv
-          ~/venv/bin/pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary -r tests/http/requirements.txt
+        uses: $/.github/actions/pkg-install
+        with:
+          pip: -r tests/http/requirements.txt
 
       - name: 'run pytest'
         if: ${{ contains(matrix.build.install_steps, 'pytest') }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,7 +48,6 @@ env:
   CURL_CI: github
   CURL_TEST_MIN: 1750
   DO_NOT_TRACK: '1'
-  HOMEBREW_NO_INSTALL_CLEANUP: '1'
   MAKEFLAGS: -j 4
   LDFLAGS: -w  # suppress 'object file was built for newer macOS version than being linked' warnings
 
@@ -91,19 +90,9 @@ jobs:
       - name: 'brew install'
         if: ${{ matrix.build.configure }}
         timeout-minutes: 5
-        run: |
-          # shellcheck disable=SC2181
-          while [[ $? == 0 ]]; do
-            for i in 1 2 3; do
-              if brew install automake libtool; then
-                break 2
-              else
-                echo "Error: wait to try again: $i"
-                sleep 10
-              fi
-            done
-            false Too many retries
-          done
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: automake libtool
 
       - name: 'toolchain versions'
         run: |
@@ -233,7 +222,6 @@ jobs:
       CC: '${{ matrix.build.compiler }}'
       MATRIX_BUILD: ${{ matrix.build.generate && 'cmake' || 'autotools' }}
       MATRIX_COMPILER: '${{ matrix.build.compiler }}'
-      MATRIX_INSTALL: '${{ matrix.build.install }}'
       MATRIX_INSTALL_STEPS: '${{ matrix.build.install_steps }}'
       MATRIX_MACOS_VERSION_MIN: '${{ matrix.build.macos-version-min }}'
     strategy:
@@ -421,28 +409,13 @@ jobs:
 
       - name: 'brew install'
         timeout-minutes: 5
-        # Run this command with retries because of spurious failures seen
-        # while running the tests, for example
-        # https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
-        env:
-          INSTALL_PACKAGES: >-
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: >-
+            pkgconf libpsl libssh2 ${{ matrix.build.install }}
             ${{ matrix.build.generate && 'ninja' || 'automake libtool' }}
             ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') && 'nghttp2 stunnel' || '' }}
             ${{ contains(matrix.build.install_steps, 'pytest') && 'caddy httpd vsftpd' || '' }}
-
-        run: |
-          # shellcheck disable=SC2181
-          while [[ $? == 0 ]]; do
-            for i in 1 2 3; do
-              if brew install pkgconf libpsl libssh2 ${INSTALL_PACKAGES} ${MATRIX_INSTALL}; then
-                break 2
-              else
-                echo "Error: wait to try again: $i"
-                sleep 10
-              fi
-            done
-            false Too many retries
-          done
 
       - name: 'toolchain versions'
         run: |
@@ -698,19 +671,9 @@ jobs:
     steps:
       - name: 'install autotools'
         if: ${{ matrix.build == 'autotools' }}
-        run: |
-          # shellcheck disable=SC2181
-          while [[ $? == 0 ]]; do
-            for i in 1 2 3; do
-              if brew install automake libtool; then
-                break 2
-              else
-                echo "Error: wait to try again: $i"
-                sleep 10
-              fi
-            done
-            false Too many retries
-          done
+        uses: $/.github/actions/pkg-install
+        with:
+          brew: automake libtool
 
       - name: 'toolchain versions'
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,7 @@ jobs:
               -DCURL_USE_LIBPSL=OFF -DCURL_ENABLE_NTLM=ON
 
     steps:
-      - name: 'brew install'
+      - name: 'install prereqs'
         if: ${{ matrix.build.configure }}
         timeout-minutes: 5
         uses: $/.github/actions/pkg-install
@@ -407,7 +407,7 @@ jobs:
             brew unlink openssl
           fi
 
-      - name: 'brew install'
+      - name: 'install prereqs'
         timeout-minutes: 5
         uses: $/.github/actions/pkg-install
         with:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -489,7 +489,7 @@ jobs:
         build: [autotools, cmake]
       fail-fast: false
     steps:
-      - name: 'install packages'
+      - name: 'install prereqs'
         timeout-minutes: 2
         uses: $/.github/actions/pkg-install
         with:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -491,11 +491,9 @@ jobs:
     steps:
       - name: 'install packages'
         timeout-minutes: 2
-        run: |
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install libfl2
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: libfl2
 
       - name: 'cache compiler (djgpp)'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -819,14 +819,9 @@ jobs:
     steps:
       - name: 'install packages'
         timeout-minutes: 2
-        env:
-          MATRIX_INSTALL_PACKAGES: '${{ matrix.install_packages }}'
-        run: |
-          ls -l /etc/apt/sources.list.d
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
-          sudo apt-get -o Dpkg::Use-Pty=0 update
-          sudo apt-get -o Dpkg::Use-Pty=0 install gcc-mingw-w64-x86-64-win32 ${MATRIX_INSTALL_PACKAGES}
+        uses: $/.github/actions/pkg-install
+        with:
+          apt: gcc-mingw-w64-x86-64-win32 ${{ matrix.install_packages }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -817,7 +817,7 @@ jobs:
           - { build: 'cmake'    , compiler: 'gcc' }
           - { build: 'cmake'    , compiler: 'clang-tidy', install_packages: 'clang-22 clang-tidy-22', CFLAGS: '-Wunused-macros' }
     steps:
-      - name: 'install packages'
+      - name: 'install prereqs'
         timeout-minutes: 2
         uses: $/.github/actions/pkg-install
         with:


### PR DESCRIPTION
Via a local custom/composite Action. To de-duplicate logic, and allow 
maintaining a single copy. It may also allow for more elaborate
workarounds for package install issues, if it becomes necessary.

Also:
- tried using `background: true` to parellize apt/brew/pip installs,
  but it's not supported in custom Actions.
- shellcheck-ci: run on composite actions.
- checksrc: run zizmor on composite actions.
  (actionlint does not support them)
- checksrc: run zizmor on dependabot YAML.
- tidy up install prereq step names.
- shellcheck-ci.sh: make it runnable from any directory.
- drop `ca-certificates` Homebrew workaround.
  Not necessary at the moment.
  Follow-up to c155cbc6380467487fcbca126366638149f04cf0 #22438
- GHA/label: move egress firewall test from GHA/Linux/aws-lc.
  The firewall runner machine does not support the `$/` local action
  syntax.
  Follow-up to e5e1c356107ea4f8208757deb69776d94496cfae #22864

Refs:
https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/
https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-an-action-in-the-same-repository-as-the-workflow

Ref: #22074 (first attempt)

---

2 weeks after closing the previous attempt, GitHub implemented
exactly the feature I was wishing for. Thanks to the kind souls
who made it happen.
