### PR TITLE
CI: tidy up

### DIFF
--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -76,13 +76,13 @@ jobs:
           done
 
       - name: 'compare generated curl_config.h files'
-        run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
+        run: .github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
 
       - name: 'compare generated libcurl.pc files'
-        run: ./.github/scripts/cmp-pkg-config.sh bld-am/libcurl.pc bld-cm/libcurl.pc
+        run: .github/scripts/cmp-pkg-config.sh bld-am/libcurl.pc bld-cm/libcurl.pc
 
       - name: 'compare generated curl-config files'
-        run: ./.github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
+        run: .github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
 
   check-macos:
     name: 'macOS'
@@ -131,13 +131,13 @@ jobs:
           pccritic --min-score 98 bld-cm/libcurl.pc
 
       - name: 'compare generated curl_config.h files'
-        run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
+        run: .github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
 
       - name: 'compare generated libcurl.pc files'
-        run: ./.github/scripts/cmp-pkg-config.sh bld-am/libcurl.pc bld-cm/libcurl.pc
+        run: .github/scripts/cmp-pkg-config.sh bld-am/libcurl.pc bld-cm/libcurl.pc
 
       - name: 'compare generated curl-config files'
-        run: ./.github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
+        run: .github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
 
   check-windows:
     name: 'Windows'
@@ -183,10 +183,10 @@ jobs:
           done
 
       - name: 'compare generated curl_config.h files'
-        run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
+        run: .github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
 
       - name: 'compare generated libcurl.pc files'
-        run: ./.github/scripts/cmp-pkg-config.sh bld-am/libcurl.pc bld-cm/libcurl.pc
+        run: .github/scripts/cmp-pkg-config.sh bld-am/libcurl.pc bld-cm/libcurl.pc
 
       - name: 'compare generated curl-config files'
-        run: ./.github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
+        run: .github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -825,8 +825,6 @@ jobs:
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
             sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
-          sudo find /etc/apt/sources.list.d -type f -not -name 'ubuntu.sources' -delete -print
-          sudo sed -i 's/priority:1/priority:9/' /etc/apt/apt-mirrors.txt; cat /etc/apt/apt-mirrors.txt
           sudo add-apt-repository 'deb https://apt.repos.intel.com/oneapi all main'
           sudo apt-get -o Dpkg::Use-Pty=0 install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -222,7 +222,7 @@ jobs:
             install_packages: gcc-16 libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev valgrind
             CC: gcc-16
             tflags: '--subset=0/2'
-            generate: -DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF -DCURL_GCC_ANALYZER=ON -DCURL_ENABLE_NTLM=ON
+            generate: -DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF -DCURL_ENABLE_NTLM=ON -DCURL_GCC_ANALYZER=ON
 
           - name: 'openssl libssh2 sync-resolver valgrind 2'
             image: ubuntu-26.04-arm

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1156,12 +1156,6 @@ jobs:
         timeout-minutes: 5
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5
 
-      - name: 'libcurl.pc, curl-config'
-        run: |
-          for f in libcurl.pc curl-config; do
-            echo "::group::${f}"; grep -v '^#' bld/"${f}" || true; echo '::endgroup::'
-          done
-
       - name: 'curl -V'
         timeout-minutes: 1
         run: |

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -118,7 +118,7 @@ fi
 
 if [[ "${CREATE_ARTIFACT:-}" = 'true' ]]; then
   cp /usr/ssl/certs/ca-bundle.crt curl-ca-bundle.crt
-  echo "Checking that https works (it should find curl-ca-bundle.crt if needed)"
+  echo 'Checking that https works (it should find curl-ca-bundle.crt if needed)'
   "${curl}" -v -fsS --retry 6 --retry-all-errors -o /dev/null https://curl.se/
   if [ -n "${APPVEYOR_PULL_REQUEST_NUMBER:-}" ]; then
     archive="curl_pr${APPVEYOR_PULL_REQUEST_NUMBER}_${APPVEYOR_PULL_REQUEST_HEAD_COMMIT}.zip"
@@ -130,9 +130,9 @@ WARNING: Do not run this build unless the download link was provided by staff.
 Anyone can submit a PR with possibly malicious code to generate a build.
 ${archive}
 EOF
-  echo "Finding curl module dependencies"
-  "${curl}" --dump-module-paths | grep -Fv "C:\Windows" | tee > files.tmp
-  echo "Creating artifact"
+  echo 'Finding curl module dependencies'
+  "${curl}" --dump-module-paths | grep -Fv 'C:\Windows' | tee > files.tmp
+  echo 'Creating artifact'
   7z a "${archive}" -y -bb1 -bsp0 -mx9 -tzip -i@files.tmp curl-ca-bundle.crt WARNING.txt
   rm files.tmp
   appveyor PushArtifact "${archive}"

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -125,11 +125,10 @@ if [[ "${CREATE_ARTIFACT:-}" = 'true' ]]; then
   else
     archive="curl_${APPVEYOR_REPO_COMMIT}.zip"
   fi
-cat << EOF > WARNING.txt
-WARNING: Do not run this build unless the download link was provided by staff.
-Anyone can submit a PR with possibly malicious code to generate a build.
-${archive}
-EOF
+  {
+    echo 'WARNING: Do not run this build unless the download link was provided by staff.'
+    echo "Anyone can submit a PR with possibly malicious code to generate a build.\n${archive}"
+  } > WARNING.txt
   echo 'Finding curl module dependencies'
   "${curl}" --dump-module-paths | grep -Fv 'C:\Windows' | tee > files.tmp
   echo 'Creating artifact'

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -127,7 +127,8 @@ if [[ "${CREATE_ARTIFACT:-}" = 'true' ]]; then
   fi
   {
     echo 'WARNING: Do not run this build unless the download link was provided by staff.'
-    echo "Anyone can submit a PR with possibly malicious code to generate a build.\n${archive}"
+    echo 'Anyone can submit a PR with possibly malicious code to generate a build.'
+    echo "${archive}"
   } > WARNING.txt
   echo 'Finding curl module dependencies'
   "${curl}" --dump-module-paths | grep -Fv 'C:\Windows' | tee > files.tmp

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -119,7 +119,7 @@ fi
 if [[ "${CREATE_ARTIFACT:-}" = 'true' ]]; then
   cp /usr/ssl/certs/ca-bundle.crt curl-ca-bundle.crt
   echo "Checking that https works (it should find curl-ca-bundle.crt if needed)"
-  "${curl}" -v -fsS --retry 6 --retry-all-errors -o /dev/null https://curl.se
+  "${curl}" -v -fsS --retry 6 --retry-all-errors -o /dev/null https://curl.se/
   if [ -n "${APPVEYOR_PULL_REQUEST_NUMBER:-}" ]; then
     archive="curl_pr${APPVEYOR_PULL_REQUEST_NUMBER}_${APPVEYOR_PULL_REQUEST_HEAD_COMMIT}.zip"
   else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,7 +94,7 @@ environment:
       CMAKE_SHA256: dfc2b2afac257555e3b9ce375b12b2883964283a366c17fec96cf4d17e4f1677
       CMAKE_GENERATOR: 'Visual Studio 18 2026'
       CMAKE_GENERATE: '-A x64 -T ClangCl -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=ON'
-      CREATE_ARTIFACT: true
+      CREATE_ARTIFACT: 'true'
 
     - job_name: 'CM VS2022, Release, x64, Schannel, Shared, Unicode, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'


### PR DESCRIPTION
- GHA/configure-vs-cmake: drop `./` prefixes from commands.
- GHA/linux: drop redundant mirror tweak from Intel C prereqs step.
  This tweak is done earlier as part of the main prereqs step.
- GHA/linux: option order.
- GHA/windows: drop duplicate `.pc` config dump from MSVC jobs.
- appveyor.sh: add trailing slash to URL.
- appveyor.sh: prefer single-quotes to match rest of script.
- appveyor.sh: replace heredoc with printf in block.
- appveyor.yml: quote truthy value.
