### PR TITLE
http2: changes in error handling

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -496,7 +496,7 @@ static CURLcode h2_process_pending_input(struct Curl_cfilter *cf,
     rv = nghttp2_session_mem_recv(ctx->h2, (const uint8_t *)buf, blen);
     if(!curlx_sztouz(rv, &nread)) {
       failf(data, "nghttp2 recv error %zd: %s", rv, nghttp2_strerror((int)rv));
-      return CURLE_HTTP2;
+      return CURLE_RECV_ERROR;
     }
     Curl_bufq_skip(&ctx->inbufq, nread);
     if(Curl_bufq_is_empty(&ctx->inbufq)) {
@@ -1253,10 +1253,10 @@ static int cf_h2_on_invalid_frame_recv(nghttp2_session *session,
       stream->error = ngerr;
       stream->closed = TRUE;
       stream->reset = TRUE;
-      return 0;  /* keep the connection alive */
     }
   }
-  return NGHTTP2_ERR_CALLBACK_FAILURE;
+  /* Return no error, nhttp2 will RST/GOAWAY by itself when needed */
+  return 0;
 }
 
 static int on_data_chunk_recv(nghttp2_session *session, uint8_t flags,

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1255,7 +1255,7 @@ static int cf_h2_on_invalid_frame_recv(nghttp2_session *session,
       stream->reset = TRUE;
     }
   }
-  /* Return no error, nhttp2 will RST/GOAWAY by itself when needed */
+  /* Return no error, nghttp2 will RST/GOAWAY by itself when needed */
   return 0;
 }
 

--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -213,7 +213,7 @@ class TestBasic:
             f'/curltest/tweak?x-hd={256 * 1024}'
         r = curl.http_get(url=url, alpn_proto=proto, extra_args=[])
         if proto == 'h2':
-            r.check_exit_code(16)  # CURLE_HTTP2
+            r.check_exit_code(56)  # CURLE_RECV_ERROR
         else:
             r.check_exit_code(0)   # 1.1 can do
 


### PR DESCRIPTION
- always treat errors from nghttp2_session_mem_recv() as fatal
- always return 0 from invalid_frame callback, so that nghttp2's internal RST/GOAWAY handling can work
- adjust test_01_14 return code expectation


