### PR TITLE
GHA: try fixing Cygwin upstream autoconf regression

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -106,9 +106,9 @@ jobs:
           # https://cygwin.com/mirrors.html
           # Main mirror status: https://archlinux.org/mirrors/kernel.org/
           site: https://mirrors.kernel.org/sourceware/cygwin/
-          # https://cygwin.com/cgi-bin2/package-grep.cgi
+          # https://cygwin.com/packages/
           packages: >-
-            ${{ matrix.build == 'autotools' && 'autoconf-15-3 automake libtool make' || 'cmake ninja' }}
+            ${{ matrix.build == 'autotools' && 'autoconf-15 automake libtool make' || 'cmake ninja' }}
             gcc-core binutils perl pkgconf
             openssh
             libpsl-devel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -108,7 +108,7 @@ jobs:
           site: https://mirrors.kernel.org/sourceware/cygwin/
           # https://cygwin.com/cgi-bin2/package-grep.cgi
           packages: >-
-            ${{ matrix.build == 'autotools' && 'autoconf automake libtool make' || 'cmake ninja' }}
+            ${{ matrix.build == 'autotools' && 'autoconf-15-3 automake libtool make' || 'cmake ninja' }}
             gcc-core binutils perl pkgconf
             openssh
             libpsl-devel
@@ -127,7 +127,6 @@ jobs:
         timeout-minutes: 2
         run: |
           PATH=/usr/bin
-          sed -i.bak 's/elsif/elif/g' /usr/bin/autoreconf; diff -u /usr/bin/autoreconf.bak /usr/bin/autoreconf || true
           autoreconf -fi
 
       - name: 'configure'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -127,6 +127,7 @@ jobs:
         timeout-minutes: 2
         run: |
           PATH=/usr/bin
+          sed -i.bak 's/elsif/elif/g' /usr/bin/autoreconf; diff -u /usr/bin/autoreconf.bak /usr/bin/autoreconf || true
           autoreconf -fi
 
       - name: 'configure'


### PR DESCRIPTION
Cygwin updated its autotools packages, and it now fails permanently 
within autoreconf, due typos in a distro-specific autoconf patch.

Fixing:
```
/usr/bin/autoreconf: line 114: syntax error near unexpected token `then'
/usr/bin/autoreconf: line 114: `        elsif  [ "${wx}" = "2.7" ] ; then'
Error: Process completed with exit code 2.
```

```diff
--- Cygwin-good
+++ Cygwin-bad
- 122 install autoconf                 15-3.................
+ 122 install autoconf                 20260320-1...........
```

Ref: https://cygwin.com/cgit/cygwin-packages/autoconf/commit/?id=f2e740061ffdc8eca95db98748b1ad14463f6e36
