### PR TITLE
Refactor is_custom_fetch_listing_match function

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1181,19 +1181,46 @@ static CURLcode imap_state_login_resp(struct Curl_easy *data,
 /* Detect IMAP listings vs. downloading a single email */
 static bool is_custom_fetch_listing_match(const char *params)
 {
+  bool isList = false;
+
   /* match " 1:* (FLAGS ..." or " 1,2,3 (FLAGS ..." */
   if(*params++ != ' ')
     return FALSE;
 
-  while(ISDIGIT(*params)) {
-    params++;
+  while(*params != ' ') {
+    while(ISDIGIT(*params)) {
+      params++;
+      if(*params == 0)
+        return FALSE;
+    }
+    if(*params == ':') {
+      params++;
+      isList = TRUE;
+    }
+    else if(*params == ',') {
+      params++;
+      isList = TRUE;
+    }
+    if(*params == '*') {
+      params++;
+    }
     if(*params == 0)
       return FALSE;
   }
-  if(*params == ':')
-    return TRUE;
-  if(*params == ',')
-    return TRUE;
+  if(*params == ' ') {
+    params++;
+  }
+
+  /* query of multiple bodies */
+  if(curl_strnequal(params, "BODY", 4)) {
+    return FALSE;
+  }
+
+  /* query of list with various fields */
+  if(*params == '(') {
+    return isList;
+  }
+
   return FALSE;
 }
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1188,12 +1188,10 @@ static bool is_custom_fetch_listing_match(const char *params)
     return FALSE;
 
   while(*params != ' ') {
-    while(ISDIGIT(*params)) {
+    if(ISDIGIT(*params)) {
       params++;
-      if(*params == 0)
-        return FALSE;
     }
-    if(*params == ':') {
+    else if(*params == ':') {
       params++;
       isList = TRUE;
     }
@@ -1201,10 +1199,10 @@ static bool is_custom_fetch_listing_match(const char *params)
       params++;
       isList = TRUE;
     }
-    if(*params == '*') {
+    else if(*params == '*') {
       params++;
     }
-    if(*params == 0)
+    else
       return FALSE;
   }
   if(*params == ' ') {
@@ -1215,9 +1213,18 @@ static bool is_custom_fetch_listing_match(const char *params)
   if(curl_strnequal(params, "BODY", 4)) {
     return FALSE;
   }
+  if(curl_strnequal(params, "RFC822", 6)) {
+    return FALSE;
+  }
 
   /* query of list with various fields */
   if(*params == '(') {
+    if(curl_strnequal(params + 1, "BODY", 4)) {
+      return FALSE;
+    }
+    if(curl_strnequal(params + 1, "RFC822", 6)) {
+      return FALSE;
+    }
     return isList;
   }
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1181,7 +1181,7 @@ static CURLcode imap_state_login_resp(struct Curl_easy *data,
 /* Detect IMAP listings vs. downloading a single email */
 static bool is_custom_fetch_listing_match(const char *params)
 {
-  bool isList = false;
+  bool isList = FALSE;
 
   /* match " 1:* (FLAGS ..." or " 1,2,3 (FLAGS ..." */
   if(*params++ != ' ')


### PR DESCRIPTION
Refactor is_custom_fetch_listing_match function to improve parameter handling and logic for detecting listings.

Well, I tried to improve this to fix the issue https://github.com/curl/curl/issues/22832 here.
We check a bit better to find the end of the list of IDs and then if BODY comes, it's an email download or ( for a list of fields.
