### PR TITLE
libssh2: skip repeat checkp() for already-absent hashed key types

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -652,6 +652,11 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data,
      !CURL_EASY_STR(data, STRING_SSH_HOST_PUBLIC_KEY_SHA256)) {
     struct libssh2_knownhost *store = NULL;
     struct connectdata *conn = data->conn;
+    /* key types already confirmed absent for this host, so repeat hashed
+       entries of the same type do not each force a fresh checkp() scan
+       of the whole known_hosts set */
+    int absent_types[6];
+    size_t num_absent_types = 0;
     /* lets try to find our host in the known hosts file */
     while(!libssh2_knownhost_get(sshc->kh, &store, store)) {
       /* For non-standard ports, the name is enclosed in */
@@ -686,17 +691,32 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data,
           }
         }
         else if(store->key) {
-          int keycheck = libssh2_knownhost_checkp(
-            sshc->kh, conn->origin->hostname,
-            (conn->origin->port != PORT_SSH) ? conn->origin->port : -1,
-            store->key, strlen(store->key),
-            LIBSSH2_KNOWNHOST_TYPE_PLAIN |
-              LIBSSH2_KNOWNHOST_KEYENC_BASE64 |
-              (store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK),
-            NULL);
-          if(keycheck == LIBSSH2_KNOWNHOST_CHECK_MATCH) {
-            found = TRUE;
-            break;
+          int type = store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK;
+          bool type_absent = FALSE;
+          size_t i;
+          for(i = 0; i < num_absent_types; i++) {
+            if(absent_types[i] == type) {
+              type_absent = TRUE;
+              break;
+            }
+          }
+          if(!type_absent) {
+            int keycheck = libssh2_knownhost_checkp(
+              sshc->kh, conn->origin->hostname,
+              (conn->origin->port != PORT_SSH) ? conn->origin->port : -1,
+              store->key, strlen(store->key),
+              LIBSSH2_KNOWNHOST_TYPE_PLAIN |
+                LIBSSH2_KNOWNHOST_KEYENC_BASE64 |
+                type,
+              NULL);
+            if(keycheck == LIBSSH2_KNOWNHOST_CHECK_MATCH) {
+              found = TRUE;
+              break;
+            }
+            else if(keycheck == LIBSSH2_KNOWNHOST_CHECK_NOTFOUND &&
+                    num_absent_types < CURL_ARRAYSIZE(absent_types)) {
+              absent_types[num_absent_types++] = type;
+            }
           }
         }
       }

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -654,9 +654,10 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data,
     struct connectdata *conn = data->conn;
     /* key types already confirmed absent for this host, so repeat hashed
        entries of the same type do not each force a fresh checkp() scan
-       of the whole known_hosts set */
-    int absent_types[6];
-    size_t num_absent_types = 0;
+       of the whole known_hosts set. one slot per possible key type (indexed
+       by the type shifted down) so no entry ordering can overflow it */
+    bool absent_type[(LIBSSH2_KNOWNHOST_KEY_MASK >>
+                      LIBSSH2_KNOWNHOST_KEY_SHIFT) + 1] = { FALSE };
     /* lets try to find our host in the known hosts file */
     while(!libssh2_knownhost_get(sshc->kh, &store, store)) {
       /* For non-standard ports, the name is enclosed in */
@@ -691,32 +692,23 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data,
           }
         }
         else if(store->key) {
-          int type = store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK;
-          bool type_absent = FALSE;
-          size_t i;
-          for(i = 0; i < num_absent_types; i++) {
-            if(absent_types[i] == type) {
-              type_absent = TRUE;
-              break;
-            }
-          }
-          if(!type_absent) {
+          unsigned int type = (store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK)
+                              >> LIBSSH2_KNOWNHOST_KEY_SHIFT;
+          if(!absent_type[type]) {
             int keycheck = libssh2_knownhost_checkp(
               sshc->kh, conn->origin->hostname,
               (conn->origin->port != PORT_SSH) ? conn->origin->port : -1,
               store->key, strlen(store->key),
               LIBSSH2_KNOWNHOST_TYPE_PLAIN |
                 LIBSSH2_KNOWNHOST_KEYENC_BASE64 |
-                type,
+                (store->typemask & LIBSSH2_KNOWNHOST_KEY_MASK),
               NULL);
             if(keycheck == LIBSSH2_KNOWNHOST_CHECK_MATCH) {
               found = TRUE;
               break;
             }
-            else if(keycheck == LIBSSH2_KNOWNHOST_CHECK_NOTFOUND &&
-                    num_absent_types < CURL_ARRAYSIZE(absent_types)) {
-              absent_types[num_absent_types++] = type;
-            }
+            else if(keycheck == LIBSSH2_KNOWNHOST_CHECK_NOTFOUND)
+              absent_type[type] = TRUE;
           }
         }
       }


### PR DESCRIPTION
follow-up to #22874 (landed in 323c184). that fix added a `libssh2_knownhost_checkp()` call per hashed known_hosts entry so the entry is matched against the requested host before its key type gets used. each `checkp()` rescans the whole known_hosts set though, so a file with many hashed entries of the same type does one full scan per entry.

this caches the key types already confirmed absent for the connecting host. `checkp()` returning NOTFOUND for a (host, port, type) means there is no entry of that type for the host at all, which does not depend on the key bytes passed in. so once a type comes back NOTFOUND, any later hashed entry of that same type can be skipped. if the host does have an entry of that type, `checkp()` returns MATCH or MISMATCH instead and nothing is cached, so real matches are still found. the MATCH path and the switch on `store->typemask` afterward are unchanged.

pure perf, no behavior change.

tested: runtests.pl 3500 1459 600, full SFTP/SCP keyword set (58/58), checksrc.pl.
