### PR TITLE
mulit_ev: remove socket references on forget

### DIFF
--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -253,7 +253,7 @@ static CURLMcode mev_forget_socket(struct Curl_multi *multi,
       if(sdata) {
         struct easy_pollset *ps = mev_get_last_pollset(sdata, NULL);
         if(ps)
-          (void)Curl_pollset_remove(sdata, ps, s);
+          Curl_pollset_remove(ps, s);
       }
     } while(Curl_uint32_spbset_next(&entry->xfers, mid, &mid));
   }
@@ -261,7 +261,7 @@ static CURLMcode mev_forget_socket(struct Curl_multi *multi,
   if(entry->conn) {
     struct easy_pollset *ps = mev_get_last_pollset(data, entry->conn);
     if(ps)
-      (void)Curl_pollset_remove(data, ps, s);
+      Curl_pollset_remove(ps, s);
   }
 
   mev_sh_entry_kill(multi, s);

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -231,21 +231,6 @@ static CURLMcode mev_forget_socket(struct Curl_multi *multi,
   if(!entry) /* we never knew or already forgot about this socket */
     return CURLM_OK;
 
-  /* We managed this socket before, tell the socket callback to forget it. */
-  if(entry->announced && multi->socket_cb) {
-    struct Curl_mapi_guard guard;
-
-    NOVERBOSE((void)cause);
-    CURL_TRC_M(data, "ev %s, call(fd=%" FMT_SOCKET_T ", ev=REMOVE)", cause, s);
-    CURL_CBAPI_MULTI_START(&guard, multi, multi_socket_cb);
-    rc = multi->socket_cb(data, s, CURL_POLL_REMOVE,
-                          multi->socket_userp, entry->user_data);
-    CURL_CBAPI_END(&guard);
-    entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
-    if(entry)
-      entry->announced = FALSE;
-  }
-
   /* Remove the socket from any pollset that is still registered. */
   if(Curl_uint32_spbset_first(&entry->xfers, &mid)) {
     do {
@@ -262,6 +247,21 @@ static CURLMcode mev_forget_socket(struct Curl_multi *multi,
     struct easy_pollset *ps = mev_get_last_pollset(data, entry->conn);
     if(ps)
       Curl_pollset_remove(ps, s);
+  }
+
+  /* We managed this socket before, tell the socket callback to forget it. */
+  if(entry->announced && multi->socket_cb) {
+    struct Curl_mapi_guard guard;
+
+    NOVERBOSE((void)cause);
+    CURL_TRC_M(data, "ev %s, call(fd=%" FMT_SOCKET_T ", ev=REMOVE)", cause, s);
+    CURL_CBAPI_MULTI_START(&guard, multi, multi_socket_cb);
+    rc = multi->socket_cb(data, s, CURL_POLL_REMOVE,
+                          multi->socket_userp, entry->user_data);
+    CURL_CBAPI_END(&guard);
+    entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+    if(entry)
+      entry->announced = FALSE;
   }
 
   mev_sh_entry_kill(multi, s);

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -131,6 +131,52 @@ static bool mev_sh_entry_conn_known(struct mev_sh_entry *e,
   return (e->conn == conn);
 }
 
+static void mev_pollset_dtor(const void *key, size_t klen, void *entry)
+{
+  struct easy_pollset *ps = entry;
+  (void)key;
+  (void)klen;
+  if(ps) {
+    Curl_pollset_cleanup(ps);
+    curlx_free(ps);
+  }
+}
+
+static struct easy_pollset *mev_add_new_conn_pollset(struct connectdata *conn)
+{
+  struct easy_pollset *ps;
+
+  ps = Curl_pollset_create();
+  if(!ps)
+    return NULL;
+  if(Curl_conn_meta_set(conn, CURL_META_MEV_POLLSET, ps, mev_pollset_dtor))
+    return NULL;
+  return ps;
+}
+
+static struct easy_pollset *mev_add_new_xfer_pollset(struct Curl_easy *data)
+{
+  struct easy_pollset *ps;
+
+  ps = Curl_pollset_create();
+  if(!ps)
+    return NULL;
+  if(Curl_meta_set(data, CURL_META_MEV_POLLSET, ps, mev_pollset_dtor))
+    return NULL;
+  return ps;
+}
+
+static struct easy_pollset *mev_get_last_pollset(struct Curl_easy *data,
+                                                 struct connectdata *conn)
+{
+  if(data) {
+    if(conn)
+      return Curl_conn_meta_get(conn, CURL_META_MEV_POLLSET);
+    return Curl_meta_get(data, CURL_META_MEV_POLLSET);
+  }
+  return NULL;
+}
+
 static bool mev_sh_entry_xfer_add(struct mev_sh_entry *e,
                                   struct Curl_easy *data)
 {
@@ -179,6 +225,7 @@ static CURLMcode mev_forget_socket(struct Curl_multi *multi,
                                    const char *cause)
 {
   struct mev_sh_entry *entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+  uint32_t mid;
   int rc = 0;
 
   if(!entry) /* we never knew or already forgot about this socket */
@@ -197,6 +244,24 @@ static CURLMcode mev_forget_socket(struct Curl_multi *multi,
     entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
     if(entry)
       entry->announced = FALSE;
+  }
+
+  /* Remove the socket from any pollset that is still registered. */
+  if(Curl_uint32_spbset_first(&entry->xfers, &mid)) {
+    do {
+      struct Curl_easy *sdata = Curl_multi_get_easy(multi, mid);
+      if(sdata) {
+        struct easy_pollset *ps = mev_get_last_pollset(sdata, NULL);
+        if(ps)
+          (void)Curl_pollset_remove(sdata, ps, s);
+      }
+    } while(Curl_uint32_spbset_next(&entry->xfers, mid, &mid));
+  }
+
+  if(entry->conn) {
+    struct easy_pollset *ps = mev_get_last_pollset(data, entry->conn);
+    if(ps)
+      (void)Curl_pollset_remove(data, ps, s);
   }
 
   mev_sh_entry_kill(multi, s);
@@ -431,52 +496,6 @@ static CURLMcode mev_pollset_diff(struct Curl_multi *multi,
   /* Remember for next time */
   Curl_pollset_move(prev_ps, ps);
   return CURLM_OK;
-}
-
-static void mev_pollset_dtor(const void *key, size_t klen, void *entry)
-{
-  struct easy_pollset *ps = entry;
-  (void)key;
-  (void)klen;
-  if(ps) {
-    Curl_pollset_cleanup(ps);
-    curlx_free(ps);
-  }
-}
-
-static struct easy_pollset *mev_add_new_conn_pollset(struct connectdata *conn)
-{
-  struct easy_pollset *ps;
-
-  ps = Curl_pollset_create();
-  if(!ps)
-    return NULL;
-  if(Curl_conn_meta_set(conn, CURL_META_MEV_POLLSET, ps, mev_pollset_dtor))
-    return NULL;
-  return ps;
-}
-
-static struct easy_pollset *mev_add_new_xfer_pollset(struct Curl_easy *data)
-{
-  struct easy_pollset *ps;
-
-  ps = Curl_pollset_create();
-  if(!ps)
-    return NULL;
-  if(Curl_meta_set(data, CURL_META_MEV_POLLSET, ps, mev_pollset_dtor))
-    return NULL;
-  return ps;
-}
-
-static struct easy_pollset *mev_get_last_pollset(struct Curl_easy *data,
-                                                 struct connectdata *conn)
-{
-  if(data) {
-    if(conn)
-      return Curl_conn_meta_get(conn, CURL_META_MEV_POLLSET);
-    return Curl_meta_get(data, CURL_META_MEV_POLLSET);
-  }
-  return NULL;
 }
 
 static CURLMcode mev_assess(struct Curl_multi *multi,

--- a/lib/select.c
+++ b/lib/select.c
@@ -632,6 +632,23 @@ CURLcode Curl_pollset_set(struct Curl_easy *data,
                              (!do_out ? CURL_POLL_OUT : 0));
 }
 
+void Curl_pollset_remove(struct easy_pollset *ps, curl_socket_t sock)
+{
+  int i;
+  for(i = 0; i < ps->n; ++i) {
+    if(ps->sockets[i] == sock) {
+      if((i + 1) < ps->n) {
+        memmove(&ps->sockets[i], &ps->sockets[i + 1],
+                (ps->n - (i + 1)) * sizeof(ps->sockets[0]));
+        memmove(&ps->actions[i], &ps->actions[i + 1],
+                (ps->n - (i + 1)) * sizeof(ps->actions[0]));
+      }
+      --ps->n;
+      return;
+    }
+  }
+}
+
 /*
  * Return values:
  *   -1 = error

--- a/lib/select.c
+++ b/lib/select.c
@@ -634,7 +634,7 @@ CURLcode Curl_pollset_set(struct Curl_easy *data,
 
 void Curl_pollset_remove(struct easy_pollset *ps, curl_socket_t sock)
 {
-  int i;
+  unsigned int i;
   for(i = 0; i < ps->n; ++i) {
     if(ps->sockets[i] == sock) {
       if((i + 1) < ps->n) {

--- a/lib/select.h
+++ b/lib/select.h
@@ -160,6 +160,8 @@ CURLcode Curl_pollset_set(struct Curl_easy *data,
   Curl_pollset_change(data, ps, sock, CURL_POLL_IN, 0)
 #define Curl_pollset_remove_in(data, ps, sock) \
   Curl_pollset_change(data, ps, sock, 0, CURL_POLL_IN)
+#define Curl_pollset_remove(data, ps, sock) \
+  Curl_pollset_change(data, ps, sock, 0, CURL_POLL_IN | CURL_POLL_OUT)
 #define Curl_pollset_add_out(data, ps, sock) \
   Curl_pollset_change(data, ps, sock, CURL_POLL_OUT, 0)
 #define Curl_pollset_remove_out(data, ps, sock) \

--- a/lib/select.h
+++ b/lib/select.h
@@ -160,8 +160,6 @@ CURLcode Curl_pollset_set(struct Curl_easy *data,
   Curl_pollset_change(data, ps, sock, CURL_POLL_IN, 0)
 #define Curl_pollset_remove_in(data, ps, sock) \
   Curl_pollset_change(data, ps, sock, 0, CURL_POLL_IN)
-#define Curl_pollset_remove(data, ps, sock) \
-  Curl_pollset_change(data, ps, sock, 0, CURL_POLL_IN | CURL_POLL_OUT)
 #define Curl_pollset_add_out(data, ps, sock) \
   Curl_pollset_change(data, ps, sock, CURL_POLL_OUT, 0)
 #define Curl_pollset_remove_out(data, ps, sock) \
@@ -172,6 +170,8 @@ CURLcode Curl_pollset_set(struct Curl_easy *data,
   Curl_pollset_change(data, ps, sock, CURL_POLL_IN, CURL_POLL_OUT)
 #define Curl_pollset_set_out_only(data, ps, sock) \
   Curl_pollset_change(data, ps, sock, CURL_POLL_OUT, CURL_POLL_IN)
+
+void Curl_pollset_remove(struct easy_pollset *ps, curl_socket_t sock);
 
 /* return < = on error, 0 on timeout or how many sockets are ready */
 int Curl_pollset_poll(struct Curl_easy *data,


### PR DESCRIPTION
When multi_ev is informed that a socket is about to be closed, it cleans up its entry for it (if it exists), but it did not remove it from any remembered "last pollset"s. When the OS reuses the file descriptor, this may lead to socket identity confusion on detecting changes of use.

Remove the socket from any pollset that is registered at the socket entry of multi_ev when a socket is being "forgotten".

Found-by: @cmeister2

