### PR TITLE
GHA: set `cache-mode`

### DIFF
--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 jobs:
   split:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -35,6 +35,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   DO_NOT_TRACK: '1'

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -30,6 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   DO_NOT_TRACK: '1'

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -234,6 +234,7 @@ jobs:
             --ignore ubuntu-26.04 \
             --ignore ubuntu-24.04-firewall \
             --ignore 'unexpected key "background"' \
+            --ignore 'unexpected key "cache-mode"' \
             --ignore 'unexpected key "wait"' \
             --ignore 'unexpected key "wait-all"' \
             --ignore 'must run script with "run" section' \

--- a/.github/workflows/checkurls.yml
+++ b/.github/workflows/checkurls.yml
@@ -22,6 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   DO_NOT_TRACK: '1'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   DO_NOT_TRACK: '1'

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -37,6 +37,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   CURL_CI: github

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -32,6 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   CW_NOGET: 'curl trurl'

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -20,6 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   CURL_TEST_MIN: 1500

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,6 +39,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: write
 
 env:
   DO_NOT_TRACK: '1'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -32,6 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: write
 
 env:
   MAKEFLAGS: -j 5
@@ -71,7 +72,6 @@ jobs:
   build-cache:
     name: 'Build caches'
     runs-on: ubuntu-26.04
-
     steps:
       - name: 'cache awslc'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   DO_NOT_TRACK: '1'

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -46,6 +46,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   MAKEFLAGS: -j 5

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,6 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: write
 
 env:
   MAKEFLAGS: -j 5

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 # Apple APIs and the macos-version-min value required to avoid deprecation
 # warnings with llvm/clang, and/or the feature getting enabled at build-time
@@ -56,6 +57,7 @@ jobs:
     name: "iOS, ${{ (matrix.build.generator && format('CM-{0}', matrix.build.generator)) || (matrix.build.generate && 'CM' || 'AM' )}} ${{ matrix.build.name }} arm64"
     runs-on: macos-latest
     timeout-minutes: 10
+    cache-mode: write
     env:
       DEVELOPER_DIR: "/Applications/Xcode${{ matrix.build.xcode && format('_{0}', matrix.build.xcode) || '' }}.app/Contents/Developer"
       CC: 'clang'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -32,6 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: none
 
 env:
   CURL_CI: github
@@ -257,6 +258,7 @@ jobs:
     name: "AmigaOS, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} gcc AmiSSL m68k"
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    cache-mode: write
     env:
       MAKEFLAGS: -j 5
       MATRIX_BUILD: '${{ matrix.build }}'
@@ -477,6 +479,7 @@ jobs:
     name: "MS-DOS, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} djgpp !ssl i586"
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    cache-mode: write
     env:
       LDFLAGS: -s
       MAKEFLAGS: -j 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,6 +48,7 @@ jobs:
   build-cache:
     name: 'Build caches'
     runs-on: ${{ matrix.image }}
+    cache-mode: write-only
     strategy:
       matrix:
         image: [windows-11-arm, windows-2022]  # Cannot share cache between arm and intel: https://github.com/actions/cache/issues/1622
@@ -75,6 +76,7 @@ jobs:
     needs: build-cache
     runs-on: windows-2022
     timeout-minutes: 10
+    cache-mode: read
     defaults:
       run:
         shell: D:\cygwin\bin\bash.exe '{0}'  # zizmor: ignore[misfeature]
@@ -245,6 +247,7 @@ jobs:
     needs: build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: ${{ contains(matrix.tflags, '-t') && 14 || 10 }}
+    cache-mode: read
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
@@ -585,6 +588,7 @@ jobs:
     needs: build-cache
     runs-on: windows-2022
     timeout-minutes: 10
+    cache-mode: write
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
@@ -803,6 +807,7 @@ jobs:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-26.04
     timeout-minutes: 10
+    cache-mode: none
     env:
       LDFLAGS: -s
       MAKEFLAGS: -j 5
@@ -916,6 +921,7 @@ jobs:
     needs: build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: ${{ matrix.arch == 'arm64' && 12 || 10 }}
+    cache-mode: read
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,6 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+cache-mode: write
 
 env:
   CURL_CI: github
@@ -48,7 +49,6 @@ jobs:
   build-cache:
     name: 'Build caches'
     runs-on: ${{ matrix.image }}
-    cache-mode: write  # needs read permission for 'lookup-only: true'
     strategy:
       matrix:
         image: [windows-11-arm, windows-2022]  # Cannot share cache between arm and intel: https://github.com/actions/cache/issues/1622
@@ -59,7 +59,7 @@ jobs:
         with:
           path: C:\my-stunnel
           key: ${{ runner.os }}-stunnel-${{ env.STUNNEL_VERSION }}-amd64
-          lookup-only: true
+          lookup-only: true  # requires cache read permission
 
       - name: 'install test prereqs (stunnel)'
         if: ${{ !steps.cache-stunnel.outputs.cache-hit }}
@@ -247,7 +247,6 @@ jobs:
     needs: build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: ${{ contains(matrix.tflags, '-t') && 14 || 10 }}
-    cache-mode: read
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
@@ -588,7 +587,6 @@ jobs:
     needs: build-cache
     runs-on: windows-2022
     timeout-minutes: 10
-    cache-mode: write
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]
@@ -921,7 +919,6 @@ jobs:
     needs: build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: ${{ matrix.arch == 'arm64' && 12 || 10 }}
-    cache-mode: read
     defaults:
       run:
         shell: msys2 {0}  # zizmor: ignore[misfeature]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,7 +48,7 @@ jobs:
   build-cache:
     name: 'Build caches'
     runs-on: ${{ matrix.image }}
-    cache-mode: write-only
+    cache-mode: write  # needs read permission for 'lookup-only: true'
     strategy:
       matrix:
         image: [windows-11-arm, windows-2022]  # Cannot share cache between arm and intel: https://github.com/actions/cache/issues/1622


### PR DESCRIPTION
Limit cache access to the minimum required.

Refs:
https://github.blog/changelog/2026-09-10-control-github-actions-cache-access-with-cache-mode/
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#cache-mode
https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#bypassing-the-default-untrusted-trigger-cache-restriction

---

- [x] check and tweak settings where implicit MSYS2 caching is done.

<!--
        IMPORTANT:
        If you cannot understand or explain your work without using
        Artificial Intelligence (AI) then do not file here. Do not paste
        massive AI generated explanations. We accept the use of AI as long as
        it is digestible. Please explain your issues or improvements briefly
        and clearly in your own human voice.
-->
