### PR TITLE
GHA: fix yaml comment in http3-linux.yml

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -231,7 +231,7 @@ jobs:
             libev-dev
             libuv1-dev
             libc-ares-dev
-            libp11-kit-dev autopoint bison gperf gtk-doc-tools libtasn1-bin  # for GnuTLS
+            libp11-kit-dev autopoint bison gperf gtk-doc-tools libtasn1-bin
 
       - name: 'build awslc'
         if: ${{ !steps.cache-awslc.outputs.cache-hit }}


### PR DESCRIPTION
Codex Security insists that this was not a valid yaml comment but the words were instead passed as arguments to the command.


