### PR TITLE
peer: speed up "same destination" check

### DIFF
--- a/lib/peer.c
+++ b/lib/peer.c
@@ -333,9 +333,12 @@ static bool peer_same_hostname(struct Curl_peer *p1, struct Curl_peer *p2)
   return (p1->unix_socket == p2->unix_socket) &&
          (p1->abstract_uds == p2->abstract_uds) &&
          (p1->ipv6 == p2->ipv6) &&
-         (p1->unix_socket ?
-          !strcmp(p1->hostname, p2->hostname) :
-          curl_strequal(p1->hostname, p2->hostname));
+         /* unix_socket paths are case-sensitive, hostnames are not.
+          * Do strcmp() fist on both, since we do a lot of matches
+          * on the same names and platform strcmp is way faster. */
+         (!strcmp(p1->hostname, p2->hostname) ||
+          (!p1->unix_socket &&
+           curl_strequal(p1->hostname, p2->hostname)));
 }
 
 bool Curl_peer_same_destination(struct Curl_peer *p1, struct Curl_peer *p2)

--- a/lib/peer.c
+++ b/lib/peer.c
@@ -334,7 +334,7 @@ static bool peer_same_hostname(struct Curl_peer *p1, struct Curl_peer *p2)
          (p1->abstract_uds == p2->abstract_uds) &&
          (p1->ipv6 == p2->ipv6) &&
          /* unix_socket paths are case-sensitive, hostnames are not.
-          * Do strcmp() fist on both, since we do a lot of matches
+          * Do strcmp() first on both, since we do a lot of matches
           * on the same names and platform strcmp is way faster. */
          (!strcmp(p1->hostname, p2->hostname) ||
           (!p1->unix_socket &&

--- a/lib/url.c
+++ b/lib/url.c
@@ -690,14 +690,16 @@ static bool url_match_multiplex_limits(struct connectdata *conn,
     /* If multiplexed, make sure we do not go over concurrency limit */
     if(conn->attached_xfers >=
             Curl_multi_max_concurrent_streams(m->data->multi)) {
-      infof(m->data, "client side MAX_CONCURRENT_STREAMS reached"
-            ", skip (%u)", conn->attached_xfers);
+      infof(m->data, "connection #%" FMT_OFF_T " reached "
+            "MAX_CONCURRENT_STREAMS(%u), skip",
+            conn->connection_id, conn->attached_xfers);
       return FALSE;
     }
     if(conn->attached_xfers >=
        Curl_conn_get_max_concurrent(m->data, conn, FIRSTSOCKET)) {
-      infof(m->data, "MAX_CONCURRENT_STREAMS reached, skip (%u)",
-            conn->attached_xfers);
+      infof(m->data, "connection #%" FMT_OFF_T "reached "
+            "MAX_CONCURRENT_STREAMS(%u), skip",
+            conn->connection_id, conn->attached_xfers);
       return FALSE;
     }
     /* When not multiplexed, we have a match here! */


### PR DESCRIPTION
The dominant use in `Curl_peer_same_destination()` are checks on the very same hostname. Speed up the case-insensitive matching by performing a `strcmp()` first that is platform optimized.

Tested by running

```sh
> python3 tests/http/scorecard.py -r --request-count=500000 --request-parallel=50000 h2
```

which also shows that our pipewait handling is not very good with large parallelism against the same host.