### PR TITLE
SSH: gate username logging behind CURL_TRC_SSH

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2611,7 +2611,12 @@ static CURLcode myssh_connect(struct Curl_easy *data, bool *done)
   }
 
   if(Curl_creds_has_user(conn->creds)) {
-    infof(data, "User: %s", conn->creds->user);
+    /* The SSH username is credentials-adjacent data and may reveal sensitive
+       information (cloud-provider default users, corporate SSO identities).
+       Log it only at SSH-trace level, not unconditionally via infof, to
+       match the gating used in libssh2.c and curl's policy of stripping
+       userinfo from URLs in verbose output. */
+    CURL_TRC_SSH(data, "User: %s", conn->creds->user);
     rc = ssh_options_set(sshc->ssh_session, SSH_OPTIONS_USER,
                          conn->creds->user);
     if(rc != SSH_OK) {

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1681,9 +1681,13 @@ static CURLcode ssh_state_auth_agent(struct Curl_easy *data,
 
   if(rc == LIBSSH2_ERROR_NONE) {
     sshc->authed = TRUE;
-    infof(data, "SSH: agent authenticated user '%s' with key '%s'",
-          Curl_creds_user(data->conn->creds),
-          sshc->sshagent_identity->comment);
+    /* Both the username and the agent identity's comment are credentials-
+       adjacent data (the comment often embeds the absolute path to the
+       private key file, e.g. '/home/user/.ssh/id_ed25519'). Trace-level
+       only, matching the SSH_AUTH_AGENT_LIST trace above. */
+    CURL_TRC_SSH(data, "SSH: agent authenticated user '%s' with key '%s'",
+                 Curl_creds_user(data->conn->creds),
+                 sshc->sshagent_identity->comment);
     myssh_to(data, sshc, SSH_AUTH_DONE);
   }
   else {
@@ -3400,7 +3404,14 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
   if(!sshc)
     return CURLE_FAILED_INIT;
 
-  infof(data, "SSH: user '%s'", Curl_creds_user(conn->creds));
+  /* The SSH username is part of the connection credentials and may reveal
+     sensitive information (cloud-provider default users like 'ec2-user',
+     corporate SSO identities, etc.). Log it only at SSH-trace level, not
+     unconditionally via infof, to match the gating already applied to the
+     password just below and to the agent-auth trace at the SSH_AUTH_AGENT
+     state. This is consistent with curl's policy of stripping userinfo from
+     URLs in verbose output. */
+  CURL_TRC_SSH(data, "SSH: user '%s'", Curl_creds_user(conn->creds));
 #ifdef CURL_LIBSSH2_DEBUG
   infof(data, "SSH: password %s", Curl_creds_passwd(conn->creds));
   sock = conn->sock[FIRSTSOCKET];


### PR DESCRIPTION
The SSH username is logged unconditionally via infof() at three sitesin the SSH backends. The password right next to it is correctly gatedbehind #ifdef CURL_LIBSSH2_DEBUG. This patch gates the username thesame way the agent-auth trace already is , via CURL_TRC_SSH, theper-feature trace macro.After the patch:
curl -v scp://user@host/... no longer prints the username.
curl --trace-config all -v scp://user@host/... still does.
The username is part of the connection credentials. curl alreadytreats it as such:
The URL parser strips userinfo from logged URLs.
lib/vssh/libssh2.c:3405 gates the password behind #ifdef CURL_LIBSSH2_DEBUG.
lib/vssh/libssh2.c:1660 already uses CURL_TRC_SSH for the same kind of data.
Three sites are inconsistent with that:
lib/vssh/libssh2.c:3403 — SSH: user '<USER>' on every connect
lib/vssh/libssh2.c:1684 — SSH: agent authenticated user '<USER>' with key '<KEY-COMMENT>'
lib/vssh/libssh.c:2614 — User: <USER> in the libssh backend
Reproduced against curl 8.14.1 built from source. After applying theequivalent fix, the username no longer appears in -v output.Not tagging this as a security fix , verbose mode is opt-in.