### PR TITLE
dynhds: grow header array geometrically

### DIFF
--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -146,7 +146,7 @@ CURLcode Curl_dynhds_add(struct dynhds *dynhds,
     goto out;
 
   if(dynhds->hds_len + 1 >= dynhds->hds_allc) {
-    size_t nallc = dynhds->hds_len + 16;
+    size_t nallc = dynhds->hds_allc ? dynhds->hds_allc * 2 : 16;
     struct dynhds_entry **nhds;
 
     if(dynhds->max_entries && nallc > dynhds->max_entries)


### PR DESCRIPTION
Curl_dynhds_add() grew its pointer array by a fixed 16 slots per resize. Appending N headers therefore repeatedly copied the existing pointers, resulting in O(N²) aggregate work.

Grow the array geometrically instead. Appends are now amortized O(1), while the existing max_entries cap continues to limit the allocation when configured.