### PR TITLE
imap: compare selected mailbox names case-sensitively

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -2076,7 +2076,9 @@ static CURLcode imap_perform(struct Curl_easy *data, bool *connected,
   /* Determine if the requested mailbox (with the same UIDVALIDITY if set)
      has already been selected on this connection */
   if(imap->mailbox && imapc->mailbox &&
-     curl_strequal(imap->mailbox, imapc->mailbox) &&
+     (!strcmp(imap->mailbox, imapc->mailbox) ||
+      (curl_strequal(imap->mailbox, "INBOX") &&
+       curl_strequal(imapc->mailbox, "INBOX"))) &&
      (!imap->uidvalidity_set || !imapc->mb_uidvalidity_set ||
       (imap->uidvalidity == imapc->mb_uidvalidity)))
     selected = TRUE;

--- a/tests/data/test804
+++ b/tests/data/test804
@@ -24,10 +24,10 @@ body
 imap
 </server>
 <name>
-IMAP does not perform SELECT if reusing the same mailbox
+IMAP selects a mailbox when its case changes
 </name>
 <command>
-'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER/;MAILINDEX=123/;SECTION=1' 'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER/;MAILINDEX=456/;SECTION=2.3' -u user:secret
+'imap://%HOSTIP:%IMAPPORT/Private/;MAILINDEX=123/;SECTION=1' 'imap://%HOSTIP:%IMAPPORT/private/;MAILINDEX=456/;SECTION=2.3' -u user:secret
 </command>
 </client>
 
@@ -36,10 +36,11 @@ IMAP does not perform SELECT if reusing the same mailbox
 <protocol crlf="yes">
 A001 CAPABILITY
 A002 LOGIN user secret
-A003 SELECT %TESTNUMBER
+A003 SELECT Private
 A004 FETCH 123 BODY[1]
-A005 FETCH 456 BODY[2.3]
-A006 LOGOUT
+A005 SELECT private
+A006 FETCH 456 BODY[2.3]
+A007 LOGOUT
 </protocol>
 </verify>
 </testcase>


### PR DESCRIPTION
When an authenticated IMAP connection is reused, libcurl checks whether the requested mailbox is already selected. The previous comparison was case-insensitive for every mailbox, so a request for `private` could reuse a connection with `Private` selected and skip `SELECT`.

RFC 9051 section 5.1 requires non-INBOX mailbox names to be case-sensitive. This changes the selected-mailbox check to compare exact names, while retaining case-insensitive handling for the reserved `INBOX` name.

The existing IMAP reuse test now covers a case-changing mailbox request and verifies that both SELECT commands are sent.

Closes HackerOne report #3976342.

Validation:
- `cmake --build /home/bobbeh/koth/loot/curl-mail-round2-20260828/build-master-clean -j2` passed.
- `git diff --check` passed.
- The focused test runner could not execute because this build lacks `tests/server/servers` and `curlinfo`; no test pass is claimed for that runner.
