### PR TITLE
test440: raise alloc limit

### DIFF
--- a/tests/data/test440
+++ b/tests/data/test440
@@ -75,7 +75,7 @@ https://this.hsts.example./%TESTNUMBER
 7
 </errorcode>
 <limits>
-Allocations: 172
+Allocations: 200
 </limits>
 </verify>
 </testcase>


### PR DESCRIPTION
spurious fails in some Windows CI runs, raise a bit more


