### PR TITLE
mbedtls: fix ticket handling

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1303,10 +1303,12 @@ do_send:
     switch(nwritten) {
 #ifdef MBEDTLS_SSL_PROTO_TLS1_3
     case MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET:
-      mbed_new_session(cf, data);
+      result = mbed_new_session(cf, data);
       /* This return code is not blocking. Having treated the new
        * ticket, resume sending until we get a "real" result. */
-      goto do_send;
+      if(!result)
+        goto do_send;
+      break;
 #endif
     case MBEDTLS_ERR_SSL_WANT_READ:
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
@@ -1471,10 +1473,12 @@ do_read:
     switch(nread) {
 #ifdef MBEDTLS_SSL_SESSION_TICKETS
     case MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET:
-      mbed_new_session(cf, data);
+      result = mbed_new_session(cf, data);
       /* This is not blocking anything. We can try again until a
        * "real" result comes. */
-      goto do_read;
+      if(!result)
+        goto do_read;
+      break;
 #endif
     case MBEDTLS_ERR_SSL_WANT_READ:
       connssl->io_need = CURL_SSL_IO_NEED_RECV;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1275,6 +1275,9 @@ static CURLcode mbed_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   int nwritten;
 
   DEBUGASSERT(backend);
+#ifdef MBEDTLS_SSL_PROTO_TLS1_3
+do_send:
+#endif
   *pnwritten = 0;
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
   /* mbedTLS is picky when a mbedtls_ssl_write() was previously blocked.
@@ -1300,6 +1303,10 @@ static CURLcode mbed_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     switch(nwritten) {
 #ifdef MBEDTLS_SSL_PROTO_TLS1_3
     case MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET:
+      mbed_new_session(cf, data);
+      /* This return code is not blocking. Having treated the new
+       * ticket, resume sending until we get a "real" result. */
+      goto do_send;
 #endif
     case MBEDTLS_ERR_SSL_WANT_READ:
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
@@ -1448,6 +1455,9 @@ static CURLcode mbed_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   int nread;
 
   DEBUGASSERT(backend);
+#ifdef MBEDTLS_SSL_SESSION_TICKETS
+do_read:
+#endif
   *pnread = 0;
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
 
@@ -1462,7 +1472,9 @@ static CURLcode mbed_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 #ifdef MBEDTLS_SSL_SESSION_TICKETS
     case MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET:
       mbed_new_session(cf, data);
-      FALLTHROUGH();
+      /* This is not blocking anything. We can try again until a
+       * "real" result comes. */
+      goto do_read;
 #endif
     case MBEDTLS_ERR_SSL_WANT_READ:
       connssl->io_need = CURL_SSL_IO_NEED_RECV;


### PR DESCRIPTION
Getting MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET from mbedTLS is in no way blocking. Send/receive calls need to make another attempt afterwards to get the "real" result.
