### PR TITLE
shellcheck-ci.sh: drop redundant GHA expression filter

### DIFF
--- a/.github/scripts/shellcheck-ci.sh
+++ b/.github/scripts/shellcheck-ci.sh
@@ -18,7 +18,7 @@ git ls-files '.github/actions/**/*.yml' '.github/workflows/*.yml' | while read -
     echo '#!/usr/bin/env bash'
     echo 'set -eu'
     yq eval '.. | select(has("run") and (.run | type == "!!str")) | .run + "\ntrue\n"' "${f}"
-  } | sed -E 's|\$\{\{ .+ \}\}|GHA_EXPRESSION|g' | shellcheck -
+  } | shellcheck -
 done
 
 # Circle CI


### PR DESCRIPTION
GHA expressions are no longer used and no longer allowed in GHA scripts.

Follow-up to 17a669426f36b467dfd945b4b35f6211598b7977 #17537

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
