### PR TITLE
ssl: dedup ssl_fsslctx

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1935,7 +1935,7 @@ static CURLcode setopt_cptr_ssl(struct Curl_easy *data, CURLoption option,
      * Set an SSL_CTX callback parameter pointer
      */
     if(Curl_ssl_supports(data, SSLSUPP_SSL_CTX)) {
-      data->set.ssl.fsslctxp = ptr;
+      data->set.ssl_fsslctxp = ptr;
       break;
     }
     else
@@ -2626,7 +2626,7 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_SSL_CTX)) {
-      s->ssl.fsslctx = va_arg(param, curl_ssl_ctx_callback);
+      s->ssl_fsslctx = va_arg(param, curl_ssl_ctx_callback);
       break;
     }
     else

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -891,6 +891,8 @@ struct UserDefined {
                                     the hostname and port to connect to */
   time_t timevalue;       /* what time to compare with */
   struct ssl_config_data ssl;  /* user defined SSL stuff */
+  curl_ssl_ctx_callback ssl_fsslctx; /* function to initialize SSL ctx */
+  void *ssl_fsslctxp;        /* parameter for call back */
 #ifndef CURL_DISABLE_PROXY
   struct ssl_config_data proxy_ssl;  /* user defined SSL stuff for proxy */
   struct curl_slist *proxyheaders; /* linked list of extra CONNECT headers */

--- a/lib/vdns/doh.c
+++ b/lib/vdns/doh.c
@@ -353,10 +353,10 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
     }
     if(data->set.ssl.certinfo)
       ERROR_CHECK_SETOPT(CURLOPT_CERTINFO, 1L);
-    if(data->set.ssl.fsslctx)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_FUNCTION, data->set.ssl.fsslctx);
-    if(data->set.ssl.fsslctxp)
-      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_DATA, data->set.ssl.fsslctxp);
+    if(data->set.ssl_fsslctx)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_FUNCTION, data->set.ssl_fsslctx);
+    if(data->set.ssl_fsslctxp)
+      ERROR_CHECK_SETOPT(CURLOPT_SSL_CTX_DATA, data->set.ssl_fsslctxp);
     if(CURL_EASY_STR(data, STRING_SSL_EC_CURVES)) {
       ERROR_CHECK_SETOPT(CURLOPT_SSL_EC_CURVES,
                          CURL_EASY_STR(data, STRING_SSL_EC_CURVES));

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1018,9 +1018,9 @@ static CURLcode mbed_configure_ssl(struct Curl_cfilter *cf,
 #endif
 
   /* give application a chance to interfere with mbedTLS set up. */
-  if(data->set.ssl.fsslctx) {
-    result = (*data->set.ssl.fsslctx)(data, &backend->config,
-                                      data->set.ssl.fsslctxp);
+  if(data->set.ssl_fsslctx) {
+    result = (*data->set.ssl_fsslctx)(data, &backend->config,
+                                      data->set.ssl_fsslctxp);
     if(result)
       failf(data, "error signaled by SSL ctx callback");
   }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3947,7 +3947,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   }
 
   /* give application a chance to interfere with SSL set up. */
-  if(data->set.ssl.fsslctx) {
+  if(data->set.ssl_fsslctx) {
     struct Curl_mapi_guard guard;
     /* When a user callback is installed to modify the SSL_CTX,
      * we need to do the full initialization before calling it.
@@ -3959,8 +3959,8 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
       octx->x509_store_setup = TRUE;
     }
     CURL_CBAPI_START(&guard, data, easy_fsslctx);
-    result = (*data->set.ssl.fsslctx)(data, octx->ssl_ctx,
-                                      data->set.ssl.fsslctxp);
+    result = (*data->set.ssl_fsslctx)(data, octx->ssl_ctx,
+                                      data->set.ssl_fsslctxp);
     CURL_CBAPI_END(&guard);
     if(result) {
       failf(data, "error signaled by SSL ctx callback");

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -64,8 +64,6 @@ struct ssl_primary_config {
 struct ssl_config_data {
   struct ssl_primary_config primary;
   long certverifyresult; /* result from the certificate verification */
-  curl_ssl_ctx_callback fsslctx; /* function to initialize SSL ctx */
-  void *fsslctxp;        /* parameter for call back */
   BIT(certinfo);     /* gather lots of certificate info */
   BIT(earlydata);    /* use TLS 1.3 early data */
   BIT(enable_beast); /* allow this flaw for interoperability's sake */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1419,14 +1419,14 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
   }
 
   /* give application a chance to interfere with SSL set up. */
-  if(data->set.ssl.fsslctx) {
+  if(data->set.ssl_fsslctx) {
     if(!wctx->x509_store_setup) {
       result = Curl_wssl_setup_x509_store(cf, data, wctx);
       if(result)
         goto out;
     }
-    result = (*data->set.ssl.fsslctx)(data, wctx->ssl_ctx,
-                                      data->set.ssl.fsslctxp);
+    result = (*data->set.ssl_fsslctx)(data, wctx->ssl_ctx,
+                                      data->set.ssl_fsslctxp);
     if(result) {
       failf(data, "error signaled by SSL ctx callback");
       goto out;


### PR DESCRIPTION
The members fsslctx(p) in `struct ssl_config_data` were only set on `data->set.ssl` and never on `data->set.proxy_ssl`, yet were used from the first one in all TLS filters that support it.

Move the callback and its userdata outside the config struct, since we need it only once.
