### PR TITLE
remove ssl_primary config from easy handle

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -414,8 +414,8 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
 #ifdef LDAP_OPT_X_TLS
     if(conn->ssl_config.verifypeer) {
       /* OpenLDAP SDK supports BASE64 files. */
-      if(data->set.ssl.primary.cert_type &&
-         !curl_strequal(data->set.ssl.primary.cert_type, "PEM")) {
+      if(conn->ssl_config.cert_type &&
+         !curl_strequal(conn->ssl_config.cert_type, "PEM")) {
         failf(data, "LDAP local: ERROR OpenLDAP only supports PEM cert-type");
         result = CURLE_SSL_CERTPROBLEM;
         goto quit;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -313,10 +313,10 @@ CURLcode Curl_setopt_SSLVERSION(struct Curl_easy *data, CURLoption option,
    */
   {
     long version, version_max;
-    struct ssl_primary_config *primary = &data->set.ssl.primary;
+    struct ssl_easy_config *sslc = &data->set.ssl;
 #ifndef CURL_DISABLE_PROXY
     if(option != CURLOPT_SSLVERSION)
-      primary = &data->set.proxy_ssl.primary;
+      sslc = &data->set.proxy_ssl;
 #else
     (void)option; /* unused */
 #endif
@@ -333,8 +333,8 @@ CURLcode Curl_setopt_SSLVERSION(struct Curl_easy *data, CURLoption option,
     if(version == CURL_SSLVERSION_DEFAULT)
       version = CURL_SSLVERSION_TLSv1_2;
 
-    primary->version = (unsigned char)version;
-    primary->version_max = (unsigned int)version_max;
+    sslc->version = (unsigned char)version;
+    sslc->version_max = (unsigned int)version_max;
   }
   return CURLE_OK;
 }
@@ -522,7 +522,7 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     /*
      * Enable peer SSL verifying for proxy.
      */
-    s->proxy_ssl.primary.verifypeer = enabled;
+    s->proxy_ssl.verifypeer = enabled;
 
     /* Update the current connection proxy_ssl_config. */
     Curl_ssl_conn_config_update(data, TRUE);
@@ -531,7 +531,7 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     /*
      * Enable verification of the hostname in the peer certificate for proxy
      */
-    s->proxy_ssl.primary.verifyhost = enabled;
+    s->proxy_ssl.verifyhost = enabled;
     ok = 2;
     /* Update the current connection proxy_ssl_config. */
     Curl_ssl_conn_config_update(data, TRUE);
@@ -616,7 +616,7 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     /*
      * Enable peer SSL verifying.
      */
-    s->ssl.primary.verifypeer = enabled;
+    s->ssl.verifypeer = enabled;
 
     /* Update the current connection ssl_config. */
     Curl_ssl_conn_config_update(data, FALSE);
@@ -654,7 +654,7 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     /* Obviously people are not reading documentation and too many thought
        this argument took a boolean when it was not and misused it.
        Treat 1 and 2 the same */
-    s->ssl.primary.verifyhost = enabled;
+    s->ssl.verifyhost = enabled;
     ok = 2;
 
     /* Update the current connection ssl_config. */
@@ -667,7 +667,7 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     if(!Curl_ssl_cert_status_request())
       return CURLE_NOT_BUILT_IN;
 
-    s->ssl.primary.verifystatus = enabled;
+    s->ssl.verifystatus = enabled;
 
     /* Update the current connection ssl_config. */
     Curl_ssl_conn_config_update(data, FALSE);
@@ -698,9 +698,9 @@ static CURLcode setopt_long_bool(struct Curl_easy *data, CURLoption option,
     s->ignorecl = enabled;
     break;
   case CURLOPT_SSL_SESSIONID_CACHE:
-    s->ssl.primary.cache_session = enabled;
+    s->ssl.cache_session = enabled;
 #ifndef CURL_DISABLE_PROXY
-    s->proxy_ssl.primary.cache_session = s->ssl.primary.cache_session;
+    s->proxy_ssl.cache_session = s->ssl.cache_session;
 #endif
     break;
 #ifdef USE_SSH
@@ -934,11 +934,11 @@ static CURLcode setopt_long_ssl(struct Curl_easy *data, CURLoption option,
       s->use_ssl = (unsigned char)arg;
     break;
   case CURLOPT_SSL_OPTIONS:
-    s->ssl.primary.ssl_options = (unsigned char)(arg & 0xff);
+    s->ssl.ssl_options = (unsigned char)(arg & 0xff);
     break;
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSL_OPTIONS:
-    s->proxy_ssl.primary.ssl_options = (unsigned char)(arg & 0xff);
+    s->proxy_ssl.ssl_options = (unsigned char)(arg & 0xff);
     break;
 #endif
   case CURLOPT_SSL_ENABLE_NPN:

--- a/lib/url.c
+++ b/lib/url.c
@@ -2367,7 +2367,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
 #endif
                                         needle);
     if(result) {
-      DEBUGF(infof(data, "Error: clone connection SSL config\n"));
+      DEBUGF(infof(data, "Error: clone connection SSL config"));
       goto out;
     }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -295,10 +295,6 @@ CURLcode Curl_close(struct Curl_easy **datap)
 #ifndef CURL_DISABLE_DIGEST_AUTH
   curlx_free(data->state.envproxy);
 #endif
-  Curl_ssl_config_cleanup(&data->set.ssl.primary);
-#ifndef CURL_DISABLE_PROXY
-  Curl_ssl_config_cleanup(&data->set.proxy_ssl.primary);
-#endif
   curlx_memzero(data, sizeof(*data));
   curlx_free(data);
   return CURLE_OK;
@@ -356,9 +352,9 @@ void Curl_init_userdefined(struct Curl_easy *data)
 
   set->httpauth = CURLAUTH_BASIC;  /* defaults to basic */
 
-  Curl_ssl_config_init(&data->set.ssl.primary);
+  Curl_ssl_config_init(&data->set.ssl);
 #ifndef CURL_DISABLE_PROXY
-  Curl_ssl_config_init(&data->set.proxy_ssl.primary);
+  Curl_ssl_config_init(&data->set.proxy_ssl);
   set->proxyport = 0;
   set->proxytype = CURLPROXY_HTTP; /* defaults to HTTP proxy */
   set->proxyauth = CURLAUTH_BASIC; /* defaults to basic */
@@ -582,6 +578,10 @@ struct url_conn_match {
   struct Curl_easy *data;
   struct connectdata *needle;
   struct curltime now;
+  struct ssl_filter_config ssl_config;
+#ifndef CURL_DISABLE_PROXY
+  struct ssl_filter_config proxy_ssl_config;
+#endif
   BIT(may_multiplex);
   BIT(want_ntlm_http);
   BIT(want_proxy_ntlm_http);
@@ -722,7 +722,7 @@ static bool url_match_ssl_use(struct connectdata *conn,
       return FALSE;
     /* We may reuse this as an auto-TLS upgrade, but only if the SSL
      * config parameters match. */
-    if(!Curl_ssl_conn_config_match(m->data, conn, FALSE))
+    if(!Curl_ssl_conn_config_match(m->data, &m->ssl_config, conn, FALSE))
       return FALSE;
   }
   else if(m->require_tls)
@@ -747,7 +747,8 @@ static bool url_match_proxy_use(struct connectdata *conn,
   if(CURL_PROXY_IS_HTTPS(m->needle->http_proxy.proxytype)) {
     /* https proxies come in different types, http/1.1, h2, ... */
     /* match SSL config to proxy */
-    if(!Curl_ssl_conn_config_match(m->data, conn, TRUE)) {
+    if(!Curl_ssl_conn_config_match(m->data, &m->proxy_ssl_config,
+                                   conn, TRUE)) {
       DEBUGF(infof(m->data,
                    "Connection #%" FMT_OFF_T
                    " has different SSL proxy parameters, cannot reuse",
@@ -886,7 +887,7 @@ static bool url_match_ssl_config(struct connectdata *conn,
 {
   /* If talking/upgrading to TLS, conn needs to use the same SSL options. */
   if(((m->needle->scheme->flags & PROTOPT_SSL) || m->may_tls) &&
-     !Curl_ssl_conn_config_match(m->data, conn, FALSE)) {
+     !Curl_ssl_conn_config_match(m->data, &m->ssl_config, conn, FALSE)) {
     DEBUGF(infof(m->data, "Connection #%" FMT_OFF_T
                  " has different SSL parameters, cannot reuse",
                  conn->connection_id));
@@ -1090,58 +1091,20 @@ static bool url_match_result(void *userdata)
  */
 static bool url_attach_existing(struct Curl_easy *data,
                                 struct connectdata *needle,
-                                bool *waitpipe)
+                                struct url_conn_match *m)
 {
   struct cpool *cpool = Curl_cpool_get_instance(data);
-  struct url_conn_match match;
   bool success;
 
   DEBUGASSERT(!data->conn);
 
-  memset(&match, 0, sizeof(match));
-  match.data = data;
-  match.needle = needle;
-  match.now = *Curl_pgrs_now(data);
-  match.may_multiplex = xfer_may_multiplex(data, needle);
-
   Curl_cpool_prune_dead(cpool, data);
-
-#ifdef USE_NTLM
-  match.want_ntlm_http =
-    (data->state.authhost.want & CURLAUTH_NTLM) &&
-    (needle->scheme->protocol & PROTO_FAMILY_HTTP) &&
-    Curl_auth_allowed_to_host(data);
-#ifndef CURL_DISABLE_PROXY
-  match.want_proxy_ntlm_http =
-    needle->http_proxy.creds &&
-    (data->state.authproxy.want & CURLAUTH_NTLM) &&
-    (needle->scheme->protocol & PROTO_FAMILY_HTTP);
-#endif
-#endif
-
-#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
-  match.want_nego_http =
-    (data->state.authhost.want & CURLAUTH_NEGOTIATE) &&
-    (needle->scheme->protocol & PROTO_FAMILY_HTTP) &&
-    Curl_auth_allowed_to_host(data);
-#ifndef CURL_DISABLE_PROXY
-  match.want_proxy_nego_http =
-    needle->http_proxy.creds &&
-    (data->state.authproxy.want & CURLAUTH_NEGOTIATE) &&
-    (needle->scheme->protocol & PROTO_FAMILY_HTTP);
-#endif
-#endif
-  match.require_tls = data->set.use_ssl >= CURLUSESSL_CONTROL;
-  match.may_tls = data->set.use_ssl > CURLUSESSL_NONE;
 
   /* Find a connection in the pool that matches what "data + needle"
    * requires. If a suitable candidate is found, it is attached to "data". */
   success = Curl_cpool_find(data, needle->destination,
-                            url_match_conn, url_match_result, &match);
+                            url_match_conn, url_match_result, m);
 
-  /* wait_pipe is TRUE if we encounter a bundle that is undecided. There
-   * is no matching connection then, yet. */
-  *waitpipe = (bool)match.wait_pipe;
   return success;
 }
 
@@ -2199,6 +2162,62 @@ out:
   return result;
 }
 
+static CURLcode url_match_init(struct Curl_easy *data,
+                               struct connectdata *needle,
+                               struct url_conn_match *m)
+{
+  memset(m, 0, sizeof(*m));
+  m->data = data;
+  m->needle = needle;
+  m->now = *Curl_pgrs_now(data);
+  m->may_multiplex = xfer_may_multiplex(data, needle);
+
+#ifdef USE_NTLM
+  m->want_ntlm_http =
+    (data->state.authhost.want & CURLAUTH_NTLM) &&
+    (needle->scheme->protocol & PROTO_FAMILY_HTTP) &&
+    Curl_auth_allowed_to_host(data);
+#ifndef CURL_DISABLE_PROXY
+  m->want_proxy_ntlm_http =
+    needle->http_proxy.creds &&
+    (data->state.authproxy.want & CURLAUTH_NTLM) &&
+    (needle->scheme->protocol & PROTO_FAMILY_HTTP);
+#endif
+#endif
+
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_SPNEGO)
+  m->want_nego_http =
+    (data->state.authhost.want & CURLAUTH_NEGOTIATE) &&
+    (needle->scheme->protocol & PROTO_FAMILY_HTTP) &&
+    Curl_auth_allowed_to_host(data);
+#ifndef CURL_DISABLE_PROXY
+  m->want_proxy_nego_http =
+    needle->http_proxy.creds &&
+    (data->state.authproxy.want & CURLAUTH_NEGOTIATE) &&
+    (needle->scheme->protocol & PROTO_FAMILY_HTTP);
+#endif
+#endif
+  m->require_tls = data->set.use_ssl >= CURLUSESSL_CONTROL;
+  m->may_tls = data->set.use_ssl > CURLUSESSL_NONE;
+
+  /* Complete the easy's SSL configuration for connection cache matching */
+  return Curl_ssl_easy_config_complete(data, needle->origin,
+                                       &m->ssl_config,
+#ifndef CURL_DISABLE_PROXY
+                                       &m->proxy_ssl_config);
+#else
+                                       NULL);
+#endif
+}
+
+static void url_match_destroy(struct url_conn_match *m)
+{
+  Curl_ssl_config_cleanup(&m->ssl_config);
+#ifndef CURL_DISABLE_PROXY
+  Curl_ssl_config_cleanup(&m->proxy_ssl_config);
+#endif
+}
+
 /**
  * Find an existing connection for the transfer or create a new one.
  * Returns
@@ -2211,7 +2230,8 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
                                         const struct curltime *pnow)
 {
   struct connectdata *needle = NULL;
-  bool waitpipe = FALSE;
+  struct url_conn_match match;
+  bool match_initialized = FALSE;
   CURLcode result;
 
   /* create the template connection for transfer data. Use this needle to
@@ -2221,6 +2241,11 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
   if(result)
     goto out;
   DEBUGASSERT(needle);
+
+  result = url_match_init(data, needle, &match);
+  if(result)
+    goto out;
+  match_initialized = TRUE;
 
   /***********************************************************************
    * file: is a special case in that it does not need a network connection
@@ -2260,11 +2285,6 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
   }
 #endif
 
-  /* Complete the easy's SSL configuration for connection cache matching */
-  result = Curl_ssl_easy_config_complete(data, needle->origin);
-  if(result)
-    goto out;
-
   /*************************************************************
    * Reuse of existing connection is not allowed when
    * - connect_only is set or
@@ -2274,7 +2294,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
   if((!data->set.reuse_fresh || data->state.followlocation) &&
      !data->set.connect_only) {
     /* Ok, try to find and attach an existing one */
-    url_attach_existing(data, needle, &waitpipe);
+    url_attach_existing(data, needle, &match);
   }
 
   if(data->conn) {
@@ -2308,7 +2328,7 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
        that if we have reached the limit of how many connections we are
        allowed to open. */
 
-    if(waitpipe) {
+    if(match.wait_pipe) {
       /* There is a connection that *might* become usable for multiplexing
          "soon", and we wait for that */
       infof(data, "Waiting on connection to negotiate possible multiplexing.");
@@ -2339,7 +2359,13 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
 
     /* Convert needle into a full connection by filling in all the
      * remaining parts like the cloned SSL configuration. */
-    result = Curl_ssl_conn_config_init(data, needle);
+    result = Curl_ssl_conn_config_init(&match.ssl_config,
+#ifndef CURL_DISABLE_PROXY
+                                       &match.proxy_ssl_config,
+#else
+                                       NULL,
+#endif
+                                       needle);
     if(result) {
       DEBUGF(curl_mfprintf(stderr, "Error: init connection SSL config\n"));
       goto out;
@@ -2399,6 +2425,8 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
   result = Curl_conn_ev_data_setup(data);
 
 out:
+  if(match_initialized)
+    url_match_destroy(&match);
   if(needle)
     Curl_conn_free(data, needle);
   DEBUGASSERT(result || data->conn);

--- a/lib/url.c
+++ b/lib/url.c
@@ -2200,13 +2200,13 @@ static CURLcode url_match_init(struct Curl_easy *data,
   m->require_tls = data->set.use_ssl >= CURLUSESSL_CONTROL;
   m->may_tls = data->set.use_ssl > CURLUSESSL_NONE;
 
-  /* Complete the easy's SSL configuration for connection cache matching */
-  return Curl_ssl_easy_config_complete(data, needle->origin,
-                                       &m->ssl_config,
+  /* Get a shallow setup of filter configs for connection cache matching */
+  return Curl_ssl_filter_config_tmp_init(data, needle->origin,
+                                         &m->ssl_config,
 #ifndef CURL_DISABLE_PROXY
-                                       &m->proxy_ssl_config);
+                                         &m->proxy_ssl_config);
 #else
-                                       NULL);
+                                         NULL);
 #endif
 }
 
@@ -2357,17 +2357,17 @@ static CURLcode url_find_or_create_conn(struct Curl_easy *data,
       }
     }
 
-    /* Convert needle into a full connection by filling in all the
-     * remaining parts like the cloned SSL configuration. */
-    result = Curl_ssl_conn_config_init(&match.ssl_config,
+    /* Convert needle into a full connection by cloning the
+     * ssl filter config used in matching into the connection. */
+    result = Curl_ssl_conn_config_clone(&match.ssl_config,
 #ifndef CURL_DISABLE_PROXY
-                                       &match.proxy_ssl_config,
+                                        &match.proxy_ssl_config,
 #else
-                                       NULL,
+                                        NULL,
 #endif
-                                       needle);
+                                        needle);
     if(result) {
-      DEBUGF(curl_mfprintf(stderr, "Error: init connection SSL config\n"));
+      DEBUGF(infof(data, "Error: clone connection SSL config\n"));
       goto out;
     }
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -318,9 +318,9 @@ struct connectdata {
   curl_closesocket_callback fclosesocket; /* function closing the socket(s) */
   void *closesocket_client;
 
-  struct ssl_primary_config ssl_config;
+  struct ssl_filter_config ssl_config;
 #ifndef CURL_DISABLE_PROXY
-  struct ssl_primary_config proxy_ssl_config;
+  struct ssl_filter_config proxy_ssl_config;
 #endif
   char *options; /* options string, allocated */
 
@@ -893,11 +893,11 @@ struct UserDefined {
   struct curl_slist *connect_to; /* list of host:port mappings to override
                                     the hostname and port to connect to */
   time_t timevalue;       /* what time to compare with */
-  struct ssl_config_data ssl;  /* user defined SSL stuff */
+  struct ssl_easy_config ssl;  /* user defined SSL stuff */
   curl_ssl_ctx_callback ssl_fsslctx; /* function to initialize SSL ctx */
   void *ssl_fsslctxp;        /* parameter for callback */
 #ifndef CURL_DISABLE_PROXY
-  struct ssl_config_data proxy_ssl;  /* user defined SSL stuff for proxy */
+  struct ssl_easy_config proxy_ssl;  /* user defined SSL stuff for proxy */
   struct curl_slist *proxyheaders; /* linked list of extra CONNECT headers */
   uint16_t proxyport;       /* If non-zero, use this port number by
                                default. If the proxy string features a

--- a/lib/vdns/doh.c
+++ b/lib/vdns/doh.c
@@ -363,7 +363,7 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
     }
 
     (void)curl_easy_setopt(doh, CURLOPT_SSL_OPTIONS,
-                           ((long)data->set.ssl.primary.ssl_options &
+                           ((long)data->set.ssl.ssl_options &
                             ~CURLSSLOPT_AUTO_CLIENT_CERT));
   }
 

--- a/lib/vquic/cf-ngtcp2-cmn.c
+++ b/lib/vquic/cf-ngtcp2-cmn.c
@@ -118,7 +118,7 @@ void Curl_cf_ngtcp2_h3_err_set(struct Curl_cfilter *cf,
 CURLcode Curl_cf_ngtcp2_ctx_init(struct cf_ngtcp2_ctx *ctx,
                                  struct Curl_peer *origin,
                                  struct Curl_peer *peer,
-                                 struct ssl_primary_config *sslc,
+                                 struct ssl_filter_config *sslc,
                                  cf_ngtcp2_init_h3_conn *init_h3_conn_cb)
 {
   DEBUGASSERT(!ctx->initialized);

--- a/lib/vquic/cf-ngtcp2-cmn.h
+++ b/lib/vquic/cf-ngtcp2-cmn.h
@@ -154,7 +154,7 @@ struct cf_ngtcp2_ctx {
 CURLcode Curl_cf_ngtcp2_ctx_init(struct cf_ngtcp2_ctx *ctx,
                                  struct Curl_peer *origin,
                                  struct Curl_peer *peer,
-                                 struct ssl_primary_config *sslc,
+                                 struct ssl_filter_config *sslc,
                                  cf_ngtcp2_init_h3_conn *init_h3_conn_cb);
 void Curl_cf_ngtcp2_ctx_cleanup(struct cf_ngtcp2_ctx *ctx);
 void Curl_cf_ngtcp2_cmn_err_set(struct Curl_cfilter *cf,

--- a/lib/vquic/cf-ngtcp2-proxy.c
+++ b/lib/vquic/cf-ngtcp2-proxy.c
@@ -175,7 +175,7 @@ static CURLcode cf_ngtcp2_proxy_h3_init(struct Curl_cfilter *cf,
 static CURLcode cf_h3_proxy_ctx_init(struct cf_h3_proxy_ctx *ctx,
                                      struct Curl_peer *origin,
                                      struct Curl_peer *peer,
-                                     struct ssl_primary_config *sslc,
+                                     struct ssl_filter_config *sslc,
                                      struct Curl_peer *tunnel_peer,
                                      uint8_t tunnel_transport)
 {

--- a/lib/vquic/cf-quiche.c
+++ b/lib/vquic/cf-quiche.c
@@ -112,7 +112,7 @@ static void h3_stream_hash_free(unsigned int id, void *stream);
 static CURLcode cf_quiche_ctx_init(struct cf_quiche_ctx *ctx,
                                    struct Curl_peer *origin,
                                    struct Curl_peer *peer,
-                                   struct ssl_primary_config *sslc)
+                                   struct ssl_filter_config *sslc)
 {
   DEBUGASSERT(!ctx->initialized);
 #ifdef DEBUG_QUICHE

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -51,7 +51,7 @@
 
 CURLcode Curl_vquic_tls_peer_init(struct Curl_peer *origin,
                                   struct Curl_peer *peer,
-                                  struct ssl_primary_config *sslc,
+                                  struct ssl_filter_config *sslc,
                                   struct ssl_peer *ssl_peer)
 {
   char tls_id[80];
@@ -155,10 +155,10 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
                                     struct Curl_easy *data,
                                     struct ssl_peer *peer)
 {
-  struct ssl_primary_config *conn_config;
+  struct ssl_filter_config *conn_config;
   CURLcode result = CURLE_OK;
 
-  conn_config = Curl_ssl_cf_get_primary_config(cf);
+  conn_config = Curl_ssl_cf_get_filter_config(cf);
   if(!conn_config)
     return CURLE_FAILED_INIT;
 

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -68,7 +68,7 @@ typedef CURLcode Curl_vquic_session_reuse_cb(struct Curl_cfilter *cf,
 
 CURLcode Curl_vquic_tls_peer_init(struct Curl_peer *origin,
                                   struct Curl_peer *peer,
-                                  struct ssl_primary_config *sslc,
+                                  struct ssl_filter_config *sslc,
                                   struct ssl_peer *ssl_peer);
 
 /**

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -865,7 +865,7 @@ static int myssh_in_AUTH_PKEY_INIT(struct Curl_easy *data,
   /* Two choices, (1) private key was given on CMD,
    * (2) use the "default" keys. */
   if(sshc->priv_key) {
-    if(sshc->pubkey && !data->set.ssl.primary.key_passwd) {
+    if(sshc->pubkey && !sshc->passphrase) {
       rc = ssh_userauth_try_publickey(sshc->ssh_session, NULL, sshc->pubkey);
       if(rc == SSH_AUTH_AGAIN)
         return SSH_AGAIN;
@@ -877,7 +877,7 @@ static int myssh_in_AUTH_PKEY_INIT(struct Curl_easy *data,
     }
 
     rc = ssh_pki_import_privkey_file(sshc->priv_key,
-                                     data->set.ssl.primary.key_passwd, NULL,
+                                     sshc->passphrase, NULL,
                                      NULL, &sshc->privkey);
     if(rc != SSH_OK) {
       failf(data, "Could not load private key file %s", sshc->priv_key);
@@ -889,7 +889,7 @@ static int myssh_in_AUTH_PKEY_INIT(struct Curl_easy *data,
   }
   else {
     rc = ssh_userauth_publickey_auto(sshc->ssh_session, NULL,
-                                     data->set.ssl.primary.key_passwd);
+                                     sshc->passphrase);
     if(rc == SSH_AUTH_AGAIN)
       return SSH_AGAIN;
 
@@ -1916,6 +1916,7 @@ static void sshc_cleanup(struct ssh_conn *sshc)
       sshc->pubkey = NULL;
     }
 
+    curlx_safefree(sshc->passphrase);
     curlx_safefree(sshc->pub_key);
     curlx_safefree(sshc->priv_key);
     curlx_safefree(sshc->quote_path1);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1509,12 +1509,9 @@ static CURLcode ssh_state_auth_pkey(struct Curl_easy *data,
    */
   struct connectdata *conn = data->conn;
   const char *user = Curl_creds_user(conn->creds);
-  int rc =
-    libssh2_userauth_publickey_fromfile_ex(sshc->ssh_session,
-                                           user,
-                                           curlx_uztoui(strlen(user)),
-                                           sshc->pub_key,
-                                           sshc->priv_key, sshc->passphrase);
+  int rc = libssh2_userauth_publickey_fromfile_ex(
+    sshc->ssh_session, user, curlx_uztoui(strlen(user)),
+    sshc->pub_key, sshc->priv_key, sshc->passphrase ? sshc->passphrase : "");
   if(rc == LIBSSH2_ERROR_EAGAIN)
     return CURLE_AGAIN;
 
@@ -2577,6 +2574,7 @@ static CURLcode sshc_cleanup(struct ssh_conn *sshc, struct Curl_easy *data,
   DEBUGASSERT(!sshc->kh);
   DEBUGASSERT(!sshc->ssh_agent);
 
+  curlx_safefree(sshc->passphrase);
   curlx_safefree(sshc->pub_key);
   curlx_safefree(sshc->priv_key);
   curlx_safefree(sshc->quote_path1);

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -143,7 +143,7 @@ struct ssh_conn {
   const char *authlist;       /* List of auth. methods, managed by libssh2 */
 
   /* common */
-  const char *passphrase;     /* pass-phrase to use */
+  char *passphrase;           /* strdup'ed pass-phrase to use or NULL */
   char *pub_key;              /* strdup'ed public key file */
   char *priv_key;             /* strdup'ed private key file */
   sshstate state;             /* always use ssh.c:state() to change state! */

--- a/lib/vssh/vssh.c
+++ b/lib/vssh/vssh.c
@@ -427,9 +427,14 @@ CURLcode Curl_ssh_setup_pkey(struct Curl_easy *data, struct ssh_conn *sshc)
         goto fail;
     }
 
-    sshc->passphrase = data->set.ssl.primary.key_passwd;
-    if(!sshc->passphrase)
-      sshc->passphrase = "";
+    {
+      const char *keypasswd = CURL_EASY_STR(data, STRING_KEY_PASSWD);
+      if(keypasswd) {
+        sshc->passphrase = curlx_strdup(keypasswd);
+        if(!sshc->passphrase)
+          goto fail;
+      }
+    }
 
     if(sshc->pub_key)
       infof(data, "SSH: public key file '%s'", sshc->pub_key);

--- a/lib/vtls/apple.c
+++ b/lib/vtls/apple.c
@@ -87,7 +87,7 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
                                 const unsigned char *ocsp_buf,
                                 size_t ocsp_len)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   SecTrustRef trust = NULL;
   SecPolicyRef policy = NULL;
@@ -127,8 +127,7 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
 
 #if defined(HAVE_BUILTIN_AVAILABLE) && defined(SUPPORTS_SecOCSP)
   {
-    struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-    if(!ssl_config->no_revoke) {
+    if(!conn_config->no_revoke) {
       if(__builtin_available(macOS 10.9, iOS 7, tvOS 9, watchOS 2, *)) {
         /* Even without this set, validation seemingly-unavoidably fails
          * for certificates that trustd already knows to be revoked.
@@ -144,7 +143,7 @@ CURLcode Curl_vtls_apple_verify(struct Curl_cfilter *cf,
          * It seems that applications using this policy are expected to PIN
          * their certificate public keys or verification fails.
          * This does not seem to be what we want here. */
-        if(!ssl_config->revoke_best_effort) {
+        if(!conn_config->revoke_best_effort) {
           revocation_flags |= kSecRevocationRequirePositiveResponse;
         }
 #endif

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -323,7 +323,7 @@ static gnutls_x509_crt_fmt_t gnutls_do_file_type(const char *type)
 static CURLcode gnutls_set_ssl_version_min_max(
   struct Curl_easy *data,
   struct ssl_peer *peer,
-  struct ssl_primary_config *conn_config,
+  struct ssl_filter_config *conn_config,
   const char **prioritylist,
   bool tls13support)
 {
@@ -446,8 +446,8 @@ static CURLcode gtls_populate_creds(struct Curl_cfilter *cf,
                                     struct Curl_easy *data,
                                     gnutls_certificate_credentials_t creds)
 {
-  struct ssl_primary_config *config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *config = Curl_ssl_cf_get_filter_config(cf);
+  struct ssl_easy_config *ssl_config = Curl_ssl_cf_get_easy_config(cf, data);
   bool creds_are_empty = TRUE;
   int rc;
 
@@ -582,7 +582,7 @@ static bool gtls_shared_creds_expired(struct Curl_easy *data,
 static bool gtls_shared_creds_different(struct Curl_cfilter *cf,
                                         const struct gtls_shared_creds *sc)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   if(!sc->CAfile || !conn_config->CAfile)
     return sc->CAfile != conn_config->CAfile;
 
@@ -622,7 +622,7 @@ static void gtls_set_cached_creds(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
                                   struct gtls_shared_creds *sc)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
 
   DEBUGASSERT(sc);
   DEBUGASSERT(sc->creds);
@@ -653,8 +653,7 @@ CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
                                       struct gtls_ctx *gtls)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct gtls_shared_creds *cached_creds = NULL;
   bool cache_criteria_met;
   CURLcode result;
@@ -667,7 +666,7 @@ CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
     conn_config->verifypeer &&
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&
-    !ssl_config->primary.CRLfile &&
+    !conn_config->CRLfile &&
     !conn_config->native_ca_store &&
     !conn_config->clientcert; /* GnuTLS adds client cert to its credentials! */
 
@@ -841,7 +840,7 @@ static CURLcode gtls_set_priority(struct Curl_cfilter *cf,
                                   struct gtls_ctx *gtls,
                                   const char *priority)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct dynbuf buf;
   const char *err = NULL;
   CURLcode result = CURLE_OK;
@@ -886,8 +885,8 @@ static CURLcode gtls_client_init(struct Curl_cfilter *cf,
                                  size_t earlydata_max,
                                  struct gtls_ctx *gtls)
 {
-  struct ssl_primary_config *config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *config = Curl_ssl_cf_get_filter_config(cf);
+  struct ssl_easy_config *ssl_config = Curl_ssl_cf_get_easy_config(cf, data);
   unsigned int init_flags;
   int rc;
   const char *prioritylist;
@@ -982,11 +981,11 @@ static CURLcode gtls_client_init(struct Curl_cfilter *cf,
       if(result)
         return result;
     }
-    if(ssl_config->primary.cert_type &&
-       curl_strequal(ssl_config->primary.cert_type, "P12")) {
+    if(config->cert_type &&
+       curl_strequal(config->cert_type, "P12")) {
       rc = gnutls_certificate_set_x509_simple_pkcs12_file(
         gtls->shared_creds->creds, config->clientcert, GNUTLS_X509_FMT_DER,
-        ssl_config->primary.key_passwd ? ssl_config->primary.key_passwd : "");
+        config->key_passwd ? config->key_passwd : "");
       if(rc != GNUTLS_E_SUCCESS) {
         failf(data,
               "error reading X.509 potentially-encrypted key or certificate "
@@ -1004,15 +1003,14 @@ static CURLcode gtls_client_init(struct Curl_cfilter *cf,
       rc = gnutls_certificate_set_x509_key_file2(
            gtls->shared_creds->creds,
            config->clientcert,
-           ssl_config->primary.key ? ssl_config->primary.key :
-                                     config->clientcert,
-           gnutls_do_file_type(ssl_config->primary.cert_type),
-           ssl_config->primary.key_passwd,
+           config->key ? config->key : config->clientcert,
+           gnutls_do_file_type(config->cert_type),
+           config->key_passwd,
            supported_key_encryption_algorithms);
       if(rc != GNUTLS_E_SUCCESS) {
         failf(data,
               "error reading X.509 %skey file: %s",
-              ssl_config->primary.key_passwd ? "potentially-encrypted " : "",
+              config->key_passwd ? "potentially-encrypted " : "",
               gnutls_strerror(rc));
         return CURLE_SSL_CONNECT_ERROR;
       }
@@ -1085,7 +1083,7 @@ static CURLcode gtls_apply_session(
   struct Curl_ssl_session *scs,
   bool *pwas_setup)
 {
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   int rc;
 
@@ -1104,7 +1102,7 @@ static CURLcode gtls_apply_session(
     else {
       infof(data, "SSL reusing session with ALPN '%s'",
             scs->alpn ? scs->alpn : "-");
-      if(ssl_config->earlydata && scs->alpn &&
+      if(conn_config->earlydata && scs->alpn &&
          !cf->conn->bits.connect_only) {
         bool do_early_data = FALSE;
         if(sess_reuse_cb) {
@@ -1134,7 +1132,7 @@ CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
                             void *ssl_user_data,
                             Curl_gtls_init_session_reuse_cb *sess_reuse_cb)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_ssl_session *scs = NULL;
   gnutls_datum_t gtls_alpns[ALPN_ENTRIES_MAX];
   size_t gtls_alpns_count = 0;
@@ -1589,8 +1587,8 @@ static CURLcode gtls_chain_get_der(struct Curl_cfilter *cf,
    ssl_config->certverifyresult as one or more gnutls_certificate_status_t
    enumerated elements bitwise or'd. */
 static CURLcode gtls_verify_cert(struct Curl_easy *data,
-                                 struct ssl_primary_config *config,
-                                 struct ssl_config_data *ssl_config,
+                                 struct ssl_filter_config *config,
+                                 struct ssl_easy_config *ssl_config,
                                  gnutls_session_t session,
                                  struct Curl_cfilter *cf,
                                  struct ssl_peer *peer,
@@ -1643,8 +1641,8 @@ static CURLcode gtls_verify_cert(struct Curl_easy *data,
     failf(data, "SSL certificate verification failed: %s. (CAfile: %s "
           "CRLfile: %s)", cause,
           config->CAfile ? config->CAfile : "none",
-          ssl_config->primary.CRLfile ?
-          ssl_config->primary.CRLfile : "none");
+          config->CRLfile ?
+          config->CRLfile : "none");
 
     return CURLE_PEER_FAILED_VERIFICATION;
   }
@@ -1654,8 +1652,8 @@ static CURLcode gtls_verify_cert(struct Curl_easy *data,
 CURLcode Curl_gtls_verifyserver(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
                                 gnutls_session_t session,
-                                struct ssl_primary_config *config,
-                                struct ssl_config_data *ssl_config,
+                                struct ssl_filter_config *config,
+                                struct ssl_easy_config *ssl_config,
                                 struct ssl_peer *peer,
                                 const char *pinned_key)
 {
@@ -1871,8 +1869,8 @@ static CURLcode gtls_verifyserver(struct Curl_cfilter *cf,
                                   gnutls_session_t session)
 {
   struct ssl_connect_data *connssl = cf->ctx;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
+  struct ssl_easy_config *ssl_config = Curl_ssl_cf_get_easy_config(cf, data);
 #ifndef CURL_DISABLE_PROXY
   const char *pinned_key = Curl_ssl_cf_is_proxy(cf) ?
     CURL_EASY_STR(data, STRING_SSL_PINNEDPUBLICKEY_PROXY) :

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -34,8 +34,8 @@
 struct Curl_easy;
 struct Curl_cfilter;
 struct alpn_spec;
-struct ssl_primary_config;
-struct ssl_config_data;
+struct ssl_filter_config;
+struct ssl_easy_config;
 struct ssl_peer;
 struct ssl_connect_data;
 struct Curl_ssl_session;
@@ -89,8 +89,8 @@ CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
 CURLcode Curl_gtls_verifyserver(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
                                 gnutls_session_t session,
-                                struct ssl_primary_config *config,
-                                struct ssl_config_data *ssl_config,
+                                struct ssl_filter_config *config,
+                                struct ssl_easy_config *ssl_config,
                                 struct ssl_peer *peer,
                                 const char *pinned_key);
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -182,7 +182,7 @@ static int mbedtls_bio_cf_read(void *bio, unsigned char *buf, size_t blen)
 static CURLcode mbed_set_ssl_version_min_max(
   struct Curl_easy *data,
   struct mbed_ssl_backend_data *backend,
-  struct ssl_primary_config *conn_config)
+  struct ssl_filter_config *conn_config)
 {
   mbedtls_ssl_protocol_version ver_min =
 #ifdef MBEDTLS_SSL_PROTO_TLS1_2
@@ -442,7 +442,7 @@ static int mbed_verify_cb(void *ptr, mbedtls_x509_crt *crt,
                           int depth, uint32_t *flags)
 {
   struct Curl_cfilter *cf = (struct Curl_cfilter *)ptr;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_easy *data = CF_DATA_CURRENT(cf);
 
   if(depth == 0) {
@@ -479,7 +479,7 @@ static CURLcode mbed_load_cacert(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   const char * const ssl_cafile =
     /* CURLOPT_CAINFO_BLOB overrides CURLOPT_CAINFO */
@@ -487,8 +487,7 @@ static CURLcode mbed_load_cacert(struct Curl_cfilter *cf,
   const bool verifypeer = conn_config->verifypeer;
   const char * const ssl_capath = conn_config->CApath;
 #ifdef MBEDTLS_PEM_PARSE_C
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  const char * const ssl_cert_type = ssl_config->primary.cert_type;
+  const char * const ssl_cert_type = conn_config->cert_type;
 #endif
   int ret = -1;
   char errorbuf[128];
@@ -579,11 +578,11 @@ static CURLcode mbed_load_clicert(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  char * const ssl_cert = ssl_config->primary.clientcert;
-  const struct curl_blob *ssl_cert_blob = ssl_config->primary.cert_blob;
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
+  char * const ssl_cert = conn_config->clientcert;
+  const struct curl_blob *ssl_cert_blob = conn_config->cert_blob;
 #ifdef MBEDTLS_PEM_PARSE_C
-  const char * const ssl_cert_type = ssl_config->primary.cert_type;
+  const char * const ssl_cert_type = conn_config->cert_type;
 #endif
   int ret = -1;
   char errorbuf[128];
@@ -658,18 +657,18 @@ static CURLcode mbed_load_privkey(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   int ret = -1;
   char errorbuf[128];
 
   mbedtls_pk_init(&backend->pk);
 
-  if(ssl_config->primary.key || ssl_config->primary.key_blob) {
-    if(ssl_config->primary.key) {
+  if(conn_config->key || conn_config->key_blob) {
+    if(conn_config->key) {
 #ifdef MBEDTLS_FS_IO
 #if MBEDTLS_VERSION_NUMBER >= 0x04000000
-      ret = mbedtls_pk_parse_keyfile(&backend->pk, ssl_config->primary.key,
-                                     ssl_config->primary.key_passwd);
+      ret = mbedtls_pk_parse_keyfile(&backend->pk, conn_config->key,
+                                     conn_config->key_passwd);
       if(ret == 0 &&
          !(mbedtls_pk_can_do_psa(&backend->pk,
                                  PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_ANY_HASH),
@@ -679,8 +678,8 @@ static CURLcode mbed_load_privkey(struct Curl_cfilter *cf,
                                  PSA_KEY_USAGE_SIGN_HASH)))
         ret = MBEDTLS_ERR_PK_TYPE_MISMATCH;
 #else
-      ret = mbedtls_pk_parse_keyfile(&backend->pk, ssl_config->primary.key,
-                                     ssl_config->primary.key_passwd,
+      ret = mbedtls_pk_parse_keyfile(&backend->pk, conn_config->key,
+                                     conn_config->key_passwd,
                                      mbedtls_ctr_drbg_random,
                                      &rng.drbg);
       if(ret == 0 && !(mbedtls_pk_can_do(&backend->pk, MBEDTLS_PK_RSA) ||
@@ -691,7 +690,7 @@ static CURLcode mbed_load_privkey(struct Curl_cfilter *cf,
       if(ret) {
         mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
         failf(data, "mbedTLS: error reading private key %s: (-0x%04X) %s",
-              ssl_config->primary.key, (unsigned int)-ret, errorbuf);
+              conn_config->key, (unsigned int)-ret, errorbuf);
         return CURLE_SSL_CERTPROBLEM;
       }
 #else
@@ -700,8 +699,8 @@ static CURLcode mbed_load_privkey(struct Curl_cfilter *cf,
 #endif
     }
     else {
-      const struct curl_blob *ssl_key_blob = ssl_config->primary.key_blob;
-      const char *passwd = ssl_config->primary.key_passwd;
+      const struct curl_blob *ssl_key_blob = conn_config->key_blob;
+      const char *passwd = conn_config->key_passwd;
       /* Unfortunately, mbedtls_pk_parse_key() requires the data to be
          null-terminated if the data is PEM encoded (even when provided the
          exact length). */
@@ -752,8 +751,8 @@ static CURLcode mbed_load_crl(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  const char * const ssl_crlfile = ssl_config->primary.CRLfile;
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
+  const char * const ssl_crlfile = conn_config->CRLfile;
 
 #ifdef MBEDTLS_X509_CRL_PARSE_C
   mbedtls_x509_crl_init(&backend->crl);
@@ -825,8 +824,7 @@ static CURLcode mbed_configure_ssl(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   int ret;
   bool session_applied = FALSE;
   CURLcode result;
@@ -982,7 +980,7 @@ static CURLcode mbed_configure_ssl(struct Curl_cfilter *cf,
 #endif
     );
 
-  if(ssl_config->primary.key || ssl_config->primary.key_blob) {
+  if(conn_config->key || conn_config->key_blob) {
     mbedtls_ssl_conf_own_cert(&backend->config, &backend->clicert,
                               &backend->pk);
   }
@@ -1032,7 +1030,7 @@ static CURLcode mbed_connect_step1(struct Curl_cfilter *cf,
                                    struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result;
 
   if((conn_config->version == CURL_SSLVERSION_SSLv2) ||

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2540,7 +2540,7 @@ static CURLcode ossl_set_ssl_version_min_max(struct Curl_cfilter *cf,
                                              SSL_CTX *ctx,
                                              unsigned int ssl_version_min)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   /* first, TLS min version... */
   long curl_ssl_version_min = (long)ssl_version_min;
   long curl_ssl_version_max;
@@ -2973,7 +2973,7 @@ static CURLcode ossl_load_trust_anchors(struct Curl_cfilter *cf,
                                         struct ossl_ctx *octx,
                                         X509_STORE *store)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   const char * const ssl_cafile =
     /* CURLOPT_CAINFO_BLOB overrides CURLOPT_CAINFO */
@@ -3083,11 +3083,10 @@ static CURLcode ossl_populate_x509_store(struct Curl_cfilter *cf,
                                          struct ossl_ctx *octx,
                                          X509_STORE *store)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   X509_LOOKUP *lookup = NULL;
-  const char * const ssl_crlfile = ssl_config->primary.CRLfile;
+  const char * const ssl_crlfile = conn_config->CRLfile;
   unsigned long x509flags = 0;
 
   CURL_TRC_CF(data, cf, "configuring OpenSSL's x509 trust store");
@@ -3133,7 +3132,7 @@ static CURLcode ossl_populate_x509_store(struct Curl_cfilter *cf,
    */
   x509flags |= X509_V_FLAG_TRUSTED_FIRST;
 
-  if(!ssl_config->no_partialchain && !ssl_crlfile) {
+  if(!conn_config->no_partialchain && !ssl_crlfile) {
     /* Have intermediate certificates in the trust store be treated as
        trust-anchors, in the same way as self-signed root CA certificates are.
        This allows users to verify servers using the intermediate cert only,
@@ -3190,10 +3189,9 @@ static bool ossl_cached_x509_store_different(struct Curl_cfilter *cf,
                                              const struct Curl_easy *data,
                                              const struct ossl_x509_share *mb)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config =
-    Curl_ssl_cf_get_config(cf, CURL_UNCONST(data));
-  if(mb->no_partialchain != ssl_config->no_partialchain)
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
+  (void)data;
+  if(mb->no_partialchain != conn_config->no_partialchain)
     return TRUE;
   if(!mb->CAfile || !conn_config->CAfile)
     return mb->CAfile != conn_config->CAfile;
@@ -3228,7 +3226,7 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
                                        X509_STORE *store,
                                        bool is_empty)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_multi *multi = data->multi;
   struct ossl_x509_share *share;
 
@@ -3254,8 +3252,6 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
 
   if(X509_STORE_up_ref(store)) {
     char *CAfile = NULL;
-    struct ssl_config_data *ssl_config =
-      Curl_ssl_cf_get_config(cf, CURL_UNCONST(data));
 
     if(conn_config->CAfile) {
       CAfile = curlx_strdup(conn_config->CAfile);
@@ -3274,7 +3270,7 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
     share->store = store;
     share->store_is_empty = is_empty;
     share->CAfile = CAfile;
-    share->no_partialchain = ssl_config->no_partialchain;
+    share->no_partialchain = conn_config->no_partialchain;
   }
 }
 
@@ -3282,8 +3278,7 @@ CURLcode Curl_ssl_setup_x509_store(struct Curl_cfilter *cf,
                                    struct Curl_easy *data,
                                    struct ossl_ctx *octx)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   X509_STORE *cached_store;
   bool cache_criteria_met, is_empty;
@@ -3295,7 +3290,7 @@ CURLcode Curl_ssl_setup_x509_store(struct Curl_cfilter *cf,
     conn_config->verifypeer &&
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&
-    !ssl_config->primary.CRLfile &&
+    !conn_config->CRLfile &&
     !conn_config->native_ca_store;
 
   ERR_set_mark();
@@ -3327,8 +3322,7 @@ static bool ossl_apply_session(
   Curl_ossl_init_session_reuse_cb *sess_reuse_cb,
   struct Curl_ssl_session *scs)
 {
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  struct ssl_primary_config *conn_cfg = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_cfg = Curl_ssl_cf_get_filter_config(cf);
   const unsigned char *der_sessionid = scs->sdata;
   size_t der_sessionid_size = scs->sdata_len;
   SSL_SESSION *ssl_session = NULL;
@@ -3367,7 +3361,7 @@ static bool ossl_apply_session(
         infof(data, "SSL verify result: %lx",
               (unsigned long)SSL_get_verify_result(octx->ssl));
 #ifdef HAVE_OPENSSL_EARLYDATA
-        if(ssl_config->earlydata && scs->alpn &&
+        if(conn_cfg->earlydata && scs->alpn &&
            SSL_SESSION_get_max_early_data(ssl_session) &&
            !cf->conn->bits.connect_only &&
            (SSL_version(octx->ssl) == TLS1_3_VERSION)) {
@@ -3382,7 +3376,7 @@ static bool ossl_apply_session(
         }
 #else
         (void)alpns;
-        (void)ssl_config;
+        (void)conn_cfg;
         (void)sess_reuse_cb;
 #endif
       }
@@ -3403,7 +3397,7 @@ static CURLcode ossl_init_session_and_alpns(
   const struct alpn_spec *alpns_requested,
   Curl_ossl_init_session_reuse_cb *sess_reuse_cb)
 {
-  struct ssl_primary_config *conn_cfg = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_cfg = Curl_ssl_cf_get_filter_config(cf);
   struct alpn_spec alpns;
   CURLcode result;
 
@@ -3610,7 +3604,7 @@ static CURLcode ossl_init_ssl(struct ossl_ctx *octx,
   SSL_set_app_data(octx->ssl, ssl_user_data);
 
 #ifndef OPENSSL_NO_OCSP
-  if(Curl_ssl_cf_get_primary_config(cf)->verifystatus)
+  if(Curl_ssl_cf_get_filter_config(cf)->verifystatus)
     SSL_set_tlsext_status_type(octx->ssl, TLSEXT_STATUSTYPE_ocsp);
 #endif
 
@@ -3641,7 +3635,7 @@ static CURLcode ossl_init_method(struct Curl_cfilter *cf,
                                  const SSL_METHOD **pmethod,
                                  unsigned int *pssl_version_min)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
 
   *pmethod = NULL;
   *pssl_version_min = conn_config->version;
@@ -3703,11 +3697,11 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   const char *ciphers;
   const SSL_METHOD *req_method = NULL;
   ctx_option_t ctx_options = 0;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  char * const ssl_cert = ssl_config->primary.clientcert;
-  const struct curl_blob *ssl_cert_blob = ssl_config->primary.cert_blob;
-  const char * const ssl_cert_type = ssl_config->primary.cert_type;
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
+  struct ssl_easy_config *ssl_config = Curl_ssl_cf_get_easy_config(cf, data);
+  char * const ssl_cert = conn_config->clientcert;
+  const struct curl_blob *ssl_cert_blob = conn_config->cert_blob;
+  const char * const ssl_cert_type = conn_config->cert_type;
   unsigned int ssl_version_min;
   char error_buffer[256];
 
@@ -3799,7 +3793,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 
   /* unless the user explicitly asks to allow the protocol vulnerability we
      use the workaround */
-  if(!ssl_config->enable_beast)
+  if(!conn_config->enable_beast)
     ctx_options &= ~(ctx_option_t)SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
 
   DEBUGASSERT(ssl_version_min != CURL_SSLVERSION_DEFAULT);
@@ -3878,9 +3872,9 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   if(ssl_cert || ssl_cert_blob || ssl_cert_type) {
     result = client_cert(data, octx->ssl_ctx,
                          ssl_cert, ssl_cert_blob, ssl_cert_type,
-                         ssl_config->primary.key, ssl_config->primary.key_blob,
-                         ssl_config->primary.key_type,
-                         ssl_config->primary.key_passwd);
+                         conn_config->key, conn_config->key_blob,
+                         conn_config->key_type,
+                         conn_config->key_passwd);
     if(result)
       /* failf() is already done in client_cert() */
       return result;
@@ -4137,7 +4131,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
   int err;
   struct ssl_connect_data *connssl = cf->ctx;
   struct ossl_ctx *octx = (struct ossl_ctx *)connssl->backend;
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_easy_config *ssl_config = Curl_ssl_cf_get_easy_config(cf, data);
   DEBUGASSERT(connssl->connecting_state == ssl_connect_2);
   DEBUGASSERT(octx);
 
@@ -4324,8 +4318,8 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
         VERBOSE(status = "bad call (unexpected)");
         break;
       case SSL_ECH_STATUS_BAD_NAME: {
-        struct ssl_primary_config *conn_config =
-          Curl_ssl_cf_get_primary_config(cf);
+        struct ssl_filter_config *conn_config =
+          Curl_ssl_cf_get_filter_config(cf);
         if(!conn_config->verifypeer && !conn_config->verifyhost &&
            inner && !strcmp(inner, connssl->peer.origin->hostname)) {
           VERBOSE(status = "bad name (tolerated without peer verification)");
@@ -4511,7 +4505,7 @@ static CURLcode ossl_check_issuer(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
                                   X509 *server_cert)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   X509 *issuer = NULL;
   BIO *fp = NULL;
   char err_buf[256] = "";
@@ -4700,7 +4694,7 @@ static CURLcode ossl_apple_verify(struct Curl_cfilter *cf,
                                   struct ossl_ctx *octx,
                                   struct ssl_peer *peer)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct ossl_certs_ctx chain;
   CURLcode result;
 
@@ -4766,8 +4760,8 @@ CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
                                    struct ssl_peer *peer)
 {
   struct connectdata *conn = cf->conn;
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_easy_config *ssl_config = Curl_ssl_cf_get_easy_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   long ossl_verify;
   X509 *server_cert;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -526,7 +526,7 @@ static void cr_keylog_log_cb(struct rustls_str label,
 
 static CURLcode
 init_config_builder(struct Curl_easy *data,
-                    const struct ssl_primary_config *conn_config,
+                    const struct ssl_filter_config *conn_config,
                     struct rustls_client_config_builder **config_builder)
 {
   const struct rustls_supported_ciphersuite **cipher_suites = NULL;
@@ -676,7 +676,7 @@ init_config_builder_alpn(struct Curl_easy *data,
 
 static CURLcode init_config_builder_verifier_crl(
   struct Curl_easy *data,
-  const struct ssl_primary_config *conn_config,
+  const struct ssl_filter_config *conn_config,
   struct rustls_web_pki_server_cert_verifier_builder *builder)
 {
   CURLcode result = CURLE_OK;
@@ -708,7 +708,7 @@ cleanup:
 static CURLcode
 init_config_builder_verifier(struct Curl_easy *data,
                              struct rustls_client_config_builder *builder,
-                             const struct ssl_primary_config *conn_config,
+                             const struct ssl_filter_config *conn_config,
                              const struct curl_blob *ca_info_blob,
                              const char * const ssl_cafile)
 {
@@ -841,8 +841,7 @@ init_config_builder_keylog(struct Curl_easy *data,
 
 static CURLcode
 init_config_builder_client_auth(struct Curl_easy *data,
-                                const struct ssl_primary_config *conn_config,
-                                const struct ssl_config_data *ssl_config,
+                                const struct ssl_filter_config *conn_config,
                                 struct rustls_client_config_builder *builder)
 {
   struct dynbuf cert_contents;
@@ -851,14 +850,14 @@ init_config_builder_client_auth(struct Curl_easy *data,
   const struct rustls_certified_key *certified_key = NULL;
   CURLcode result = CURLE_OK;
 
-  if(conn_config->clientcert && !ssl_config->primary.key) {
+  if(conn_config->clientcert && !conn_config->key) {
     failf(data, "rustls: must provide key with certificate '%s'",
           conn_config->clientcert);
     return CURLE_SSL_CERTPROBLEM;
   }
-  else if(!conn_config->clientcert && ssl_config->primary.key) {
+  else if(!conn_config->clientcert && conn_config->key) {
     failf(data, "rustls: must provide certificate with key '%s'",
-          ssl_config->primary.key);
+          conn_config->key);
     return CURLE_SSL_CERTPROBLEM;
   }
 
@@ -872,9 +871,9 @@ init_config_builder_client_auth(struct Curl_easy *data,
     goto cleanup;
   }
 
-  if(!read_file_into(ssl_config->primary.key, &key_contents)) {
+  if(!read_file_into(conn_config->key, &key_contents)) {
     failf(data, "rustls: failed to read key file: '%s'",
-          ssl_config->primary.key);
+          conn_config->key);
     result = CURLE_SSL_CERTPROBLEM;
     goto cleanup;
   }
@@ -1020,9 +1019,8 @@ static CURLcode cr_init_backend(struct Curl_cfilter *cf,
                                 struct rustls_ssl_backend_data * const backend)
 {
   const struct ssl_connect_data *connssl = cf->ctx;
-  const struct ssl_primary_config *conn_config =
-    Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  const struct ssl_filter_config *conn_config =
+    Curl_ssl_cf_get_filter_config(cf);
   struct rustls_connection *rconn = NULL;
   struct rustls_client_config_builder *config_builder = NULL;
 
@@ -1074,10 +1072,9 @@ static CURLcode cr_init_backend(struct Curl_cfilter *cf,
     }
   }
 
-  if(conn_config->clientcert || ssl_config->primary.key) {
+  if(conn_config->clientcert || conn_config->key) {
     result = init_config_builder_client_auth(data,
                                              conn_config,
-                                             ssl_config,
                                              config_builder);
     if(result != CURLE_OK) {
       rustls_client_config_builder_free(config_builder);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -166,7 +166,7 @@ static CURLcode schannel_set_ssl_version_min_max(DWORD *enabled_protocols,
                                                  struct Curl_cfilter *cf,
                                                  struct Curl_easy *data)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   long ssl_version = conn_config->version;
   long ssl_version_max = (long)conn_config->version_max;
   long i = ssl_version;
@@ -381,7 +381,7 @@ static CURLcode get_client_cert(struct Curl_cfilter *cf,
                                 HCERTSTORE *out_cert_store,
                                 PCCERT_CONTEXT *out_cert_context)
 {
-  struct ssl_primary_config *sslc = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *sslc = Curl_ssl_cf_get_filter_config(cf);
   PCCERT_CONTEXT client_cert = NULL;
   HCERTSTORE client_cert_store = NULL;
   CURLcode result = CURLE_OK;
@@ -605,7 +605,7 @@ static CURLcode acquire_sspi_handle(struct Curl_cfilter *cf,
                                     DWORD flags,
                                     DWORD enabled_protocols)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CURLcode result;
 
@@ -724,8 +724,7 @@ static CURLcode schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                                                    struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
 
   PCCERT_CONTEXT client_cert = NULL;
   HCERTSTORE client_cert_store = NULL;
@@ -746,14 +745,14 @@ static CURLcode schannel_acquire_credential_handle(struct Curl_cfilter *cf,
     else
       flags = SCH_CRED_AUTO_CRED_VALIDATION;
 
-    if(ssl_config->no_revoke) {
+    if(conn_config->no_revoke) {
       flags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
                SCH_CRED_IGNORE_REVOCATION_OFFLINE;
 
       DEBUGF(infof(data, "schannel: disabled server certificate revocation "
                          "checks"));
     }
-    else if(ssl_config->revoke_best_effort) {
+    else if(conn_config->revoke_best_effort) {
       flags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK |
                SCH_CRED_IGNORE_REVOCATION_OFFLINE |
                SCH_CRED_REVOCATION_CHECK_CHAIN;
@@ -849,7 +848,7 @@ static CURLcode schannel_connect_step1(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct schannel_ssl_backend_data *backend =
     (struct schannel_ssl_backend_data *)connssl->backend;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   SecBuffer outbuf;
   SecBufferDesc outbuf_desc;
   SecBuffer inbuf;
@@ -1229,7 +1228,7 @@ static CURLcode schannel_connect_step2(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct schannel_ssl_backend_data *backend =
     (struct schannel_ssl_backend_data *)connssl->backend;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   int i;
   size_t nread = 0;
   SecBuffer outbuf[3];
@@ -1587,7 +1586,7 @@ static CURLcode schannel_connect_step3(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct schannel_ssl_backend_data *backend =
     (struct schannel_ssl_backend_data *)connssl->backend;
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_easy_config *ssl_config = Curl_ssl_cf_get_easy_config(cf, data);
   CURLcode result = CURLE_OK;
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CERT_CONTEXT *ccert_context = NULL;
@@ -2723,7 +2722,7 @@ static void *schannel_get_internals(struct ssl_connect_data *connssl,
 HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
                                                struct Curl_easy *data)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_multi *multi = data->multi;
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   struct schannel_cert_share *share;
@@ -2802,7 +2801,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
                                          struct Curl_easy *data,
                                          HCERTSTORE cert_store)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_multi *multi = data->multi;
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   struct schannel_cert_share *share;

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -631,8 +631,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
                                  struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   SECURITY_STATUS sspi_status;
   CURLcode result = CURLE_OK;
   CERT_CONTEXT *pCertContextServer = NULL;
@@ -724,7 +723,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
       /* Win8/Server2012 allows us to match partial chains */
       if(curlx_verify_windows_version(6, 2, 0, PLATFORM_WINNT,
                                       VERSION_GREATER_THAN_EQUAL) &&
-         !ssl_config->no_partialchain) {
+         !conn_config->no_partialchain) {
         engine_config.cbSize = sizeof(engine_config);
         engine_config.dwExclusiveFlags = CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG;
       }
@@ -764,7 +763,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
                                 NULL,
                                 pCertContextServer->hCertStore,
                                 &ChainPara,
-                                (ssl_config->no_revoke ? 0 :
+                                (conn_config->no_revoke ? 0 :
                                  CERT_CHAIN_REVOCATION_CHECK_CHAIN),
                                 NULL,
                                 &pChainContext)) {
@@ -780,7 +779,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
       DWORD dwTrustErrorMask = ~(DWORD)(CERT_TRUST_IS_NOT_TIME_NESTED);
       dwTrustErrorMask &= pSimpleChain->TrustStatus.dwErrorStatus;
 
-      if(ssl_config->revoke_best_effort) {
+      if(conn_config->revoke_best_effort) {
         /* Ignore errors when root certificates are missing the revocation
          * list URL, or when the list could not be downloaded because the
          * server is currently unreachable. */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -160,22 +160,23 @@ int Curl_ssl_init(void)
   return 1;
 }
 
-static bool ssl_prefs_check(struct Curl_easy *data)
+static bool ssl_prefs_check(struct Curl_cfilter *cf,
+                            struct Curl_easy *data)
 {
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   /* check for CURLOPT_SSLVERSION invalid parameter value */
-  const unsigned char sslver = data->set.ssl.primary.version;
-  if(sslver >= CURL_SSLVERSION_LAST) {
+  if(conn_config->version >= CURL_SSLVERSION_LAST) {
     failf(data, "Unrecognized parameter value passed via CURLOPT_SSLVERSION");
     return FALSE;
   }
 
-  switch(data->set.ssl.primary.version_max) {
+  switch(conn_config->version_max) {
   case CURL_SSLVERSION_MAX_NONE:
   case CURL_SSLVERSION_MAX_DEFAULT:
     break;
 
   default:
-    if((data->set.ssl.primary.version_max >> 16) < sslver) {
+    if((conn_config->version_max >> 16) < conn_config->version) {
       failf(data, "CURL_SSLVERSION_MAX incompatible with CURL_SSLVERSION");
       return FALSE;
     }
@@ -896,7 +897,7 @@ static ssl_peer_type get_peer_type(const char *hostname)
 CURLcode Curl_ssl_peer_init(struct ssl_peer *ssl_peer,
                             struct Curl_peer *origin,
                             struct Curl_peer *peer,
-                            struct ssl_primary_config *sslc,
+                            struct ssl_filter_config *sslc,
                             const char *tls_id,
                             uint8_t transport)
 {
@@ -986,7 +987,7 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
   *done = FALSE;
 
   if(!connssl->prefs_checked) {
-    if(!ssl_prefs_check(data)) {
+    if(!ssl_prefs_check(cf, data)) {
       result = CURLE_SSL_CONNECT_ERROR;
       goto out;
     }
@@ -1383,7 +1384,7 @@ out:
 static CURLcode cf_ssl_peer_init(struct Curl_cfilter *cf,
                                  struct Curl_peer *origin,
                                  struct Curl_peer *peer,
-                                 struct ssl_primary_config *sslc)
+                                 struct ssl_filter_config *sslc)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   char tls_id[80];
@@ -1586,8 +1587,9 @@ bool Curl_ssl_cf_is_proxy(struct Curl_cfilter *cf)
   return (cf->cft->flags & CF_TYPE_SSL) && (cf->cft->flags & CF_TYPE_PROXY);
 }
 
-struct ssl_config_data *Curl_ssl_cf_get_config(struct Curl_cfilter *cf,
-                                               struct Curl_easy *data)
+struct ssl_easy_config *
+Curl_ssl_cf_get_easy_config(struct Curl_cfilter *cf,
+                            struct Curl_easy *data)
 {
 #ifdef CURL_DISABLE_PROXY
   (void)cf;
@@ -1597,8 +1599,8 @@ struct ssl_config_data *Curl_ssl_cf_get_config(struct Curl_cfilter *cf,
 #endif
 }
 
-struct ssl_primary_config *Curl_ssl_cf_get_primary_config(
-  struct Curl_cfilter *cf)
+struct ssl_filter_config *
+Curl_ssl_cf_get_filter_config(struct Curl_cfilter *cf)
 {
 #ifdef CURL_DISABLE_PROXY
   return &cf->conn->ssl_config;

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -26,8 +26,8 @@
 #include "curl_setup.h"
 
 struct connectdata;
-struct ssl_config_data;
-struct ssl_primary_config;
+struct ssl_easy_config;
+struct ssl_filter_config;
 struct Curl_cfilter;
 struct Curl_easy;
 struct dynbuf;
@@ -110,7 +110,7 @@ curl_sslbackend Curl_ssl_backend(void);
 CURLcode Curl_ssl_peer_init(struct ssl_peer *ssl_peer,
                             struct Curl_peer *origin,
                             struct Curl_peer *peer,
-                            struct ssl_primary_config *sslc,
+                            struct ssl_filter_config *sslc,
                             const char *tls_id,
                             uint8_t transport);
 /**
@@ -202,17 +202,14 @@ CURLcode Curl_cf_ssl_proxy_insert_after(struct Curl_cfilter *cf_at,
  */
 bool Curl_ssl_supports(struct Curl_easy *data, unsigned int ssl_option);
 
-/**
- * Get the ssl_config_data in `data` that is relevant for cfilter `cf`.
- */
-struct ssl_config_data *Curl_ssl_cf_get_config(struct Curl_cfilter *cf,
-                                               struct Curl_easy *data);
+/* Get the ssl_easy_config from `data` relevant for cfilter `cf`. */
+struct ssl_easy_config *
+Curl_ssl_cf_get_easy_config(struct Curl_cfilter *cf,
+                            struct Curl_easy *data);
 
-/**
- * Get the primary config relevant for the filter from its connection.
- */
-struct ssl_primary_config *Curl_ssl_cf_get_primary_config(
-  struct Curl_cfilter *cf);
+/* Get the filter config relevant for cfilter `cf`. */
+struct ssl_filter_config *
+Curl_ssl_cf_get_filter_config(struct Curl_cfilter *cf);
 
 extern struct Curl_cftype Curl_cft_ssl;
 #ifndef CURL_DISABLE_PROXY
@@ -234,8 +231,8 @@ extern struct Curl_cftype Curl_cft_ssl_proxy;
 #define Curl_ssl_supports(a, b) FALSE
 #define Curl_ssl_cfilter_add(a, b, c, d) CURLE_NOT_BUILT_IN
 #define Curl_ssl_cfilter_remove(a, b, c) CURLE_OK
-#define Curl_ssl_cf_get_config(a, b) NULL
-#define Curl_ssl_cf_get_primary_config(a) NULL
+#define Curl_ssl_cf_get_easy_config(a, b) NULL
+#define Curl_ssl_cf_get_filter_config(a) NULL
 #endif
 
 #endif /* HEADER_CURL_VTLS_H */

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -97,7 +97,7 @@ static bool blobcmp(struct curl_blob *first, struct curl_blob *second)
   return !memcmp(first->data, second->data, first->len); /* same data */
 }
 
-void Curl_ssl_config_init(struct ssl_primary_config *sslc)
+void Curl_ssl_config_init(struct ssl_easy_config *sslc)
 {
   /*
    * libcurl 7.10 introduced SSL verification *by default*! This needs to be
@@ -108,7 +108,7 @@ void Curl_ssl_config_init(struct ssl_primary_config *sslc)
   sslc->cache_session = TRUE; /* caching by default */
 }
 
-void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc)
+void Curl_ssl_config_cleanup(struct ssl_filter_config *sslc)
 {
   if(sslc->deep_copy) {
     curlx_safefree(sslc->CApath);
@@ -134,8 +134,8 @@ void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc)
 }
 
 static bool match_ssl_primary_config(struct Curl_easy *data,
-                                     struct ssl_primary_config *c1,
-                                     struct ssl_primary_config *c2)
+                                     struct ssl_filter_config *c1,
+                                     struct ssl_filter_config *c2)
 {
   (void)data;
   if((c1->version == c2->version) &&
@@ -170,22 +170,23 @@ static bool match_ssl_primary_config(struct Curl_easy *data,
 }
 
 bool Curl_ssl_conn_config_match(struct Curl_easy *data,
+                                struct ssl_filter_config *conn_config,
                                 struct connectdata *candidate,
                                 bool proxy)
 {
 #ifndef CURL_DISABLE_PROXY
   if(proxy)
-    return match_ssl_primary_config(data, &data->set.proxy_ssl.primary,
+    return match_ssl_primary_config(data, conn_config,
                                     &candidate->proxy_ssl_config);
 #else
   (void)proxy;
 #endif
-  return match_ssl_primary_config(data, &data->set.ssl.primary,
+  return match_ssl_primary_config(data, conn_config,
                                   &candidate->ssl_config);
 }
 
-static bool clone_ssl_primary_config(struct ssl_primary_config *source,
-                                     struct ssl_primary_config *dest)
+static bool clone_ssl_primary_config(struct ssl_filter_config *source,
+                                     struct ssl_filter_config *dest)
 {
   DEBUGASSERT(!dest->deep_copy);
   dest->deep_copy = TRUE;
@@ -194,10 +195,15 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
   dest->verifypeer = source->verifypeer;
   dest->verifyhost = source->verifyhost;
   dest->verifystatus = source->verifystatus;
+  dest->ssl_options = source->ssl_options;
   dest->native_ca_store = source->native_ca_store;
   dest->cache_session = source->cache_session;
-  dest->ssl_options = source->ssl_options;
   dest->auto_client_cert = source->auto_client_cert;
+  dest->earlydata = source->earlydata;
+  dest->enable_beast = source->enable_beast;
+  dest->no_partialchain = source->no_partialchain;
+  dest->no_revoke = source->no_revoke;
+  dest->revoke_best_effort = source->revoke_best_effort;
 
   CLONE_BLOB(cert_blob);
   CLONE_BLOB(ca_info_blob);
@@ -221,24 +227,25 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
   return TRUE;
 }
 
-static void ssl_easy_config_compl_options(struct Curl_peer *origin,
-                                          struct Curl_peer *initial_origin,
-                                          struct ssl_config_data *sslc)
+static void
+ssl_easy_config_compl_options(struct Curl_peer *origin,
+                              struct Curl_peer *initial_origin,
+                              struct ssl_easy_config *sslc,
+                              struct ssl_filter_config *primary)
 {
-  uint8_t options = sslc->primary.ssl_options;
+  uint8_t options = sslc->ssl_options;
   /* If set via CURLOPT_(PROXY_)SSL_OPTIONS, we definitely use it.
    * If not, we switch it on for supported backends if no custom
    * CA settings exist. */
-  sslc->primary.native_ca_store = !!(options & CURLSSLOPT_NATIVE_CA);
-  sslc->primary.auto_client_cert =
+  primary->native_ca_store = !!(options & CURLSSLOPT_NATIVE_CA);
+  primary->earlydata = !!(options & CURLSSLOPT_EARLYDATA);
+  primary->auto_client_cert =
     Curl_peer_equal(origin, initial_origin) &&
     !!(options & CURLSSLOPT_AUTO_CLIENT_CERT);
-
-  sslc->enable_beast = !!(options & CURLSSLOPT_ALLOW_BEAST);
-  sslc->no_partialchain = !!(options & CURLSSLOPT_NO_PARTIALCHAIN);
-  sslc->no_revoke = !!(options & CURLSSLOPT_NO_REVOKE);
-  sslc->revoke_best_effort = !!(options & CURLSSLOPT_REVOKE_BEST_EFFORT);
-  sslc->earlydata = !!(options & CURLSSLOPT_EARLYDATA);
+  primary->enable_beast = !!(options & CURLSSLOPT_ALLOW_BEAST);
+  primary->no_partialchain = !!(options & CURLSSLOPT_NO_PARTIALCHAIN);
+  primary->no_revoke = !!(options & CURLSSLOPT_NO_REVOKE);
+  primary->revoke_best_effort = !!(options & CURLSSLOPT_REVOKE_BEST_EFFORT);
 }
 
 static char *ssl_easy_steal(struct Curl_easy *data, enum dupstring id)
@@ -249,19 +256,22 @@ static char *ssl_easy_steal(struct Curl_easy *data, enum dupstring id)
 }
 
 CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
-                                       struct Curl_peer *origin)
+                                       struct Curl_peer *origin,
+                                       struct ssl_filter_config *ssl_origin,
+                                       struct ssl_filter_config *ssl_proxy)
 {
-  struct ssl_config_data *sslc = &data->set.ssl;
+  struct ssl_easy_config *sslc = &data->set.ssl;
 #if defined(CURL_CA_PATH) || defined(CURL_CA_BUNDLE)
   CURLcode result;
 #endif
 
-  ssl_easy_config_compl_options(origin, data->state.initial_origin, sslc);
+  ssl_easy_config_compl_options(origin, data->state.initial_origin, sslc,
+                                ssl_origin);
 
   if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
 #if defined(USE_APPLE_SECTRUST) || defined(CURL_CA_NATIVE)
     if(!sslc->custom_capath && !sslc->custom_cafile && !sslc->custom_cablob)
-      sslc->primary.native_ca_store = TRUE;
+      ssl_origin->native_ca_store = TRUE;
 #endif
 #ifdef CURL_CA_PATH
     if(!sslc->custom_capath && !CURL_EASY_STR(data, STRING_SSL_CAPATH)) {
@@ -278,51 +288,59 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
     }
 #endif
   }
-  sslc->primary.CAfile = ssl_easy_steal(data, STRING_SSL_CAFILE);
-  sslc->primary.CRLfile = ssl_easy_steal(data, STRING_SSL_CRLFILE);
-  sslc->primary.CApath = ssl_easy_steal(data, STRING_SSL_CAPATH);
-  sslc->primary.cipher_list = ssl_easy_steal(data, STRING_SSL_CIPHER_LIST);
-  sslc->primary.cipher_list13 = ssl_easy_steal(data, STRING_SSL_CIPHER13_LIST);
-  sslc->primary.signature_algorithms =
+
+  ssl_origin->version = sslc->version;
+  ssl_origin->version_max = sslc->version_max;
+  ssl_origin->verifypeer = sslc->verifypeer;
+  ssl_origin->verifyhost = sslc->verifyhost;
+  ssl_origin->verifystatus = sslc->verifystatus;
+  ssl_origin->cache_session = sslc->cache_session;
+  ssl_origin->ssl_options = sslc->ssl_options;
+  ssl_origin->CAfile = ssl_easy_steal(data, STRING_SSL_CAFILE);
+  ssl_origin->CRLfile = ssl_easy_steal(data, STRING_SSL_CRLFILE);
+  ssl_origin->CApath = ssl_easy_steal(data, STRING_SSL_CAPATH);
+  ssl_origin->cipher_list = ssl_easy_steal(data, STRING_SSL_CIPHER_LIST);
+  ssl_origin->cipher_list13 = ssl_easy_steal(data, STRING_SSL_CIPHER13_LIST);
+  ssl_origin->signature_algorithms =
     ssl_easy_steal(data, STRING_SSL_SIGNATURE_ALGORITHMS);
-  sslc->primary.ca_info_blob = data->set.blobs[BLOB_CAINFO];
-  sslc->primary.curves = ssl_easy_steal(data, STRING_SSL_EC_CURVES);
+  ssl_origin->ca_info_blob = data->set.blobs[BLOB_CAINFO];
+  ssl_origin->curves = ssl_easy_steal(data, STRING_SSL_EC_CURVES);
   /* Maybe these should not be used for another origin. But for
    * backwards compatibility, keep them in. */
-  sslc->primary.issuercert = ssl_easy_steal(data, STRING_SSL_ISSUERCERT);
-  sslc->primary.issuercert_blob = data->set.blobs[BLOB_SSL_ISSUERCERT];
+  ssl_origin->issuercert = ssl_easy_steal(data, STRING_SSL_ISSUERCERT);
+  ssl_origin->issuercert_blob = data->set.blobs[BLOB_SSL_ISSUERCERT];
 
   if(Curl_peer_equal(data->state.initial_origin, origin)) {
-    sslc->primary.pinned_key =
+    ssl_origin->pinned_key =
       ssl_easy_steal(data, STRING_SSL_PINNEDPUBLICKEY);
-    sslc->primary.cert_blob = data->set.blobs[BLOB_CERT];
-    sslc->primary.cert_type = ssl_easy_steal(data, STRING_CERT_TYPE);
-    sslc->primary.key = ssl_easy_steal(data, STRING_KEY);
-    sslc->primary.key_type = ssl_easy_steal(data, STRING_KEY_TYPE);
-    sslc->primary.key_passwd = ssl_easy_steal(data, STRING_KEY_PASSWD);
-    sslc->primary.clientcert = ssl_easy_steal(data, STRING_CERT);
-    sslc->primary.key_blob = data->set.blobs[BLOB_KEY];
+    ssl_origin->cert_blob = data->set.blobs[BLOB_CERT];
+    ssl_origin->cert_type = ssl_easy_steal(data, STRING_CERT_TYPE);
+    ssl_origin->key = ssl_easy_steal(data, STRING_KEY);
+    ssl_origin->key_type = ssl_easy_steal(data, STRING_KEY_TYPE);
+    ssl_origin->key_passwd = ssl_easy_steal(data, STRING_KEY_PASSWD);
+    ssl_origin->clientcert = ssl_easy_steal(data, STRING_CERT);
+    ssl_origin->key_blob = data->set.blobs[BLOB_KEY];
   }
   else {
-    sslc->primary.pinned_key = NULL;
-    sslc->primary.cert_blob = NULL;
-    sslc->primary.cert_type = NULL;
-    sslc->primary.key = NULL;
-    sslc->primary.key_type = NULL;
-    sslc->primary.key_passwd = NULL;
-    sslc->primary.clientcert = NULL;
-    sslc->primary.key_blob = NULL;
+    ssl_origin->pinned_key = NULL;
+    ssl_origin->cert_blob = NULL;
+    ssl_origin->cert_type = NULL;
+    ssl_origin->key = NULL;
+    ssl_origin->key_type = NULL;
+    ssl_origin->key_passwd = NULL;
+    ssl_origin->clientcert = NULL;
+    ssl_origin->key_blob = NULL;
   }
 
 #ifndef CURL_DISABLE_PROXY
   sslc = &data->set.proxy_ssl;
-  /* no initial origin for proxy, it is not changed for redirects */
-  ssl_easy_config_compl_options(NULL, NULL, sslc);
 
-  if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
+  ssl_easy_config_compl_options(NULL, NULL, sslc, ssl_proxy);
+  if((Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL)) {
+    /* no initial origin for proxy, it is not changed for redirects */
 #if defined(USE_APPLE_SECTRUST) || defined(CURL_CA_NATIVE)
     if(!sslc->custom_capath && !sslc->custom_cafile && !sslc->custom_cablob)
-      sslc->primary.native_ca_store = TRUE;
+      ssl_proxy->native_ca_store = TRUE;
 #endif
 #ifdef CURL_CA_PATH
     if(!sslc->custom_capath &&
@@ -341,42 +359,56 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
     }
 #endif
   }
-  sslc->primary.CAfile = ssl_easy_steal(data, STRING_SSL_CAFILE_PROXY);
-  sslc->primary.CApath = ssl_easy_steal(data, STRING_SSL_CAPATH_PROXY);
-  sslc->primary.cipher_list =
+
+  ssl_proxy->version = sslc->version;
+  ssl_proxy->version_max = sslc->version_max;
+  ssl_proxy->verifypeer = sslc->verifypeer;
+  ssl_proxy->verifyhost = sslc->verifyhost;
+  ssl_proxy->verifystatus = sslc->verifystatus;
+  ssl_proxy->cache_session = sslc->cache_session;
+  ssl_proxy->ssl_options = sslc->ssl_options;
+  ssl_proxy->CAfile = ssl_easy_steal(data, STRING_SSL_CAFILE_PROXY);
+  ssl_proxy->CApath = ssl_easy_steal(data, STRING_SSL_CAPATH_PROXY);
+  ssl_proxy->cipher_list =
     ssl_easy_steal(data, STRING_SSL_CIPHER_LIST_PROXY);
-  sslc->primary.cipher_list13 =
+  ssl_proxy->cipher_list13 =
     ssl_easy_steal(data, STRING_SSL_CIPHER13_LIST_PROXY);
-  sslc->primary.pinned_key =
+  ssl_proxy->pinned_key =
     ssl_easy_steal(data, STRING_SSL_PINNEDPUBLICKEY_PROXY);
-  sslc->primary.cert_blob = data->set.blobs[BLOB_CERT_PROXY];
-  sslc->primary.ca_info_blob = data->set.blobs[BLOB_CAINFO_PROXY];
-  sslc->primary.issuercert = ssl_easy_steal(data, STRING_SSL_ISSUERCERT_PROXY);
-  sslc->primary.issuercert_blob = data->set.blobs[BLOB_SSL_ISSUERCERT_PROXY];
-  sslc->primary.CRLfile = ssl_easy_steal(data, STRING_SSL_CRLFILE_PROXY);
-  sslc->primary.cert_type = ssl_easy_steal(data, STRING_CERT_TYPE_PROXY);
-  sslc->primary.key = ssl_easy_steal(data, STRING_KEY_PROXY);
-  sslc->primary.key_type = ssl_easy_steal(data, STRING_KEY_TYPE_PROXY);
-  sslc->primary.key_passwd = ssl_easy_steal(data, STRING_KEY_PASSWD_PROXY);
-  sslc->primary.clientcert = ssl_easy_steal(data, STRING_CERT_PROXY);
-  sslc->primary.key_blob = data->set.blobs[BLOB_KEY_PROXY];
+  ssl_proxy->cert_blob = data->set.blobs[BLOB_CERT_PROXY];
+  ssl_proxy->ca_info_blob = data->set.blobs[BLOB_CAINFO_PROXY];
+  ssl_proxy->issuercert = ssl_easy_steal(data, STRING_SSL_ISSUERCERT_PROXY);
+  ssl_proxy->issuercert_blob = data->set.blobs[BLOB_SSL_ISSUERCERT_PROXY];
+  ssl_proxy->CRLfile = ssl_easy_steal(data, STRING_SSL_CRLFILE_PROXY);
+  ssl_proxy->cert_type = ssl_easy_steal(data, STRING_CERT_TYPE_PROXY);
+  ssl_proxy->key = ssl_easy_steal(data, STRING_KEY_PROXY);
+  ssl_proxy->key_type = ssl_easy_steal(data, STRING_KEY_TYPE_PROXY);
+  ssl_proxy->key_passwd = ssl_easy_steal(data, STRING_KEY_PASSWD_PROXY);
+  ssl_proxy->clientcert = ssl_easy_steal(data, STRING_CERT_PROXY);
+  ssl_proxy->key_blob = data->set.blobs[BLOB_KEY_PROXY];
+#else
+  (void)ssl_proxy;
+  DEBUGASSERT(!ssl_proxy);
 #endif /* CURL_DISABLE_PROXY */
 
   return CURLE_OK;
 }
 
-CURLcode Curl_ssl_conn_config_init(struct Curl_easy *data,
+CURLcode Curl_ssl_conn_config_init(struct ssl_filter_config *ssl_config,
+                                   struct ssl_filter_config *proxy_ssl_config,
                                    struct connectdata *conn)
 {
   /* Clone "primary" SSL configurations from the easy handle to
    * the connection. They are used for connection cache matching and
    * probably outlive the easy handle */
-  if(!clone_ssl_primary_config(&data->set.ssl.primary, &conn->ssl_config))
+  if(!clone_ssl_primary_config(ssl_config, &conn->ssl_config))
     return CURLE_OUT_OF_MEMORY;
 #ifndef CURL_DISABLE_PROXY
-  if(!clone_ssl_primary_config(&data->set.proxy_ssl.primary,
-                               &conn->proxy_ssl_config))
+  if(proxy_ssl_config &&
+     !clone_ssl_primary_config(proxy_ssl_config, &conn->proxy_ssl_config))
     return CURLE_OUT_OF_MEMORY;
+#else
+  (void)proxy_ssl_config;
 #endif
   return CURLE_OK;
 }
@@ -393,13 +425,14 @@ void Curl_ssl_conn_config_update(struct Curl_easy *data, bool for_proxy)
 {
   /* May be called on an easy that has no connection yet */
   if(data->conn) {
-    struct ssl_primary_config *src, *dest;
+    struct ssl_easy_config *src;
+    struct ssl_filter_config *dest;
 #ifndef CURL_DISABLE_PROXY
-    src = for_proxy ? &data->set.proxy_ssl.primary : &data->set.ssl.primary;
+    src = for_proxy ? &data->set.proxy_ssl : &data->set.ssl;
     dest = for_proxy ? &data->conn->proxy_ssl_config : &data->conn->ssl_config;
 #else
     (void)for_proxy;
-    src = &data->set.ssl.primary;
+    src = &data->set.ssl;
     dest = &data->conn->ssl_config;
 #endif
     dest->verifyhost = src->verifyhost;

--- a/lib/vtls/vtls_config.c
+++ b/lib/vtls/vtls_config.c
@@ -255,10 +255,10 @@ static char *ssl_easy_steal(struct Curl_easy *data, enum dupstring id)
   return CURL_UNCONST(CURL_EASY_STR(data, id));
 }
 
-CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
-                                       struct Curl_peer *origin,
-                                       struct ssl_filter_config *ssl_origin,
-                                       struct ssl_filter_config *ssl_proxy)
+CURLcode Curl_ssl_filter_config_tmp_init(
+  struct Curl_easy *data, struct Curl_peer *origin,
+  struct ssl_filter_config *ssl_origin,
+  struct ssl_filter_config *ssl_proxy)
 {
   struct ssl_easy_config *sslc = &data->set.ssl;
 #if defined(CURL_CA_PATH) || defined(CURL_CA_BUNDLE)
@@ -388,15 +388,14 @@ CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
   ssl_proxy->key_blob = data->set.blobs[BLOB_KEY_PROXY];
 #else
   (void)ssl_proxy;
-  DEBUGASSERT(!ssl_proxy);
 #endif /* CURL_DISABLE_PROXY */
 
   return CURLE_OK;
 }
 
-CURLcode Curl_ssl_conn_config_init(struct ssl_filter_config *ssl_config,
-                                   struct ssl_filter_config *proxy_ssl_config,
-                                   struct connectdata *conn)
+CURLcode Curl_ssl_conn_config_clone(struct ssl_filter_config *ssl_config,
+                                    struct ssl_filter_config *proxy_ssl_config,
+                                    struct connectdata *conn)
 {
   /* Clone "primary" SSL configurations from the easy handle to
    * the connection. They are used for connection cache matching and

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -29,7 +29,7 @@ struct Curl_easy;
 struct connectdata;
 struct Curl_peer;
 
-struct ssl_primary_config {
+struct ssl_filter_config {
   char *CApath;          /* certificate directory (does not work on Windows) */
   char *CAfile;          /* certificate to verify peer against */
   char *issuercert;      /* optional issuer certificate filename */
@@ -54,42 +54,50 @@ struct ssl_primary_config {
   BIT(verifypeer);       /* set TRUE if this is desired */
   BIT(verifyhost);       /* set TRUE if CN/SAN must match hostname */
   BIT(verifystatus);     /* set TRUE if certificate status must be checked */
-  BIT(native_ca_store); /* use the native CA store of operating system */
+  BIT(native_ca_store);  /* use the native CA store of operating system */
   BIT(cache_session);    /* cache session or not */
   BIT(deep_copy);        /* members are deep copies, eg. owned here */
+  BIT(earlydata);        /* use TLS 1.3 early data */
   BIT(auto_client_cert);   /* automatically locate and use a client
                               certificate for authentication (Schannel) */
-};
-
-struct ssl_config_data {
-  struct ssl_primary_config primary;
-  long certverifyresult; /* result from the certificate verification */
-  BIT(certinfo);     /* gather lots of certificate info */
-  BIT(earlydata);    /* use TLS 1.3 early data */
   BIT(enable_beast); /* allow this flaw for interoperability's sake */
-  BIT(no_revoke);    /* disable SSL certificate revocation checks */
   BIT(no_partialchain); /* do not accept partial certificate chains */
+  BIT(no_revoke);    /* disable SSL certificate revocation checks */
   BIT(revoke_best_effort); /* ignore SSL revocation offline/missing revocation
                               list errors */
+};
+
+struct ssl_easy_config {
+  long certverifyresult; /* result from the certificate verification */
+  uint32_t version_max; /* max supported version the client wants to use */
+  uint8_t version;    /* what version the client wants to use */
+  uint8_t ssl_options;  /* the CURLOPT_SSL_OPTIONS bitmask */
+  BIT(verifypeer);       /* set TRUE if this is desired */
+  BIT(verifyhost);       /* set TRUE if CN/SAN must match hostname */
+  BIT(verifystatus);     /* set TRUE if certificate status must be checked */
+  BIT(cache_session);    /* cache session or not */
+  BIT(certinfo);     /* gather lots of certificate info */
   BIT(custom_cafile); /* application has set custom CA file */
   BIT(custom_capath); /* application has set custom CA path */
   BIT(custom_cablob); /* application has set custom CA blob */
 };
 
-void Curl_ssl_config_init(struct ssl_primary_config *sslc);
-void Curl_ssl_config_cleanup(struct ssl_primary_config *sslc);
+void Curl_ssl_config_init(struct ssl_easy_config *sslc);
+void Curl_ssl_config_cleanup(struct ssl_filter_config *sslc);
 
 /**
- * Init the `data->set.ssl` and `data->set.proxy_ssl` for
- * connection matching use.
+ * Init the SSL configs for origin and proxy from data's settings.
  */
 CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
-                                       struct Curl_peer *origin);
+                                       struct Curl_peer *origin,
+                                       struct ssl_filter_config *ssl_origin,
+                                       struct ssl_filter_config *ssl_proxy);
 
 /**
  * Init SSL configs (main + proxy) for a new connection from the easy handle.
  */
-CURLcode Curl_ssl_conn_config_init(struct Curl_easy *data,
+CURLcode Curl_ssl_conn_config_init(struct ssl_filter_config *ssl_config,
+                                   struct ssl_filter_config *proxy_ssl_config,
                                    struct connectdata *conn);
 
 /**
@@ -99,11 +107,12 @@ CURLcode Curl_ssl_conn_config_init(struct Curl_easy *data,
 void Curl_ssl_conn_config_cleanup(struct connectdata *conn);
 
 /**
- * Return TRUE iff SSL configuration from `data` is functionally the
+ * Return TRUE if `conn_config` is functionally the
  * same as the one on `candidate`.
  * @param proxy   match the proxy SSL config or the main one
  */
 bool Curl_ssl_conn_config_match(struct Curl_easy *data,
+                                struct ssl_filter_config *conn_config,
                                 struct connectdata *candidate,
                                 bool proxy);
 

--- a/lib/vtls/vtls_config.h
+++ b/lib/vtls/vtls_config.h
@@ -85,20 +85,17 @@ struct ssl_easy_config {
 void Curl_ssl_config_init(struct ssl_easy_config *sslc);
 void Curl_ssl_config_cleanup(struct ssl_filter_config *sslc);
 
-/**
- * Init the SSL configs for origin and proxy from data's settings.
- */
-CURLcode Curl_ssl_easy_config_complete(struct Curl_easy *data,
-                                       struct Curl_peer *origin,
-                                       struct ssl_filter_config *ssl_origin,
-                                       struct ssl_filter_config *ssl_proxy);
+/* Init the SSL filter configs *shallow* for connection matching
+ * with origin and data's configuration settings. */
+CURLcode Curl_ssl_filter_config_tmp_init(
+  struct Curl_easy *data, struct Curl_peer *origin,
+  struct ssl_filter_config *ssl_origin,
+  struct ssl_filter_config *ssl_proxy);
 
-/**
- * Init SSL configs (main + proxy) for a new connection from the easy handle.
- */
-CURLcode Curl_ssl_conn_config_init(struct ssl_filter_config *ssl_config,
-                                   struct ssl_filter_config *proxy_ssl_config,
-                                   struct connectdata *conn);
+/* Clone the given filter configs into the connection. */
+CURLcode Curl_ssl_conn_config_clone(struct ssl_filter_config *ssl_config,
+                                    struct ssl_filter_config *proxy_ssl_config,
+                                    struct connectdata *conn);
 
 /**
  * Free allocated resources in SSL configs (main + proxy) for

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -124,7 +124,7 @@ out:
 }
 
 static CURLcode cf_ssl_peer_key_add_mtls(struct dynbuf *buf,
-                                         struct ssl_primary_config *ssl,
+                                         struct ssl_filter_config *ssl,
                                          bool *is_local)
 {
   CURLcode result = CURLE_OK;
@@ -194,7 +194,7 @@ static CURLcode ssl_peer_key_add_transport(struct dynbuf *buf,
 }
 
 static CURLcode ssl_peer_key_add_vrfy(struct dynbuf *buf,
-                                      struct ssl_primary_config *ssl,
+                                      struct ssl_filter_config *ssl,
                                       const struct ssl_peer *peer)
 {
   CURLcode result;
@@ -225,7 +225,7 @@ static CURLcode ssl_peer_key_add_vrfy(struct dynbuf *buf,
   return CURLE_OK;
 }
 
-static CURLcode ssl_peer_key_build(struct ssl_primary_config *ssl,
+static CURLcode ssl_peer_key_build(struct ssl_filter_config *ssl,
                                    const struct ssl_peer *peer,
                                    const char *tls_id,
                                    char **ppeer_key)
@@ -344,7 +344,7 @@ out:
 }
 
 CURLcode Curl_ssl_peer_key_make(const struct ssl_peer *peer,
-                                struct ssl_primary_config *sslc,
+                                struct ssl_filter_config *sslc,
                                 const char *tls_id,
                                 char **ppeer_key)
 {
@@ -676,8 +676,9 @@ void Curl_ssl_scache_destroy(struct Curl_ssl_scache *scache)
 bool Curl_ssl_scache_use(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   if(cf_ssl_scache_get(data)) {
-    struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-    return ssl_config ? ssl_config->primary.cache_session : FALSE;
+    struct ssl_filter_config *conn_config =
+      Curl_ssl_cf_get_filter_config(cf);
+    return conn_config ? conn_config->cache_session : FALSE;
   }
   return FALSE;
 }
@@ -740,7 +741,7 @@ bool Curl_ssl_scache_is_locked_by_current_thread(struct Curl_easy *data)
 }
 
 static bool cf_ssl_scache_match_auth(struct Curl_ssl_scache_peer *peer,
-                                     struct ssl_primary_config *conn_config)
+                                     struct ssl_filter_config *conn_config)
 {
   if(!conn_config) {
     if(peer->clientcert || peer->key_passwd)
@@ -757,7 +758,7 @@ static bool cf_ssl_scache_match_auth(struct Curl_ssl_scache_peer *peer,
 static CURLcode cf_ssl_find_peer_by_key(struct Curl_easy *data,
                                         struct Curl_ssl_scache *scache,
                                         const char *ssl_peer_key,
-                                        struct ssl_primary_config *conn_config,
+                                        struct ssl_filter_config *conn_config,
                                         struct Curl_ssl_scache_peer **ppeer)
 {
   size_t i, peer_key_len = 0;
@@ -851,7 +852,7 @@ static struct Curl_ssl_scache_peer *cf_ssl_get_free_peer(
 static CURLcode cf_ssl_add_peer(struct Curl_easy *data,
                                 struct Curl_ssl_scache *scache,
                                 const char *ssl_peer_key,
-                                struct ssl_primary_config *conn_config,
+                                struct ssl_filter_config *conn_config,
                                 struct Curl_ssl_scache_peer **ppeer)
 {
   struct Curl_ssl_scache_peer *peer = NULL;
@@ -924,7 +925,7 @@ static CURLcode cf_scache_add_session(struct Curl_cfilter *cf,
                                       struct Curl_ssl_session *s)
 {
   struct Curl_ssl_scache_peer *peer = NULL;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OUT_OF_MEMORY;
   curl_off_t now = (curl_off_t)time(NULL);
   curl_off_t max_lifetime;
@@ -979,11 +980,11 @@ CURLcode Curl_ssl_scache_put(struct Curl_cfilter *cf,
                              struct Curl_ssl_session *s)
 {
   struct Curl_ssl_scache *scache = cf_ssl_scache_get(data);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result;
-  DEBUGASSERT(ssl_config);
+  DEBUGASSERT(conn_config);
 
-  if(!scache || !ssl_config->primary.cache_session) {
+  if(!scache || !conn_config->cache_session) {
     Curl_ssl_session_destroy(s);
     return CURLE_OK;
   }
@@ -1013,7 +1014,7 @@ CURLcode Curl_ssl_scache_take(struct Curl_cfilter *cf,
                               struct Curl_ssl_session **ps)
 {
   struct Curl_ssl_scache *scache = cf_ssl_scache_get(data);
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_ssl_scache_peer *peer = NULL;
   struct Curl_llist_node *n;
   struct Curl_ssl_session *s = NULL;
@@ -1057,7 +1058,7 @@ CURLcode Curl_ssl_scache_add_obj(struct Curl_cfilter *cf,
                                  Curl_ssl_scache_obj_dtor *sobj_dtor_cb)
 {
   struct Curl_ssl_scache *scache = cf_ssl_scache_get(data);
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_ssl_scache_peer *peer = NULL;
   CURLcode result;
 
@@ -1089,7 +1090,7 @@ void *Curl_ssl_scache_get_obj(struct Curl_cfilter *cf,
                               const char *ssl_peer_key)
 {
   struct Curl_ssl_scache *scache = cf_ssl_scache_get(data);
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_ssl_scache_peer *peer = NULL;
   CURLcode result;
   void *sobj;
@@ -1114,7 +1115,7 @@ void Curl_ssl_scache_remove_all(struct Curl_cfilter *cf,
                                 const char *ssl_peer_key)
 {
   struct Curl_ssl_scache *scache = cf_ssl_scache_get(data);
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_ssl_scache_peer *peer = NULL;
   CURLcode result;
 

--- a/lib/vtls/vtls_scache.h
+++ b/lib/vtls/vtls_scache.h
@@ -62,7 +62,7 @@ void Curl_ssl_scache_destroy(struct Curl_ssl_scache *scache);
  * @param ppeer_key on successful return, the key generated
  */
 CURLcode Curl_ssl_peer_key_make(const struct ssl_peer *peer,
-                                struct ssl_primary_config *sslc,
+                                struct ssl_filter_config *sslc,
                                 const char *tls_id,
                                 char **ppeer_key);
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -525,7 +525,7 @@ static bool wssl_apply_session(
   Curl_wssl_init_session_reuse_cb *sess_reuse_cb,
   struct Curl_ssl_session *scs)
 {
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   WOLFSSL_SESSION *session = NULL;
   bool success = FALSE;
@@ -546,7 +546,7 @@ static bool wssl_apply_session(
         infof(data, "SSL reusing session with ALPN '%s'",
               scs->alpn ? scs->alpn : "-");
         success = TRUE;
-        if(ssl_config->earlydata &&
+        if(conn_config->earlydata &&
            !cf->conn->bits.connect_only &&
            !strcmp("TLSv1.3", wolfSSL_get_version(wss->ssl))) {
           bool do_early_data = FALSE;
@@ -586,7 +586,7 @@ static CURLcode wssl_populate_x509_store(struct Curl_cfilter *cf,
                                          WOLFSSL_X509_STORE *store,
                                          struct wssl_ctx *wssl)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   const char * const ssl_cafile =
     /* CURLOPT_CAINFO_BLOB overrides CURLOPT_CAINFO */
@@ -709,7 +709,7 @@ static bool wssl_cached_x509_store_expired(struct Curl_easy *data,
 static bool wssl_cached_x509_store_different(struct Curl_cfilter *cf,
                                              const struct wssl_x509_share *mb)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   if(!mb->CAfile || !conn_config->CAfile)
     return mb->CAfile != conn_config->CAfile;
 
@@ -740,7 +740,7 @@ static void wssl_set_cached_x509_store(struct Curl_cfilter *cf,
                                        struct Curl_easy *data,
                                        WOLFSSL_X509_STORE *store)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   struct Curl_multi *multi = data->multi;
   struct wssl_x509_share *share;
 
@@ -790,8 +790,7 @@ CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
                                     struct Curl_easy *data,
                                     struct wssl_ctx *wssl)
 {
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result = CURLE_OK;
   WOLFSSL_X509_STORE *cached_store;
   bool cache_criteria_met;
@@ -806,7 +805,7 @@ CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
     conn_config->verifypeer &&
     !conn_config->CApath &&
     !conn_config->ca_info_blob &&
-    !ssl_config->primary.CRLfile &&
+    !conn_config->CRLfile &&
     !conn_config->native_ca_store;
 
   cached_store = cache_criteria_met ? wssl_get_cached_x509_store(cf, data)
@@ -908,17 +907,17 @@ static int wssl_legacy_CTX_set_max_proto_version(WOLFSSL_CTX *ctx, int version)
 #endif /* OPENSSL_EXTRA */
 
 static CURLcode wssl_client_cert(struct Curl_easy *data,
-                                 struct ssl_config_data *ssl_config,
+                                 struct ssl_filter_config *conn_config,
                                  struct wssl_ctx *wctx)
 {
   /* Load the client certificate, and private key */
 #ifndef NO_FILESYSTEM
-  if(ssl_config->primary.cert_blob || ssl_config->primary.clientcert) {
-    const char *cert_file = ssl_config->primary.clientcert;
-    const char *key_file = ssl_config->primary.key;
-    const struct curl_blob *cert_blob = ssl_config->primary.cert_blob;
-    const struct curl_blob *key_blob = ssl_config->primary.key_blob;
-    int file_type = wssl_do_file_type(ssl_config->primary.cert_type);
+  if(conn_config->cert_blob || conn_config->clientcert) {
+    const char *cert_file = conn_config->clientcert;
+    const char *key_file = conn_config->key;
+    const struct curl_blob *cert_blob = conn_config->cert_blob;
+    const struct curl_blob *key_blob = conn_config->key_blob;
+    int file_type = wssl_do_file_type(conn_config->cert_type);
     int rc;
 
     switch(file_type) {
@@ -949,7 +948,7 @@ static CURLcode wssl_client_cert(struct Curl_easy *data,
       key_file = cert_file;
     }
     else
-      file_type = wssl_do_file_type(ssl_config->primary.key_type);
+      file_type = wssl_do_file_type(conn_config->key_type);
 
     rc = key_blob ?
       wolfSSL_CTX_use_PrivateKey_buffer(wctx->ssl_ctx, key_blob->data,
@@ -961,10 +960,10 @@ static CURLcode wssl_client_cert(struct Curl_easy *data,
     }
   }
 #else /* NO_FILESYSTEM */
-  if(ssl_config->primary.cert_blob) {
-    const struct curl_blob *cert_blob = ssl_config->primary.cert_blob;
-    const struct curl_blob *key_blob = ssl_config->primary.key_blob;
-    int file_type = wssl_do_file_type(ssl_config->primary.cert_type);
+  if(conn_config->cert_blob) {
+    const struct curl_blob *cert_blob = conn_config->cert_blob;
+    const struct curl_blob *key_blob = conn_config->key_blob;
+    int file_type = wssl_do_file_type(conn_config->cert_type);
     int rc;
 
     switch(file_type) {
@@ -989,7 +988,7 @@ static CURLcode wssl_client_cert(struct Curl_easy *data,
     if(!key_blob)
       key_blob = cert_blob;
     else
-      file_type = wssl_do_file_type(ssl_config->primary.key_type);
+      file_type = wssl_do_file_type(conn_config->key_type);
 
     if(wolfSSL_CTX_use_PrivateKey_buffer(wctx->ssl_ctx, key_blob->data,
                                          (long)key_blob->len,
@@ -1003,7 +1002,7 @@ static CURLcode wssl_client_cert(struct Curl_easy *data,
 }
 
 static CURLcode ssl_version(struct Curl_easy *data,
-                            struct ssl_primary_config *conn_config,
+                            struct ssl_filter_config *conn_config,
                             struct wssl_ctx *wctx,
                             int *min_version, int *max_version)
 {
@@ -1077,7 +1076,7 @@ static CURLcode ssl_version(struct Curl_easy *data,
 
 static CURLcode wssl_init_ciphers(struct Curl_easy *data,
                                   struct wssl_ctx *wctx,
-                                  struct ssl_primary_config *conn_config,
+                                  struct ssl_filter_config *conn_config,
                                   int tls_min, int tls_max)
 {
 #ifndef WOLFSSL_TLS13
@@ -1143,7 +1142,7 @@ static CURLcode wssl_init_ciphers(struct Curl_easy *data,
 
 static CURLcode wssl_init_curves(struct Curl_easy *data,
                                  struct wssl_ctx *wctx,
-                                 struct ssl_primary_config *conn_config)
+                                 struct ssl_filter_config *conn_config)
 {
   char *curves = conn_config->curves;
   /* Without an explicit list, leave the key share group selection to
@@ -1330,8 +1329,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
                             void *ssl_user_data,
                             Curl_wssl_init_session_reuse_cb *sess_reuse_cb)
 {
-  struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  struct ssl_primary_config *conn_config;
+  struct ssl_filter_config *conn_config;
   WOLFSSL_METHOD *req_method = NULL;
   struct alpn_spec alpns;
   CURLcode result = CURLE_FAILED_INIT;
@@ -1340,7 +1338,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
 
   DEBUGASSERT(!wctx->ssl_ctx);
   DEBUGASSERT(!wctx->ssl);
-  conn_config = Curl_ssl_cf_get_primary_config(cf);
+  conn_config = Curl_ssl_cf_get_filter_config(cf);
   if(!conn_config) {
     result = CURLE_FAILED_INIT;
     goto out;
@@ -1378,7 +1376,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
   if(result)
     goto out;
 
-  result = wssl_client_cert(data, ssl_config, wctx);
+  result = wssl_client_cert(data, conn_config, wctx);
   if(result)
     goto out;
 
@@ -1493,7 +1491,7 @@ static CURLcode wssl_connect_step1(struct Curl_cfilter *cf,
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct wssl_ctx *wssl = (struct wssl_ctx *)connssl->backend;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   CURLcode result;
 
   DEBUGASSERT(wssl);
@@ -1680,7 +1678,7 @@ static CURLcode wssl_handshake(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct wssl_ctx *wssl = (struct wssl_ctx *)connssl->backend;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct ssl_filter_config *conn_config = Curl_ssl_cf_get_filter_config(cf);
   int ret = -1, detail;
   CURLcode result;
 

--- a/tests/unit/unit3303.c
+++ b/tests/unit/unit3303.c
@@ -34,14 +34,16 @@ static CURLcode test_unit3303(const char *arg)
 
 #ifdef USE_SSL
   CURL *curl;
+  struct Curl_easy *data = NULL;
   struct connectdata *conn;
-  struct ssl_primary_config *primary;
   char *saved;
   static char alt_passwd[] = "wrong";
   static char alt_key[]    = "other.key";
   static char alt_ktype[]  = "DER";
   static char alt_ctype[]  = "P12";
   struct Curl_peer *origin = NULL;
+  struct ssl_filter_config ssl_config;
+  struct ssl_filter_config proxy_ssl_config;
   CURLcode result;
 
   curl_global_init(CURL_GLOBAL_ALL);
@@ -50,16 +52,16 @@ static CURLcode test_unit3303(const char *arg)
     curl_global_cleanup();
     goto unit_test_abort;
   }
+  data = (struct Curl_easy *)curl;
 
-  result = Curl_peer_create((struct Curl_easy *)curl,
-                            &Curl_scheme_https,
+  result = Curl_peer_create(data, &Curl_scheme_https,
                             "test.curl.se", 1234, &origin);
   if(result) {
     curl_easy_cleanup(curl);
     curl_global_cleanup();
     goto unit_test_abort;
   }
-  Curl_peer_link(&((struct Curl_easy *)curl)->state.initial_origin, origin);
+  Curl_peer_link(&data->state.initial_origin, origin);
 
   curl_easy_setopt(curl, CURLOPT_SSLCERT, "client.pem");
   curl_easy_setopt(curl, CURLOPT_SSLKEY, "client.key");
@@ -67,7 +69,10 @@ static CURLcode test_unit3303(const char *arg)
   curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "PEM");
   curl_easy_setopt(curl, CURLOPT_SSLKEYTYPE, "PEM");
 
-  if(Curl_ssl_easy_config_complete((struct Curl_easy *)curl, origin)) {
+  memset(&ssl_config, 0, sizeof(ssl_config));
+  memset(&proxy_ssl_config, 0, sizeof(proxy_ssl_config));
+  if(Curl_ssl_easy_config_complete(data, origin, &ssl_config,
+                                   &proxy_ssl_config)) {
     Curl_peer_unlink(&origin);
     curl_easy_cleanup(curl);
     curl_global_cleanup();
@@ -75,7 +80,8 @@ static CURLcode test_unit3303(const char *arg)
   }
 
   conn = curlx_calloc(1, sizeof(*conn));
-  if(!conn || Curl_ssl_conn_config_init((struct Curl_easy *)curl, conn)) {
+  if(!conn ||
+    Curl_ssl_conn_config_init(&ssl_config, NULL, conn)) {
     if(conn)
       Curl_ssl_conn_config_cleanup(conn);
     curlx_free(conn);
@@ -86,49 +92,42 @@ static CURLcode test_unit3303(const char *arg)
   }
 
   /* Baseline: identical config must match. */
-  fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                         FALSE),
+  fail_unless(Curl_ssl_conn_config_match(data, &ssl_config, conn, FALSE),
               "identical mTLS config should match");
 
-  primary = &((struct Curl_easy *)curl)->set.ssl.primary;
-
   /* Different key_passwd must not match. */
-  saved = primary->key_passwd;
-  primary->key_passwd = alt_passwd;
-  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                          FALSE),
+  saved = ssl_config.key_passwd;
+  ssl_config.key_passwd = alt_passwd;
+  fail_unless(!Curl_ssl_conn_config_match(data, &ssl_config, conn, FALSE),
               "different key_passwd must not reuse conn");
-  primary->key_passwd = saved;
+  ssl_config.key_passwd = saved;
 
   /* Different key path must not match. */
-  saved = primary->key;
-  primary->key = alt_key;
-  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                          FALSE),
+  saved = ssl_config.key;
+  ssl_config.key = alt_key;
+  fail_unless(!Curl_ssl_conn_config_match(data, &ssl_config, conn, FALSE),
               "different key must not reuse conn");
-  primary->key = saved;
+  ssl_config.key = saved;
 
   /* Different key type must not match. */
-  saved = primary->key_type;
-  primary->key_type = alt_ktype;
-  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                          FALSE),
+  saved = ssl_config.key_type;
+  ssl_config.key_type = alt_ktype;
+  fail_unless(!Curl_ssl_conn_config_match(data, &ssl_config, conn, FALSE),
               "different key_type must not reuse conn");
-  primary->key_type = saved;
+  ssl_config.key_type = saved;
 
   /* Different cert type must not match. */
-  saved = primary->cert_type;
-  primary->cert_type = alt_ctype;
-  fail_unless(!Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                          FALSE),
+  saved = ssl_config.cert_type;
+  ssl_config.cert_type = alt_ctype;
+  fail_unless(!Curl_ssl_conn_config_match(data, &ssl_config, conn, FALSE),
               "different cert_type must not reuse conn");
-  primary->cert_type = saved;
+  ssl_config.cert_type = saved;
 
   /* All fields restored: must match again. */
-  fail_unless(Curl_ssl_conn_config_match((struct Curl_easy *)curl, conn,
-                                         FALSE),
+  fail_unless(Curl_ssl_conn_config_match(data, &ssl_config, conn, FALSE),
               "restored mTLS config should match");
 
+  Curl_ssl_config_cleanup(&ssl_config);
   Curl_ssl_conn_config_cleanup(conn);
   curlx_free(conn);
   curl_easy_cleanup(curl);

--- a/tests/unit/unit3303.c
+++ b/tests/unit/unit3303.c
@@ -71,8 +71,8 @@ static CURLcode test_unit3303(const char *arg)
 
   memset(&ssl_config, 0, sizeof(ssl_config));
   memset(&proxy_ssl_config, 0, sizeof(proxy_ssl_config));
-  if(Curl_ssl_easy_config_complete(data, origin, &ssl_config,
-                                   &proxy_ssl_config)) {
+  if(Curl_ssl_filter_config_tmp_init(data, origin, &ssl_config,
+                                     &proxy_ssl_config)) {
     Curl_peer_unlink(&origin);
     curl_easy_cleanup(curl);
     curl_global_cleanup();
@@ -81,7 +81,7 @@ static CURLcode test_unit3303(const char *arg)
 
   conn = curlx_calloc(1, sizeof(*conn));
   if(!conn ||
-    Curl_ssl_conn_config_init(&ssl_config, NULL, conn)) {
+    Curl_ssl_conn_config_clone(&ssl_config, NULL, conn)) {
     if(conn)
       Curl_ssl_conn_config_cleanup(conn);
     curlx_free(conn);

--- a/tests/unit/unit3304.c
+++ b/tests/unit/unit3304.c
@@ -45,7 +45,7 @@ static CURLcode test_unit3304(const char *arg)
 #ifdef USE_SSL
   struct Curl_peer origin;
   struct ssl_peer peer;
-  struct ssl_primary_config ssl;
+  struct ssl_filter_config ssl;
   char *key1 = NULL;
   char *key2 = NULL;
   static char base_hostname[] = "example.com";


### PR DESCRIPTION
The easy handle owned 2 `struct ssl_primary_config` when curl is built with proxy support. These structs were basically only used during connection matching and, for a new connection, cloned into the `connectdata` struct.

Remove these from the easy handle and keep them in the url connection matcher on the stack.

Removal also found several places in TLS backends where the struct from the easy handle was used wrongly instead of the connection's version.

This should shrink the easy handle by another 300+ bytes.

