### PR TITLE
easy: make ca_cache_timeout standalone

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -914,7 +914,7 @@ static CURLcode setopt_long_ssl(struct Curl_easy *data, CURLoption option,
     if(Curl_ssl_supports(data, SSLSUPP_CA_CACHE)) {
       result = value_range(&arg, -1, -1, INT_MAX);
       if(!result)
-        s->general_ssl.ca_cache_timeout = (int)arg;
+        s->ssl_ca_cache_timeout = (int)arg;
     }
     else
       result = CURLE_NOT_BUILT_IN;

--- a/lib/url.c
+++ b/lib/url.c
@@ -352,7 +352,7 @@ void Curl_init_userdefined(struct Curl_easy *data)
   set->dns_cache_timeout_ms = 60000; /* Timeout every 60 seconds by default */
 
   /* Timeout every 24 hours by default */
-  set->general_ssl.ca_cache_timeout = 24 * 60 * 60;
+  set->ssl_ca_cache_timeout = 24 * 60 * 60;
 
   set->httpauth = CURLAUTH_BASIC;  /* defaults to basic */
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -900,7 +900,6 @@ struct UserDefined {
   uint8_t proxytype; /* what kind of proxy */
   uint8_t socks5auth;/* kind of SOCKS5 authentication to use (bitmask) */
 #endif
-  struct ssl_general_config general_ssl; /* general user defined SSL stuff */
   timediff_t dns_cache_timeout_ms; /* DNS cache timeout (milliseconds) */
   uint32_t buffer_size;        /* size of receive buffer to use */
   uint32_t upload_buffer_size; /* size of upload buffer to use, keep it >=
@@ -968,6 +967,8 @@ struct UserDefined {
 #ifndef CURL_DISABLE_SMTP
   struct curl_slist *mail_rcpt; /* linked list of mail recipients */
 #endif
+  int ssl_ca_cache_timeout;  /* Certificate store cache timeout (seconds) */
+
   int tcp_keepidle;     /* seconds in idle before sending keepalive probe */
   int tcp_keepintvl;    /* seconds between TCP keepalive probes */
   int tcp_keepcnt;      /* maximum number of keepalive probes */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -570,9 +570,8 @@ static CURLcode gtls_populate_creds(struct Curl_cfilter *cf,
 static bool gtls_shared_creds_expired(struct Curl_easy *data,
                                       const struct gtls_shared_creds *sc)
 {
-  const struct ssl_general_config *cfg = &data->set.general_ssl;
   timediff_t elapsed_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &sc->time);
-  timediff_t timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
+  timediff_t timeout_ms = data->set.ssl_ca_cache_timeout * (timediff_t)1000;
 
   if(timeout_ms < 0)
     return FALSE;
@@ -663,7 +662,7 @@ CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
   /* Consider the X509 store cacheable if it comes exclusively from a CAfile,
      or no source is provided and we are falling back to OpenSSL's built-in
      default. */
-  cache_criteria_met = (data->set.general_ssl.ca_cache_timeout != 0) &&
+  cache_criteria_met = (data->set.ssl_ca_cache_timeout != 0) &&
     conn_config->verifypeer &&
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3176,12 +3176,11 @@ static void oss_x509_share_free(void *key, size_t key_len, void *p)
 static bool ossl_cached_x509_store_expired(struct Curl_easy *data,
                                            const struct ossl_x509_share *mb)
 {
-  const struct ssl_general_config *cfg = &data->set.general_ssl;
-  if(cfg->ca_cache_timeout < 0)
+  if(data->set.ssl_ca_cache_timeout < 0)
     return FALSE;
   else {
     timediff_t elapsed_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &mb->time);
-    timediff_t timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
+    timediff_t timeout_ms = data->set.ssl_ca_cache_timeout * (timediff_t)1000;
 
     return elapsed_ms >= timeout_ms;
   }
@@ -3292,7 +3291,7 @@ CURLcode Curl_ssl_setup_x509_store(struct Curl_cfilter *cf,
   /* Consider the X509 store cacheable if it comes exclusively from a CAfile,
      or no source is provided and we are falling back to OpenSSL's built-in
      default. */
-  cache_criteria_met = (data->set.general_ssl.ca_cache_timeout != 0) &&
+  cache_criteria_met = (data->set.ssl_ca_cache_timeout != 0) &&
     conn_config->verifypeer &&
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2727,7 +2727,6 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
   struct Curl_multi *multi = data->multi;
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   struct schannel_cert_share *share;
-  const struct ssl_general_config *cfg = &data->set.general_ssl;
   timediff_t timeout_ms;
   unsigned char info_blob_digest[CURL_SHA256_DIGEST_LENGTH];
 
@@ -2745,14 +2744,14 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
   }
 
   /* zero ca_cache_timeout completely disables caching */
-  if(!cfg->ca_cache_timeout) {
+  if(!data->set.ssl_ca_cache_timeout) {
     return NULL;
   }
 
   /* check for cache timeout by using the cached_x509_store_expired timediff
      calculation pattern from openssl.c.
      negative timeout means retain forever. */
-  timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
+  timeout_ms = data->set.ssl_ca_cache_timeout * (timediff_t)1000;
   if(timeout_ms >= 0) {
     timediff_t elapsed_ms =
       curlx_ptimediff_ms(Curl_pgrs_now(data), &share->time);

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -78,10 +78,6 @@ struct ssl_config_data {
   BIT(custom_cablob); /* application has set custom CA blob */
 };
 
-struct ssl_general_config {
-  int ca_cache_timeout;  /* Certificate store cache timeout (seconds) */
-};
-
 void Curl_ssl_config_init(struct ssl_primary_config *sslc);
 void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc);
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -697,9 +697,8 @@ static void wssl_x509_share_free(void *key, size_t key_len, void *p)
 static bool wssl_cached_x509_store_expired(struct Curl_easy *data,
                                            const struct wssl_x509_share *mb)
 {
-  const struct ssl_general_config *cfg = &data->set.general_ssl;
   timediff_t elapsed_ms = curlx_ptimediff_ms(Curl_pgrs_now(data), &mb->time);
-  timediff_t timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
+  timediff_t timeout_ms = data->set.ssl_ca_cache_timeout * (timediff_t)1000;
 
   if(timeout_ms < 0)
     return FALSE;
@@ -803,7 +802,7 @@ CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
   /* Consider the X509 store cacheable if it comes exclusively from a CAfile,
      or no source is provided and we are falling back to wolfSSL's built-in
      default. */
-  cache_criteria_met = (data->set.general_ssl.ca_cache_timeout != 0) &&
+  cache_criteria_met = (data->set.ssl_ca_cache_timeout != 0) &&
     conn_config->verifypeer &&
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&


### PR DESCRIPTION
The `struct ssl_general_config` had only a single `int` member. Dissolve the struct and make the `int ssl_ca_cache_timeout` a direct member of `data->set`.

