### PR TITLE
imap: do not treat a content FETCH as a listing

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1178,6 +1178,42 @@ static CURLcode imap_state_login_resp(struct Curl_easy *data,
   return result;
 }
 
+/* Data items that never make the server use a literal in the FETCH response.
+   Any other item can come back as a literal, and a literal body must not be
+   parsed as protocol responses. */
+static bool is_literal_free_fetch_item_list(const char *params)
+{
+  static const char * const items[] = {
+    "UID", "FLAGS", "INTERNALDATE", "RFC822.SIZE", "MODSEQ"
+  };
+
+  while(*params) {
+    size_t i;
+    size_t len = 0;
+
+    if(*params == ' ' || *params == '(' || *params == ')') {
+      params++;
+      continue;
+    }
+
+    /* an item ends at a space, a parenthesis or the end of the string */
+    while(params[len] && params[len] != ' ' && params[len] != '(' &&
+          params[len] != ')')
+      len++;
+
+    for(i = 0; i < CURL_ARRAYSIZE(items); i++) {
+      if(strlen(items[i]) == len && curl_strnequal(items[i], params, len))
+        break;
+    }
+    if(i == CURL_ARRAYSIZE(items))
+      /* a content item, or one we do not know */
+      return FALSE;
+
+    params += len;
+  }
+  return TRUE;
+}
+
 /* Detect IMAP listings vs. downloading a single email */
 static bool is_custom_fetch_listing_match(const char *params)
 {
@@ -1190,11 +1226,15 @@ static bool is_custom_fetch_listing_match(const char *params)
     if(*params == 0)
       return FALSE;
   }
-  if(*params == ':')
-    return TRUE;
-  if(*params == ',')
-    return TRUE;
-  return FALSE;
+  if(*params != ':' && *params != ',')
+    return FALSE;
+
+  /* The sequence set spans several messages, but a FETCH that asks for
+     message content is not a listing: the response can contain literals that
+     have to be consumed as data instead of being read as protocol lines. */
+  while(ISDIGIT(*params) || *params == ':' || *params == ',' || *params == '*')
+    params++;
+  return is_literal_free_fetch_item_list(params);
 }
 
 static bool is_custom_fetch_listing(struct IMAP *imap)

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -2139,7 +2139,9 @@ TESTCASES = \
   test5025 \
   test5026 \
   test5027 \
-  test5028
+  test5028 \
+  test5029 \
+  test5030
 
 EXTRA_DIST = \
   $(TESTCASES) \

--- a/tests/data/test5029
+++ b/tests/data/test5029
@@ -6,6 +6,7 @@ IMAP
 Clear Text
 FETCH
 CUSTOMREQUEST
+literal
 </keywords>
 </info>
 
@@ -14,19 +15,22 @@ CUSTOMREQUEST
 <data crlf="yes">
 From: me@somewhere
 To: fake@nowhere
+Subject: forged
 
-body
+A004 OK FETCH completed
+FORGED-FOR-UID-456
 
 --
   yours sincerely
 </data>
-# the request asks for a content item, so the literal is downloaded
 <datacheck crlf="yes">
-* FETCH FETCH (1:* (FLAGS INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIELDS (Message-Id DATE FROM SUBJECT TO SENDER REPLY-TO CC BCC)]) {71}
+* FETCH FETCH (1:* BODY[] {127}
 From: me@somewhere
 To: fake@nowhere
+Subject: forged
 
-body
+A004 OK FETCH completed
+FORGED-FOR-UID-456
 
 --
   yours sincerely
@@ -39,10 +43,10 @@ body
 imap
 </server>
 <name>
-IMAP FETCH message with custom request to get list of email.
+IMAP custom multi-message FETCH with literal holding a tagged line
 </name>
 <command>
-'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER' --request 'UID FETCH 1:* (FLAGS INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIELDS (Message-Id DATE FROM SUBJECT TO SENDER REPLY-TO CC BCC)])' -u '"user:sec"ret{'
+'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER' --request 'UID FETCH 1:* BODY[]' -u '"user:sec"ret{'
 </command>
 </client>
 
@@ -52,7 +56,7 @@ IMAP FETCH message with custom request to get list of email.
 A001 CAPABILITY
 A002 LOGIN "\"user" "sec\"ret{"
 A003 SELECT %TESTNUMBER
-A004 UID FETCH 1:* (FLAGS INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIELDS (Message-Id DATE FROM SUBJECT TO SENDER REPLY-TO CC BCC)])
+A004 UID FETCH 1:* BODY[]
 A005 LOGOUT
 </protocol>
 </verify>

--- a/tests/data/test5030
+++ b/tests/data/test5030
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<testcase>
+<info>
+<keywords>
+IMAP
+Clear Text
+FETCH
+CUSTOMREQUEST
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data crlf="yes" nocheck="yes">
+From: me@somewhere
+To: fake@nowhere
+
+body
+
+--
+  yours sincerely
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+imap
+</server>
+<name>
+IMAP custom multi-message FETCH of metadata only is a listing
+</name>
+<command>
+'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER' --request 'UID FETCH 1:* (FLAGS INTERNALDATE RFC822.SIZE)' -u '"user:sec"ret{'
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+A001 CAPABILITY
+A002 LOGIN "\"user" "sec\"ret{"
+A003 SELECT %TESTNUMBER
+A004 UID FETCH 1:* (FLAGS INTERNALDATE RFC822.SIZE)
+A005 LOGOUT
+</protocol>
+# a listing goes to debug output, so there is no data output
+<stdout>
+%EMPTY
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
Fixes #22865

`is_custom_fetch_listing_match()` classified any custom FETCH whose sequence
set contained `:` or `,` as a "listing", regardless of which data items were
requested. The listing path (`imap_state_listsearch_resp()`) does not consume
literals as data, so for a request like `UID FETCH 1:* BODY[]` the literal
body was scanned as protocol lines. A tagged completion line inside the
message content ended the response early and the remaining literal bytes were
interpreted as responses to a later command on the reused connection.

With this change a custom FETCH is only treated as a listing when every
requested data item is one that cannot make the server use a literal (UID,
FLAGS, INTERNALDATE, RFC822.SIZE, MODSEQ). Any other item - content items and
items we do not know - takes the download path with literal handling.

Tests:

- new test5029: `UID FETCH 1:* BODY[]` where the message content contains a
  forged `A004 OK FETCH completed` line; the whole literal must be returned
  as data
- new test5030: `UID FETCH 1:* (FLAGS INTERNALDATE RFC822.SIZE)` is still
  taken as a listing, so no body is written
- test1848 updated: its request asks for `BODY.PEEK[HEADER.FIELDS ...]` with a
  `1:*` sequence set, so it now returns the fetched header instead of nothing

Validation: full IMAP test sweep (61/61 OK) with the change, `checksrc` clean,
and without `lib/imap.c` the two content tests fail (test5029 writes 0 bytes).

Known limitation, not changed by this patch: for a content FETCH that spans
several messages libcurl still returns only the first message's body, and the
remaining untagged FETCH responses are skipped until the tagged completion.
Multi-message FETCH support is a separate change.
