### PR TITLE
hash: change key arguments to const

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -136,7 +136,7 @@ static struct cpool_bundle *cpool_find_bundle(struct cpool *cpool,
                                               const char *destination)
 {
   return Curl_hash_pick(
-    &cpool->dest2bundle, CURL_UNCONST(destination), strlen(destination) + 1);
+    &cpool->dest2bundle, destination, strlen(destination) + 1);
 }
 
 static void cpool_remove_bundle(struct cpool *cpool,
@@ -144,8 +144,7 @@ static void cpool_remove_bundle(struct cpool *cpool,
 {
   if(!cpool)
     return;
-  Curl_hash_delete(&cpool->dest2bundle,
-                   CURL_UNCONST(destination), strlen(destination) + 1);
+  Curl_hash_delete(&cpool->dest2bundle, destination, strlen(destination) + 1);
 }
 
 static void cpool_remove_conn(struct cpool *cpool,
@@ -303,8 +302,7 @@ static struct cpool_bundle *cpool_add_bundle(struct cpool *cpool,
     return NULL;
 
   if(!Curl_hash_add(&cpool->dest2bundle,
-                    CURL_UNCONST(destination), strlen(destination) + 1,
-                    bundle)) {
+                    destination, strlen(destination) + 1, bundle)) {
     cpool_bundle_destroy(bundle);
     return NULL;
   }
@@ -712,8 +710,7 @@ bool Curl_cpool_find(struct Curl_easy *data,
 
   CPOOL_LOCK(cpool, data);
   bundle = Curl_hash_pick(&cpool->dest2bundle,
-                          CURL_UNCONST(destination),
-                          strlen(destination) + 1);
+                          destination, strlen(destination) + 1);
   if(bundle) {
     struct Curl_llist_node *curr = Curl_llist_head(&bundle->conns);
     while(curr) {

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1447,9 +1447,9 @@ CURLcode Curl_meta_set(struct Curl_easy *data, const char *key,
                        void *meta_data, Curl_meta_dtor *meta_dtor)
 {
   DEBUGASSERT(meta_data); /* never set to NULL */
-  if(!Curl_hash_add2(&data->meta_hash, CURL_UNCONST(key), strlen(key) + 1,
+  if(!Curl_hash_add2(&data->meta_hash, key, strlen(key) + 1,
                      meta_data, meta_dtor)) {
-    meta_dtor(CURL_UNCONST(key), strlen(key) + 1, meta_data);
+    meta_dtor(key, strlen(key) + 1, meta_data);
     return CURLE_OUT_OF_MEMORY;
   }
   return CURLE_OK;
@@ -1457,12 +1457,12 @@ CURLcode Curl_meta_set(struct Curl_easy *data, const char *key,
 
 void Curl_meta_remove(struct Curl_easy *data, const char *key)
 {
-  Curl_hash_delete(&data->meta_hash, CURL_UNCONST(key), strlen(key) + 1);
+  Curl_hash_delete(&data->meta_hash, key, strlen(key) + 1);
 }
 
 void *Curl_meta_get(struct Curl_easy *data, const char *key)
 {
-  return Curl_hash_pick(&data->meta_hash, CURL_UNCONST(key), strlen(key) + 1);
+  return Curl_hash_pick(&data->meta_hash, key, strlen(key) + 1);
 }
 
 void Curl_meta_reset(struct Curl_easy *data)

--- a/lib/file.c
+++ b/lib/file.c
@@ -90,7 +90,7 @@ static void file_cleanup(struct FILEPROTO *file)
   }
 }
 
-static void file_easy_dtor(void *key, size_t klen, void *entry)
+static void file_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct FILEPROTO *file = entry;
   (void)key;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4369,7 +4369,7 @@ static CURLcode ftp_doing(struct Curl_easy *data,
   return result;
 }
 
-static void ftp_easy_dtor(void *key, size_t klen, void *entry)
+static void ftp_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct FTP *ftp = entry;
   (void)key;
@@ -4378,7 +4378,7 @@ static void ftp_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(ftp);
 }
 
-static void ftp_conn_dtor(void *key, size_t klen, void *entry)
+static void ftp_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct ftp_conn *ftpc = entry;
   (void)key;

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -33,13 +33,13 @@
 #define ITERINIT 0x5FEDCBA9
 #endif
 
-typedef size_t (*hash_function)(void *key,
+typedef size_t (*hash_function)(const void *key,
                                 size_t key_length,
                                 size_t slots_num);
 
-typedef size_t (*comp_function)(void *key1,
+typedef size_t (*comp_function)(const void *key1,
                                 size_t key1_len,
-                                void *key2,
+                                const void *key2,
                                 size_t key2_len);
 
 /* Curl_hash stores its type in a uint8_t. */
@@ -57,7 +57,8 @@ static char *hash_elem_key(struct Curl_hash_element *he)
   return (char *)he + offsetof(struct Curl_hash_element, key);
 }
 
-static size_t hash_socket(void *key, size_t key_length, size_t slots_num)
+static size_t hash_socket(const void *key, size_t key_length,
+                          size_t slots_num)
 {
   curl_socket_t socket;
 
@@ -68,8 +69,8 @@ static size_t hash_socket(void *key, size_t key_length, size_t slots_num)
   return (size_t)(socket % (curl_socket_t)slots_num);
 }
 
-static size_t compare_socket(void *key1, size_t key1_len,
-                             void *key2, size_t key2_len)
+static size_t compare_socket(const void *key1, size_t key1_len,
+                             const void *key2, size_t key2_len)
 {
   curl_socket_t socket1;
   curl_socket_t socket2;
@@ -81,8 +82,8 @@ static size_t compare_socket(void *key1, size_t key1_len,
   return socket1 == socket2;
 }
 
-static size_t compare_bytes(void *key1, size_t key1_len,
-                            void *key2, size_t key2_len)
+static size_t compare_bytes(const void *key1, size_t key1_len,
+                            const void *key2, size_t key2_len)
 {
   return (key1_len == key2_len) && !memcmp(key1, key2, key1_len);
 }
@@ -171,7 +172,7 @@ void Curl_hash_init(struct Curl_hash *h,
 
 static struct Curl_hash_element *hash_elem_create(const void *key,
                                                   size_t key_len,
-                                                  const void *p,
+                                                  void *p,
                                                   Curl_hash_elem_dtor dtor)
 {
   struct Curl_hash_element *he;
@@ -183,7 +184,7 @@ static struct Curl_hash_element *hash_elem_create(const void *key,
     /* copy the key */
     memcpy(hash_elem_key(he), key, key_len);
     he->key_len = key_len;
-    he->ptr = CURL_UNCONST(p);
+    he->ptr = p;
     he->dtor = dtor;
   }
   return he;
@@ -227,7 +228,8 @@ static void hash_elem_link(struct Curl_hash *h,
   ++h->size;
 }
 
-void *Curl_hash_add2(struct Curl_hash *h, void *key, size_t key_len, void *p,
+void *Curl_hash_add2(struct Curl_hash *h,
+                     const void *key, size_t key_len, void *p,
                      Curl_hash_elem_dtor dtor)
 {
   const struct hash_functions *functions;
@@ -272,7 +274,8 @@ void *Curl_hash_add2(struct Curl_hash *h, void *key, size_t key_len, void *p,
  * @unittest: 1602
  * @unittest: 1603
  */
-void *Curl_hash_add(struct Curl_hash *h, void *key, size_t key_len, void *p)
+void *Curl_hash_add(struct Curl_hash *h,
+                    const void *key, size_t key_len, void *p)
 {
   return Curl_hash_add2(h, key, key_len, p, NULL);
 }
@@ -282,7 +285,7 @@ void *Curl_hash_add(struct Curl_hash *h, void *key, size_t key_len, void *p)
  *
  * @unittest: 1603
  */
-int Curl_hash_delete(struct Curl_hash *h, void *key, size_t key_len)
+int Curl_hash_delete(struct Curl_hash *h, const void *key, size_t key_len)
 {
   const struct hash_functions *functions;
 
@@ -313,7 +316,7 @@ int Curl_hash_delete(struct Curl_hash *h, void *key, size_t key_len)
  *
  * @unittest: 1603
  */
-void *Curl_hash_pick(struct Curl_hash *h, void *key, size_t key_len)
+void *Curl_hash_pick(struct Curl_hash *h, const void *key, size_t key_len)
 {
   const struct hash_functions *functions;
 
@@ -406,7 +409,7 @@ void Curl_hash_clean_with_criterium(struct Curl_hash *h, void *user,
   }
 }
 
-size_t Curl_hash_str(void *key, size_t key_length, size_t slots_num)
+size_t Curl_hash_str(const void *key, size_t key_length, size_t slots_num)
 {
   const char *key_str = (const char *)key;
   const char *end = key_str + key_length;

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -27,7 +27,7 @@
 
 typedef void (*Curl_hash_dtor)(void *);
 
-typedef void (*Curl_hash_elem_dtor)(void *key, size_t key_len, void *p);
+typedef void (*Curl_hash_elem_dtor)(const void *key, size_t key_len, void *p);
 
 /* How keys in a hash are interpreted. */
 typedef enum {
@@ -70,18 +70,20 @@ void Curl_hash_init(struct Curl_hash *h,
                     Curl_hash_type type,
                     Curl_hash_dtor dtor);
 
-void *Curl_hash_add(struct Curl_hash *h, void *key, size_t key_len, void *p);
-void *Curl_hash_add2(struct Curl_hash *h, void *key, size_t key_len, void *p,
+void *Curl_hash_add(struct Curl_hash *h,
+                    const void *key, size_t key_len, void *p);
+void *Curl_hash_add2(struct Curl_hash *h,
+                     const void *key, size_t key_len, void *p,
                      Curl_hash_elem_dtor dtor);
-int Curl_hash_delete(struct Curl_hash *h, void *key, size_t key_len);
-void *Curl_hash_pick(struct Curl_hash *h, void *key, size_t key_len);
+int Curl_hash_delete(struct Curl_hash *h, const void *key, size_t key_len);
+void *Curl_hash_pick(struct Curl_hash *h, const void *key, size_t key_len);
 
 void Curl_hash_destroy(struct Curl_hash *h);
 size_t Curl_hash_count(struct Curl_hash *h);
 void Curl_hash_clean(struct Curl_hash *h);
 void Curl_hash_clean_with_criterium(struct Curl_hash *h, void *user,
                                     int (*comp)(void *, void *));
-size_t Curl_hash_str(void *key, size_t key_length, size_t slots_num);
+size_t Curl_hash_str(const void *key, size_t key_length, size_t slots_num);
 void Curl_hash_start_iterate(struct Curl_hash *hash,
                              struct Curl_hash_iterator *iter);
 struct Curl_hash_element *Curl_hash_next_element(

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -2237,7 +2237,7 @@ static CURLcode imap_doing(struct Curl_easy *data, bool *dophase_done)
   return result;
 }
 
-static void imap_easy_dtor(void *key, size_t klen, void *entry)
+static void imap_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct IMAP *imap = entry;
   (void)key;
@@ -2246,7 +2246,7 @@ static void imap_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(imap);
 }
 
-static void imap_conn_dtor(void *key, size_t klen, void *entry)
+static void imap_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct imap_conn *imapc = entry;
   (void)key;

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -91,7 +91,7 @@ struct MQTT {
   BIT(pingsent); /* 1 while we wait for ping response */
 };
 
-static void mqtt_easy_dtor(void *key, size_t klen, void *entry)
+static void mqtt_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct MQTT *mq = entry;
   (void)key;
@@ -101,7 +101,7 @@ static void mqtt_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(mq);
 }
 
-static void mqtt_conn_dtor(void *key, size_t klen, void *entry)
+static void mqtt_conn_dtor(const void *key, size_t klen, void *entry)
 {
   (void)key;
   (void)klen;

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -73,7 +73,7 @@ static struct mev_sh_entry *mev_sh_entry_get(struct Curl_hash *sh,
 {
   if(s != CURL_SOCKET_BAD) {
     /* only look for proper sockets */
-    return Curl_hash_pick(sh, (char *)&s, sizeof(curl_socket_t));
+    return Curl_hash_pick(sh, (const char *)&s, sizeof(curl_socket_t));
   }
   return NULL;
 }
@@ -433,7 +433,7 @@ static CURLMcode mev_pollset_diff(struct Curl_multi *multi,
   return CURLM_OK;
 }
 
-static void mev_pollset_dtor(void *key, size_t klen, void *entry)
+static void mev_pollset_dtor(const void *key, size_t klen, void *entry)
 {
   struct easy_pollset *ps = entry;
   (void)key;

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -554,7 +554,7 @@ static CURLcode oldap_perform_starttls(struct Curl_easy *data)
 }
 #endif
 
-static void oldap_easy_dtor(void *key, size_t klen, void *entry)
+static void oldap_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct ldapreqinfo *lr = entry;
   (void)key;
@@ -562,7 +562,7 @@ static void oldap_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(lr);
 }
 
-static void oldap_conn_dtor(void *key, size_t klen, void *entry)
+static void oldap_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct ldapconninfo *li = entry;
   (void)key;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1650,7 +1650,7 @@ static CURLcode pop3_doing(struct Curl_easy *data, bool *dophase_done)
   return result;
 }
 
-static void pop3_easy_dtor(void *key, size_t klen, void *entry)
+static void pop3_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct POP3 *pop3 = entry;
   (void)key;
@@ -1662,7 +1662,7 @@ static void pop3_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(pop3);
 }
 
-static void pop3_conn_dtor(void *key, size_t klen, void *entry)
+static void pop3_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct pop3_conn *pop3c = entry;
   (void)key;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -85,7 +85,7 @@ static CURLcode rtsp_do_pollset(struct Curl_easy *data,
 
 #define MAX_RTP_BUFFERSIZE 1000000 /* arbitrary */
 
-static void rtsp_easy_dtor(void *key, size_t klen, void *entry)
+static void rtsp_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct RTSP *rtsp = entry;
   (void)key;
@@ -93,7 +93,7 @@ static void rtsp_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(rtsp);
 }
 
-static void rtsp_conn_dtor(void *key, size_t klen, void *entry)
+static void rtsp_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct rtsp_conn *rtspc = entry;
   (void)key;

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -371,7 +371,7 @@ static void request_state(struct Curl_easy *data,
   }
 }
 
-static void smb_easy_dtor(void *key, size_t klen, void *entry)
+static void smb_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct smb_request *req = entry;
   (void)key;
@@ -380,7 +380,7 @@ static void smb_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(req);
 }
 
-static void smb_conn_dtor(void *key, size_t klen, void *entry)
+static void smb_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct smb_conn *smbc = entry;
   (void)key;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1947,7 +1947,7 @@ static CURLcode smtp_doing(struct Curl_easy *data, bool *dophase_done)
   return result;
 }
 
-static void smtp_easy_dtor(void *key, size_t klen, void *entry)
+static void smtp_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct SMTP *smtp = entry;
   (void)key;
@@ -1955,7 +1955,7 @@ static void smtp_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(smtp);
 }
 
-static void smtp_conn_dtor(void *key, size_t klen, void *entry)
+static void smtp_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct smtp_conn *smtpc = entry;
   (void)key;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -167,7 +167,7 @@ static void printoption(struct Curl_easy *data,
 }
 #endif /* !CURLVERBOSE */
 
-static void telnet_easy_dtor(void *key, size_t klen, void *entry)
+static void telnet_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct TELNET *tn = entry;
   (void)key;

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -883,7 +883,7 @@ static CURLcode tftp_state_machine(struct tftp_conn *state,
   return result;
 }
 
-static void tftp_conn_dtor(void *key, size_t klen, void *entry)
+static void tftp_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct tftp_conn *state = entry;
   (void)key;

--- a/lib/url.c
+++ b/lib/url.c
@@ -2549,9 +2549,9 @@ void Curl_data_priority_clear_state(struct Curl_easy *data)
 CURLcode Curl_conn_meta_set(struct connectdata *conn, const char *key,
                             void *meta_data, Curl_meta_dtor *meta_dtor)
 {
-  if(!Curl_hash_add2(&conn->meta_hash, CURL_UNCONST(key), strlen(key) + 1,
+  if(!Curl_hash_add2(&conn->meta_hash, key, strlen(key) + 1,
                      meta_data, meta_dtor)) {
-    meta_dtor(CURL_UNCONST(key), strlen(key) + 1, meta_data);
+    meta_dtor(key, strlen(key) + 1, meta_data);
     return CURLE_OUT_OF_MEMORY;
   }
   return CURLE_OK;
@@ -2559,12 +2559,12 @@ CURLcode Curl_conn_meta_set(struct connectdata *conn, const char *key,
 
 void Curl_conn_meta_remove(struct connectdata *conn, const char *key)
 {
-  Curl_hash_delete(&conn->meta_hash, CURL_UNCONST(key), strlen(key) + 1);
+  Curl_hash_delete(&conn->meta_hash, key, strlen(key) + 1);
 }
 
 void *Curl_conn_meta_get(struct connectdata *conn, const char *key)
 {
-  return Curl_hash_pick(&conn->meta_hash, CURL_UNCONST(key), strlen(key) + 1);
+  return Curl_hash_pick(&conn->meta_hash, key, strlen(key) + 1);
 }
 
 struct Curl_easy *Curl_get_admin(struct Curl_easy *data)

--- a/lib/url.h
+++ b/lib/url.h
@@ -48,7 +48,7 @@ CURLcode Curl_parse_login_details(const char *login, const size_t len,
 /* Attach/Clear/Get meta data for an easy handle. Needs to provide
  * a destructor, will be automatically called when the easy handle
  * is reset or closed. */
-typedef void Curl_meta_dtor(void *key, size_t key_len, void *meta_data);
+typedef void Curl_meta_dtor(const void *key, size_t key_len, void *meta_data);
 
 /* Set the transfer meta data for the key. Any existing entry for that
  * key will be destroyed.

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -150,7 +150,7 @@ bool Curl_auth_allowed_to_origin(struct Curl_easy *data,
 }
 
 #ifdef USE_NTLM
-static void ntlm_conn_dtor(void *key, size_t klen, void *entry)
+static void ntlm_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct ntlmdata *ntlm = entry;
   (void)key;
@@ -180,7 +180,7 @@ void Curl_auth_ntlm_remove(struct connectdata *conn, bool proxy)
 #endif /* USE_NTLM */
 
 #ifdef USE_KERBEROS5
-static void krb5_conn_dtor(void *key, size_t klen, void *entry)
+static void krb5_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct kerberos5data *krb5 = entry;
   (void)key;
@@ -204,7 +204,7 @@ struct kerberos5data *Curl_auth_krb5_get(struct connectdata *conn)
 #endif /* USE_KERBEROS5 */
 
 #ifdef USE_GSASL
-static void gsasl_conn_dtor(void *key, size_t klen, void *entry)
+static void gsasl_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct gsasldata *gsasl = entry;
   (void)key;
@@ -228,7 +228,7 @@ struct gsasldata *Curl_auth_gsasl_get(struct connectdata *conn)
 #endif /* USE_GSASL */
 
 #ifdef USE_SPNEGO
-static void nego_conn_dtor(void *key, size_t klen, void *entry)
+static void nego_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct negotiatedata *nego = entry;
   (void)key;

--- a/lib/vdns/doh.c
+++ b/lib/vdns/doh.c
@@ -210,7 +210,7 @@ static size_t doh_probe_write_cb(char *contents, size_t size, size_t nmemb,
 
 static void doh_probe_done(struct Curl_easy *doh,
                            struct Curl_easy *master, CURLcode result);
-static void doh_probe_dtor(void *key, size_t klen, void *e)
+static void doh_probe_dtor(const void *key, size_t klen, void *e)
 {
   (void)key;
   (void)klen;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2506,7 +2506,7 @@ static CURLcode myssh_block_statemach(struct Curl_easy *data,
   return result;
 }
 
-static void myssh_easy_dtor(void *key, size_t klen, void *entry)
+static void myssh_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct SSHPROTO *sshp = entry;
   (void)key;
@@ -2515,7 +2515,7 @@ static void myssh_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(sshp);
 }
 
-static void myssh_conn_dtor(void *key, size_t klen, void *entry)
+static void myssh_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct ssh_conn *sshc = entry;
   (void)key;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3236,7 +3236,7 @@ static CURLcode ssh_block_statemach(struct Curl_easy *data,
   return result;
 }
 
-static void myssh_easy_dtor(void *key, size_t klen, void *entry)
+static void myssh_easy_dtor(const void *key, size_t klen, void *entry)
 {
   struct SSHPROTO *sshp = entry;
   (void)key;
@@ -3247,7 +3247,7 @@ static void myssh_easy_dtor(void *key, size_t klen, void *entry)
   curlx_free(sshp);
 }
 
-static void myssh_conn_dtor(void *key, size_t klen, void *entry)
+static void myssh_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct ssh_conn *sshc = entry;
   (void)key;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -596,7 +596,7 @@ static struct gtls_shared_creds *gtls_get_cached_creds(struct Curl_cfilter *cf,
 
   if(data->multi) {
     shared_creds = Curl_hash_pick(&data->multi->proto_hash,
-                                  CURL_UNCONST(MPROTO_GTLS_X509_KEY),
+                                  MPROTO_GTLS_X509_KEY,
                                   CURL_CSTRLEN(MPROTO_GTLS_X509_KEY));
     if(shared_creds && shared_creds->creds &&
        !gtls_shared_creds_expired(data, shared_creds) &&
@@ -640,7 +640,7 @@ static void gtls_set_cached_creds(struct Curl_cfilter *cf,
     return;
 
   if(!Curl_hash_add2(&data->multi->proto_hash,
-                     CURL_UNCONST(MPROTO_GTLS_X509_KEY),
+                     MPROTO_GTLS_X509_KEY,
                      CURL_CSTRLEN(MPROTO_GTLS_X509_KEY),
                      sc, gtls_shared_creds_hash_free)) {
     Curl_gtls_shared_creds_free(&sc); /* down reference again */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -607,7 +607,8 @@ static struct gtls_shared_creds *gtls_get_cached_creds(struct Curl_cfilter *cf,
   return NULL;
 }
 
-static void gtls_shared_creds_hash_free(void *key, size_t key_len, void *p)
+static void gtls_shared_creds_hash_free(const void *key,
+                                        size_t key_len, void *p)
 {
   struct gtls_shared_creds *sc = p;
   DEBUGASSERT(key_len == CURL_CSTRLEN(MPROTO_GTLS_X509_KEY));

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3159,7 +3159,7 @@ struct ossl_x509_share {
   BIT(no_partialchain); /* keep partial chain state */
 };
 
-static void oss_x509_share_free(void *key, size_t key_len, void *p)
+static void oss_x509_share_free(const void *key, size_t key_len, void *p)
 {
   struct ossl_x509_share *share = p;
   DEBUGASSERT(key_len == CURL_CSTRLEN(MPROTO_OSSL_X509_KEY));
@@ -3211,7 +3211,7 @@ static X509_STORE *ossl_get_cached_x509_store(struct Curl_cfilter *cf,
   DEBUGASSERT(multi);
   *pempty = TRUE;
   share = multi ? Curl_hash_pick(&multi->proto_hash,
-                                 CURL_UNCONST(MPROTO_OSSL_X509_KEY),
+                                 MPROTO_OSSL_X509_KEY,
                                  CURL_CSTRLEN(MPROTO_OSSL_X509_KEY)) : NULL;
   if(share && share->store &&
      !ossl_cached_x509_store_expired(data, share) &&
@@ -3236,7 +3236,7 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
   if(!multi)
     return;
   share = Curl_hash_pick(&multi->proto_hash,
-                         CURL_UNCONST(MPROTO_OSSL_X509_KEY),
+                         MPROTO_OSSL_X509_KEY,
                          CURL_CSTRLEN(MPROTO_OSSL_X509_KEY));
 
   if(!share) {
@@ -3244,7 +3244,7 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
     if(!share)
       return;
     if(!Curl_hash_add2(&multi->proto_hash,
-                       CURL_UNCONST(MPROTO_OSSL_X509_KEY),
+                       MPROTO_OSSL_X509_KEY,
                        CURL_CSTRLEN(MPROTO_OSSL_X509_KEY),
                        share, oss_x509_share_free)) {
       curlx_free(share);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2737,7 +2737,7 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
   }
 
   share = Curl_hash_pick(&multi->proto_hash,
-                         CURL_UNCONST(MPROTO_SCHANNEL_CERT_SHARE_KEY),
+                         MPROTO_SCHANNEL_CERT_SHARE_KEY,
                          CURL_CSTRLEN(MPROTO_SCHANNEL_CERT_SHARE_KEY));
   if(!share || !share->cert_store) {
     return NULL;
@@ -2829,7 +2829,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   }
 
   share = Curl_hash_pick(&multi->proto_hash,
-                         CURL_UNCONST(MPROTO_SCHANNEL_CERT_SHARE_KEY),
+                         MPROTO_SCHANNEL_CERT_SHARE_KEY,
                          CURL_CSTRLEN(MPROTO_SCHANNEL_CERT_SHARE_KEY));
   if(!share) {
     share = curlx_calloc(1, sizeof(*share));
@@ -2838,7 +2838,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
       return FALSE;
     }
     if(!Curl_hash_add2(&multi->proto_hash,
-                       CURL_UNCONST(MPROTO_SCHANNEL_CERT_SHARE_KEY),
+                       MPROTO_SCHANNEL_CERT_SHARE_KEY,
                        CURL_CSTRLEN(MPROTO_SCHANNEL_CERT_SHARE_KEY),
                        share, schannel_cert_share_free)) {
       curlx_free(share);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2784,7 +2784,7 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
   return share->cert_store;
 }
 
-static void schannel_cert_share_free(void *key, size_t key_len, void *p)
+static void schannel_cert_share_free(const void *key, size_t key_len, void *p)
 {
   struct schannel_cert_share *share = p;
   DEBUGASSERT(key_len == CURL_CSTRLEN(MPROTO_SCHANNEL_CERT_SHARE_KEY));

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -680,7 +680,7 @@ struct wssl_x509_share {
   struct curltime time;      /* when the cached store was created */
 };
 
-static void wssl_x509_share_free(void *key, size_t key_len, void *p)
+static void wssl_x509_share_free(const void *key, size_t key_len, void *p)
 {
   struct wssl_x509_share *share = p;
   DEBUGASSERT(key_len == CURL_CSTRLEN(MPROTO_WSSL_X509_KEY));

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -725,7 +725,7 @@ static WOLFSSL_X509_STORE *wssl_get_cached_x509_store(struct Curl_cfilter *cf,
 
   DEBUGASSERT(multi);
   share = multi ? Curl_hash_pick(&multi->proto_hash,
-                                 CURL_UNCONST(MPROTO_WSSL_X509_KEY),
+                                 MPROTO_WSSL_X509_KEY,
                                  CURL_CSTRLEN(MPROTO_WSSL_X509_KEY)) : NULL;
   if(share && share->store &&
      !wssl_cached_x509_store_expired(data, share) &&
@@ -748,7 +748,7 @@ static void wssl_set_cached_x509_store(struct Curl_cfilter *cf,
   if(!multi)
     return;
   share = Curl_hash_pick(&multi->proto_hash,
-                         CURL_UNCONST(MPROTO_WSSL_X509_KEY),
+                         MPROTO_WSSL_X509_KEY,
                          CURL_CSTRLEN(MPROTO_WSSL_X509_KEY));
 
   if(!share) {
@@ -756,7 +756,7 @@ static void wssl_set_cached_x509_store(struct Curl_cfilter *cf,
     if(!share)
       return;
     if(!Curl_hash_add2(&multi->proto_hash,
-                       CURL_UNCONST(MPROTO_WSSL_X509_KEY),
+                       MPROTO_WSSL_X509_KEY,
                        CURL_CSTRLEN(MPROTO_WSSL_X509_KEY),
                        share, wssl_x509_share_free)) {
       curlx_free(share);

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1360,7 +1360,7 @@ CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req)
   return result;
 }
 
-static void ws_conn_dtor(void *key, size_t klen, void *entry)
+static void ws_conn_dtor(const void *key, size_t klen, void *entry)
 {
   struct websocket *ws = entry;
   (void)key;

--- a/tests/unit/unit1603.c
+++ b/tests/unit/unit1603.c
@@ -34,7 +34,7 @@ static void t1603_mydtor(void *p)
 
 static size_t elem_dtor_calls;
 
-static void my_elem_dtor(void *key, size_t key_len, void *p)
+static void my_elem_dtor(const void *key, size_t key_len, void *p)
 {
   (void)p;
   (void)key;


### PR DESCRIPTION
hash.h functions had `void *key` as argument in several functions and those should be `const void *key` instead as they are not modified.

Saves a ton of `CURL_UNCONST` use, often on string constants where they are definitely not wanted.

