### PR TITLE
GHA: switch back to Azure apt mirror, strip the rest

### DIFF
--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -31,8 +31,8 @@ runs:
         # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
         cat /etc/apt/apt-mirrors.txt
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
-        sudo apt-get -o Dpkg::Use-Pty=0 update
-        sudo apt-get -o Dpkg::Use-Pty=0 install ${PACKAGES}
+        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::Acquire::http=1 -o Debug::Acquire::https=1 update
+        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::Acquire::http=1 -o Debug::Acquire::https=1 install ${PACKAGES}
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -26,7 +26,8 @@ runs:
         sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
         ls -l /etc/apt/sources.list.d
         sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-        # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+        # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
+        cat /etc/apt/apt-mirrors.txt
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
         sudo apt-get -o Dpkg::Use-Pty=0 update
         sudo apt-get -o Dpkg::Use-Pty=0 install ${PACKAGES}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -26,6 +26,9 @@ runs:
         sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
         ls -l /etc/apt/sources.list.d
         sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
+        rm -f /etc/apt/sources.list.d/ubuntu.sources
+        sudo sed -i '/\/archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+        sudo sed -i '/\/security\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
         # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
         cat /etc/apt/apt-mirrors.txt
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -26,8 +26,6 @@ runs:
         sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
         ls -l /etc/apt/sources.list.d
         sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-        cat /etc/apt/sources.list.d/ubuntu.sources
-        rm -f /etc/apt/sources.list.d/ubuntu.sources
         sudo sed -i '/\/archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
         sudo sed -i '/\/security\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
         # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -31,8 +31,8 @@ runs:
         # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
         cat /etc/apt/apt-mirrors.txt
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
-        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::pkgAcquire::Worker=1 update
-        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::pkgAcquire::Worker=1 install ${PACKAGES}
+        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::Acquire::http=1 -o Debug::Acquire::https=1 update
+        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::Acquire::http=1 -o Debug::Acquire::https=1 install ${PACKAGES}
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -31,8 +31,8 @@ runs:
         # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
         cat /etc/apt/apt-mirrors.txt
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
-        sudo apt-get -o Dpkg::Use-Pty=0 update
-        sudo apt-get -o Dpkg::Use-Pty=0 install ${PACKAGES}
+        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::pkgAcquire::Worker=1 update
+        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::pkgAcquire::Worker=1 install ${PACKAGES}
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -26,6 +26,7 @@ runs:
         sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
         ls -l /etc/apt/sources.list.d
         sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
+        cat /etc/apt/sources.list.d/ubuntu.sources
         rm -f /etc/apt/sources.list.d/ubuntu.sources
         sudo sed -i '/\/archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
         sudo sed -i '/\/security\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -26,7 +26,7 @@ runs:
         sudo rm -f /etc/apt/apt.conf.d/20apt-esm-hook.conf || true
         ls -l /etc/apt/sources.list.d
         sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-        sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
+        # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
         sudo apt-get -o Dpkg::Use-Pty=0 update
         sudo apt-get -o Dpkg::Use-Pty=0 install ${PACKAGES}

--- a/.github/actions/pkg-install/action.yml
+++ b/.github/actions/pkg-install/action.yml
@@ -31,8 +31,8 @@ runs:
         # sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt
         cat /etc/apt/apt-mirrors.txt
         [[ "${PACKAGES}" = *':i386'* ]] && sudo dpkg --add-architecture i386
-        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::Acquire::http=1 -o Debug::Acquire::https=1 update
-        sudo apt-get -o Dpkg::Use-Pty=0 -o Debug::Acquire::http=1 -o Debug::Acquire::https=1 install ${PACKAGES}
+        sudo apt-get -o Dpkg::Use-Pty=0 update
+        sudo apt-get -o Dpkg::Use-Pty=0 install ${PACKAGES}
 
     - name: 'install (brew)'
       if: ${{ inputs.brew }}


### PR DESCRIPTION
Hopefully fixing:
```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
  Error: The action has timed out.
```
Ref: https://github.com/curl/curl/actions/runs/34571926256/job/103175759594#step:2:66

Follow-up to 50ff4f2927e3e319d39ba86bbcac3f57e5c89984 #21414
