### PR TITLE
libssh2: match hashed known_hosts entries by host

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -685,9 +685,19 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data,
             break;
           }
         }
-        else {
-          found = TRUE;
-          break;
+        else if(store->key) {
+          int keycheck = libssh2_knownhost_checkp(
+            sshc->kh, conn->origin->hostname,
+            (conn->origin->port != PORT_SSH) ? conn->origin->port : -1,
+            store->key, strlen(store->key),
+            LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+              LIBSSH2_KNOWNHOST_KEYENC_BASE64 |
+              (store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK),
+            NULL);
+          if(keycheck == LIBSSH2_KNOWNHOST_CHECK_MATCH) {
+            found = TRUE;
+            break;
+          }
         }
       }
     }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -2100,6 +2100,8 @@ TESTCASES = \
   test3400 \
   test3401 \
   \
+  test3500 \
+  \
   test4000 \
   test4001 \
   test4644 \

--- a/tests/data/test3500
+++ b/tests/data/test3500
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+SFTP
+known_hosts
+libssh2
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+Test data
+for hashed known hosts
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+sftp
+</server>
+<features>
+sftp
+libssh2
+!badlibssh
+</features>
+<precheck>
+%PERL %SRCDIR/libtest/test3500.pl %LOGDIR/server/curl_host_key.pub %LOGDIR/known%TESTNUMBER "[%HOSTIP]:%SSHPORT"
+</precheck>
+<name>
+SFTP matches requested hashed known_hosts entry
+</name>
+<command>
+--knownhosts %LOGDIR/known%TESTNUMBER --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: sftp://%HOSTIP:%SSHPORT%SFTP_PWD/%LOGDIR/file%TESTNUMBER.txt
+</command>
+<file name="%LOGDIR/file%TESTNUMBER.txt">
+Test data
+for hashed known hosts
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -49,7 +49,8 @@ EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_
   test1022.pl \
   test307.pl \
   test610.pl \
-  test613.pl
+  test613.pl \
+  test3500.pl
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 

--- a/tests/libtest/test3500.pl
+++ b/tests/libtest/test3500.pl
@@ -1,0 +1,72 @@
+#!/usr/bin/env perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+use strict;
+use warnings;
+
+use Digest::SHA qw(hmac_sha1);
+use MIME::Base64 qw(encode_base64);
+
+sub errout {
+    print $_[0] . "\n";
+    exit 1;
+}
+
+if(@ARGV != 3) {
+    errout "Usage: $0 host-public-key known-hosts-file target";
+}
+
+my ($hostkey_file, $knownhosts_file, $target) = @ARGV;
+open(my $hostkey, "<", $hostkey_file) or errout "$!";
+my $hostkey_line = <$hostkey>;
+close($hostkey) or errout "$!";
+
+my ($hostkey_algo, $hostkey_data) = split(/\s+/, $hostkey_line);
+if(!$hostkey_algo || !$hostkey_data) {
+    errout "Failed parsing SSH host public key";
+}
+
+my $rsa_key =
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgSyqrUP2xhqLqkyopVapoKeucYIp" .
+    "ZXeUqj+Q9WLWyXka5re62Y3R/lxZUXtkJjlpdD2LNMFenNlDQvPaXH5Utllt+c3z" .
+    "wOkOLy7RXX5S37SfQFm/0fPkZqoZfMDB6XDcwA4cakjCRn4oZyKs8dWAxoNaTtYc" .
+    "nKKMJ6rmc8PttykJw9fwiKAjPyYf21/BMvWIzu9req+TrDA/Jcd2UAug94CikJIX" .
+    "uwKmSYleAOo4eJWx8GyujgEgZn05eq+K1LSg9RqRVIxOdqjoE5K3abBfs0rmUuLd" .
+    "MFh7nHseTFXYbKzpz46V7iZMfFuoyURrzVsqGUm+/m7dxBM98In12kOm3";
+my $ed25519_key =
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAqmXRY8k+W9GtpWxYru6ELAXYHdXq" .
+    "jf33ziITGTiJUN";
+my $other_key = $hostkey_algo eq "ssh-ed25519" ? $rsa_key : $ed25519_key;
+
+my $salt = "curl-knownhosts-test";
+my $salt64 = encode_base64($salt, "");
+my $hash64 = encode_base64(hmac_sha1("unrelated.invalid", $salt), "");
+my $target_hash64 = encode_base64(hmac_sha1($target, $salt), "");
+
+open(my $knownhosts, ">", $knownhosts_file) or errout "$!";
+print $knownhosts "|1|$salt64|$hash64 $other_key\n";
+print $knownhosts "|1|$salt64|$target_hash64 $hostkey_algo $hostkey_data\n";
+close($knownhosts) or errout "$!";
+
+exit 0;


### PR DESCRIPTION
libssh2_knownhost_get() does not return a plaintext name for hashed entries. The current scan treats the first such entry as the requested host and selects its key type, even when the hash belongs to a different host.

Use libssh2_knownhost_checkp() to verify each hashed entry against the requested hostname and port before selecting its key type.

Test 3500 puts an unrelated hashed entry before a valid entry for the requested host. It fails before this change and passes afterward.

Tests:
- runtests.pl 3500
- runtests.pl 1459
- runtests.pl 600
- curl-lint