### PR TITLE
netrc: survive comment-only .netrc file

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -562,6 +562,8 @@ static NETRCcode netrc_scan_file(struct Curl_easy *data,
     }
     store->loaded = TRUE;
   }
+  if(!curlx_dyn_len(filebuf))
+    return NETRC_NO_MATCH;
 
   return netrc_scan(data, curlx_dyn_ptr(filebuf), hostname, user, pcreds);
 }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -1967,6 +1967,7 @@ TESTCASES = \
   test2412 \
   test2413 \
   test2414 \
+  test2429 \
   test2453 \
   \
   test2500 \

--- a/tests/data/test2429
+++ b/tests/data/test2429
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+netrc
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="headers">
+HTTP/1.1 200 OK
+Content-Length: 6
+Content-Type: text/html
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+use netrc file with only comments
+</name>
+<file name="%LOGDIR/netrc" nonewline="yes">
+# only a comment line
+</file>
+
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --netrc --netrc-file %LOGDIR/netrc
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="headers">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
A .netrc file with only a comment and no newline caused an NULL dereference

Verify with test 2429

Reported-by: Max Dymond
